### PR TITLE
CDash: fix variables in CTestConfig.cmake

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -13,6 +13,8 @@ set(CTEST_SUBMIT_URL https://my.cdash.org/submit.php?project=WarpX)
 
 set(CTEST_DROP_SITE_CDASH TRUE)
 
-# Additional settings
-set(CTEST_SITE "Azure-Pipelines")
-set(CTEST_BUILD_NAME "CI-Development")
+# Set site and build names
+# - CTest script variables: CTEST_SITE, CTEST_BUILD_NAME
+# - CTest module variables: SITE, BUILDNAME
+set(SITE "Azure-Pipelines")
+set(BUILDNAME "CI-Development")


### PR DESCRIPTION
Try using CTest module variables, instead of CTest script variables, given that we are not using a CTest script, to fix fields displayed in the CDash dashboard.

Examples of guidance from the official documentation (https://cmake.org/cmake/help/v3.24/manual/ctest.1.html):

![Screenshot from 2025-01-28 11-04-12](https://github.com/user-attachments/assets/a59e088d-8da6-4e2d-a0f4-d5dd508047a4)

![Screenshot from 2025-01-28 11-08-45](https://github.com/user-attachments/assets/f677da64-dfc4-4b98-85dc-79e360f1f915)

However, this seems to be true for all other variables in CTestConfig.cmake. Should we try to update them all?
