### PR TITLE
WarpX class: sort_particles_for_deposition and sort_idx_type no longer static

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -584,7 +584,8 @@ void WarpX::HandleParticlesAtBoundaries (int step, amrex::Real cur_time, int num
         if (verbose) {
             amrex::Print() << Utils::TextMsg::Info("re-sorting particles");
         }
-        mypc->SortParticlesByBin(sort_bin_size);
+        mypc->SortParticlesByBin(
+            sort_bin_size, sort_particles_for_deposition, sort_idx_type);
     }
 }
 

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -585,7 +585,7 @@ void WarpX::HandleParticlesAtBoundaries (int step, amrex::Real cur_time, int num
             amrex::Print() << Utils::TextMsg::Info("re-sorting particles");
         }
         mypc->SortParticlesByBin(
-            sort_bin_size, sort_particles_for_deposition, sort_idx_type);
+            sort_bin_size, m_sort_particles_for_deposition, m_sort_idx_type);
     }
 }
 

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -211,7 +211,10 @@ public:
 
     void WriteHeader (std::ostream& os) const;
 
-    void SortParticlesByBin (amrex::IntVect bin_size);
+    void SortParticlesByBin (
+        const amrex::IntVect& bin_size,
+        bool sort_particles_for_deposition,
+        const amrex::IntVect& sort_idx_type);
 
     void Redistribute ();
 

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -611,11 +611,14 @@ MultiParticleContainer::GetChargeDensity (int lev, bool local)
 }
 
 void
-MultiParticleContainer::SortParticlesByBin (amrex::IntVect bin_size)
+MultiParticleContainer::SortParticlesByBin (
+    const amrex::IntVect& bin_size,
+    const bool sort_particles_for_deposition,
+    const amrex::IntVect& sort_idx_type)
 {
     for (auto& pc : allcontainers) {
-        if (WarpX::sort_particles_for_deposition) {
-            pc->SortParticlesForDeposition(WarpX::sort_idx_type);
+        if (sort_particles_for_deposition) {
+            pc->SortParticlesForDeposition(sort_idx_type);
         } else {
             pc->SortParticlesByBin(bin_size);
         }

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -352,11 +352,6 @@ public:
     static utils::parser::IntervalsParser sort_intervals;
     static amrex::IntVect sort_bin_size;
 
-    //! If true, particles will be sorted in the order x -> y -> z -> ppc for faster deposition
-    static bool sort_particles_for_deposition;
-    //! Specifies the type of grid used for the above sorting, i.e. cell-centered, nodal, or mixed
-    static amrex::IntVect sort_idx_type;
-
     static bool do_multi_J;
     static int do_multi_J_n_depositions;
 
@@ -1488,6 +1483,18 @@ private:
     int nox_fft = 16;
     int noy_fft = 16;
     int noz_fft = 16;
+
+
+
+    //! If true, particles will be sorted in the order x -> y -> z -> ppc for faster deposition
+#if defined(AMREX_USE_CUDA)
+    bool sort_particles_for_deposition = true;
+#else
+    bool sort_particles_for_deposition = false;
+#endif
+
+    //! Specifies the type of grid used for the above sorting, i.e. cell-centered, nodal, or mixed
+    amrex::IntVect sort_idx_type = amrex::IntVect(AMREX_D_DECL(0,0,0));
 
     //! Solve Poisson equation when loading an external magnetic field to clean divergence
     //! This is useful to remove errors that could lead to non-zero B field divergence

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1488,13 +1488,13 @@ private:
 
     //! If true, particles will be sorted in the order x -> y -> z -> ppc for faster deposition
 #if defined(AMREX_USE_CUDA)
-    bool sort_particles_for_deposition = true;
+    bool m_sort_particles_for_deposition = true;
 #else
-    bool sort_particles_for_deposition = false;
+    bool m_sort_particles_for_deposition = false;
 #endif
 
     //! Specifies the type of grid used for the above sorting, i.e. cell-centered, nodal, or mixed
-    amrex::IntVect sort_idx_type = amrex::IntVect(AMREX_D_DECL(0,0,0));
+    amrex::IntVect m_sort_idx_type = amrex::IntVect(AMREX_D_DECL(0,0,0));
 
     //! Solve Poisson equation when loading an external magnetic field to clean divergence
     //! This is useful to remove errors that could lead to non-zero B field divergence

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1377,7 +1377,7 @@ WarpX::ReadParameters ()
             }
         }
 
-        pp_warpx.query("sort_particles_for_deposition",sort_particles_for_deposition);
+        pp_warpx.query("sort_particles_for_deposition",m_sort_particles_for_deposition);
         Vector<int> vect_sort_idx_type(AMREX_SPACEDIM,0);
         const bool sort_idx_type_is_specified =
             utils::parser::queryArrWithParser(
@@ -1385,7 +1385,7 @@ WarpX::ReadParameters ()
                 vect_sort_idx_type, 0, AMREX_SPACEDIM);
         if (sort_idx_type_is_specified){
             for (int i=0; i<AMREX_SPACEDIM; i++) {
-                sort_idx_type[i] = vect_sort_idx_type[i];
+                m_sort_idx_type[i] = vect_sort_idx_type[i];
             }
         }
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -164,14 +164,6 @@ bool WarpX::refine_plasma     = false;
 utils::parser::IntervalsParser WarpX::sort_intervals;
 amrex::IntVect WarpX::sort_bin_size(AMREX_D_DECL(1,1,1));
 
-#if defined(AMREX_USE_CUDA)
-bool WarpX::sort_particles_for_deposition = true;
-#else
-bool WarpX::sort_particles_for_deposition = false;
-#endif
-
-amrex::IntVect WarpX::sort_idx_type(AMREX_D_DECL(0,0,0));
-
 bool WarpX::do_dynamic_scheduling = true;
 
 bool WarpX::do_multi_J = false;


### PR DESCRIPTION
This PR turns the public static variables of the WarpX class `sort_particles_for_deposition` and `sort_idx_type` into private member variables. The final goal is to avoid static variables in the WarpX class.