### PR TITLE
Synchronize after copying in 2D reduced diagnostics

### DIFF
--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity2D.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity2D.cpp
@@ -315,6 +315,7 @@ void DifferentialLuminosity2D::ComputeDiags (int step)
 
         // Copy data from GPU memory
         m_h_data_2D.copy(m_d_data_2D);
+        Gpu::streamSynchronize();
 
         // reduced sum over mpi ranks
         const int size = static_cast<int> (m_d_data_2D.size());

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.cpp
@@ -149,7 +149,7 @@ void ParticleHistogram2D::ComputeDiags (int step)
     }
 
     d_data_2D.copy(m_h_data_2D);
-    Gpu::streamSynchronize();
+    // Gpu::streamSynchronize() is not needed, because there is a sync in WarpXParIter constructor later
 
     auto d_table = d_data_2D.table();
 

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.cpp
@@ -149,6 +149,8 @@ void ParticleHistogram2D::ComputeDiags (int step)
     }
 
     d_data_2D.copy(m_h_data_2D);
+    Gpu::streamSynchronize();
+
     auto d_table = d_data_2D.table();
 
     // get a reference to WarpX instance
@@ -244,6 +246,7 @@ void ParticleHistogram2D::ComputeDiags (int step)
 
     // Copy data from GPU memory
     m_h_data_2D.copy(d_data_2D);
+    Gpu::streamSynchronize();
 
     // reduced sum over mpi ranks
     const int size = static_cast<int> (d_data_2D.size());


### PR DESCRIPTION
Add `Gpu::streamSynchronize();` after copying `TableData` from either host-to-device and device-to-host in the `ParticleHistogram2D` and `DifferentialLuminosity2D` reduced diagnostics. 

We have observed unstable behaviors with the `DifferentialLuminosity2D` diagnostic and @RemiLehe suggested this could be a reason. 

Marked as bug, unless otherwise recommended. 


