### PR TITLE
Remove an unnecessary call to WarpX::GetInstance()

### DIFF
--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -320,7 +320,7 @@ WarpX::ComputeCostsHeuristic (amrex::Vector<std::unique_ptr<amrex::LayoutData<am
 
     for (int lev = 0; lev <= finest_level; ++lev)
     {
-        const auto & mypc_ref = GetInstance().GetPartContainer();
+        const auto & mypc_ref = GetPartContainer();
         const auto nSpecies = mypc_ref.nSpecies();
 
         // Species loop


### PR DESCRIPTION
This PR removes an unnecessary call to ` WarpX::GetInstance()`  from a member function of the `WarpX` class.