### PR TITLE
Add doxygen documentation regarding `is_igf_2d_slices`

### DIFF
--- a/Source/FieldSolver/ElectrostaticSolvers/ElectrostaticSolver.H
+++ b/Source/FieldSolver/ElectrostaticSolvers/ElectrostaticSolver.H
@@ -76,14 +76,15 @@ public:
      *  \f[
      *      \vec{\nabla}^2 r \phi - (\vec{\beta}\cdot\vec{\nabla})^2 r \phi = -\frac{r \rho}{\epsilon_0}
      *  \f]
-     * \param[out] phi The potential to be computed by this function
      * \param[in] rho The charge density for a given species (relativistic solver)
      *                               or total charge density (labframe solver)
+     * \param[out] phi The potential to be computed by this function
      * \param[in] beta Represents the velocity of the source of `phi`
      * \param[in] required_precision The relative convergence threshold for the MLMG solver
      * \param[in] absolute_tolerance The absolute convergence threshold for the MLMG solver
      * \param[in] max_iters The maximum number of iterations allowed for the MLMG solver
      * \param[in] verbosity The verbosity setting for the MLMG solver
+     * \param[in] is_igf_2d_slices boolean to select between fully 3D Poisson solver and quasi-3D, i.e. one 2D Poisson solve on every z slice (defulat: false)
      */
     void computePhi (
         ablastr::fields::MultiLevelScalarField const& rho,

--- a/Source/FieldSolver/ElectrostaticSolvers/ElectrostaticSolver.H
+++ b/Source/FieldSolver/ElectrostaticSolvers/ElectrostaticSolver.H
@@ -84,7 +84,7 @@ public:
      * \param[in] absolute_tolerance The absolute convergence threshold for the MLMG solver
      * \param[in] max_iters The maximum number of iterations allowed for the MLMG solver
      * \param[in] verbosity The verbosity setting for the MLMG solver
-     * \param[in] is_igf_2d_slices boolean to select between fully 3D Poisson solver and quasi-3D, i.e. one 2D Poisson solve on every z slice (defulat: false)
+     * \param[in] is_igf_2d_slices boolean to select between fully 3D Poisson solver and quasi-3D, i.e. one 2D Poisson solve on every z slice (default: false)
      */
     void computePhi (
         ablastr::fields::MultiLevelScalarField const& rho,

--- a/Source/ablastr/fields/IntegratedGreenFunctionSolver.H
+++ b/Source/ablastr/fields/IntegratedGreenFunctionSolver.H
@@ -124,6 +124,7 @@ namespace ablastr::fields
      * @param[out] phi the electrostatic potential amrex::MultiFab
      * @param[in] cell_size an arreay of 3 reals dx dy dz
      * @param[in] ba amrex::BoxArray with the grid of a given level
+     * @param[in] is_igf_2d boolean to select between fully 3D Poisson solver and quasi-3D, i.e. one 2D Poisson solve on every z slice (defulat: false)
      */
     void
     computePhiIGF (amrex::MultiFab const & rho,

--- a/Source/ablastr/fields/IntegratedGreenFunctionSolver.H
+++ b/Source/ablastr/fields/IntegratedGreenFunctionSolver.H
@@ -124,7 +124,7 @@ namespace ablastr::fields
      * @param[out] phi the electrostatic potential amrex::MultiFab
      * @param[in] cell_size an arreay of 3 reals dx dy dz
      * @param[in] ba amrex::BoxArray with the grid of a given level
-     * @param[in] is_igf_2d boolean to select between fully 3D Poisson solver and quasi-3D, i.e. one 2D Poisson solve on every z slice (defulat: false)
+     * @param[in] is_igf_2d boolean to select between fully 3D Poisson solver and quasi-3D, i.e. one 2D Poisson solve on every z slice (default: false)
      */
     void
     computePhiIGF (amrex::MultiFab const & rho,

--- a/Source/ablastr/fields/PoissonSolver.H
+++ b/Source/ablastr/fields/PoissonSolver.H
@@ -179,7 +179,7 @@ inline void interpolatePhiBetweenLevels (
  * \param[in] grids the grids per level (e.g., from AmrMesh)
  * \param[in] grid_type Integer that corresponds to the type of grid used in the simulation (collocated, staggered, hybrid)
  * \param[in] is_solver_igf_on_lev0 boolean to select the Poisson solver: 1 for FFT on level 0 & Multigrid on other levels, 0 for Multigrid on all levels
- * \param[in] is_igf_2d boolean to select between fully 3D Poisson solver and quasi-3D, i.e. one 2D Poisson solve on every z slice (defulat: false)
+ * \param[in] is_igf_2d boolean to select between fully 3D Poisson solver and quasi-3D, i.e. one 2D Poisson solve on every z slice (default: false)
  * \param[in] eb_enabled solve with embedded boundaries
  * \param[in] do_single_precision_comms perform communications in single precision
  * \param[in] rel_ref_ratio mesh refinement ratio between levels (default: 1)

--- a/Source/ablastr/fields/PoissonSolver.H
+++ b/Source/ablastr/fields/PoissonSolver.H
@@ -179,6 +179,7 @@ inline void interpolatePhiBetweenLevels (
  * \param[in] grids the grids per level (e.g., from AmrMesh)
  * \param[in] grid_type Integer that corresponds to the type of grid used in the simulation (collocated, staggered, hybrid)
  * \param[in] is_solver_igf_on_lev0 boolean to select the Poisson solver: 1 for FFT on level 0 & Multigrid on other levels, 0 for Multigrid on all levels
+ * \param[in] is_igf_2d boolean to select between fully 3D Poisson solver and quasi-3D, i.e. one 2D Poisson solve on every z slice (defulat: false)
  * \param[in] eb_enabled solve with embedded boundaries
  * \param[in] do_single_precision_comms perform communications in single precision
  * \param[in] rel_ref_ratio mesh refinement ratio between levels (default: 1)


### PR DESCRIPTION
Add Doxygen documentation regarding `is_igf_2d_slices`.
This is a boolean flag that lets the user select between two types of FFT-based Poisson solver:
* fully 3D: solves Poisson equation in 3D geometry 
* quasi-3D: solves many 2D Poisson equations, one for each `z` slice, independently one another  