### PR TITLE
Embedded Boundary: take ScaleEdges and ScaleAreas out of WarpX class

### DIFF
--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -11,6 +11,9 @@
 #include "BoundaryConditions/PML.H"
 #include "BoundaryConditions/PMLComponent.H"
 #include "Fields.H"
+#ifdef AMREX_USE_EB
+#   include "EmbeddedBoundary/EmbeddedBoundary.H"
+#endif
 #ifdef WARPX_USE_FFT
 #   include "FieldSolver/SpectralSolver/SpectralFieldData.H"
 #endif
@@ -739,7 +742,7 @@ PML::PML (const int lev, const BoxArray& grid_ba,
 
             ablastr::fields::VectorField t_pml_edge_lengths = warpx.m_fields.get_alldirs(FieldType::pml_edge_lengths, lev);
             WarpX::ComputeEdgeLengths(t_pml_edge_lengths, eb_fact);
-            WarpX::ScaleEdges(t_pml_edge_lengths, WarpX::CellSize(lev));
+            warpx::embedded_boundary::ScaleEdges(t_pml_edge_lengths, WarpX::CellSize(lev));
 
         }
     }

--- a/Source/EmbeddedBoundary/CMakeLists.txt
+++ b/Source/EmbeddedBoundary/CMakeLists.txt
@@ -2,10 +2,10 @@ foreach(D IN LISTS WarpX_DIMS)
     warpx_set_suffix_dims(SD ${D})
     target_sources(lib_${SD}
       PRIVATE
+        EmbeddedBoundary.cpp
         Enabled.cpp
         WarpXInitEB.cpp
         WarpXFaceExtensions.cpp
         WarpXFaceInfoBox.H
-        Enabled.cpp
     )
 endforeach()

--- a/Source/EmbeddedBoundary/EmbeddedBoundary.H
+++ b/Source/EmbeddedBoundary/EmbeddedBoundary.H
@@ -1,0 +1,37 @@
+/* Copyright 2021-2025 Lorenzo Giacomel, Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#ifndef WARPX_EMBEDDED_BOUNDARY_EMBEDDED_BOUNDARY_H_
+#define WARPX_EMBEDDED_BOUNDARY_EMBEDDED_BOUNDARY_H_
+
+#include "Enabled.H"
+
+#ifdef AMREX_USE_EB
+
+#include <ablastr/fields/MultiFabRegister.H>
+
+#include <AMReX_REAL.H>
+
+#include <array>
+
+namespace warpx::embedded_boundary
+{
+    /**
+    * \brief Scale the edges lengths by the mesh width to obtain the real lengths.
+    */
+    void ScaleEdges (ablastr::fields::VectorField& edge_lengths,
+                            const std::array<amrex::Real,3>& cell_size);
+    /**
+    * \brief Scale the edges areas by the mesh width to obtain the real areas.
+    */
+    void ScaleAreas (ablastr::fields::VectorField& face_areas,
+                    const std::array<amrex::Real,3>& cell_size);
+}
+
+#endif
+
+#endif //WARPX_EMBEDDED_BOUNDARY_EMBEDDED_BOUNDARY_H_

