### PR TITLE
WarpX class: make verboncoeur_axis_correction a private member variable

### DIFF
--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -1504,7 +1504,7 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
 }
 
 void
-WarpX::ApplyInverseVolumeScalingToChargeDensity (MultiFab* Rho, int lev)
+WarpX::ApplyInverseVolumeScalingToChargeDensity (MultiFab* Rho, int lev) const
 {
     const amrex::IntVect ngRho = Rho->nGrowVect();
     const std::array<Real,3>& dx = WarpX::CellSize(lev);

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -1340,7 +1340,7 @@ WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, Mu
     constexpr int NODE = amrex::IndexType::NODE;
 
     // See Verboncoeur JCP 174, 421-427 (2001) for the modified volume factor
-    const amrex::Real axis_volume_factor = (verboncoeur_axis_correction ? 1._rt/3._rt : 1._rt/4._rt);
+    const amrex::Real axis_volume_factor = (m_verboncoeur_axis_correction ? 1._rt/3._rt : 1._rt/4._rt);
 
     for ( MFIter mfi(*Jx, TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
@@ -1513,7 +1513,7 @@ WarpX::ApplyInverseVolumeScalingToChargeDensity (MultiFab* Rho, int lev)
     constexpr int NODE = amrex::IndexType::NODE;
 
     // See Verboncoeur JCP 174, 421-427 (2001) for the modified volume factor
-    const amrex::Real axis_volume_factor = (verboncoeur_axis_correction ? 1._rt/3._rt : 1._rt/4._rt);
+    const amrex::Real axis_volume_factor = (m_verboncoeur_axis_correction ? 1._rt/3._rt : 1._rt/4._rt);
 
     Box tilebox;
 

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -1331,7 +1331,7 @@ void WarpX::DampFieldsInGuards(const int lev, amrex::MultiFab* mf)
 // It is faster to apply this on the grid than to do it particle by particle.
 // It is put here since there isn't another nice place for it.
 void
-WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, MultiFab* Jz, int lev)
+WarpX::ApplyInverseVolumeScalingToCurrentDensity (MultiFab* Jx, MultiFab* Jy, MultiFab* Jz, int lev) const
 {
     const amrex::IntVect ngJ = Jx->nGrowVect();
     const std::array<Real,3>& dx = WarpX::CellSize(lev);

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -643,7 +643,7 @@ public:
                                                    int lev) const;
 
     void ApplyInverseVolumeScalingToChargeDensity(amrex::MultiFab* Rho,
-                                                  int lev);
+                                                  int lev) const;
 #endif
 
     /**

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -640,7 +640,7 @@ public:
     void ApplyInverseVolumeScalingToCurrentDensity(amrex::MultiFab* Jx,
                                                    amrex::MultiFab* Jy,
                                                    amrex::MultiFab* Jz,
-                                                   int lev);
+                                                   int lev) const;
 
     void ApplyInverseVolumeScalingToChargeDensity(amrex::MultiFab* Rho,
                                                   int lev);

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -341,10 +341,6 @@ public:
     //! small time steps.
     static bool galerkin_interpolation;
 
-    //! Flag whether the Verboncoeur correction is applied to the current and charge density
-    //! on the axis when using RZ.
-    static bool verboncoeur_axis_correction;
-
     //! If true, a bilinear filter is used to smooth charge and currents
     static bool use_filter;
     //! If true, the bilinear filtering of charge and currents is done in Fourier space
@@ -1490,6 +1486,10 @@ private:
 
     // whether to use subcycling
     bool m_do_subcycling = false;
+
+    //! Flag whether the Verboncoeur correction is applied to the current and charge density
+    //! on the axis when using RZ.
+    bool m_verboncoeur_axis_correction = true;
 
     // Macroscopic properties
     std::unique_ptr<MacroscopicProperties> m_macroscopic_properties;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -156,8 +156,6 @@ int WarpX::current_centering_noz = 2;
 bool WarpX::use_fdtd_nci_corr = false;
 bool WarpX::galerkin_interpolation = true;
 
-bool WarpX::verboncoeur_axis_correction = true;
-
 bool WarpX::use_filter = true;
 bool WarpX::use_kspace_filter       = true;
 bool WarpX::use_filter_compensation = false;
@@ -735,7 +733,7 @@ WarpX::ReadParameters ()
 
 #ifdef WARPX_DIM_RZ
         const ParmParse pp_boundary("boundary");
-        pp_boundary.query("verboncoeur_axis_correction", verboncoeur_axis_correction);
+        pp_boundary.query("verboncoeur_axis_correction", m_verboncoeur_axis_correction);
 #endif
 
         // Read timestepping options


### PR DESCRIPTION
This PR changes `verboncoeur_axis_correction` from a static WarpX class variable to a private member variable (renamed `m_verboncoeur_axis_correction`).
This is a small step towards reducing the use of static variables in the WarpX class.