### PR TITLE
Fix HIP CI

### DIFF
--- a/.github/workflows/dependencies/hip.sh
+++ b/.github/workflows/dependencies/hip.sh
@@ -28,7 +28,9 @@ sudo apt-key add rocm.gpg.key
 
 source /etc/os-release # set UBUNTU_CODENAME: focal or jammy or ...
 
-echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/${1-latest} ${UBUNTU_CODENAME} main" \
+VERSION=${1-6.3.2}
+
+echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/${VERSION} ${UBUNTU_CODENAME} main" \
   | sudo tee /etc/apt/sources.list.d/rocm.list
 echo 'export PATH=/opt/rocm/llvm/bin:/opt/rocm/bin:/opt/rocm/profiler/bin:/opt/rocm/opencl/bin:$PATH' \
   | sudo tee -a /etc/profile.d/rocm.sh
@@ -50,12 +52,16 @@ sudo apt-get install -y --no-install-recommends \
     libzstd-dev     \
     ninja-build     \
     openmpi-bin     \
-    rocm-dev        \
-    rocfft-dev      \
-    rocprim-dev     \
-    rocsparse-dev   \
-    rocrand-dev     \
-    hiprand-dev
+    rocm-dev${VERSION}        \
+    roctracer-dev${VERSION}   \
+    rocprofiler-dev${VERSION} \
+    rocrand-dev${VERSION}     \
+    rocfft-dev${VERSION}      \
+    rocprim-dev${VERSION}     \
+    rocsparse-dev${VERSION}
+
+# hiprand-dev is a new package that does not exist in old versions
+sudo apt-get install -y --no-install-recommends hiprand-dev${VERSION} || true
 
 # ccache
 $(dirname "$0")/ccache.sh
@@ -68,11 +74,6 @@ which clang
 which clang++
 export CXX=$(which clang++)
 export CC=$(which clang)
-
-# "mpic++ --showme" forgets open-pal in Ubuntu 20.04 + OpenMPI 4.0.3
-#   https://bugs.launchpad.net/ubuntu/+source/openmpi/+bug/1941786
-#   https://github.com/open-mpi/ompi/issues/9317
-export LDFLAGS="-lopen-pal"
 
 # cmake-easyinstall
 #

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build_hip_3d_sp:
     name: HIP 3D SP
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       CXXFLAGS: "-Werror -Wno-deprecated-declarations -Wno-error=pass-failed"
       CMAKE_GENERATOR: Ninja
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: install dependencies
       shell: bash
-      run: .github/workflows/dependencies/hip.sh
+      run: .github/workflows/dependencies/hip.sh 6.3.2
     - name: CCache Cache
       uses: actions/cache@v4
       with:
@@ -47,11 +47,6 @@ jobs:
         which clang++
         export CXX=$(which clang++)
         export CC=$(which clang)
-
-        # "mpic++ --showme" forgets open-pal in Ubuntu 20.04 + OpenMPI 4.0.3
-        #   https://bugs.launchpad.net/ubuntu/+source/openmpi/+bug/1941786
-        #   https://github.com/open-mpi/ompi/issues/9317
-        export LDFLAGS="-lopen-pal"
 
         cmake -S . -B build_sp \
           -DCMAKE_VERBOSE_MAKEFILE=ON \
@@ -75,7 +70,7 @@ jobs:
 
   build_hip_2d_dp:
     name: HIP 2D DP
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       CXXFLAGS: "-Werror -Wno-deprecated-declarations -Wno-error=pass-failed"
       CMAKE_GENERATOR: Ninja
@@ -84,7 +79,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: install dependencies
       shell: bash
-      run: .github/workflows/dependencies/hip.sh
+      run: .github/workflows/dependencies/hip.sh 6.3.2
     - name: CCache Cache
       uses: actions/cache@v4
       with:
@@ -106,11 +101,6 @@ jobs:
         which clang++
         export CXX=$(which clang++)
         export CC=$(which clang)
-
-        # "mpic++ --showme" forgets open-pal in Ubuntu 20.04 + OpenMPI 4.0.3
-        #   https://bugs.launchpad.net/ubuntu/+source/openmpi/+bug/1941786
-        #   https://github.com/open-mpi/ompi/issues/9317
-        export LDFLAGS="-lopen-pal"
 
         cmake -S . -B build_2d \
           -DCMAKE_VERBOSE_MAKEFILE=ON \

--- a/Source/AcceleratorLattice/LatticeElementFinder.H
+++ b/Source/AcceleratorLattice/LatticeElementFinder.H
@@ -114,6 +114,9 @@ struct LatticeElementFinderDevice
                                     AcceleratorLattice const& accelerator_lattice,
                                     LatticeElementFinder const & h_finder);
 
+    /* Whether the class has been initialized */
+    bool m_initialized = false;
+
     /* Size and location of the index lookup table */
     amrex::Real m_zmin;
     amrex::Real m_dz;

