### PR TITLE
PICMI Diagnostics settings: added handling method for ParticleHistogram2D in Reduced Diagnostics

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -4083,7 +4083,7 @@ class ReducedDiagnostic(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
 
     bin_max_abs: float
         For diagnostic type 'ParticleHistogram2D', the maximum value of the bins for the abscissa axis.
-    
+
     bin_max_ord: float
         For diagnostic type 'ParticleHistogram2D', the maximum value of the bins for the ordinate axis.
 
@@ -4092,7 +4092,7 @@ class ReducedDiagnostic(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
 
     bin_min_ord: float
         For diagnostic type 'ParticleHistogram2D', the minimum value of the bins for the ordinate axis.
-    
+
     bin_number_abs: integer
         For diagnostic type 'ParticleHistogram2D', the number of bins used for the histogram for the abscissa axis.
 

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -4282,7 +4282,7 @@ class ReducedDiagnostic(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
                 ]
                 if expr is not None
             ):
-                self.user_defined_kw[k] = kwargs.pop(k)
+                self.user_defined_kw[k] = kw.pop(k)
 
         return kw
 

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -4061,7 +4061,7 @@ class ReducedDiagnostic(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
 
     species: species instance
         The name of the species for which to calculate the diagnostic, required for
-        diagnostic types 'BeamRelevant', 'ParticleHistogram', and 'ParticleExtrema'
+        diagnostic types 'BeamRelevant', 'ParticleHistogram', 'ParticleHistogram2D', and 'ParticleExtrema'
 
     bin_number: integer
         For diagnostic type 'ParticleHistogram', the number of bins used for the histogram
@@ -4079,7 +4079,34 @@ class ReducedDiagnostic(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
         For diagnostic type 'ParticleHistogram', the function evaluated to produce the histogram data
 
     filter_function: string, optional
-        For diagnostic type 'ParticleHistogram', the function to filter whether particles are included in the histogram
+        For diagnostic types 'ParticleHistogram' and 'ParticleHistogram2D', the function to filter whether particles are included in the histogram
+
+    bin_max_abs: float
+        For diagnostic type 'ParticleHistogram2D', the maximum value of the bins for the abscissa axis.
+    
+    bin_max_ord: float
+        For diagnostic type 'ParticleHistogram2D', the maximum value of the bins for the ordinate axis.
+
+    bin_min_abs: float
+        For diagnostic type 'ParticleHistogram2D', the minimum value of the bins for the abscissa axis.
+
+    bin_min_ord: float
+        For diagnostic type 'ParticleHistogram2D', the minimum value of the bins for the ordinate axis.
+    
+    bin_number_abs: integer
+        For diagnostic type 'ParticleHistogram2D', the number of bins used for the histogram for the abscissa axis.
+
+    bin_number_ord: integer
+        For diagnostic type 'ParticleHistogram2D', the number of bins used for the histogram for the ordinate axis.
+
+    histogram_function_abs: string
+        For diagnostic type 'ParticleHistogram2D', the histogram function for the abscissa axis.
+
+    histogram_function_ord: string
+        For diagnostic type 'ParticleHistogram2D', the histogram function for the ordinate axis.
+
+    value_function: string, optional
+        For diagnostic type 'ParticleHistogram2D', the expression for the weight used to calculate the histogram.
 
     reduced_function: string
         For diagnostic type 'FieldReduction', the function of the fields to evaluate
@@ -4269,9 +4296,7 @@ class ReducedDiagnostic(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
         )
 
         filter_function = kw.pop("filter_function", None)
-        value_function = kw.pop(
-            "filter_function", "1."
-        )  # set the weight to be 1 by default, i.e., count the number of particles
+        value_function = kw.pop("value_function", None)
 
         self.__setattr__("filter_function(t,x,y,z,ux,uy,uz,w)", filter_function)
         self.__setattr__("value_function(t,x,y,z,ux,uy,uz,w)", value_function)

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -4121,7 +4121,7 @@ class ReducedDiagnostic(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
     target_up_x, target_up_y, target_up_z: floats
         For diagnostic type 'FieldProbe', the vector specifying up in the 'Plane'
     """
-
+   
     def __init__(
         self,
         diag_type,
@@ -4162,6 +4162,7 @@ class ReducedDiagnostic(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
         self._species_reduced_diagnostics = [
             "BeamRelevant",
             "ParticleHistogram",
+            "ParticleHistogram2D",
             "ParticleExtrema",
         ]
 
@@ -4172,6 +4173,8 @@ class ReducedDiagnostic(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
             self.species = species.name
             if self.type == "ParticleHistogram":
                 kw = self._handle_particle_histogram(**kw)
+            elif self.type == "ParticleHistogram2D":
+                kw = self._handle_particle_histogram2d(**kw)
         elif self.type == "FieldProbe":
             kw = self._handle_field_probe(**kw)
         elif self.type == "FieldReduction":
@@ -4246,6 +4249,40 @@ class ReducedDiagnostic(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
             ):
                 self.user_defined_kw[k] = kw[k]
                 del kw[k]
+
+        return kw
+
+    def _handle_particle_histogram2d(self, **kw):
+        self.bin_number_abs = kw.pop("bin_number_abs")
+        self.bin_number_ord = kw.pop("bin_number_ord")
+        self.bin_min_abs = kw.pop("bin_min_abs")
+        self.bin_max_abs = kw.pop("bin_max_abs")
+        self.bin_min_ord = kw.pop("bin_min_ord")
+        self.bin_max_ord = kw.pop("bin_max_ord")
+        histogram_function_abs = kw.pop("histogram_function_abs")
+        histogram_function_ord = kw.pop("histogram_function_ord")
+        self.__setattr__("histogram_function_abs(t,x,y,z,ux,uy,uz,w)", histogram_function_abs)
+        self.__setattr__("histogram_function_ord(t,x,y,z,ux,uy,uz,w)", histogram_function_ord)
+
+        filter_function = kw.pop("filter_function", None)
+        value_function = kw.pop("filter_function", "1.") # set the weight to be 1 by default, i.e., count the number of particles 
+
+        self.__setattr__("filter_function(t,x,y,z,ux,uy,uz,w)", filter_function)
+        self.__setattr__("value_function(t,x,y,z,ux,uy,uz,w)", value_function)
+
+        # Check the function expressions for constants
+        for k in list(kw.keys()):
+            if any(
+                re.search(r'\b%s\b'%k, expr)
+                for expr in [
+                    histogram_function_abs,
+                    histogram_function_ord,
+                    filter_function,
+                    value_function
+                ]
+                if expr is not None
+            ):
+                self.user_defined_kw[k] = kwargs.pop(k)
 
         return kw
 

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -4121,7 +4121,7 @@ class ReducedDiagnostic(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
     target_up_x, target_up_y, target_up_z: floats
         For diagnostic type 'FieldProbe', the vector specifying up in the 'Plane'
     """
-   
+
     def __init__(
         self,
         diag_type,
@@ -4261,11 +4261,17 @@ class ReducedDiagnostic(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
         self.bin_max_ord = kw.pop("bin_max_ord")
         histogram_function_abs = kw.pop("histogram_function_abs")
         histogram_function_ord = kw.pop("histogram_function_ord")
-        self.__setattr__("histogram_function_abs(t,x,y,z,ux,uy,uz,w)", histogram_function_abs)
-        self.__setattr__("histogram_function_ord(t,x,y,z,ux,uy,uz,w)", histogram_function_ord)
+        self.__setattr__(
+            "histogram_function_abs(t,x,y,z,ux,uy,uz,w)", histogram_function_abs
+        )
+        self.__setattr__(
+            "histogram_function_ord(t,x,y,z,ux,uy,uz,w)", histogram_function_ord
+        )
 
         filter_function = kw.pop("filter_function", None)
-        value_function = kw.pop("filter_function", "1.") # set the weight to be 1 by default, i.e., count the number of particles 
+        value_function = kw.pop(
+            "filter_function", "1."
+        )  # set the weight to be 1 by default, i.e., count the number of particles
 
         self.__setattr__("filter_function(t,x,y,z,ux,uy,uz,w)", filter_function)
         self.__setattr__("value_function(t,x,y,z,ux,uy,uz,w)", value_function)
@@ -4273,12 +4279,12 @@ class ReducedDiagnostic(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
         # Check the function expressions for constants
         for k in list(kw.keys()):
             if any(
-                re.search(r'\b%s\b'%k, expr)
+                re.search(r"\b%s\b" % k, expr)
                 for expr in [
                     histogram_function_abs,
                     histogram_function_ord,
                     filter_function,
-                    value_function
+                    value_function,
                 ]
                 if expr is not None
             ):


### PR DESCRIPTION
This PR is to implement the ParticleHistogram2D diagnostics to PICMI interface. As mentioned in #5664, ParticleHistogram2D is available from the input file settings, but not yet for PICMI python input. This PR adds the _handle_particle_histogram2d function, which is similar as _handle_particle_histogram function, into the ReducedDiagnostic class. This should make ParticleHistogram2D diagnostic functional from PICMI input.

To create a ParticleHistogram2D diagnostics in PICMI input file, one needs to set these necessary parameters :
hist2d = picmi.ReducedDiagnostic(diag_type='ParticleHistogram2D', ...), with species, histogram_function_abs, histogram_function_ord, bin_min_abs, bin_max_abs, bin_min_ord, bin_max_ord, bin_number_abs, bin_number_ord, value_function (optional, I set it to "1" by default) and filter_function (optional, default None) specified in kwargs.

Finally, use the add_diagnostic(hist2d) to add it into simulation object, and a ParticleHistogram2D diagnostic will be recorded in simulation.