### PR TITLE
Ionization.H : remove duplicate call to `m_get_externalEB`

### DIFF
--- a/Source/Particles/ElementaryProcess/Ionization.H
+++ b/Source/Particles/ElementaryProcess/Ionization.H
@@ -119,7 +119,6 @@ struct IonizationFilterFunc
                            m_ex_type, m_ey_type, m_ez_type, m_bx_type, m_by_type, m_bz_type,
                            m_dinv, m_xyzmin, m_lo, m_n_rz_azimuthal_modes,
                            m_nox, m_galerkin_interpolation);
-            m_get_externalEB(i, ex, ey, ez, bx, by, bz);
 
             // Compute electric field amplitude in the particle's frame of
             // reference (particularly important when in boosted frame).

--- a/Source/Particles/ElementaryProcess/Ionization.H
+++ b/Source/Particles/ElementaryProcess/Ionization.H
@@ -112,7 +112,6 @@ struct IonizationFilterFunc
             amrex::ParticleReal bx = m_Bx_external_particle;
             amrex::ParticleReal by = m_By_external_particle;
             amrex::ParticleReal bz = m_Bz_external_particle;
-
             m_get_externalEB(i, ex, ey, ez, bx, by, bz);
 
             doGatherShapeN(xp, yp, zp, ex, ey, ez, bx, by, bz,

--- a/Source/Particles/ElementaryProcess/Ionization.H
+++ b/Source/Particles/ElementaryProcess/Ionization.H
@@ -112,13 +112,14 @@ struct IonizationFilterFunc
             amrex::ParticleReal bx = m_Bx_external_particle;
             amrex::ParticleReal by = m_By_external_particle;
             amrex::ParticleReal bz = m_Bz_external_particle;
-            m_get_externalEB(i, ex, ey, ez, bx, by, bz);
 
             doGatherShapeN(xp, yp, zp, ex, ey, ez, bx, by, bz,
                            m_ex_arr, m_ey_arr, m_ez_arr, m_bx_arr, m_by_arr, m_bz_arr,
                            m_ex_type, m_ey_type, m_ez_type, m_bx_type, m_by_type, m_bz_type,
                            m_dinv, m_xyzmin, m_lo, m_n_rz_azimuthal_modes,
                            m_nox, m_galerkin_interpolation);
+
+            m_get_externalEB(i, ex, ey, ez, bx, by, bz);
 
             // Compute electric field amplitude in the particle's frame of
             // reference (particularly important when in boosted frame).

--- a/Source/Particles/ElementaryProcess/Ionization.H
+++ b/Source/Particles/ElementaryProcess/Ionization.H
@@ -113,13 +113,13 @@ struct IonizationFilterFunc
             amrex::ParticleReal by = m_By_external_particle;
             amrex::ParticleReal bz = m_Bz_external_particle;
 
+             m_get_externalEB(i, ex, ey, ez, bx, by, bz);
+
             doGatherShapeN(xp, yp, zp, ex, ey, ez, bx, by, bz,
                            m_ex_arr, m_ey_arr, m_ez_arr, m_bx_arr, m_by_arr, m_bz_arr,
                            m_ex_type, m_ey_type, m_ez_type, m_bx_type, m_by_type, m_bz_type,
                            m_dinv, m_xyzmin, m_lo, m_n_rz_azimuthal_modes,
                            m_nox, m_galerkin_interpolation);
-
-            m_get_externalEB(i, ex, ey, ez, bx, by, bz);
 
             // Compute electric field amplitude in the particle's frame of
             // reference (particularly important when in boosted frame).

--- a/Source/Particles/ElementaryProcess/Ionization.H
+++ b/Source/Particles/ElementaryProcess/Ionization.H
@@ -113,7 +113,7 @@ struct IonizationFilterFunc
             amrex::ParticleReal by = m_By_external_particle;
             amrex::ParticleReal bz = m_Bz_external_particle;
 
-             m_get_externalEB(i, ex, ey, ez, bx, by, bz);
+            m_get_externalEB(i, ex, ey, ez, bx, by, bz);
 
             doGatherShapeN(xp, yp, zp, ex, ey, ez, bx, by, bz,
                            m_ex_arr, m_ey_arr, m_ez_arr, m_bx_arr, m_by_arr, m_bz_arr,


### PR DESCRIPTION
While working on another PR I uncovered what I think to be a bug where `m_get_externalEB` is called two times. This PR fixes this bug