### PR TITLE
Move checkEarlyUnusedParams from WarpX class to anonymous namespace

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -61,6 +61,23 @@
 using namespace amrex;
 using ablastr::utils::SignalHandling;
 
+namespace
+{
+    /** Print Unused Parameter Warnings after Step 1
+     *
+     * Instead of waiting for a simulation to end, we already do an early "unused parameter check"
+     * after step 1 to inform users early of potential issues with their simulation setup.
+     */
+    void checkEarlyUnusedParams ()
+    {
+        amrex::Print() << "\n"; // better: conditional \n based on return value
+        amrex::ParmParse::QueryUnusedInputs();
+
+        // Print the warning list right after the first step.
+        amrex::Print() << ablastr::warn_manager::GetWMInstance().PrintGlobalWarnings("FIRST STEP");
+    }
+}
+
 void
 WarpX::Synchronize () {
     using ablastr::fields::Direction;
@@ -310,7 +327,7 @@ WarpX::Evolve (int numsteps)
 
         // inputs: unused parameters (e.g. typos) check after step 1 has finished
         if (!early_params_checked) {
-            checkEarlyUnusedParams();
+            ::checkEarlyUnusedParams();
             early_params_checked = true;
         }
 
@@ -459,15 +476,6 @@ bool WarpX::checkStopSimulation (amrex::Real cur_time)
     m_exit_loop_due_to_interrupt_signal = SignalHandling::TestAndResetActionRequestFlag(SignalHandling::SIGNAL_REQUESTS_BREAK);
     return (cur_time >= stop_time - 1.e-3*dt[0])  ||
         m_exit_loop_due_to_interrupt_signal;
-}
-
-void WarpX::checkEarlyUnusedParams ()
-{
-    amrex::Print() << "\n"; // better: conditional \n based on return value
-    amrex::ParmParse::QueryUnusedInputs();
-
-    // Print the warning list right after the first step.
-    amrex::Print() << ablastr::warn_manager::GetWMInstance().PrintGlobalWarnings("FIRST STEP");
 }
 
 void WarpX::ExplicitFillBoundaryEBUpdateAux ()

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1583,13 +1583,6 @@ private:
     [[nodiscard]]
     bool checkStopSimulation (amrex::Real cur_time);
 
-    /** Print Unused Parameter Warnings after Step 1
-     *
-     * Instead of waiting for a simulation to end, we already do an early "unused parameter check"
-     * after step 1 to inform users early of potential issues with their simulation setup.
-     */
-    void checkEarlyUnusedParams ();
-
     /** Perform essential particle house keeping at boundaries
      *
      * Inject, communicate, scrape and sort particles.


### PR DESCRIPTION
`checkEarlyUnusedParams` is only used once inside `WarpX::Evolve`.  Therefore, this PR moves the function from the WarpX class to an anonymous namespae inside `WarpXEvolve.cpp` .
The final goal is to reduce the complexity of the WarpX class.