--- a/Source/AcceleratorLattice/LatticeElementFinder.cpp
+++ b/Source/AcceleratorLattice/LatticeElementFinder.cpp
@@ -92,6 +92,8 @@ LatticeElementFinderDevice::InitLatticeElementFinderDevice (WarpXParIter const& 
                                                             LatticeElementFinder const & h_finder)
 {
 
+    m_initialized = true;
+
     auto& warpx = WarpX::GetInstance();
 
     int const lev = a_pti.GetLevel();

--- a/Source/Particles/Gather/GetExternalFields.H
+++ b/Source/Particles/Gather/GetExternalFields.H
@@ -73,7 +73,6 @@ struct GetExternalEBField
         using namespace amrex::literals;
 
         if (d_lattice_element_finder.m_initialized) {
-            // Note that the "*" is needed since d_lattice_element_finder is optional
             d_lattice_element_finder(i, field_Ex, field_Ey, field_Ez,
                                         field_Bx, field_By, field_Bz);
         }

--- a/Source/Particles/Gather/GetExternalFields.H
+++ b/Source/Particles/Gather/GetExternalFields.H
@@ -56,10 +56,10 @@ struct GetExternalEBField
     const amrex::ParticleReal* AMREX_RESTRICT m_uy = nullptr;
     const amrex::ParticleReal* AMREX_RESTRICT m_uz = nullptr;
 
-    LatticeElementFinderDevice* d_lattice_element_finder = nullptr;
+    LatticeElementFinderDevice d_lattice_element_finder;
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    bool isNoOp () const { return (m_Etype == None && m_Btype == None && !d_lattice_element_finder); }
+    bool isNoOp () const { return (m_Etype == None && m_Btype == None && !d_lattice_element_finder.m_initialized); }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void operator () (long i,
@@ -72,10 +72,10 @@ struct GetExternalEBField
     {
         using namespace amrex::literals;
 
-        if (d_lattice_element_finder) {
+        if (d_lattice_element_finder.m_initialized) {
             // Note that the "*" is needed since d_lattice_element_finder is optional
-            (*d_lattice_element_finder)(i, field_Ex, field_Ey, field_Ez,
-                                           field_Bx, field_By, field_Bz);
+            d_lattice_element_finder(i, field_Ex, field_Ey, field_Ez,
+                                        field_Bx, field_By, field_Bz);
         }
 
         if (m_Etype == None && m_Btype == None) { return; }

--- a/Source/Particles/Gather/GetExternalFields.H
+++ b/Source/Particles/Gather/GetExternalFields.H
@@ -15,8 +15,6 @@
 #include <AMReX_Parser.H>
 #include <AMReX_REAL.H>
 
-#include <optional>
-
 
 /** \brief Functor class that assigns external
  *         field values (E and B) to particles.

--- a/Source/Particles/Gather/GetExternalFields.H
+++ b/Source/Particles/Gather/GetExternalFields.H
@@ -56,10 +56,10 @@ struct GetExternalEBField
     const amrex::ParticleReal* AMREX_RESTRICT m_uy = nullptr;
     const amrex::ParticleReal* AMREX_RESTRICT m_uz = nullptr;
 
-    std::optional<LatticeElementFinderDevice> d_lattice_element_finder;
+    LatticeElementFinderDevice* d_lattice_element_finder = nullptr;
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    bool isNoOp () const { return (m_Etype == None && m_Btype == None && !d_lattice_element_finder.has_value()); }
+    bool isNoOp () const { return (m_Etype == None && m_Btype == None && !d_lattice_element_finder); }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void operator () (long i,

--- a/Source/Particles/Gather/GetExternalFields.cpp
+++ b/Source/Particles/Gather/GetExternalFields.cpp
@@ -22,7 +22,7 @@ GetExternalEBField::GetExternalEBField (const WarpXParIter& a_pti, long a_offset
 
     AcceleratorLattice const & accelerator_lattice = warpx.get_accelerator_lattice(lev);
     if (accelerator_lattice.m_lattice_defined) {
-        *d_lattice_element_finder = accelerator_lattice.GetFinderDeviceInstance(a_pti, static_cast<int>(a_offset));
+        d_lattice_element_finder = accelerator_lattice.GetFinderDeviceInstance(a_pti, static_cast<int>(a_offset));
     }
 
     m_gamma_boost = WarpX::gamma_boost;

--- a/Source/Particles/Gather/GetExternalFields.cpp
+++ b/Source/Particles/Gather/GetExternalFields.cpp
@@ -22,7 +22,7 @@ GetExternalEBField::GetExternalEBField (const WarpXParIter& a_pti, long a_offset
 
     AcceleratorLattice const & accelerator_lattice = warpx.get_accelerator_lattice(lev);
     if (accelerator_lattice.m_lattice_defined) {
-        d_lattice_element_finder = accelerator_lattice.GetFinderDeviceInstance(a_pti, static_cast<int>(a_offset));
+        *d_lattice_element_finder = accelerator_lattice.GetFinderDeviceInstance(a_pti, static_cast<int>(a_offset));
     }
 
     m_gamma_boost = WarpX::gamma_boost;


### PR DESCRIPTION
- [x] Update HIP CI workflow to run on Ubuntu 24.04
- [x] Add HIP version to CLI, default 6.3.2
- [x] Fix bug caused by using `std::optional` on device