### PR TITLE
Add MCC forward scattering

### DIFF
--- a/Docs/source/refs.bib
+++ b/Docs/source/refs.bib
@@ -35,6 +35,17 @@ volume = {19},
 year = {1991}
 }
 
+@misc{Janssen2016
+author = {Janssen, J. F. J. and Pitchford L. C. and Hagelaar G. J. M. and van Dijk J.},
+doi = {10.1088/0963-0252/25/5/055026},
+journal = {Plasma Sources Science and Technology},
+number = {5},
+pages = {055026},
+title = {{Evaluation of angular scattering models for electron-neutral collisions in Monte Carlo simulations}},
+volume = {25},
+year = {2016}
+}
+
 @misc{Lim2007,
 author = {Lim, Chul-Hyun},
 issn = {0419-4217},

--- a/Docs/source/theory/multiphysics/collisions.rst
+++ b/Docs/source/theory/multiphysics/collisions.rst
@@ -128,6 +128,14 @@ Excitation
 
 The process is also the same as for elastic scattering except the excitation energy cost is subtracted from the particle energy. This is done by reducing the velocity before a scattering angle is chosen.
 
+Forward scattering
+^^^^^^^^^^^^^^^^^^
+
+This process operates in two ways:
+
+1. If an excitation energy cost is provided, the energy cost is subtracted from the particle energy and no scattering is performed.
+2. If an excitation energy cost is not provided, the particle is not scattered and the velocity is unchanged (corresponding to a scattering angle of :math:`0` in the elastic scattering process above).
+
 Benchmarks
 ----------
 

--- a/Docs/source/theory/multiphysics/collisions.rst
+++ b/Docs/source/theory/multiphysics/collisions.rst
@@ -136,6 +136,8 @@ This process operates in two ways:
 1. If an excitation energy cost is provided, the energy cost is subtracted from the particle energy and no scattering is performed.
 2. If an excitation energy cost is not provided, the particle is not scattered and the velocity is unchanged (corresponding to a scattering angle of :math:`0` in the elastic scattering process above).
 
+See :cite:t:`b-Janssen2016` for a recommended use of this process.
+
 Benchmarks
 ----------
 

--- a/Docs/source/theory/multiphysics/collisions.rst
+++ b/Docs/source/theory/multiphysics/collisions.rst
@@ -121,7 +121,7 @@ The particle velocity in the COM frame is then isotropically scattered using the
 Back scattering
 ^^^^^^^^^^^^^^^
 
-The process is the same as for elastic scattering above expect the scattering angle is fixed at :math:`\pi`, meaning the particle velocity in the COM frame is updated to :math:`-\vec{u}_c`.
+The process is the same as for elastic scattering above except the scattering angle is fixed at :math:`\pi`, meaning the particle velocity in the COM frame is updated to :math:`-\vec{u}_c`.
 
 Excitation
 ^^^^^^^^^^

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2167,7 +2167,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
 
 * ``<collision_name>.scattering_processes`` (`strings` separated by spaces)
     Only for ``dsmc`` and ``background_mcc``. The scattering processes that should be
-    included. Available options are ``elastic``, ``back`` & ``charge_exchange``
+    included. Available options are ``elastic``, ``excitationX``, ``forward``, ``back``, and ``charge_exchange``
     for ions and ``elastic``, ``excitationX``, ``ionization`` & ``forward`` for electrons.
     Multiple excitation events can be included for electrons corresponding to
     excitation to different levels, the ``X`` above can be changed to a unique

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2168,7 +2168,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
 * ``<collision_name>.scattering_processes`` (`strings` separated by spaces)
     Only for ``dsmc`` and ``background_mcc``. The scattering processes that should be
     included. Available options are ``elastic``, ``back`` & ``charge_exchange``
-    for ions and ``elastic``, ``excitationX`` & ``ionization`` for electrons.
+    for ions and ``elastic``, ``excitationX``, ``ionization`` & ``forward`` for electrons.
     Multiple excitation events can be included for electrons corresponding to
     excitation to different levels, the ``X`` above can be changed to a unique
     identifier for each excitation process. For each scattering process specified

--- a/Source/Particles/Collision/BackgroundMCC/BackgroundMCCCollision.cpp
+++ b/Source/Particles/Collision/BackgroundMCC/BackgroundMCCCollision.cpp
@@ -106,6 +106,14 @@ BackgroundMCCCollision::BackgroundMCCCollision (std::string const& collision_nam
             utils::parser::getWithParser(
                 pp_collision_name, kw_energy.c_str(), energy);
         }
+        // if the scattering process is forward scattering get the energy
+        // associated with the process if it is given (this allows forward
+        // scattering to be used both with and without a fixed energy loss)
+        else if (scattering_process.find("forward") != std::string::npos) {
+            const std::string kw_energy = scattering_process + "_energy";
+            utils::parser::queryWithParser(
+                pp_collision_name, kw_energy.c_str(), energy);
+        }
 
         ScatteringProcess process(scattering_process, cross_section_file, energy);
 

--- a/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
@@ -46,6 +46,14 @@ DSMCFunc::DSMCFunc (
             utils::parser::getWithParser(
                 pp_collision_name, kw_energy.c_str(), energy);
         }
+        // if the scattering process is forward scattering get the energy
+        // associated with the process if it is given (this allows forward
+        // scattering to be used both with and without a fixed energy loss)
+        else if (scattering_process.find("forward") != std::string::npos) {
+            const std::string kw_energy = scattering_process + "_energy";
+            utils::parser::queryWithParser(
+                pp_collision_name, kw_energy.c_str(), energy);
+        }
 
         ScatteringProcess process(scattering_process, cross_section_file, energy);
 

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -202,6 +202,8 @@ public:
                     else {
                         amrex::Abort("Uneven mass charge-exchange not implemented yet.");
                     }
+                } else if (mask[i] == int(ScatteringProcessType::FORWARD)) {
+                    amrex::Abort("Forward scattering with DSMC not implemented yet.");
                 }
                 else {
                     amrex::Abort("Unknown scattering process.");

--- a/Source/Particles/Collision/ScatteringProcess.H
+++ b/Source/Particles/Collision/ScatteringProcess.H
@@ -21,6 +21,7 @@ enum class ScatteringProcessType {
     CHARGE_EXCHANGE,
     EXCITATION,
     IONIZATION,
+    FORWARD,
 };
 
 class ScatteringProcess

--- a/Source/Particles/Collision/ScatteringProcess.cpp
+++ b/Source/Particles/Collision/ScatteringProcess.cpp
@@ -87,6 +87,8 @@ ScatteringProcess::parseProcessType(const std::string& scattering_process)
         return ScatteringProcessType::IONIZATION;
     } else if (scattering_process.find("excitation") != std::string::npos) {
         return ScatteringProcessType::EXCITATION;
+    } else if (scattering_process.find("forward") != std::string::npos) {
+        return ScatteringProcessType::FORWARD;
     } else {
         return ScatteringProcessType::INVALID;
     }


### PR DESCRIPTION
Added a version of forward scattering suggested in [J F J Janssen et al (2016)](https://doi.org/10.1088/0963-0252/25/5/055026). This process decreases total particle energy by the process' energy threshold. If no energy threshold is given in the input file, this process is equivalent to no collision being carried out (no scattering and no energy change).

Adjusted documentation appropriately and fixed a pre-existing typo.

Feature was tested on my own machine by confirming with python callbacks that the pre-collision and post-collision velocities were equal in the case of no energy cost threshold being supplied, and that the velocities were scaled down by the appropriate amount when a threshold was supplied (it was also checked that particle direction was the same before and after collision). No formal test was added since no current MCC tests exist and adding a framework to access cross sections while executing tests was prohibitive.