### PR TITLE
Doc: Frontier OpenMP Load

### DIFF
--- a/Tools/machines/frontier-olcf/frontier_warpx.profile.example
+++ b/Tools/machines/frontier-olcf/frontier_warpx.profile.example
@@ -13,6 +13,9 @@ module load cray-mpich/8.1.28
 module load cce/17.0.0  # must be loaded after rocm
 # https://docs.olcf.ornl.gov/systems/frontier_user_guide.html#compatible-compiler-rocm-toolchain-versions
 
+# Fix for OpenMP Runtime (OLCFHELP-21543)
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${ROCM_PATH}/llvm/lib
+
 # optional: faster builds
 module load ccache
 module load ninja


### PR DESCRIPTION
Work-around for the ROCm module that does not add the `llvm/lib` sub-directory to the `LD_LIBRARY_PATH`. Only an issue on `install`, if runpath is stripped (default).