### PR TITLE
Pass gamma_boost as an argument to AcceleratorLattice and LatticeElementFinder

### DIFF
--- a/Source/AcceleratorLattice/AcceleratorLattice.H
+++ b/Source/AcceleratorLattice/AcceleratorLattice.H
@@ -42,10 +42,15 @@ public:
      * \brief Initialize the element finder instance at the given level of refinement
      *
      * @param[in] lev the level of refinement
+     * @param[in] gamma_boost the Lorentz factor of the boosted frame
      * @param[in] ba the box array at the level of refinement
      * @param[in] dm the distribution map at the level of refinement
      */
-    void InitElementFinder (int lev, amrex::BoxArray const & ba, amrex::DistributionMapping const & dm);
+    void InitElementFinder (
+        int lev,
+        amrex::Real gamma_boost,
+        amrex::BoxArray const & ba,
+        amrex::DistributionMapping const & dm);
 
     /**
      * \brief Update the element finder, needed when the simulation frame has moved relative to the lab frame

--- a/Source/AcceleratorLattice/AcceleratorLattice.H
+++ b/Source/AcceleratorLattice/AcceleratorLattice.H
@@ -47,8 +47,8 @@ public:
      * @param[in] dm the distribution map at the level of refinement
      */
     void InitElementFinder (
-        int lev,
-        amrex::Real gamma_boost,
+        int const lev,
+        amrex::Real const gamma_boost,
         amrex::BoxArray const & ba,
         amrex::DistributionMapping const & dm);
 

--- a/Source/AcceleratorLattice/AcceleratorLattice.H
+++ b/Source/AcceleratorLattice/AcceleratorLattice.H
@@ -47,8 +47,8 @@ public:
      * @param[in] dm the distribution map at the level of refinement
      */
     void InitElementFinder (
-        int const lev,
-        amrex::Real const gamma_boost,
+        int lev,
+        amrex::Real gamma_boost,
         amrex::BoxArray const & ba,
         amrex::DistributionMapping const & dm);
 

--- a/Source/AcceleratorLattice/AcceleratorLattice.cpp
+++ b/Source/AcceleratorLattice/AcceleratorLattice.cpp
@@ -76,13 +76,15 @@ AcceleratorLattice::ReadLattice (std::string const & root_name, amrex::ParticleR
 }
 
 void
-AcceleratorLattice::InitElementFinder (int const lev, amrex::BoxArray const & ba, amrex::DistributionMapping const & dm)
+AcceleratorLattice::InitElementFinder (
+    int const lev, amrex::Real const gamma_boost,
+    amrex::BoxArray const & ba, amrex::DistributionMapping const & dm)
 {
     if (m_lattice_defined) {
         m_element_finder = std::make_unique<amrex::LayoutData<LatticeElementFinder>>(ba, dm);
         for (amrex::MFIter mfi(*m_element_finder); mfi.isValid(); ++mfi)
         {
-            (*m_element_finder)[mfi].InitElementFinder(lev, mfi, *this);
+            (*m_element_finder)[mfi].InitElementFinder(lev, gamma_boost, mfi, *this);
         }
     }
 }

--- a/Source/AcceleratorLattice/LatticeElementFinder.H
+++ b/Source/AcceleratorLattice/LatticeElementFinder.H
@@ -30,10 +30,12 @@ struct LatticeElementFinder
      * \brief Initialize the element finder at the level and grid
      *
      * @param[in] lev the refinement level
+     * @param[in] gamma_boost the Lorentz factor of the boosted frame
      * @param[in] a_mfi specifies the grid where the finder is defined
      * @param[in] accelerator_lattice a reference to the accelerator lattice at the refinement level
      */
-    void InitElementFinder (int lev, amrex::MFIter const& a_mfi,
+    void InitElementFinder (int lev, amrex::Real gamma_boost,
+                            amrex::MFIter const& a_mfi,
                             AcceleratorLattice const& accelerator_lattice);
 
     /**

--- a/Source/AcceleratorLattice/LatticeElementFinder.H
+++ b/Source/AcceleratorLattice/LatticeElementFinder.H
@@ -34,7 +34,7 @@ struct LatticeElementFinder
      * @param[in] a_mfi specifies the grid where the finder is defined
      * @param[in] accelerator_lattice a reference to the accelerator lattice at the refinement level
      */
-    void InitElementFinder (int const lev, amrex::Real const gamma_boost,
+    void InitElementFinder (int lev, amrex::Real gamma_boost,
                             amrex::MFIter const& a_mfi,
                             AcceleratorLattice const& accelerator_lattice);
 

--- a/Source/AcceleratorLattice/LatticeElementFinder.H
+++ b/Source/AcceleratorLattice/LatticeElementFinder.H
@@ -34,7 +34,7 @@ struct LatticeElementFinder
      * @param[in] a_mfi specifies the grid where the finder is defined
      * @param[in] accelerator_lattice a reference to the accelerator lattice at the refinement level
      */
-    void InitElementFinder (int lev, amrex::Real gamma_boost,
+    void InitElementFinder (int const lev, amrex::Real const gamma_boost,
                             amrex::MFIter const& a_mfi,
                             AcceleratorLattice const& accelerator_lattice);
 

--- a/Source/AcceleratorLattice/LatticeElementFinder.cpp
+++ b/Source/AcceleratorLattice/LatticeElementFinder.cpp
@@ -15,7 +15,8 @@
 using namespace amrex::literals;
 
 void
-LatticeElementFinder::InitElementFinder (int const lev, amrex::MFIter const& a_mfi,
+LatticeElementFinder::InitElementFinder (int const lev, const amrex::Real gamma_boost,
+                                         amrex::MFIter const& a_mfi,
                                          AcceleratorLattice const& accelerator_lattice)
 {
 
@@ -26,8 +27,8 @@ LatticeElementFinder::InitElementFinder (int const lev, amrex::MFIter const& a_m
 
     m_dz = WarpX::CellSize(lev)[2];
 
-    m_gamma_boost = WarpX::gamma_boost;
-    m_uz_boost = std::sqrt(WarpX::gamma_boost*WarpX::gamma_boost - 1._prt)*PhysConst::c;
+    m_gamma_boost = gamma_boost;
+    m_uz_boost = std::sqrt(m_gamma_boost*m_gamma_boost - 1._prt)*PhysConst::c;
 
     AllocateIndices(accelerator_lattice);
 

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -285,7 +285,7 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
         }
 
         // Re-initialize the lattice element finder with the new ba and dm.
-        m_accelerator_lattice[lev]->InitElementFinder(lev, ba, dm);
+        m_accelerator_lattice[lev]->InitElementFinder(lev, gamma_boost, ba, dm);
 
         if (costs[lev] != nullptr)
         {

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -2101,7 +2101,7 @@ WarpX::AllocLevelData (int lev, const BoxArray& ba, const DistributionMapping& d
                   guard_cells.ng_alloc_Rho, guard_cells.ng_alloc_F, guard_cells.ng_alloc_G, aux_is_nodal);
 
     m_accelerator_lattice[lev] = std::make_unique<AcceleratorLattice>();
-    m_accelerator_lattice[lev]->InitElementFinder(lev, ba, dm);
+    m_accelerator_lattice[lev]->InitElementFinder(lev, gamma_boost, ba, dm);
 
 }
 


### PR DESCRIPTION
This PR is a small step towards the goal of reducing the usage of static variables in the WarpX class.