### PR TITLE
Update differential luminosity test 

### DIFF
--- a/Examples/Tests/diff_lumi_diag/inputs_test_3d_diff_lumi_diag_photons
+++ b/Examples/Tests/diff_lumi_diag/inputs_test_3d_diff_lumi_diag_photons
@@ -3,7 +3,9 @@ FILE = inputs_base_3d
 
 # Test with electrons/positrons: use parse_density_function
 
-beam1.species_type = electron
+particles.photon_species = beam1 beam2
+
+beam1.species_type = photon
 beam1.injection_style = "NUniformPerCell"
 beam1.num_particles_per_cell_each_dim = 1 1 1
 beam1.profile = parse_density_function
@@ -15,7 +17,7 @@ beam1.ymax =  4*sigmay
 beam1.zmin =-muz-4*sigmaz
 beam1.zmax =-muz+4*sigmaz
 
-beam2.species_type = positron
+beam2.species_type = photon
 beam2.injection_style = "NUniformPerCell"
 beam2.num_particles_per_cell_each_dim = 1 1 1
 beam2.profile = parse_density_function

--- a/Regression/Checksum/benchmarks_json/test_3d_diff_lumi_diag_photons.json
+++ b/Regression/Checksum/benchmarks_json/test_3d_diff_lumi_diag_photons.json
@@ -1,24 +1,25 @@
 {
   "lev=0": {
-    "rho_beam1": 656097367.2335038,
-    "rho_beam2": 656097367.2335038
-  },
-  "beam1": {
-    "particle_momentum_x": 0.0,
-    "particle_momentum_y": 0.0,
-    "particle_momentum_z": 1.7512476113279403e-11,
-    "particle_position_x": 0.2621440000000001,
-    "particle_position_y": 0.005242880000000001,
-    "particle_position_z": 314572.79999473685,
-    "particle_weight": 11997744756.90957
+    "rho_beam1": 0.0,
+    "rho_beam2": 0.0
   },
   "beam2": {
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 1.7513431895752007e-11,
+    "particle_momentum_z": 1.7511853009715152e-11,
     "particle_position_x": 0.2621440000000001,
-    "particle_position_y": 0.005242880000000001,
-    "particle_position_z": 314572.79999472946,
+    "particle_position_y": 0.005242880000000004,
+    "particle_position_z": 314572.8000000002,
+    "particle_weight": 11997744756.909575
+  },
+  "beam1": {
+    "particle_momentum_x": 0.0,
+    "particle_momentum_y": 0.0,
+    "particle_momentum_z": 1.75121641230803e-11,
+    "particle_position_x": 0.2621440000000001,
+    "particle_position_y": 0.005242880000000004,
+    "particle_position_z": 314572.8000000004,
     "particle_weight": 11997744756.909573
   }
 }
+


### PR DESCRIPTION
Fixes the species in the test: `test_3d_diff_lumi_diag_photons` from `electron` and `positron` to `photons`.
Updates checksums consequently. 


(Off Topic: it's 5555!)