### PR TITLE
WarpX class: simplify return type of get_spectral_solver_fp using `auto&`

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1084,13 +1084,7 @@ public:
     void PSATDSubtractCurrentPartialSumsAvg ();
 
 #ifdef WARPX_USE_FFT
-
-#   ifdef WARPX_DIM_RZ
-        SpectralSolverRZ&
-#   else
-        SpectralSolver&
-#   endif
-            get_spectral_solver_fp (int lev) {return *spectral_solver_fp[lev];}
+    auto&  get_spectral_solver_fp (int lev) {return *spectral_solver_fp[lev];}
 #endif
 
     FiniteDifferenceSolver * get_pointer_fdtd_solver_fp (int lev) { return m_fdtd_solver_fp[lev].get(); }


### PR DESCRIPTION
This PR simplifies the return type of a method of the WarpX class by replacing:
```
#   ifdef WARPX_DIM_RZ
        SpectralSolverRZ&
#   else
        SpectralSolver&
#   endif
```
with
```
auto&
```