### PR TITLE
Docs and issue templates: clarify usage of issues and discussions 

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/blank_issue.md
@@ -10,3 +10,5 @@ Before opening this issue, consider opening a discussion instead!
 
 Issues are used to report bugs, installation problems or to request new features.
 Discussions are used to ask more open-ended questions, brainstorm, ask our feedback, etc.
+
+You can find more details on how to use issues and discussions [here](https://github.com/ECP-WarpX/WarpX/blob/development/CONTRIBUTING.rst).

--- a/.github/ISSUE_TEMPLATE/blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/blank_issue.md
@@ -1,0 +1,12 @@
+---
+name: Blank issue
+about: Ask us a question
+labels: [question]
+---
+
+Are you here because you have something to report that is neither a bug, a new feature, nor an installation problem?
+
+Before opening this issue, consider opening a discussion instead!
+
+Issues are used to report bugs, installation problems or to request new features.
+Discussions are used to ask more open-ended questions, brainstorm, ask our feedback, etc.

--- a/.github/ISSUE_TEMPLATE/blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/blank_issue.md
@@ -6,7 +6,7 @@ labels: [question]
 
 Are you here because you have something to report that is neither a bug, a new feature, nor an installation problem?
 
-Before opening this issue, consider opening a discussion instead!
+Before opening this issue, consider opening a [discussion](https://github.com/ECP-WarpX/WarpX/discussions) instead!
 
 Issues are used to report bugs, installation problems or to request new features.
 Discussions are used to ask more open-ended questions, brainstorm, ask our feedback, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,1 @@
-blank_issues_enabled: true
+blank_issues_enabled: false

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -17,6 +17,7 @@ What to do when
 ^^^^^^^^^^^^^^^
 
 Issues
+""""""
 
 Issues are used to track tasks that the contributors and/or maintainers can work on.
 Use issues for reporting bugs or installation problems and for requesting new features.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -12,6 +12,33 @@ Git workflow
 The WarpX project uses `git <https://git-scm.com>`_ for version control.
 If you are new to git, you can follow `this tutorial <https://swcarpentry.github.io/git-novice/>`__.
 
+
+What to do when
+---------------
+
+Issues
+
+Issues are used to track tasks that the contributors and/or maintainers can work on.
+Use issues for reporting bugs or installation problems and for requesting new features.
+
+If you've found a bug and wish to report it, first search the open issues and pull requests to see if someone else has already reported the same thing.
+If it's something new, open an issue using a template.
+We'll use the issue to address the problem you've encountered.
+
+Discussions
+
+Discussions are for open-ended conversations, general questions, brainstorming ideas.
+Please, use discussions if you want to ask us something that is not technically a bug or a feature.
+Feel free to ping us there!
+
+Pull Requests (PRs)
+
+Open a pull request if you want to add a new feature yourself.
+Follow the guide below for more details.
+
+
+Thank you for contributing! 🥰
+
 Configure your GitHub Account & Development Machine
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -19,24 +19,24 @@ What to do when
 Issues
 """"""
 
-Issues are used to track tasks that the contributors and/or maintainers can work on.
+`Issues <https://github.com/ECP-WarpX/WarpX/issues>`__ are used to track tasks that the contributors and/or maintainers can work on.
 Use issues for reporting bugs or installation problems and for requesting new features.
 
-If you've found a bug and wish to report it, first search the open issues and pull requests to see if someone else has already reported the same thing.
+If you've found a bug and wish to report it, first search the open issues and `pull requests <https://github.com/ECP-WarpX/WarpX/pulls>`__ to see if someone else has already reported the same thing.
 If it's something new, open an issue using a template.
 We'll use the issue to address the problem you've encountered.
 
 Discussions
 """""""""""
 
-Discussions are for open-ended conversations, general questions, brainstorming ideas.
+`Discussions <https://github.com/ECP-WarpX/WarpX/discussions>`__ are for open-ended conversations, general questions, brainstorming ideas.
 Please, use discussions if you want to ask us something that is not technically a bug or a feature.
 Feel free to ping us there!
 
 Pull Requests (PRs)
 """""""""""""""""""
 
-Open a pull request if you want to add a new feature yourself.
+Open a `pull request <https://github.com/ECP-WarpX/WarpX/pulls>`__ if you want to add a new feature yourself.
 Follow the guide below for more details.
 
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -33,6 +33,7 @@ Please, use discussions if you want to ask us something that is not technically 
 Feel free to ping us there!
 
 Pull Requests (PRs)
+"""""""""""""""""""
 
 Open a pull request if you want to add a new feature yourself.
 Follow the guide below for more details.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -27,6 +27,7 @@ If it's something new, open an issue using a template.
 We'll use the issue to address the problem you've encountered.
 
 Discussions
+"""""""""""
 
 Discussions are for open-ended conversations, general questions, brainstorming ideas.
 Please, use discussions if you want to ask us something that is not technically a bug or a feature.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -14,7 +14,7 @@ If you are new to git, you can follow `this tutorial <https://swcarpentry.github
 
 
 What to do when
----------------
+^^^^^^^^^^^^^^^
 
 Issues
 


### PR DESCRIPTION
This PR adds guidance and best practices on how to use issues and discussions.
This is useful to avoid issues that should be discussions, for example.