### PR TITLE
WarpX class: make zmax_plasma_to_compute_max_step a private member variable and remove do_compute_max_step_from_zmax

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -530,7 +530,7 @@ WarpX::InitData ()
     // WarpX::computeMaxStepBoostAccelerator
     // needs to start from the initial zmin_domain_boost,
     // even if restarting from a checkpoint file
-    if (do_compute_max_step_from_zmax) {
+    if (m_zmax_plasma_to_compute_max_step.has_value()) {
         zmin_domain_boost_step_0 = geom[0].ProbLo(WARPX_ZINDEX);
     }
     if (restart_chkfile.empty())
@@ -798,7 +798,7 @@ WarpX::ComputePMLFactors ()
 void
 WarpX::ComputeMaxStep ()
 {
-    if (do_compute_max_step_from_zmax) {
+    if (m_zmax_plasma_to_compute_max_step.has_value()) {
         computeMaxStepBoostAccelerator();
     }
 }
@@ -831,7 +831,7 @@ WarpX::computeMaxStepBoostAccelerator() {
 
     // End of the plasma: Transform input argument
     // zmax_plasma_to_compute_max_step to boosted frame.
-    const Real len_plasma_boost = zmax_plasma_to_compute_max_step/gamma_boost;
+    const Real len_plasma_boost = m_zmax_plasma_to_compute_max_step.value()/gamma_boost;
     // Plasma velocity
     const Real v_plasma_boost = -beta_boost * PhysConst::c;
     // Get time at which the lower end of the simulation domain passes the

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -361,14 +361,7 @@ public:
     static amrex::Real beta_boost;
     //! Direction of the Lorentz transform that defines the boosted frame of the simulation
     static amrex::Vector<int> boost_direction;
-    //! If specified, the maximum number of iterations is computed automatically so that
-    //! the lower end of the simulation domain along z reaches #zmax_plasma_to_compute_max_step
-    //! in the boosted frame
-    static amrex::Real zmax_plasma_to_compute_max_step;
-    //! Set to true if #zmax_plasma_to_compute_max_step is specified, in which case
-    //! the maximum number of iterations is computed automatically so that the lower end of the
-    //! simulation domain along z reaches #zmax_plasma_to_compute_max_step in the boosted frame
-    static bool do_compute_max_step_from_zmax;
+
     //! store initial value of zmin_domain_boost because WarpX::computeMaxStepBoostAccelerator
     //! needs the initial value of zmin_domain_boost, even if restarting from a checkpoint file
     static amrex::Real zmin_domain_boost_step_0;
@@ -1545,6 +1538,11 @@ private:
 
     int max_step   = std::numeric_limits<int>::max();
     amrex::Real stop_time = std::numeric_limits<amrex::Real>::max();
+
+    //! If specified, the maximum number of iterations is computed automatically so that
+    //! the lower end of the simulation domain along z reaches #zmax_plasma_to_compute_max_step
+    //! in the boosted frame
+    std::optional<amrex::Real> m_zmax_plasma_to_compute_max_step = std::nullopt;
 
     int regrid_int = -1;
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -111,9 +111,7 @@ amrex::IntVect WarpX::m_fill_guards_current = amrex::IntVect(0);
 Real WarpX::gamma_boost = 1._rt;
 Real WarpX::beta_boost = 0._rt;
 Vector<int> WarpX::boost_direction = {0,0,0};
-bool WarpX::do_compute_max_step_from_zmax = false;
 bool WarpX::compute_max_step_from_btd = false;
-Real WarpX::zmax_plasma_to_compute_max_step = 0._rt;
 Real WarpX::zmin_domain_boost_step_0 = 0._rt;
 
 int WarpX::max_particle_its_in_implicit_scheme = 21;
@@ -491,7 +489,6 @@ WarpX::~WarpX ()
 void
 WarpX::ReadParameters ()
 {
-
     {
         const ParmParse pp;// Traditionally, max_step and stop_time do not have prefix.
         utils::parser::queryWithParser(pp, "max_step", max_step);
@@ -673,9 +670,9 @@ WarpX::ReadParameters ()
 
         // queryWithParser returns 1 if argument zmax_plasma_to_compute_max_step is
         // specified by the user, 0 otherwise.
-        do_compute_max_step_from_zmax = utils::parser::queryWithParser(
-            pp_warpx, "zmax_plasma_to_compute_max_step",
-            zmax_plasma_to_compute_max_step);
+        if(auto temp = 0.0_rt; utils::parser::queryWithParser(pp_warpx, "zmax_plasma_to_compute_max_step",temp)){
+            m_zmax_plasma_to_compute_max_step = temp;
+        }
 
         pp_warpx.query("compute_max_step_from_btd",
             compute_max_step_from_btd);


### PR DESCRIPTION
This PR combines the following static variables of the WarpX class:
```
static amrex::Real zmax_plasma_to_compute_max_step;
static bool do_compute_max_step_from_zmax;
```
into a single private member variable:
```
std::optional<amrex::Real> m_zmax_plasma_to_compute_max_step = std::nullopt;
```

This is a small step towards reducing reliance on static class variables.