### PR TITLE
WarpX class: AllocInitMultiFab and imultifab_map no longer static

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -404,7 +404,7 @@ public:
      * \param[in] name The name of the iMultiFab to use in the map
      * \param[in] initial_value The optional initial value
      */
-    static void AllocInitMultiFab (
+    void AllocInitMultiFab (
         std::unique_ptr<amrex::iMultiFab>& mf,
         const amrex::BoxArray& ba,
         const amrex::DistributionMapping& dm,
@@ -417,7 +417,7 @@ public:
     // Maps of all of the iMultiFabs used (this can include MFs from other classes)
     // This is a convenience for the Python interface, allowing all iMultiFabs
     // to be easily referenced from Python.
-    static std::map<std::string, amrex::iMultiFab *> imultifab_map;
+    std::map<std::string, amrex::iMultiFab *> imultifab_map;
 
     /**
      * \brief

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -176,8 +176,6 @@ bool WarpX::do_dynamic_scheduling = true;
 bool WarpX::do_multi_J = false;
 int WarpX::do_multi_J_n_depositions;
 
-std::map<std::string, amrex::iMultiFab *> WarpX::imultifab_map;
-
 IntVect WarpX::filter_npass_each_dir(1);
 
 int WarpX::n_field_gather_buffer = -1;


### PR DESCRIPTION
This PR contributes to reducing the usage of static member functions and static variables in the WarpX class.


**Note:** I have observed a [failure](https://dev.azure.com/ECP-WarpX/WarpX/_build/results?buildId=20508&view=logs&jobId=5dcb75fd-7a98-5ebf-88d6-c1115a1d979a&j=5dcb75fd-7a98-5ebf-88d6-c1115a1d979a&t=f00e0ae1-a8d3-5558-a3f3-078bee0de0f0) of the test `test_2d_embedded_circle` . This failure does not seem to be related to the PR. I have observed that sometimes `embedded_circle` tests fail for apparently random reasons. We should look into that, since it might be a race condition or an undefined behavior issue.