### PR TITLE
Update CMake version for Perlmutter AY25

### DIFF
--- a/Tools/machines/perlmutter-nersc/perlmutter_cpu_warpx.profile.example
+++ b/Tools/machines/perlmutter-nersc/perlmutter_cpu_warpx.profile.example
@@ -7,7 +7,7 @@ if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in yo
 
 # required dependencies
 module load cpu
-module load cmake/3.24.3
+module load cmake/3.30.2
 module load cray-fftw/3.3.10.6
 
 # optional: for QED support with detailed tables

--- a/Tools/machines/perlmutter-nersc/perlmutter_gpu_warpx.profile.example
+++ b/Tools/machines/perlmutter-nersc/perlmutter_gpu_warpx.profile.example
@@ -12,7 +12,7 @@ module load craype
 module load craype-x86-milan
 module load craype-accel-nvidia80
 module load cudatoolkit
-module load cmake/3.24.3
+module load cmake/3.30.2
 
 # optional: for QED support with detailed tables
 export BOOST_ROOT=/global/common/software/spackecp/perlmutter/e4s-23.08/default/spack/opt/spack/linux-sles15-zen3/gcc-12.3.0/boost-1.83.0-nxqk3hnci5g3wqv75wvsmuke3w74mzxi


### PR DESCRIPTION
Update CMake as per NERSC automated message upon loading cmake/3.24.3: 

_"This module is deprecated and scheduled for removal at the end of AY24 (Jan 14, 2025). Please move to cmake/3.30.2."_