### PR TITLE
Move Fornberg coefficients calculations from WarpX to ablastr

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
@@ -11,6 +11,7 @@
 #include "Utils/WarpXConst.H"
 
 #include <ablastr/math/FiniteDifference.H>
+#include <ablastr/utils/Enums.H>
 
 #include <AMReX_BLassert.H>
 #include <AMReX_Box.H>
@@ -239,7 +240,7 @@ SpectralKSpace::getModifiedKComponent (const DistributionMapping& dm,
             {
                 p_modified_k[i] = 0;
                 for (int n=0; n<nstencil; n++){
-                    if (grid_type == GridType::Collocated){
+                    if (grid_type == ablastr::utils::enums::GridType::Collocated){
                         p_modified_k[i] += p_stencil_coef[n]*
                             std::sin( p_k[i]*(n+1)*delta_x )/( (n+1)*delta_x );
                     } else {
@@ -253,7 +254,7 @@ SpectralKSpace::getModifiedKComponent (const DistributionMapping& dm,
                 // (i.e. highest *real* k) is 0. However, the above calculation
                 // based on stencil coefficients does not give 0 to machine precision.
                 // Therefore, we need to enforce the fact that the modified k be 0 here.
-                if (grid_type == GridType::Collocated){
+                if (grid_type == ablastr::utils::enums::GridType::GridType::Collocated){
                     if (i_dim == 0){
                         // Because of the real-to-complex FFTs, the first axis (idim=0)
                         // contains only the positive k, and the Nyquist frequency is

--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
@@ -7,9 +7,10 @@
  */
 #include "SpectralKSpace.H"
 
-#include "WarpX.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
+
+#include <ablastr/math/FiniteDifference.H>
 
 #include <AMReX_BLassert.H>
 #include <AMReX_Box.H>
@@ -211,7 +212,8 @@ SpectralKSpace::getModifiedKComponent (const DistributionMapping& dm,
     } else {
 
         // Compute real-space stencil coefficients
-        Vector<Real> h_stencil_coef = WarpX::getFornbergStencilCoefficients(n_order, grid_type);
+        Vector<Real> h_stencil_coef =
+            ablastr::math::getFornbergStencilCoefficients(n_order, grid_type);
         Gpu::DeviceVector<Real> d_stencil_coef(h_stencil_coef.size());
         Gpu::copyAsync(Gpu::hostToDevice, h_stencil_coef.begin(), h_stencil_coef.end(),
                        d_stencil_coef.begin());

--- a/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralKSpace.cpp
@@ -254,7 +254,7 @@ SpectralKSpace::getModifiedKComponent (const DistributionMapping& dm,
                 // (i.e. highest *real* k) is 0. However, the above calculation
                 // based on stencil coefficients does not give 0 to machine precision.
                 // Therefore, we need to enforce the fact that the modified k be 0 here.
-                if (grid_type == ablastr::utils::enums::GridType::GridType::Collocated){
+                if (grid_type == ablastr::utils::enums::GridType::Collocated){
                     if (i_dim == 0){
                         // Because of the real-to-complex FFTs, the first axis (idim=0)
                         // contains only the positive k, and the Nyquist frequency is

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -943,16 +943,6 @@ public:
 
     void ApplyFilterandSumBoundaryRho (int lev, int glev, amrex::MultiFab& rho, int icomp, int ncomp);
 
-    /**
-     * \brief Returns an array of coefficients (Fornberg coefficients), corresponding
-     * to the weight of each point in a finite-difference approximation of a derivative
-     * (up to order \c n_order).
-     *
-     * \param[in] n_order order of the finite-difference approximation
-     * \param[in] a_grid_type type of grid (collocated or not)
-     */
-    static amrex::Vector<amrex::Real> getFornbergStencilCoefficients (int n_order, ablastr::utils::enums::GridType a_grid_type);
-
     // Device vectors of stencil coefficients used for finite-order centering of fields
     amrex::Gpu::DeviceVector<amrex::Real> device_field_centering_stencil_coeffs_x;
     amrex::Gpu::DeviceVector<amrex::Real> device_field_centering_stencil_coeffs_y;

--- a/Source/ablastr/math/CMakeLists.txt
+++ b/Source/ablastr/math/CMakeLists.txt
@@ -1,1 +1,9 @@
+foreach(D IN LISTS WarpX_DIMS)
+    warpx_set_suffix_dims(SD ${D})
+    target_sources(ablastr_${SD}
+      PRIVATE
+        FiniteDifference.cpp
+    )
+endforeach()
+
 add_subdirectory(fft)

--- a/Source/ablastr/math/FiniteDifference.H
+++ b/Source/ablastr/math/FiniteDifference.H
@@ -1,0 +1,44 @@
+/* Copyright 2021-2025 Edoardo Zoni, Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef ABLASTR_MATH_FINITE_DIFFERENCE_H_
+#define ABLASTR_MATH_FINITE_DIFFERENCE_H_
+
+#include "ablastr/utils/Enums.H"
+
+#include <AMReX_Vector.H>
+#include <AMReX_REAL.H>
+
+namespace ablastr::math
+{
+    /**
+     * \brief Returns an array of coefficients (Fornberg coefficients), corresponding
+     * to the weight of each point in a finite-difference approximation of a derivative
+     * (up to order \c n_order).
+     *
+     * \param[in] n_order order of the finite-difference approximation
+     * \param[in] a_grid_type type of grid (collocated or not)
+     */
+    [[nodiscard]] amrex::Vector<amrex::Real>
+    getFornbergStencilCoefficients (
+        int n_order, ablastr::utils::enums::GridType a_grid_type);
+
+    /**
+     * \brief Re-orders the Fornberg coefficients so that they can be used more conveniently for
+     * finite-order centering operations. For example, for finite-order centering of order 6,
+     * the Fornberg coefficients \c (c_0,c_1,c_2) are re-ordered as \c (c_2,c_1,c_0,c_0,c_1,c_2).
+     *
+     * \param[in,out] ordered_coeffs host vector where the re-ordered Fornberg coefficients will be stored
+     * \param[in] unordered_coeffs host vector storing the original sequence of Fornberg coefficients
+     * \param[in] order order of the finite-order centering along a given direction
+     */
+    void
+    ReorderFornbergCoefficients (
+        amrex::Vector<amrex::Real>& ordered_coeffs,
+        const amrex::Vector<amrex::Real>& unordered_coeffs, int order);
+}
+
+#endif //ABLASTR_MATH_FINITE_DIFFERENCE_H_

--- a/Source/ablastr/math/FiniteDifference.cpp
+++ b/Source/ablastr/math/FiniteDifference.cpp
@@ -1,0 +1,77 @@
+/* Copyright 2021-2025 Edoardo Zoni, Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#include "FiniteDifference.H"
+
+#include "ablastr/utils/TextMsg.H"
+
+using namespace ablastr::utils::enums;
+using namespace amrex;
+
+namespace ablastr::math
+{
+
+    amrex::Vector<amrex::Real>
+    getFornbergStencilCoefficients (const int n_order, GridType a_grid_type)
+    {
+        ABLASTR_ALWAYS_ASSERT_WITH_MESSAGE(n_order % 2 == 0, "n_order must be even");
+
+        const int m = n_order / 2;
+        amrex::Vector<amrex::Real> coeffs;
+        coeffs.resize(m);
+
+        // There are closed-form formula for these coefficients, but they result in
+        // an overflow when evaluated numerically. One way to avoid the overflow is
+        // to calculate the coefficients by recurrence.
+
+        // Coefficients for collocated (nodal) finite-difference approximation
+        if (a_grid_type == GridType::Collocated)
+        {
+            // First coefficient
+            coeffs.at(0) = m * 2._rt / (m+1);
+            // Other coefficients by recurrence
+            for (int n = 1; n < m; n++)
+            {
+                coeffs.at(n) = - (m-n) * 1._rt / (m+n+1) * coeffs.at(n-1);
+            }
+        }
+        // Coefficients for staggered finite-difference approximation
+        else
+        {
+            amrex::Real prod = 1.;
+            for (int k = 1; k < m+1; k++)
+            {
+                prod *= (m + k) / (4._rt * k);
+            }
+            // First coefficient
+            coeffs.at(0) = 4_rt * m * prod * prod;
+            // Other coefficients by recurrence
+            for (int n = 1; n < m; n++)
+            {
+                coeffs.at(n) = - ((2_rt*n-1) * (m-n)) * 1._rt / ((2_rt*n+1) * (m+n)) * coeffs.at(n-1);
+            }
+        }
+
+        return coeffs;
+    }
+
+    void
+    ReorderFornbergCoefficients (
+        amrex::Vector<amrex::Real>& ordered_coeffs,
+        const amrex::Vector<amrex::Real>& unordered_coeffs,
+        const int order)
+    {
+        const int n = order / 2;
+        for (int i = 0; i < n; i++) {
+            ordered_coeffs[i] = unordered_coeffs[n-1-i];
+        }
+        for (int i = n; i < order; i++) {
+            ordered_coeffs[i] = unordered_coeffs[i-n];
+        }
+    }
+
+}

--- a/Source/ablastr/math/FiniteDifference.cpp
+++ b/Source/ablastr/math/FiniteDifference.cpp
@@ -9,14 +9,12 @@
 
 #include "ablastr/utils/TextMsg.H"
 
-using namespace ablastr::utils::enums;
 using namespace amrex;
 
 namespace ablastr::math
 {
-
     amrex::Vector<amrex::Real>
-    getFornbergStencilCoefficients (const int n_order, GridType a_grid_type)
+    getFornbergStencilCoefficients (const int n_order, ablastr::utils::enums::GridType::GridType a_grid_type)
     {
         ABLASTR_ALWAYS_ASSERT_WITH_MESSAGE(n_order % 2 == 0, "n_order must be even");
 
@@ -29,7 +27,7 @@ namespace ablastr::math
         // to calculate the coefficients by recurrence.
 
         // Coefficients for collocated (nodal) finite-difference approximation
-        if (a_grid_type == GridType::Collocated)
+        if (a_grid_type == ablastr::utils::enums::GridType::Collocated)
         {
             // First coefficient
             coeffs.at(0) = m * 2._rt / (m+1);

--- a/Source/ablastr/math/FiniteDifference.cpp
+++ b/Source/ablastr/math/FiniteDifference.cpp
@@ -9,12 +9,14 @@
 
 #include "ablastr/utils/TextMsg.H"
 
+using namespace ablastr::utils::enums;
 using namespace amrex;
 
 namespace ablastr::math
 {
+
     amrex::Vector<amrex::Real>
-    getFornbergStencilCoefficients (const int n_order, ablastr::utils::enums::GridType::GridType a_grid_type)
+    getFornbergStencilCoefficients (const int n_order, GridType a_grid_type)
     {
         ABLASTR_ALWAYS_ASSERT_WITH_MESSAGE(n_order % 2 == 0, "n_order must be even");
 
@@ -27,7 +29,7 @@ namespace ablastr::math
         // to calculate the coefficients by recurrence.
 
         // Coefficients for collocated (nodal) finite-difference approximation
-        if (a_grid_type == ablastr::utils::enums::GridType::Collocated)
+        if (a_grid_type == GridType::Collocated)
         {
             // First coefficient
             coeffs.at(0) = m * 2._rt / (m+1);

--- a/Source/ablastr/math/Make.package
+++ b/Source/ablastr/math/Make.package
@@ -1,3 +1,5 @@
-include $(WARPX_HOME)/Source/ablastr/math/fft/Make.package
+CEXE_sources += FiniteDifference.cpp
 
-VPATH_LOCATIONS   += $(WARPX_HOME)/Source/ablastr
+VPATH_LOCATIONS   += $(WARPX_HOME)/Source/ablastr/math
+
+include $(WARPX_HOME)/Source/ablastr/math/fft/Make.package


### PR DESCRIPTION
The calculation of Fornberg stencil coefficients is rather general, and it can be shared with other projects of the BLAST family. Therefore, this PR moves the responsible functions into `ablastr`.

Specifically, the PR does the following:

- 2 new files (`FiniteDifference.H` and `FiniteDifference.cpp`) are created under `ablastr/math` (`CMakeLists.txt` and `Make.package` accordingly)
- the static method of the WarpX class `getFornbergStencilCoefficients` and the `ReorderFornbergCoefficients` function (originally defined in an anonymous namespace in `WarpX.cpp`) are moved to these new files, inside the namespace `ablastr::math`
- the two methods are minimally adapted (e.g., `AMREX_ALWAYS_ASSERT_WITH_MESSAGE` becomes `ABLASTR_ALWAYS_ASSERT_WITH_MESSAGE`)
- `WarpX.cpp` and `SpectralKSpace.cpp` (where the aforementioned functions were called)  are updated

Note that with this PR `SpectralKSpace.cpp` does not need anymore to include the heavy `WarpX.H` header.