### PR TITLE
Catch warpx not being initialized in library loader

### DIFF
--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -40,9 +40,14 @@ class LibWarpX:
             # Once loaded, it gets added to the dictionary so this code won't be called again.
             self.load_library()
             return self.__dict__[attribute]
+        elif attribute == "warpx":
+            # A `warpx` attribute has not yet been assigned, so `initialize_warpx` has not been called.
+            raise AttributeError(
+                "Trying to access libwarpx.warpx before initialize_warpx has been called!"
+            )
         else:
             # For any other attribute, call the built-in routine - this should always
-            # return an AttributeException.
+            # return an AttributeError.
             return self.__getattribute__(attribute)
 
     def _get_package_root(self):
@@ -142,8 +147,6 @@ class LibWarpX:
         self.warpx.initialize_data()
         self.libwarpx_so.execute_python_callback("afterinit")
         self.libwarpx_so.execute_python_callback("particleloader")
-
-        # self.libwarpx_so.warpx_init()
 
         self.initialized = True
 

--- a/Python/pywarpx/particle_containers.py
+++ b/Python/pywarpx/particle_containers.py
@@ -35,7 +35,7 @@ class ParticleContainerWrapper(object):
                     self.name
                 )
             except AttributeError as e:
-                msg = "This is likely caused by attempting to access a ParticleContainerWrapper before initialize_warpx has been called"
+                msg = "You must initialize WarpX before accessing a ParticleContainerWrapper's particle_container."
                 raise AttributeError(msg) from e
 
         return self._particle_container
@@ -777,7 +777,7 @@ class ParticleBoundaryBufferWrapper(object):
             try:
                 self._particle_buffer = libwarpx.warpx.get_particle_boundary_buffer()
             except AttributeError as e:
-                msg = "This is likely caused by attempting to access a ParticleBoundaryBufferWrapper before initialize_warpx has been called"
+                msg = "You must initialize WarpX before accessing a ParticleBoundaryBufferWrapper's particle_buffer."
                 raise AttributeError(msg) from e
 
         return self._particle_buffer


### PR DESCRIPTION
Follows up on, https://github.com/ECP-WarpX/WarpX/pull/5412, using @ax3l's [suggestion](https://github.com/ECP-WarpX/WarpX/pull/5412#pullrequestreview-2556960357) to catch warpx not being initialized when accessing libwarpx.warpx