### PR TITLE
Make do_subcycling a private variable of the WarpX class

### DIFF
--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -94,7 +94,7 @@ WarpX::ComputeDt ()
     dt.resize(0);
     dt.resize(max_level+1,deltat);
 
-    if (do_subcycling) {
+    if (m_do_subcycling) {
         for (int lev = max_level-1; lev >= 0; --lev) {
             dt[lev] = dt[lev+1] * refRatio(lev)[0];
         }

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -187,7 +187,7 @@ WarpX::Evolve (int numsteps)
             OneStep_multiJ(cur_time);
         }
         // Electromagnetic case: no subcycling or no mesh refinement
-        else if ( !do_subcycling || (finest_level == 0))
+        else if ( !m_do_subcycling || (finest_level == 0))
         {
             OneStep_nosub(cur_time);
             // E: guard cells are up-to-date
@@ -195,14 +195,14 @@ WarpX::Evolve (int numsteps)
             // F: guard cells are NOT up-to-date
         }
         // Electromagnetic case: subcycling with one level of mesh refinement
-        else if (do_subcycling && (finest_level == 1))
+        else if (m_do_subcycling && (finest_level == 1))
         {
             OneStep_sub1(cur_time);
         }
         else
         {
             WARPX_ABORT_WITH_MESSAGE(
-                "do_subcycling = " + std::to_string(do_subcycling)
+                "do_subcycling = " + std::to_string(m_do_subcycling)
                 + " is an unsupported do_subcycling type.");
         }
 

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -850,7 +850,7 @@ WarpX::computeMaxStepBoostAccelerator() {
     const Real interaction_time_boost = (len_plasma_boost-zmin_domain_boost_step_0)/
         (moving_window_v-v_plasma_boost);
     // Divide by dt, and update value of max_step.
-    const auto computed_max_step = (do_subcycling)?
+    const auto computed_max_step = (m_do_subcycling)?
         static_cast<int>(interaction_time_boost/dt[0]):
         static_cast<int>(interaction_time_boost/dt[maxLevel()]);
     max_step = computed_max_step;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -391,7 +391,6 @@ public:
     //! Specifies the type of grid used for the above sorting, i.e. cell-centered, nodal, or mixed
     static amrex::IntVect sort_idx_type;
 
-    static bool do_subcycling;
     static bool do_multi_J;
     static int do_multi_J_n_depositions;
 
@@ -1453,6 +1452,9 @@ private:
     // Timestepping parameters
     std::optional<amrex::Real> m_const_dt;
     std::optional<amrex::Real> m_max_dt;
+
+    // whether to use subcycling
+    bool m_do_subcycling = false;
 
     // Macroscopic properties
     std::unique_ptr<MacroscopicProperties> m_macroscopic_properties;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -179,7 +179,6 @@ amrex::IntVect WarpX::sort_idx_type(AMREX_D_DECL(0,0,0));
 
 bool WarpX::do_dynamic_scheduling = true;
 
-bool WarpX::do_subcycling = false;
 bool WarpX::do_multi_J = false;
 int WarpX::do_multi_J_n_depositions;
 bool WarpX::safe_guard_cells = false;
@@ -448,7 +447,7 @@ WarpX::WarpX ()
     // (e.g., use_fdtd_nci_corr)
     if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD) {
         AMREX_ALWAYS_ASSERT(use_fdtd_nci_corr == 0);
-        AMREX_ALWAYS_ASSERT(do_subcycling == 0);
+        AMREX_ALWAYS_ASSERT(m_do_subcycling == 0);
     }
 
     if (WarpX::current_deposition_algo != CurrentDepositionAlgo::Esirkepov) {
@@ -622,7 +621,7 @@ WarpX::ReadParameters ()
         utils::parser::queryWithParser(pp_warpx, "cfl", cfl);
         pp_warpx.query("verbose", verbose);
         utils::parser::queryWithParser(pp_warpx, "regrid_int", regrid_int);
-        pp_warpx.query("do_subcycling", do_subcycling);
+        pp_warpx.query("do_subcycling", m_do_subcycling);
         pp_warpx.query("do_multi_J", do_multi_J);
         if (do_multi_J)
         {
@@ -636,7 +635,7 @@ WarpX::ReadParameters ()
         override_sync_intervals =
             utils::parser::IntervalsParser(override_sync_intervals_string_vec);
 
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(do_subcycling != 1 || max_level <= 1,
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_do_subcycling != 1 || max_level <= 1,
                                          "Subcycling method 1 only works for 2 levels.");
 
         ReadBoostedFrameParameters(gamma_boost, beta_boost, boost_direction);
@@ -2045,7 +2044,7 @@ WarpX::AllocLevelData (int lev, const BoxArray& ba, const DistributionMapping& d
     guard_cells.Init(
         dt[lev],
         dx,
-        do_subcycling,
+        m_do_subcycling,
         WarpX::use_fdtd_nci_corr,
         grid_type,
         do_moving_window,
@@ -2408,7 +2407,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
                              ncomps, ngPhi, 0.0_rt );
     }
 
-    if (do_subcycling && lev == 0)
+    if (m_do_subcycling && lev == 0)
     {
         m_fields.alloc_init(FieldType::current_store, Direction{0}, lev, amrex::convert(ba,jx_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
         m_fields.alloc_init(FieldType::current_store, Direction{1}, lev, amrex::convert(ba,jy_nodal_flag), dm, ncomps, ngJ, 0.0_rt);


### PR DESCRIPTION
This PR makes  `do_subcycling` (renamed `m_do_subcycling`) a private member variable of the `WarpX` class.
This is part of the effort towards making WarpX class less static.