--- a/Source/EmbeddedBoundary/EmbeddedBoundary.cpp
+++ b/Source/EmbeddedBoundary/EmbeddedBoundary.cpp
@@ -1,0 +1,78 @@
+/* Copyright 2021-2025 Lorenzo Giacomel, Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#include "Enabled.H"
+
+#ifdef AMREX_USE_EB
+
+#include "EmbeddedBoundary.H"
+
+#include "Utils/TextMsg.H"
+
+#include <AMReX_BLProfiler.H>
+#include <AMReX_Box.H>
+#include <AMReX_GpuLaunch.H>
+#include <AMReX_GpuQualifiers.H>
+#include <AMReX_MFIter.H>
+
+namespace web = warpx::embedded_boundary;
+
+void
+web::ScaleEdges (ablastr::fields::VectorField& edge_lengths,
+            const std::array<amrex::Real,3>& cell_size)
+{
+    BL_PROFILE("ScaleEdges");
+
+#if !defined(WARPX_DIM_3D) && !defined(WARPX_DIM_XZ) && !defined(WARPX_DIM_RZ)
+    WARPX_ABORT_WITH_MESSAGE("ScaleEdges only implemented in 2D and 3D");
+#endif
+
+    for (int idim = 0; idim < 3; ++idim){
+#if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+        if (idim == 1) { continue; }
+#endif
+        for (amrex::MFIter mfi(*edge_lengths[0]); mfi.isValid(); ++mfi) {
+            const amrex::Box& box = mfi.tilebox(edge_lengths[idim]->ixType().toIntVect(),
+                                                edge_lengths[idim]->nGrowVect() );
+            auto const &edge_lengths_dim = edge_lengths[idim]->array(mfi);
+            amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                edge_lengths_dim(i, j, k) *= cell_size[idim];
+            });
+        }
+    }
+}
+
+
+void
+web::ScaleAreas (ablastr::fields::VectorField& face_areas,
+            const std::array<amrex::Real,3>& cell_size)
+{
+    BL_PROFILE("ScaleAreas");
+
+#if !defined(WARPX_DIM_3D) && !defined(WARPX_DIM_XZ) && !defined(WARPX_DIM_RZ)
+    WARPX_ABORT_WITH_MESSAGE("ScaleAreas only implemented in 2D and 3D");
+#endif
+
+    for (int idim = 0; idim < 3; ++idim) {
+#if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+        if (idim == 0 || idim == 2) { continue; }
+#endif
+        for (amrex::MFIter mfi(*face_areas[0]); mfi.isValid(); ++mfi) {
+            const amrex::Box& box = mfi.tilebox(face_areas[idim]->ixType().toIntVect(),
+                                                face_areas[idim]->nGrowVect() );
+            amrex::Real const full_area = cell_size[(idim+1)%3]*cell_size[(idim+2)%3];
+            auto const &face_areas_dim = face_areas[idim]->array(mfi);
+
+            amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                face_areas_dim(i, j, k) *= full_area;
+            });
+
+        }
+    }
+}
+
+#endif

--- a/Source/EmbeddedBoundary/Make.package
+++ b/Source/EmbeddedBoundary/Make.package
@@ -1,9 +1,11 @@
+CEXE_headers += EmbeddedBoundary.H
 CEXE_headers += Enabled.H
 CEXE_headers += ParticleScraper.H
 CEXE_headers += ParticleBoundaryProcess.H
 CEXE_headers += DistanceToEB.H
 CEXE_headers += WarpXFaceInfoBox.H
 
+CEXE_sources += EmbeddedBoundary.cpp
 CEXE_sources += Enabled.cpp
 CEXE_sources += WarpXInitEB.cpp
 CEXE_sources += WarpXFaceExtensions.cpp

--- a/Source/EmbeddedBoundary/WarpXInitEB.cpp
+++ b/Source/EmbeddedBoundary/WarpXInitEB.cpp
@@ -239,58 +239,6 @@ WarpX::ComputeFaceAreas (VectorField& face_areas,
     }
 }
 
-
-void
-WarpX::ScaleEdges (ablastr::fields::VectorField& edge_lengths,
-                   const std::array<amrex::Real,3>& cell_size) {
-    BL_PROFILE("ScaleEdges");
-
-#if !defined(WARPX_DIM_3D) && !defined(WARPX_DIM_XZ) && !defined(WARPX_DIM_RZ)
-    WARPX_ABORT_WITH_MESSAGE("ScaleEdges only implemented in 2D and 3D");
-#endif
-
-    for (int idim = 0; idim < 3; ++idim){
-#if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-        if (idim == 1) { continue; }
-#endif
-        for (amrex::MFIter mfi(*edge_lengths[0]); mfi.isValid(); ++mfi) {
-            const amrex::Box& box = mfi.tilebox(edge_lengths[idim]->ixType().toIntVect(),
-                                                edge_lengths[idim]->nGrowVect() );
-            auto const &edge_lengths_dim = edge_lengths[idim]->array(mfi);
-            amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                edge_lengths_dim(i, j, k) *= cell_size[idim];
-            });
-        }
-    }
-}
-
-void
-WarpX::ScaleAreas (ablastr::fields::VectorField& face_areas,
-                  const std::array<amrex::Real,3>& cell_size) {
-    BL_PROFILE("ScaleAreas");
-
-#if !defined(WARPX_DIM_3D) && !defined(WARPX_DIM_XZ) && !defined(WARPX_DIM_RZ)
-    WARPX_ABORT_WITH_MESSAGE("ScaleAreas only implemented in 2D and 3D");
-#endif
-
-    for (int idim = 0; idim < 3; ++idim) {
-#if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-        if (idim == 0 || idim == 2) { continue; }
-#endif
-        for (amrex::MFIter mfi(*face_areas[0]); mfi.isValid(); ++mfi) {
-            const amrex::Box& box = mfi.tilebox(face_areas[idim]->ixType().toIntVect(),
-                                                face_areas[idim]->nGrowVect() );
-            amrex::Real const full_area = cell_size[(idim+1)%3]*cell_size[(idim+2)%3];
-            auto const &face_areas_dim = face_areas[idim]->array(mfi);
-
-            amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                face_areas_dim(i, j, k) *= full_area;
-            });
-
-        }
-    }
-}
-
 void
 WarpX::MarkReducedShapeCells (
     std::unique_ptr<amrex::iMultiFab> & eb_reduce_particle_shape,

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -17,6 +17,9 @@
 #include "Diagnostics/MultiDiagnostics.H"
 #include "Diagnostics/ReducedDiags/MultiReducedDiags.H"
 #include "EmbeddedBoundary/Enabled.H"
+#ifdef AMREX_USE_EB
+#   include "EmbeddedBoundary/EmbeddedBoundary.H"
+#endif
 #include "Fields.H"
 #include "FieldSolver/ElectrostaticSolvers/ElectrostaticSolver.H"
 #include "FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.H"
@@ -1237,11 +1240,11 @@ void WarpX::InitializeEBGridData (int lev)
 
                 auto edge_lengths_lev = m_fields.get_alldirs(FieldType::edge_lengths, lev);
                 ComputeEdgeLengths(edge_lengths_lev, eb_fact);
-                ScaleEdges(edge_lengths_lev, CellSize(lev));
+                warpx::embedded_boundary::ScaleEdges(edge_lengths_lev, CellSize(lev));
 
                 auto face_areas_lev = m_fields.get_alldirs(FieldType::face_areas, lev);
                 ComputeFaceAreas(face_areas_lev, eb_fact);
-                ScaleAreas(face_areas_lev, CellSize(lev));
+                warpx::embedded_boundary::ScaleAreas(face_areas_lev, CellSize(lev));
 
                 // Compute additional quantities required for the ECT solver
                 MarkExtensionCells();

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1061,18 +1061,7 @@ public:
     */
     static void ComputeFaceAreas (ablastr::fields::VectorField& face_areas,
                                   const amrex::EBFArrayBoxFactory& eb_fact);
-
-    /**
-    * \brief Scale the edges lengths by the mesh width to obtain the real lengths.
-    */
-    static void ScaleEdges (ablastr::fields::VectorField& edge_lengths,
-                            const std::array<amrex::Real,3>& cell_size);
-    /**
-    * \brief Scale the edges areas by the mesh width to obtain the real areas.
-    */
-    static void ScaleAreas (ablastr::fields::VectorField& face_areas,
-                            const std::array<amrex::Real,3>& cell_size);
-    /**
+   /**
     * \brief Initialize information for cell extensions.
     *        The flags convention for m_flag_info_face is as follows
     *          - 0 for unstable cells


### PR DESCRIPTION
`ScaleAreas` and `ScaleEdges` are pure functions that can be easily taken out of the WarpX class, in order to make it simpler.

This PR places these two functions under a newly created namespace `warpx::embedded_boundary`, inside the files `EmbeddedBoundray/EmbeddedBoundary.H/cpp` .