### PR TITLE
Old MF Wrapper: Warn of no CuPy

### DIFF
--- a/Python/pywarpx/fields.py
+++ b/Python/pywarpx/fields.py
@@ -303,6 +303,10 @@ class _MultiFABWrapper(object):
         # Note: transposing creates a view and not a copy.
         device_arr4 = self.mf.array(mfi)
         if libwarpx.libwarpx_so.Config.have_gpu:
+            xp, cupy_status = load_cupy()
+            if cupy_status is not None:
+                libwarpx.amr.Print(cupy_status)
+
             if cp is not None:
                 device_arr = device_arr4.to_cupy(copy=False)
             else:


### PR DESCRIPTION
There is an old code path that does not warn when it implicitly hopes that managed memory is enabled. This adds a warning.

In general, we should use the new pyAMReX-ported MultiFabWrapper, which is safer to use.