### PR TITLE
Only allocate `edge_lengths` and `face_areas` when using the ECT solver

### DIFF
--- a/Examples/Tests/embedded_boundary_python_api/inputs_test_3d_embedded_boundary_picmi.py
+++ b/Examples/Tests/embedded_boundary_python_api/inputs_test_3d_embedded_boundary_picmi.py
@@ -43,7 +43,7 @@ grid = picmi.Cartesian3DGrid(
 
 flag_correct_div = False
 
-solver = picmi.ElectromagneticSolver(grid=grid, method="Yee", cfl=1.0)
+solver = picmi.ElectromagneticSolver(grid=grid, method="ECT", cfl=1.0)
 
 n_cavity = 30
 L_cavity = n_cavity * unit

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
@@ -168,11 +168,7 @@ class FiniteDifferenceSolver
           *
           * \param[out] Jfield  vector of current MultiFabs at a given level
           * \param[in] Bfield   vector of magnetic field MultiFabs at a given level
-<<<<<<< HEAD
           * \param[in] eb_update_E indicate in which cell E should be updated (related to embedded boundaries)
-=======
-          * \param[in] eb_update_E indicate in which cell E should be udpated (related to embedded boundaries)
->>>>>>> 8136934a5 (Remove edge_length and faces)
           * \param[in] lev  level number for the calculation
           */
         void CalculateCurrentAmpere (

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
@@ -147,11 +147,7 @@ class FiniteDifferenceSolver
           * \param[in] Bfield   vector of magnetic field MultiFabs at a given level
           * \param[in] rhofield scalar ion charge density Multifab at a given level
           * \param[in] Pefield  scalar electron pressure MultiFab at a given level
-<<<<<<< HEAD
           * \param[in] eb_update_E indicate in which cell E should be updated (related to embedded boundaries)
-=======
-          * \param[in] eb_update_E indicate in which cell E should be udpated (related to embedded boundaries)
->>>>>>> 8136934a5 (Remove edge_length and faces)
           * \param[in] lev  level number for the calculation
           * \param[in] hybrid_model instance of the hybrid-PIC model
           * \param[in] solve_for_Faraday boolean flag for whether the E-field is solved to be used in Faraday's equation

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H
@@ -147,7 +147,11 @@ class FiniteDifferenceSolver
           * \param[in] Bfield   vector of magnetic field MultiFabs at a given level
           * \param[in] rhofield scalar ion charge density Multifab at a given level
           * \param[in] Pefield  scalar electron pressure MultiFab at a given level
+<<<<<<< HEAD
           * \param[in] eb_update_E indicate in which cell E should be updated (related to embedded boundaries)
+=======
+          * \param[in] eb_update_E indicate in which cell E should be udpated (related to embedded boundaries)
+>>>>>>> 8136934a5 (Remove edge_length and faces)
           * \param[in] lev  level number for the calculation
           * \param[in] hybrid_model instance of the hybrid-PIC model
           * \param[in] solve_for_Faraday boolean flag for whether the E-field is solved to be used in Faraday's equation
@@ -168,7 +172,11 @@ class FiniteDifferenceSolver
           *
           * \param[out] Jfield  vector of current MultiFabs at a given level
           * \param[in] Bfield   vector of magnetic field MultiFabs at a given level
+<<<<<<< HEAD
           * \param[in] eb_update_E indicate in which cell E should be updated (related to embedded boundaries)
+=======
+          * \param[in] eb_update_E indicate in which cell E should be udpated (related to embedded boundaries)
+>>>>>>> 8136934a5 (Remove edge_length and faces)
           * \param[in] lev  level number for the calculation
           */
         void CalculateCurrentAmpere (

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -1241,23 +1241,27 @@ void WarpX::InitializeEBGridData (int lev)
 
             auto const eb_fact = fieldEBFactory(lev);
 
-            auto edge_lengths_lev = m_fields.get_alldirs(FieldType::edge_lengths, lev);
-            ComputeEdgeLengths(edge_lengths_lev, eb_fact);
-            ScaleEdges(edge_lengths_lev, CellSize(lev));
-
-            auto face_areas_lev = m_fields.get_alldirs(FieldType::face_areas, lev);
-            ComputeFaceAreas(face_areas_lev, eb_fact);
-            ScaleAreas(face_areas_lev, CellSize(lev));
-
             if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT) {
+
+                auto edge_lengths_lev = m_fields.get_alldirs(FieldType::edge_lengths, lev);
+                ComputeEdgeLengths(edge_lengths_lev, eb_fact);
+                ScaleEdges(edge_lengths_lev, CellSize(lev));
+
+                auto face_areas_lev = m_fields.get_alldirs(FieldType::face_areas, lev);
+                ComputeFaceAreas(face_areas_lev, eb_fact);
+                ScaleAreas(face_areas_lev, CellSize(lev));
+
                 // Compute additional quantities required for the ECT solver
                 MarkExtensionCells();
                 ComputeFaceExtensions();
+
                 // Mark on which grid points E should be updated
                 MarkUpdateECellsECT( m_eb_update_E[lev], edge_lengths_lev );
                 // Mark on which grid points B should be updated
                 MarkUpdateBCellsECT( m_eb_update_B[lev], face_areas_lev, edge_lengths_lev);
+
             } else {
+
                 // Mark on which grid points E should be updated (stair-case approximation)
                 MarkUpdateCellsStairCase(
                     m_eb_update_E[lev],
@@ -1268,6 +1272,7 @@ void WarpX::InitializeEBGridData (int lev)
                     m_eb_update_B[lev],
                     m_fields.get_alldirs(FieldType::Bfield_fp, lev),
                     eb_fact );
+
             }
 
         }

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -2324,6 +2324,8 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
                                   guard_cells.ng_FieldSolver, lev, "m_eb_update_B[y]");
                 AllocInitMultiFab(m_eb_update_B[lev][2], amrex::convert(ba, Bz_nodal_flag), dm, ncomps,
                                   guard_cells.ng_FieldSolver, lev, "m_eb_update_B[z]");
+            }
+            if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT) {
 
                 //! EB: Lengths of the mesh edges
                 m_fields.alloc_init(FieldType::edge_lengths, Direction{0}, lev, amrex::convert(ba, Ex_nodal_flag),
@@ -2340,9 +2342,6 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
                     dm, ncomps, guard_cells.ng_FieldSolver, 0.0_rt);
                 m_fields.alloc_init(FieldType::face_areas, Direction{2}, lev, amrex::convert(ba, Bz_nodal_flag),
                     dm, ncomps, guard_cells.ng_FieldSolver, 0.0_rt);
-
-            }
-            if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT) {
 
                 AllocInitMultiFab(m_flag_info_face[lev][0], amrex::convert(ba, Bx_nodal_flag), dm, ncomps,
                                   guard_cells.ng_FieldSolver, lev, "m_flag_info_face[x]");


### PR DESCRIPTION
Following #5558, the MultiFab `edge_lengths` and `face_areas` are not used anymore, expect for the ECT solver. Thus, only allocateing them when using the ECT solver saves a considerable amount of memory.