### PR TITLE
WarpX class: make dt_update_interval a private member variable

### DIFF
--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -48,7 +48,7 @@ WarpX::ComputeDt ()
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_const_dt.has_value(), "warpx.const_dt must be specified with the hybrid-PIC solver.");
     } else if (electromagnetic_solver_id == ElectromagneticSolverAlgo::None) {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            m_const_dt.has_value() || dt_update_interval.isActivated(),
+            m_const_dt.has_value() || m_dt_update_interval.isActivated(),
             "warpx.const_dt must be specified with the electrostatic solver, or warpx.dt_update_interval must be > 0."
         );
     }

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -130,7 +130,7 @@ WarpX::Evolve (int numsteps)
         // Update timestep for electrostatic solver if a constant dt is not provided
         // This first synchronizes the position and velocity before setting the new timestep
         if (electromagnetic_solver_id == ElectromagneticSolverAlgo::None &&
-            !m_const_dt.has_value() && dt_update_interval.contains(step+1)) {
+            !m_const_dt.has_value() && m_dt_update_interval.contains(step+1)) {
             if (verbose) {
                 amrex::Print() << Utils::TextMsg::Info("updating timestep");
             }

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1401,7 +1401,7 @@ private:
     amrex::Vector<amrex::Real> t_new;
     amrex::Vector<amrex::Real> t_old;
     amrex::Vector<amrex::Real> dt;
-    static utils::parser::IntervalsParser dt_update_interval; // How often to update the timestep when using adaptive timestepping
+    utils::parser::IntervalsParser m_dt_update_interval = utils::parser::IntervalsParser{}; // How often to update the timestep when using adaptive timestepping
 
     // Particle container
     std::unique_ptr<MultiParticleContainer> mypc;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -184,8 +184,6 @@ bool WarpX::do_multi_J = false;
 int WarpX::do_multi_J_n_depositions;
 bool WarpX::safe_guard_cells = false;
 
-utils::parser::IntervalsParser WarpX::dt_update_interval;
-
 std::map<std::string, amrex::iMultiFab *> WarpX::imultifab_map;
 
 IntVect WarpX::filter_npass_each_dir(1);
@@ -743,7 +741,7 @@ WarpX::ReadParameters ()
         utils::parser::queryWithParser(pp_warpx, "max_dt", m_max_dt);
         std::vector<std::string> dt_interval_vec = {"-1"};
         pp_warpx.queryarr("dt_update_interval", dt_interval_vec);
-        dt_update_interval = utils::parser::IntervalsParser(dt_interval_vec);
+        m_dt_update_interval = utils::parser::IntervalsParser(dt_interval_vec);
 
         // Filter defaults to true for the explicit scheme, and false for the implicit schemes
         if (evolve_scheme != EvolveScheme::Explicit) {


### PR DESCRIPTION
This PR changes `dt_update_interval` from a static WarpX class variable to a private member variable (renamed `m_dt_update_interval`).
This is a small step towards reducing the use of static variables in the WarpX class.