### PR TITLE
WarpX class: make mirror-related variables private member variables

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -1190,16 +1190,16 @@ WarpX::applyMirrors (Real time)
     using ablastr::fields::Direction;
 
     // something to do?
-    if (num_mirrors == 0) {
+    if (m_num_mirrors == 0) {
         return;
     }
 
     // Loop over the mirrors
-    for(int i_mirror=0; i_mirror<num_mirrors; ++i_mirror)
+    for(int i_mirror=0; i_mirror<m_num_mirrors; ++i_mirror)
     {
         // Get mirror properties (lower and upper z bounds)
-        amrex::Real z_min = mirror_z[i_mirror];
-        amrex::Real z_max_tmp = z_min + mirror_z_width[i_mirror];
+        amrex::Real z_min = m_mirror_z[i_mirror];
+        amrex::Real z_max_tmp = z_min + m_mirror_z_width[i_mirror];
 
         // Boost quantities for boosted frame simulations
         if (gamma_boost>1)
@@ -1211,9 +1211,9 @@ WarpX::applyMirrors (Real time)
         // Loop over levels
         for(int lev=0; lev<=finest_level; lev++)
         {
-            // Mirror must contain at least mirror_z_npoints[i_mirror] cells
+            // Mirror must contain at least m_mirror_z_npoints[i_mirror] cells
             const amrex::Real dz = WarpX::CellSize(lev)[2];
-            const amrex::Real z_max = std::max(z_max_tmp, z_min+mirror_z_npoints[i_mirror]*dz);
+            const amrex::Real z_max = std::max(z_max_tmp, z_min+m_mirror_z_npoints[i_mirror]*dz);
 
             // Set each field on the fine patch to zero between z_min and z_max
             NullifyMF(m_fields, "Efield_fp", Direction{0}, lev, z_min, z_max);

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -480,11 +480,6 @@ public:
 
     amrex::Vector<amrex::Real> m_v_comoving = amrex::Vector<amrex::Real>(3, amrex::Real(0.));
 
-    static int num_mirrors;
-    amrex::Vector<amrex::Real> mirror_z;
-    amrex::Vector<amrex::Real> mirror_z_width;
-    amrex::Vector<int> mirror_z_npoints;
-
     /// object with all reduced diagnostics, similar to MultiParticleContainer for species.
     std::unique_ptr<MultiReducedDiags> reduced_diags;
 
@@ -1478,6 +1473,12 @@ private:
     std::unique_ptr<ExternalFieldParams> m_p_ext_field_params;
 
     amrex::Real moving_window_x = std::numeric_limits<amrex::Real>::max();
+
+    // Mirrors
+    int m_num_mirrors = 0;
+    amrex::Vector<amrex::Real> m_mirror_z;
+    amrex::Vector<amrex::Real> m_mirror_z_width;
+    amrex::Vector<int> m_mirror_z_npoints;
 
     // Plasma injection parameters
     int warpx_do_continuous_injection = 0;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -165,8 +165,6 @@ bool WarpX::use_filter_compensation = false;
 bool WarpX::serialize_initial_conditions = false;
 bool WarpX::refine_plasma     = false;
 
-int WarpX::num_mirrors = 0;
-
 utils::parser::IntervalsParser WarpX::sort_intervals;
 amrex::IntVect WarpX::sort_bin_size(AMREX_D_DECL(1,1,1));
 
@@ -789,17 +787,17 @@ WarpX::ReadParameters ()
 #endif
 
         utils::parser::queryWithParser(
-            pp_warpx, "num_mirrors", num_mirrors);
-        if (num_mirrors>0){
-            mirror_z.resize(num_mirrors);
+            pp_warpx, "num_mirrors", m_num_mirrors);
+        if (m_num_mirrors>0){
+            m_mirror_z.resize(m_num_mirrors);
             utils::parser::getArrWithParser(
-                pp_warpx, "mirror_z", mirror_z, 0, num_mirrors);
-            mirror_z_width.resize(num_mirrors);
+                pp_warpx, "mirror_z", m_mirror_z, 0, m_num_mirrors);
+            m_mirror_z_width.resize(m_num_mirrors);
             utils::parser::getArrWithParser(
-                pp_warpx, "mirror_z_width", mirror_z_width, 0, num_mirrors);
-            mirror_z_npoints.resize(num_mirrors);
+                pp_warpx, "mirror_z_width", m_mirror_z_width, 0, m_num_mirrors);
+            m_mirror_z_npoints.resize(m_num_mirrors);
             utils::parser::getArrWithParser(
-                pp_warpx, "mirror_z_npoints", mirror_z_npoints, 0, num_mirrors);
+                pp_warpx, "mirror_z_npoints", m_mirror_z_npoints, 0, m_num_mirrors);
         }
 
         pp_warpx.query("do_single_precision_comms", do_single_precision_comms);
@@ -1175,7 +1173,7 @@ WarpX::ReadParameters ()
         // implicit evolve schemes not setup to use mirrors
         if (evolve_scheme == EvolveScheme::SemiImplicitEM ||
             evolve_scheme == EvolveScheme::ThetaImplicitEM) {
-            WARPX_ALWAYS_ASSERT_WITH_MESSAGE( num_mirrors == 0,
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE( m_num_mirrors == 0,
                 "Mirrors cannot be used with Implicit evolve schemes.");
         }
 


### PR DESCRIPTION
`num_mirrors` was a static class variable. This PR makes it a private member variable, with the aim of making WarpX less static. The name is also changed into  `m_num_mirrors`. 
With the occasion, also the variables `mirror_z`. `mirror_z_width`, and `mirror_z_npoints` are renamed with an `m_` prefix and made private.
