### PR TITLE
WarpX class: ProjectionCleanDivB no longer static

### DIFF
--- a/Source/Python/WarpX.cpp
+++ b/Source/Python/WarpX.cpp
@@ -267,7 +267,7 @@ The physical fields in WarpX have the following naming:
             "Sets the EB potential string and updates the function parser."
         )
         .def("run_div_cleaner",
-            [] () { wx.ProjectionCleanDivB(); },
+            [] (WarpX& wx) { wx.ProjectionCleanDivB(); },
             "Executes projection based divergence cleaner on loaded Bfield_fp_external."
         )
         .def("synchronize",

--- a/Source/Python/WarpX.cpp
+++ b/Source/Python/WarpX.cpp
@@ -266,8 +266,8 @@ The physical fields in WarpX have the following naming:
             py::arg("potential"),
             "Sets the EB potential string and updates the function parser."
         )
-        .def_static("run_div_cleaner",
-            [] () { WarpX::ProjectionCleanDivB(); },
+        .def("run_div_cleaner",
+            [] () { wx.ProjectionCleanDivB(); },
             "Executes projection based divergence cleaner on loaded Bfield_fp_external."
         )
         .def("synchronize",

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -849,7 +849,7 @@ public:
 
     void ComputeDivE(amrex::MultiFab& divE, int lev);
 
-    static void ProjectionCleanDivB ();
+    void ProjectionCleanDivB ();
 
     [[nodiscard]] amrex::IntVect getngEB() const { return guard_cells.ng_alloc_EB; }
     [[nodiscard]] amrex::IntVect getngF() const { return guard_cells.ng_alloc_F; }


### PR DESCRIPTION
This PR contributes to reducing the usage of static member functions and static variables in the WarpX class.
