### PR TITLE
WarpXInitEB: fix " int eb_update" shadowing  "std::array< std::unique_ptr<amrex::iMultiFab>,3> & eb_update"

### DIFF
--- a/Source/EmbeddedBoundary/WarpXInitEB.cpp
+++ b/Source/EmbeddedBoundary/WarpXInitEB.cpp
@@ -363,7 +363,7 @@ WarpX::MarkUpdateCellsStairCase (
                     int const k_start = k;
 #endif
                     // Loop over neighboring cells
-                    int eb_update = 1;
+                    int eb_update_flag = 1;
                     for (int i_cell = i_start; i_cell <= i; ++i_cell) {
                         for (int j_cell = j_start; j_cell <= j; ++j_cell) {
                             for (int k_cell = k_start; k_cell <= k; ++k_cell) {
@@ -371,12 +371,12 @@ WarpX::MarkUpdateCellsStairCase (
                                 // (i.e. if they are not regular cells), do not update field
                                 // (`isRegular` returns `false` if the cell is either partially or fully covered.)
                                 if ( !flag(i_cell, j_cell, k_cell).isRegular() ) {
-                                    eb_update = 0;
+                                    eb_update_flag = 0;
                                 }
                             }
                         }
                     }
-                    eb_update_arr(i, j, k) = eb_update;
+                    eb_update_arr(i, j, k) = eb_update_flag;
                 });
 
             }


### PR DESCRIPTION
This PR fixes the following issue:

```
/home/vsts/work/1/s/Source/EmbeddedBoundary/WarpXInitEB.cpp:366:25: warning: declaration of ‘int eb_update’ shadows a parameter [-Wshadow]
  366 |                     int eb_update = 1;
      |                         ^~~~~~~~~
/home/vsts/work/1/s/Source/EmbeddedBoundary/WarpXInitEB.cpp:296:56: note: shadowed declaration is here
  296 |     std::array< std::unique_ptr<amrex::iMultiFab>,3> & eb_update,
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
```

Found in https://dev.azure.com/ECP-WarpX/WarpX/_build/results?buildId=20383&view=logs&j=8aa019fd-d859-51bf-081f-826e7fa9e37a