### PR TITLE
WarpX.cpp : move free function TagWithLevelSuffix inside WarpX::AllocInitMultiFab

### DIFF
--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -3314,14 +3314,6 @@ WarpX::isAnyParticleBoundaryThermal ()
     return false;
 }
 
-std::string
-TagWithLevelSuffix (std::string name, int const level)
-{
-    // Add the suffix "[level=level]"
-    name.append("[level=").append(std::to_string(level)).append("]");
-    return name;
-}
-
 void
 WarpX::AllocInitMultiFab (
     std::unique_ptr<amrex::iMultiFab>& mf,
@@ -3333,7 +3325,8 @@ WarpX::AllocInitMultiFab (
     const std::string& name,
     std::optional<const int> initial_value)
 {
-    const auto name_with_suffix = TagWithLevelSuffix(name, level);
+    // Add the suffix "[level=level]"
+    const auto name_with_suffix = name + "[level=" + std::to_string(level) + "]";
     const auto tag = amrex::MFInfo().SetTag(name_with_suffix);
     mf = std::make_unique<amrex::iMultiFab>(ba, dm, ncomp, ngrow, tag);
     if (initial_value) {


### PR DESCRIPTION
`TagWithLevelSuffix` is used only once inside `WarpX::AllocInitMultiFab`, and it can be replaced with a one-liner. 
For this reason, in order to simplify the WarpX class, I would suggest implementing the functionality  directly inside `WarpX::AllocInitMultiFab`