### PR TITLE
CMake/CTest: Opt-in Disable Signal Handling

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -141,7 +141,7 @@ jobs:
       df -h
       # configure
       export AMReX_CMAKE_FLAGS="-DAMReX_ASSERTIONS=ON -DAMReX_TESTING=ON"
-      export WARPX_TEST_FLAGS="-DWarpX_TEST_CLEANUP=ON -DWarpX_TEST_FPETRAP=ON -DWarpX_TEST_DEBUG=ON"
+      export WARPX_TEST_FLAGS="-DWarpX_TEST_CLEANUP=ON -DWarpX_TEST_FPETRAP=ON -DWarpX_BACKTRACE_INFO=ON"
       cmake -S . -B build    \
         ${AMReX_CMAKE_FLAGS} \
         ${WARPX_CMAKE_FLAGS} \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,16 +82,16 @@ option(WarpX_QED_TOOLS     "Build external tool to generate QED lookup tables (r
                                                                         OFF)
 
 # Advanced option to run tests
-option(WarpX_TEST_CLEANUP "Clean up test directories (for CI)" OFF)
-option(WarpX_TEST_DEBUGGER "Run tests without AMReX signal handling (to attach debuggers)" OFF)
-option(WarpX_TEST_FPETRAP "Run tests with FPE-trapping runtime parameters (for CI)" OFF)
+option(WarpX_TEST_CLEANUP "Clean up automated test directories" OFF)
+option(WarpX_TEST_DEBUGGER "Run automated tests without AMReX signal handling (to attach debuggers)" OFF)
+option(WarpX_TEST_FPETRAP "Run automated tests with FPE-trapping runtime parameters" OFF)
 mark_as_advanced(WarpX_TEST_CLEANUP)
 mark_as_advanced(WarpX_TEST_DEBUGGER)
 mark_as_advanced(WarpX_TEST_FPETRAP)
 
 # Advanced option to compile with the -g1 option for minimal debug symbols
 # (useful to see, e.g., line numbers in backtraces)
-option(WarpX_BACKTRACE_INFO "Compile tests with -g1 for debug symbols" OFF)
+option(WarpX_BACKTRACE_INFO "Compile with -g1 for minimal debug symbols (currently used in CI tests)" OFF)
 mark_as_advanced(WarpX_BACKTRACE_INFO)
 if(WarpX_BACKTRACE_INFO)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g1")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,10 +89,11 @@ mark_as_advanced(WarpX_TEST_CLEANUP)
 mark_as_advanced(WarpX_TEST_DEBUGGER)
 mark_as_advanced(WarpX_TEST_FPETRAP)
 
-# Advanced option to run CI tests with the -g compile option
-option(WarpX_TEST_DEBUG "Compile tests with -g1 for symbols (for CI)" OFF)
-mark_as_advanced(WarpX_TEST_DEBUG)
-if(WarpX_TEST_DEBUG)
+# Advanced option to compile with the -g1 option for minimal debug symbols
+# (useful to see, e.g., line numbers in backtraces)
+option(WarpX_BACKTRACE_INFO "Compile tests with -g1 for debug symbols" OFF)
+mark_as_advanced(WarpX_BACKTRACE_INFO)
+if(WarpX_BACKTRACE_INFO)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g1")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,16 +81,16 @@ option(WarpX_QED_TABLE_GEN "QED table generation (requires PICSAR and Boost)"
 option(WarpX_QED_TOOLS     "Build external tool to generate QED lookup tables (requires PICSAR and Boost)"
                                                                         OFF)
 
-# Advanced option to automatically clean up CI test directories
-option(WarpX_TEST_CLEANUP "Clean up CI test directories" OFF)
+# Advanced option to run tests
+option(WarpX_TEST_CLEANUP "Clean up test directories (for CI)" OFF)
+option(WarpX_TEST_DEBUGGER "Run tests without AMReX signal handling (to attach debuggers)" OFF)
+option(WarpX_TEST_FPETRAP "Run tests with FPE-trapping runtime parameters (for CI)" OFF)
 mark_as_advanced(WarpX_TEST_CLEANUP)
-
-# Advanced option to run CI tests with FPE-trapping runtime parameters
-option(WarpX_TEST_FPETRAP "Run CI tests with FPE-trapping runtime parameters" OFF)
+mark_as_advanced(WarpX_TEST_DEBUGGER)
 mark_as_advanced(WarpX_TEST_FPETRAP)
 
 # Advanced option to run CI tests with the -g compile option
