### PR TITLE
Docs: configure conda to use only `conda-forge`

### DIFF
--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -74,6 +74,13 @@ Conda (Linux/macOS/Windows)
 
       conda config --set auto_activate_base false
 
+   In order to make sure that the conda configuration uses ``conda-forge`` as the only channel, which will help avoid issues with blocked ``defaults`` or ``anaconda`` repositories, please set the following configurations:
+
+   .. code-block:: bash
+
+      conda config --add channels conda-forge
+      conda config --set channel_priority strict
+
 .. tab-set::
 
    .. tab-item:: With MPI (only Linux/macOS)

--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -52,20 +52,12 @@ For all other systems, we recommend to use a **package dependency manager**:
 Pick *one* of the installation methods below to install all dependencies for WarpX development in a consistent manner.
 
 
-Conda (Linux/macOS/Windows)
----------------------------
+Conda-Forge (Linux/macOS/Windows)
+---------------------------------
 
-`Conda <https://conda.io>`__/`Mamba <https://mamba.readthedocs.io>`__ are cross-compatible, user-level package managers.
+`Conda-Forge <https://conda-forge.org/download/>`__ is a repository for cross-compatible, user-level packages.
 
 .. tip::
-
-   We recommend to configure your conda to use the faster ``libmamba`` `dependency solver <https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community>`__.
-
-   .. code-block:: bash
-
-      conda update -y -n base conda
-      conda install -y -n base conda-libmamba-solver
-      conda config --set solver libmamba
 
    We recommend to deactivate that conda self-activates its ``base`` environment.
    This `avoids interference with the system and other package managers <https://collegeville.github.io/CW20/WorkshopResources/WhitePapers/huebl-working-with-multiple-pkg-mgrs.pdf>`__.
@@ -111,19 +103,19 @@ For OpenMP support, you will further need:
 
       .. code-block:: bash
 
-         conda install -c conda-forge libgomp
+         mamba install -c conda-forge libgomp
 
    .. tab-item:: macOS or Windows
 
       .. code-block:: bash
 
-         conda install -c conda-forge llvm-openmp
+         mamba install -c conda-forge llvm-openmp
 
 For Nvidia CUDA GPU support, you will need to have `a recent CUDA driver installed <https://developer.nvidia.com/cuda-downloads>`__ or you can lower the CUDA version of `the Nvidia cuda package <https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#conda-installation>`__ and `conda-forge to match your drivers <https://docs.cupy.dev/en/stable/install.html#install-cupy-from-conda-forge>`__ and then add these packages:
 
 .. code-block:: bash
 
-   conda install -c nvidia -c conda-forge cuda cuda-nvtx-dev cupy
+   mamba install -c nvidia -c conda-forge cuda cuda-nvtx-dev cupy
 
 More info for `CUDA-enabled ML packages <https://twitter.com/jeremyphoward/status/1697435241152127369>`__.
 

--- a/Docs/source/install/users.rst
+++ b/Docs/source/install/users.rst
@@ -38,20 +38,12 @@ If want to use WarpX on a specific high-performance computing (HPC) systems, jum
 
    .. image:: conda.svg
 
-Using the Conda Package
------------------------
+Using the Conda-Forge Package
+-----------------------------
 
-A package for WarpX is available via the `Conda <https://conda.io>`_ package manager.
+A package for WarpX is available via `Conda-Forge <https://conda-forge.org/download/>`__.
 
 .. tip::
-
-   We recommend to configure your conda to use the faster ``libmamba`` `dependency solver <https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community>`__.
-
-   .. code-block:: bash
-
-      conda update -y -n base conda
-      conda install -y -n base conda-libmamba-solver
-      conda config --set solver libmamba
 
    We recommend to deactivate that conda self-activates its ``base`` environment.
    This `avoids interference with the system and other package managers <https://collegeville.github.io/CW20/WorkshopResources/WhitePapers/huebl-working-with-multiple-pkg-mgrs.pdf>`__.
@@ -60,14 +52,21 @@ A package for WarpX is available via the `Conda <https://conda.io>`_ package man
 
       conda config --set auto_activate_base false
 
+   In order to make sure that the conda configuration uses ``conda-forge`` as the only channel, which will help avoid issues with blocked ``defaults`` or ``anaconda`` repositories, please set the following configurations:
+
+   .. code-block:: bash
+
+      conda config --add channels conda-forge
+      conda config --set channel_priority strict
+
 .. code-block:: bash
 
-   conda create -n warpx -c conda-forge warpx
-   conda activate warpx
+   mamba create -n warpx -c conda-forge warpx
+   mamba activate warpx
 
 .. note::
 
-   The ``warpx`` `conda package <https://anaconda.org/conda-forge/warpx>`__ does not yet provide GPU support.
+   The ``warpx`` package on conda-forge does not yet provide `GPU support <https://github.com/conda-forge/warpx-feedstock/issues/89>`__.
 
 
 .. _install-spack:


### PR DESCRIPTION
Requested by @ax3l:

> We might also need to rework our conda docs, to change the default channel priorities to only use `conda-forge`. By default, many people have the `anaconda` repos in them too and, although we do not use them, this can break the build in this situation: some labs now block them in their firewall due to recent events, and then the installer just aborts instead of trying the next channel in the list. Very easy to do, I think we just need to prepend `conda-forge` in the channels (instead of the CLI) or add a guide to install Conda/Mamba from Conda-Forge/Minimamba instead of Anaconda.

This PR adds instructions to:
1. add `conda-forge` to the top of the channel list;
2. set the channel priority to strict.

Hopefully this should be enough?