### PR TITLE
WarpX and PML headers: remove unused fieldFactory() methods

### DIFF
--- a/Source/BoundaryConditions/PML.H
+++ b/Source/BoundaryConditions/PML.H
@@ -221,11 +221,6 @@ private:
     // Factory for field data
     std::unique_ptr<amrex::FabFactory<amrex::FArrayBox> > pml_field_factory;
 
-    [[nodiscard]] amrex::FabFactory<amrex::FArrayBox> const& fieldFactory () const noexcept
-    {
-        return *pml_field_factory;
-    }
-
 #ifdef AMREX_USE_EB
     [[nodiscard]] amrex::EBFArrayBoxFactory const& fieldEBFactory () const noexcept {
         return static_cast<amrex::EBFArrayBoxFactory const&>(*pml_field_factory);

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1542,12 +1542,6 @@ private:
     // Factory for field data
     amrex::Vector<std::unique_ptr<amrex::FabFactory<amrex::FArrayBox> > > m_field_factory;
 
-    [[nodiscard]]
-    amrex::FabFactory<amrex::FArrayBox> const& fieldFactory (int lev) const noexcept
-    {
-        return *m_field_factory[lev];
-    }
-
     /** Stop the simulation at the end of the current step due to a received Unix signal?
      */
     bool m_exit_loop_due_to_interrupt_signal = false;


### PR DESCRIPTION
This PR removes two unused functions defined in the headers `WarpX.H` and `PML.H`