### PR TITLE
WarpX class: remove unused methods GetMacroscopicProperties and GetHybridPICModel

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -157,9 +157,7 @@ public:
 
     MultiParticleContainer& GetPartContainer () { return *mypc; }
     MultiFluidContainer& GetFluidContainer () { return *myfl; }
-    MacroscopicProperties& GetMacroscopicProperties () { return *m_macroscopic_properties; }
     ElectrostaticSolver& GetElectrostaticSolver () {return *m_electrostatic_solver;}
-    HybridPICModel& GetHybridPICModel () { return *m_hybrid_pic_model; }
     [[nodiscard]] HybridPICModel * get_pointer_HybridPICModel () const { return m_hybrid_pic_model.get(); }
     MultiDiagnostics& GetMultiDiags () {return *multi_diags;}
     ParticleBoundaryBuffer& GetParticleBoundaryBuffer () { return *m_particle_boundary_buffer; }


### PR DESCRIPTION
The methods `GetMacroscopicProperties` and `GetHybridPICModel` of the WarpX class are currently unused. We may consider to remove them.