### PR TITLE
Use `self_fields_verbosity` value for magnetostatic solver

### DIFF
--- a/Source/FieldSolver/MagnetostaticSolver/MagnetostaticSolver.cpp
+++ b/Source/FieldSolver/MagnetostaticSolver/MagnetostaticSolver.cpp
@@ -136,13 +136,12 @@ WarpX::AddMagnetostaticFieldLabFrame()
     else {
         required_precision = 1e-11;
     }
-    const int verbosity = 2;
 
     computeVectorPotential(
         m_fields.get_mr_levels_alldirs(FieldType::current_fp, finest_level),
         m_fields.get_mr_levels_alldirs(FieldType::vector_potential_fp_nodal, finest_level),
         required_precision, absolute_tolerance, magnetostatic_solver_max_iters,
-        verbosity
+        magnetostatic_solver_verbosity
     );
 }
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -902,6 +902,7 @@ public:
     // Magnetostatic Solver Interface
     MagnetostaticSolver::VectorPoissonBoundaryHandler m_vector_poisson_boundary_handler;
     int magnetostatic_solver_max_iters = 200;
+    int magnetostatic_solver_verbosity = 2;
     void ComputeMagnetostaticField ();
     void AddMagnetostaticFieldLabFrame ();
     void computeVectorPotential (ablastr::fields::MultiLevelVectorField const& curr,

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -684,6 +684,7 @@ WarpX::ReadParameters ()
         "To use the FFT Poisson solver, compile with WARPX_USE_FFT=ON.");
 #endif
         utils::parser::queryWithParser(pp_warpx, "self_fields_max_iters", magnetostatic_solver_max_iters);
+        utils::parser::queryWithParser(pp_warpx, "self_fields_verbosity", magnetostatic_solver_verbosity);
 
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         (


### PR DESCRIPTION
This is another temporary fix (similar to #5517) to close #5530. 