### PR TITLE
CI: CDash dashboard support

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -158,8 +158,9 @@ jobs:
       # determine if the build was triggered by a push to the development branch
       if [[ "$(Build.SourceBranch)" == "refs/heads/development" ]]; then
         # run tests (exclude pytest.AMReX when running Python tests)
-        # and submit results to CDash as Continuous
-        ctest --test-dir build --output-on-failure -E AMReX -D Continuous
+        # and submit results to CDash as Experimental
+        ctest --test-dir build --output-on-failure -E AMReX \
+          -D ExperimentalTest -D ExperimentalSubmit
       else
         # run tests (exclude pytest.AMReX when running Python tests)
         ctest --test-dir build --output-on-failure -E AMReX

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -155,8 +155,15 @@ jobs:
   - bash: |
       # set options
       set -o nounset errexit pipefail
-      # run tests (exclude pytest.AMReX when running Python tests)
-      ctest --test-dir build --output-on-failure -E AMReX
+      # determine if the build was triggered by a push to the development branch
+      if [[ "$(Build.SourceBranch)" == "refs/heads/development" ]]; then
+        # run tests (exclude pytest.AMReX when running Python tests)
+        # and submit results to CDash as Continuous
+        ctest --test-dir build --output-on-failure -E AMReX -D Continuous
+      else
+        # run tests (exclude pytest.AMReX when running Python tests)
+        ctest --test-dir build --output-on-failure -E AMReX
+      fi
     displayName: 'Test'
 
   - bash: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,7 +193,8 @@ if(WarpX_FFT)
     set(ABLASTR_FFT ON CACHE STRING "FFT-based solvers" FORCE)
 endif()
 
-# this defined the variable BUILD_TESTING which is ON by default
+# Define the variable BUILD_TESTING (ON by default),
+# include CDash dashboard testing module
 include(CTest)
 
 

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,0 +1,20 @@
+## This file should be placed in the root directory of your project.
+## Then modify the CMakeLists.txt file in the root directory of your
+## project to incorporate the testing dashboard.
+##
+## # The following are required to submit to the CDash dashboard:
+##   ENABLE_TESTING()
+##   INCLUDE(CTest)
+
+set(CTEST_PROJECT_NAME WarpX)
+set(CTEST_NIGHTLY_START_TIME 08:00:00 UTC)
+
+if(CMAKE_VERSION VERSION_GREATER 3.14)
+  set(CTEST_SUBMIT_URL https://my.cdash.org/submit.php?project=WarpX)
+else()
+  set(CTEST_DROP_METHOD "https")
+  set(CTEST_DROP_SITE "my.cdash.org")
+  set(CTEST_DROP_LOCATION "/submit.php?project=WarpX")
+endif()
+
+set(CTEST_DROP_SITE_CDASH TRUE)

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -9,12 +9,6 @@
 set(CTEST_PROJECT_NAME WarpX)
 set(CTEST_NIGHTLY_START_TIME 08:00:00 UTC)
 
-if(CMAKE_VERSION VERSION_GREATER 3.14)
-  set(CTEST_SUBMIT_URL https://my.cdash.org/submit.php?project=WarpX)
-else()
-  set(CTEST_DROP_METHOD "https")
-  set(CTEST_DROP_SITE "my.cdash.org")
-  set(CTEST_DROP_LOCATION "/submit.php?project=WarpX")
-endif()
+set(CTEST_SUBMIT_URL https://my.cdash.org/submit.php?project=WarpX)
 
 set(CTEST_DROP_SITE_CDASH TRUE)

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -12,3 +12,7 @@ set(CTEST_NIGHTLY_START_TIME 08:00:00 UTC)
 set(CTEST_SUBMIT_URL https://my.cdash.org/submit.php?project=WarpX)
 
 set(CTEST_DROP_SITE_CDASH TRUE)
+
+# Additional settings
+set(CTEST_SITE "Azure-Pipelines")
+set(CTEST_BUILD_NAME "CI-Development")


### PR DESCRIPTION
Trying to add and set up CDash dashboard support for WarpX. Close #5292.

Online project results: https://my.cdash.org/index.php?project=WarpX

Relevant documentation:
- https://cmake.org/cmake/help/book/mastering-cmake/chapter/CDash.html
- https://public.kitware.com/Wiki/CDash:Administration#Creating_a_project (project settings)
- https://cmake.org/cmake/help/latest/guide/tutorial/Adding%20Support%20for%20a%20Testing%20Dashboard.html