### PR TITLE
WarpX class: move out PSATDCurrentCorrection and PSATDVayDeposition

### DIFF
--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -100,6 +100,43 @@ namespace {
         solver.BackwardTransform(lev, *vector_field[2], compz, fill_guards);
 #endif
     }
+
+    /**
+     * \brief Correct current in Fourier space so that the continuity equation is satisfied
+     */
+    void PSATDCurrentCorrection (
+        const int finest_level,
+        amrex::Vector<std::unique_ptr<SpectralSolver>>& spectral_solver_fp,
+        amrex::Vector<std::unique_ptr<SpectralSolver>>& spectral_solver_cp)
+    {
+        for (int lev = 0; lev <= finest_level; ++lev)
+        {
+            spectral_solver_fp[lev]->CurrentCorrection();
+            if (spectral_solver_cp[lev])
+            {
+                spectral_solver_cp[lev]->CurrentCorrection();
+            }
+        }
+    }
+
+    /**
+     * \brief Vay deposition in Fourier space (https://doi.org/10.1016/j.jcp.2013.03.010)
+     */
+    void PSATDVayDeposition (
+        const int finest_level,
+        amrex::Vector<std::unique_ptr<SpectralSolver>>& spectral_solver_fp,
+        amrex::Vector<std::unique_ptr<SpectralSolver>>& spectral_solver_cp)
+    {
+        for (int lev = 0; lev <= finest_level; ++lev)
+        {
+            spectral_solver_fp[lev]->VayDeposition();
+            if (spectral_solver_cp[lev])
+            {
+                spectral_solver_cp[lev]->VayDeposition();
+            }
+        }
+    }
+
 }
 
 void WarpX::PSATDForwardTransformEB ()
@@ -466,32 +503,6 @@ void WarpX::PSATDForwardTransformRho (
 #endif
 }
 
-void WarpX::PSATDCurrentCorrection ()
-{
-    for (int lev = 0; lev <= finest_level; ++lev)
-    {
-        spectral_solver_fp[lev]->CurrentCorrection();
-
-        if (spectral_solver_cp[lev])
-        {
-            spectral_solver_cp[lev]->CurrentCorrection();
-        }
-    }
-}
-
-void WarpX::PSATDVayDeposition ()
-{
-    for (int lev = 0; lev <= finest_level; ++lev)
-    {
-        spectral_solver_fp[lev]->VayDeposition();
-
-        if (spectral_solver_cp[lev])
-        {
-            spectral_solver_cp[lev]->VayDeposition();
-        }
-    }
-}
-
 void WarpX::PSATDSubtractCurrentPartialSumsAvg ()
 {
     using ablastr::fields::Direction;
@@ -744,7 +755,7 @@ WarpX::PushPSATD (amrex::Real start_time)
             PSATDForwardTransformRho(rho_fp_string, rho_cp_string, 1, rho_new);
 
             // Correct J in k-space
-            PSATDCurrentCorrection();
+            ::PSATDCurrentCorrection(finest_level, spectral_solver_fp, spectral_solver_cp);
 
             // Inverse FFT of J
             PSATDBackwardTransformJ(current_fp_string, current_cp_string);
@@ -759,7 +770,7 @@ WarpX::PushPSATD (amrex::Real start_time)
             PSATDForwardTransformRho(rho_fp_string, rho_cp_string, 1, rho_new);
 
             // Compute J from D in k-space
-            PSATDVayDeposition();
+            ::PSATDVayDeposition(finest_level, spectral_solver_fp, spectral_solver_cp);
 
             // Inverse FFT of J, subtract cumulative sums of D
             current_fp_string = "current_fp";
@@ -797,7 +808,7 @@ WarpX::PushPSATD (amrex::Real start_time)
 #endif
 
             // Correct J in k-space
-            PSATDCurrentCorrection();
+            ::PSATDCurrentCorrection(finest_level, spectral_solver_fp, spectral_solver_cp);
 
             // Inverse FFT of J
             PSATDBackwardTransformJ(current_fp_string, current_cp_string);
@@ -813,7 +824,7 @@ WarpX::PushPSATD (amrex::Real start_time)
             PSATDForwardTransformJ(current_fp_string, current_cp_string);
 
             // Compute J from D in k-space
-            PSATDVayDeposition();
+            ::PSATDVayDeposition(finest_level, spectral_solver_fp, spectral_solver_cp);
 
             // Inverse FFT of J, subtract cumulative sums of D
             current_fp_string = "current_fp";

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -101,15 +101,14 @@ namespace {
 #endif
     }
 
-
-#   ifndef WARPX_DIM_RZ
     /**
      * \brief Correct current in Fourier space so that the continuity equation is satisfied
      */
+    template <typename SpectralSolverType>
     void PSATDCurrentCorrection (
         const int finest_level,
-        amrex::Vector<std::unique_ptr<SpectralSolver>>& spectral_solver_fp,
-        amrex::Vector<std::unique_ptr<SpectralSolver>>& spectral_solver_cp)
+        amrex::Vector<std::unique_ptr<SpectralSolverType>>& spectral_solver_fp,
+        amrex::Vector<std::unique_ptr<SpectralSolverType>>& spectral_solver_cp)
     {
         for (int lev = 0; lev <= finest_level; ++lev)
         {
@@ -124,10 +123,11 @@ namespace {
     /**
      * \brief Vay deposition in Fourier space (https://doi.org/10.1016/j.jcp.2013.03.010)
      */
+    template <typename SpectralSolverType>
     void PSATDVayDeposition (
         const int finest_level,
-        amrex::Vector<std::unique_ptr<SpectralSolver>>& spectral_solver_fp,
-        amrex::Vector<std::unique_ptr<SpectralSolver>>& spectral_solver_cp)
+        amrex::Vector<std::unique_ptr<SpectralSolverType>>& spectral_solver_fp,
+        amrex::Vector<std::unique_ptr<SpectralSolverType>>& spectral_solver_cp)
     {
         for (int lev = 0; lev <= finest_level; ++lev)
         {
@@ -138,8 +138,6 @@ namespace {
             }
         }
     }
-#   endif
-
 }
 
 void WarpX::PSATDForwardTransformEB ()

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -101,6 +101,8 @@ namespace {
 #endif
     }
 
+
+#   ifndef WARPX_DIM_RZ
     /**
      * \brief Correct current in Fourier space so that the continuity equation is satisfied
      */
@@ -136,6 +138,7 @@ namespace {
             }
         }
     }
+#   endif
 
 }
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1668,16 +1668,6 @@ private:
     void PSATDBackwardTransformG ();
 
     /**
-     * \brief Correct current in Fourier space so that the continuity equation is satisfied
-     */
-    void PSATDCurrentCorrection ();
-
-    /**
-     * \brief Vay deposition in Fourier space (https://doi.org/10.1016/j.jcp.2013.03.010)
-     */
-    void PSATDVayDeposition ();
-
-    /**
      * \brief Update all necessary fields in spectral space
      */
     void PSATDPushSpectralFields ();


### PR DESCRIPTION
`PSATDCurrentCorrection` and `PSATDVayDeposition` are member functions of the WarpX class, but they are used only in `WarpXPushFieldsEM.cpp` and they can be easily turned into pure functions. Therefore, this PR moves them inside an anonymous namespace in `WarpXPushFieldsEM.cpp` . The goal is the simplification of the WarpX class.