### PR TITLE
WarpX class: move PrintDtDxDyDz to an anonymous namespace in WarpXInitData.cpp

### DIFF
--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -134,22 +134,3 @@ WarpX::UpdateDtFromParticleSpeeds ()
         dt[lev] = dt[lev+1] * refRatio(lev)[0];
     }
 }
-
-void
-WarpX::PrintDtDxDyDz ()
-{
-    for (int lev=0; lev <= max_level; lev++) {
-        const amrex::Real* dx_lev = geom[lev].CellSize();
-        amrex::Print() << "Level " << lev << ": dt = " << dt[lev]
-#if defined(WARPX_DIM_1D_Z)
-                       << " ; dz = " << dx_lev[0] << '\n';
-#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-                       << " ; dx = " << dx_lev[0]
-                       << " ; dz = " << dx_lev[1] << '\n';
-#elif defined(WARPX_DIM_3D)
-                       << " ; dx = " << dx_lev[0]
-                       << " ; dy = " << dx_lev[1]
-                       << " ; dz = " << dx_lev[2] << '\n';
-#endif
-    }
-}

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -93,6 +93,27 @@ using namespace amrex;
 
 namespace
 {
+
+    /** Print dt and dx,dy,dz */
+    void PrintDtDxDyDz (
+        int max_level, const amrex::Vector<Geometry>& geom, const amrex::Vector<amrex::Real>& dt)
+    {
+        for (int lev=0; lev <= max_level; lev++) {
+            const amrex::Real* dx_lev = geom[lev].CellSize();
+            amrex::Print() << "Level " << lev << ": dt = " << dt[lev]
+    #if defined(WARPX_DIM_1D_Z)
+                           << " ; dz = " << dx_lev[0] << '\n';
+    #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+                           << " ; dx = " << dx_lev[0]
+                           << " ; dz = " << dx_lev[1] << '\n';
+    #elif defined(WARPX_DIM_3D)
+                           << " ; dx = " << dx_lev[0]
+                           << " ; dy = " << dx_lev[1]
+                           << " ; dz = " << dx_lev[2] << '\n';
+    #endif
+        }
+    }
+
     /**
      * \brief Check that the number of guard cells is smaller than the number of valid cells,
      * for a given MultiFab, and abort otherwise.
@@ -539,14 +560,14 @@ WarpX::InitData ()
     if (restart_chkfile.empty())
     {
         ComputeDt();
-        WarpX::PrintDtDxDyDz();
+        ::PrintDtDxDyDz(max_level, geom, dt);
         InitFromScratch();
         InitDiagnostics();
     }
     else
     {
         InitFromCheckpoint();
-        WarpX::PrintDtDxDyDz();
+        PrintDtDxDyDz(max_level, geom, dt);
         PostRestart();
         reduced_diags->InitData();
     }

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -567,7 +567,7 @@ WarpX::InitData ()
     else
     {
         InitFromCheckpoint();
-        PrintDtDxDyDz(max_level, geom, dt);
+        ::PrintDtDxDyDz(max_level, geom, dt);
         PostRestart();
         reduced_diags->InitData();
     }

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -468,9 +468,6 @@ public:
     /** Write a file that record all inputs: inputs file + command line options */
     void WriteUsedInputsFile () const;
 
-    /** Print dt and dx,dy,dz */
-    void PrintDtDxDyDz ();
-
     /**
      * \brief
      * Compute the last time step of the simulation


### PR DESCRIPTION
`PrintDtDxDyDz` is used only twice in `WarpXInitData.cpp`. Therefore, this PR turns it from a method of the WarpX class to a simple function inside an anonymous namespace in `WarpXInitData.cpp`