### PR TITLE
RTD: Fix GA Integration

### DIFF
--- a/Docs/requirements.txt
+++ b/Docs/requirements.txt
@@ -27,5 +27,6 @@ sphinx-copybutton
 sphinx-design
 sphinx_rtd_theme>=1.1.1
 sphinxcontrib-bibtex
+sphinxcontrib-googleanalytics
 sphinxcontrib-napoleon
 yt  # for checksumAPI

--- a/Docs/source/conf.py
+++ b/Docs/source/conf.py
@@ -56,7 +56,12 @@ extensions = [
     "sphinx_design",
     "breathe",
     "sphinxcontrib.bibtex",
+    "sphinxcontrib.googleanalytics",
 ]
+
+# Google Analytics
+googleanalytics_id = "G-QZGY5060MZ"
+googleanalytics_enabled = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]


### PR DESCRIPTION
GA was dropped from RTD in early Oct, 2024. This adds it again.