### PR TITLE
Fix Dangling Ref in EB Init

### DIFF
--- a/Source/EmbeddedBoundary/WarpXInitEB.cpp
+++ b/Source/EmbeddedBoundary/WarpXInitEB.cpp
@@ -147,7 +147,7 @@ WarpX::MarkReducedShapeCells (
         amrex::Array4<int> const & eb_reduce_particle_shape_arr = eb_reduce_particle_shape->array(mfi);
 
         // Check if the box (including one layer of guard cells) contains a mix of covered and regular cells
-        const amrex::Box& eb_info_box = mfi.tilebox(amrex::IntVect::TheCellVector()).grow(1);
+        const amrex::Box eb_info_box = mfi.tilebox(amrex::IntVect::TheCellVector()).grow(1);
         amrex::FabType const fab_type = eb_flag[mfi].getType( eb_info_box );
 
         if (fab_type == amrex::FabType::regular) { // All cells in the box are regular
@@ -240,7 +240,7 @@ WarpX::MarkUpdateCellsStairCase (
             amrex::Array4<int> const & eb_update_arr = eb_update[idim]->array(mfi);
 
             // Check if the box (including one layer of guard cells) contains a mix of covered and regular cells
-            const amrex::Box& eb_info_box = mfi.tilebox(amrex::IntVect::TheCellVector()).grow(1);
+            const amrex::Box eb_info_box = mfi.tilebox(amrex::IntVect::TheCellVector()).grow(1);
             amrex::FabType const fab_type = eb_flag[mfi].getType( eb_info_box );
 
             if (fab_type == amrex::FabType::regular) { // All cells in the box are regular


### PR DESCRIPTION
Follow-up to #5209: My compiler says those locations would reference temporary objects that were destroyed at the end of the line. That seems to be the case indeed.

Copy instead to make the temporary a named and thus persistent variable.

![Screenshot from 2025-02-03 16-59-22](https://github.com/user-attachments/assets/8259f6d7-099b-4d09-8382-f24baefb5793)

Update: also saw a local crash from this while developing #5481