### PR TITLE
WarpX class: make do_divb_cleaning_external a private member variable

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -590,7 +590,7 @@ WarpX::InitData ()
     WriteUsedInputsFile();
 
     // Run div cleaner here on loaded external fields
-    if (WarpX::do_divb_cleaning_external) {
+    if (m_do_divb_cleaning_external) {
         WarpX::ProjectionCleanDivB();
     }
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -294,10 +294,6 @@ public:
     //! Solve additional Maxwell equation for G in order to control errors in magnetic Gauss' law
     static bool do_divb_cleaning;
 
-    //! Solve Poisson equation when loading an external magnetic field to clean divergence
-    //! This is useful to remove errors that could lead to non-zero B field divergence
-    static bool do_divb_cleaning_external;
-
     //! Order of the particle shape factors (splines) along x
     static int nox;
     //! Order of the particle shape factors (splines) along y
@@ -1586,6 +1582,10 @@ private:
     int nox_fft = 16;
     int noy_fft = 16;
     int noz_fft = 16;
+
+    //! Solve Poisson equation when loading an external magnetic field to clean divergence
+    //! This is useful to remove errors that could lead to non-zero B field divergence
+    bool m_do_divb_cleaning_external = false;
 
     //! Domain decomposition on Level 0
     amrex::IntVect numprocs{0};

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -120,7 +120,6 @@ int WarpX::max_particle_its_in_implicit_scheme = 21;
 ParticleReal WarpX::particle_tol_in_implicit_scheme = 1.e-10;
 bool WarpX::do_dive_cleaning = false;
 bool WarpX::do_divb_cleaning = false;
-bool WarpX::do_divb_cleaning_external = false;
 bool WarpX::do_single_precision_comms = false;
 
 bool WarpX::do_shared_mem_charge_deposition = false;
@@ -1070,9 +1069,9 @@ WarpX::ReadParameters ()
                 || WarpX::electrostatic_solver_id == ElectrostaticSolverAlgo::LabFrameElectroMagnetostatic)
                 && WarpX::poisson_solver_id == PoissonSolverAlgo::Multigrid)))
         {
-            do_divb_cleaning_external = true;
+            m_do_divb_cleaning_external = true;
         }
-        pp_warpx.query("do_divb_cleaning_external", do_divb_cleaning_external);
+        pp_warpx.query("do_divb_cleaning_external", m_do_divb_cleaning_external);
 
         // If true, the current is deposited on a nodal grid and centered onto
         // a staggered grid. Setting warpx.do_current_centering=1 makes sense


### PR DESCRIPTION
This PR changes `do_divb_cleaning_external` from a static WarpX class variable to a private member variable (renamed `m_do_divb_cleaning_external`).
This is a small step towards reducing the use of static variables in the WarpX class.