### PR TITLE
python callback at restart

### DIFF
--- a/Python/pywarpx/callbacks.py
+++ b/Python/pywarpx/callbacks.py
@@ -406,13 +406,16 @@ def callfromafterInitEsolve(f):
 def installafterInitEsolve(f):
     installcallback("afterInitEsolve", f)
 
+
 # ----------------------------------------------------------------------------
 def callfromafterInitatRestart(f):
     installcallback("afterInitatRestart", f)
     return f
 
+
 def installafterInitatRestart(f):
     installcallback("afterInitatRestart", f)
+
 
 # ----------------------------------------------------------------------------
 def callfromafterinit(f):

--- a/Python/pywarpx/callbacks.py
+++ b/Python/pywarpx/callbacks.py
@@ -280,6 +280,7 @@ callback_instances = {
     "loadExternalFields": {},
     "beforeInitEsolve": {},
     "afterInitEsolve": {},
+    "afterInitatRestart": {},
     "afterinit": {},
     "beforecollisions": {},
     "aftercollisions": {},
@@ -405,6 +406,13 @@ def callfromafterInitEsolve(f):
 def installafterInitEsolve(f):
     installcallback("afterInitEsolve", f)
 
+# ----------------------------------------------------------------------------
+def callfromafterInitatRestart(f):
+    installcallback("afterInitatRestart", f)
+    return f
+
+def installafterInitatRestart(f):
+    installcallback("afterInitatRestart", f)
 
 # ----------------------------------------------------------------------------
 def callfromafterinit(f):

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -610,6 +610,9 @@ WarpX::InitData ()
             AddExternalFields(lev);
         }
     }
+    else {
+        ExecutePythonCallback("afterInitatRestart");
+    }
 
     if (restart_chkfile.empty() || write_diagnostics_on_restart) {
         // Write full diagnostics before the first iteration.


### PR DESCRIPTION
This PR adds a python callback option after initialization at restart, enabling users to read user-defined checkpoint vars that could be written using the python call afterdiagnostics that already exists