-option(WarpX_TEST_DEBUG "Run CI tests with the -g compile option" OFF)
+option(WarpX_TEST_DEBUG "Compile tests with -g1 for symbols (for CI)" OFF)
 mark_as_advanced(WarpX_TEST_DEBUG)
 if(WarpX_TEST_DEBUG)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g1")

--- a/Docs/source/install/cmake.rst
+++ b/Docs/source/install/cmake.rst
@@ -143,10 +143,10 @@ CMake Option                  Default & Values                               Des
 ``WarpX_pybind11_repo``       ``https://github.com/pybind/pybind11.git``     Repository URI to pull and build pybind11 from
 ``WarpX_pybind11_branch``     *we set and maintain a compatible commit*      Repository branch for ``WarpX_pybind11_repo``
 ``WarpX_pybind11_internal``   **ON**/OFF                                     Needs a pre-installed pybind11 library if set to ``OFF``
-``WarpX_TEST_CLEANUP``        ON/**OFF**                                     Clean up test directories (for CI)
-``WarpX_TEST_DEBUG``          ON/**OFF**                                     Compile tests with -g1 for symbols (for CI)
-``WarpX_TEST_DEBUGGER``       ON/**OFF**                                     Run tests without AMReX signal handling (to attach debuggers)
-``WarpX_TEST_FPETRAP``        ON/**OFF**                                     Run tests with FPE-trapping runtime parameters (for CI)
+``WarpX_TEST_CLEANUP``        ON/**OFF**                                     Clean up automated test directories
+``WarpX_TEST_DEBUGGER``       ON/**OFF**                                     Run automated tests without AMReX signal handling (to attach debuggers)
+``WarpX_TEST_FPETRAP``        ON/**OFF**                                     Run automated tests with FPE-trapping runtime parameters
+``WarpX_BACKTRACE_INFO``      ON/**OFF**                                     Compile with -g1 for minimal debug symbols (currently used in CI tests)
 ============================= ============================================== ===========================================================
 
 For example, one can also build against a local AMReX copy.

--- a/Docs/source/install/cmake.rst
+++ b/Docs/source/install/cmake.rst
@@ -143,6 +143,10 @@ CMake Option                  Default & Values                               Des
 ``WarpX_pybind11_repo``       ``https://github.com/pybind/pybind11.git``     Repository URI to pull and build pybind11 from
 ``WarpX_pybind11_branch``     *we set and maintain a compatible commit*      Repository branch for ``WarpX_pybind11_repo``
 ``WarpX_pybind11_internal``   **ON**/OFF                                     Needs a pre-installed pybind11 library if set to ``OFF``
+``WarpX_TEST_CLEANUP``        ON/**OFF**                                     Clean up test directories (for CI)
+``WarpX_TEST_DEBUG``          ON/**OFF**                                     Compile tests with -g1 for symbols (for CI)
+``WarpX_TEST_DEBUGGER``       ON/**OFF**                                     Run tests without AMReX signal handling (to attach debuggers)
+``WarpX_TEST_FPETRAP``        ON/**OFF**                                     Run tests with FPE-trapping runtime parameters (for CI)
 ============================= ============================================== ===========================================================
 
 For example, one can also build against a local AMReX copy.

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -145,6 +145,7 @@ function(add_warpx_test
         set(runtime_params
             "amrex.abort_on_unused_inputs = 1"
             "amrex.throw_exception = 1"
+            "amrex.signal_handling = 0"
             "warpx.always_warn_immediately = 1"
             "warpx.do_dynamic_scheduling = 0"
             "warpx.serialize_initial_conditions = 1"
@@ -158,6 +159,9 @@ function(add_warpx_test
                 "amrex.fpe_trap_overflow = 1"
                 "amrex.fpe_trap_zero = 1"
             )
+        endif()
+        if(WarpX_TEST_DEBUGGER)
+            set(runtime_params_fpetrap "amrex.signal_handling = 0")
         endif()
         add_test(
             NAME ${name}.run

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -145,7 +145,6 @@ function(add_warpx_test
         set(runtime_params
             "amrex.abort_on_unused_inputs = 1"
             "amrex.throw_exception = 1"
-            "amrex.signal_handling = 0"
             "warpx.always_warn_immediately = 1"
             "warpx.do_dynamic_scheduling = 0"
             "warpx.serialize_initial_conditions = 1"


### PR DESCRIPTION
In IDEs, we want to attach debuggers to CTest runs. This needs an option to [disable signal handling from AMReX](https://amrex-codes.github.io/amrex/docs_html/Debugging.html#breaking-into-debuggers) to work.