### PR TITLE
ABLASTR: Silence/Disable `write_used_inputs_file`

### DIFF
--- a/Source/ablastr/utils/UsedInputsFile.H
+++ b/Source/ablastr/utils/UsedInputsFile.H
@@ -19,9 +19,10 @@ namespace ablastr::utils
      * Only the AMReX IOProcessor writes.
      *
      * @param filename the name of the text file to write
+     * @param verbose print information about the file location to stdout
      */
     void
-    write_used_inputs_file (std::string const & filename);
+    write_used_inputs_file (std::string const & filename, bool verbose=true);
 }
 
 #endif // ABLASTR_USED_INPUTS_FILE_H

--- a/Source/ablastr/utils/UsedInputsFile.cpp
+++ b/Source/ablastr/utils/UsedInputsFile.cpp
@@ -11,14 +11,20 @@
 #include <AMReX_ParmParse.H>
 #include <AMReX_Print.H>
 
-#include <ios>
+#include <ostream>
 #include <string>
 
 
 void
-ablastr::utils::write_used_inputs_file (std::string const & filename)
+ablastr::utils::write_used_inputs_file (std::string const & filename, bool verbose)
 {
-    amrex::Print() << "For full input parameters, see the file: " << filename << "\n\n";
+    if (filename.empty() || filename == "/dev/null") {
+        return;
+    }
+
+    if (verbose) {
+        amrex::Print() << "For full input parameters, see the file: " << filename << "\n\n";
+    }
 
     if (amrex::ParallelDescriptor::IOProcessor()) {
         std::ofstream jobInfoFile;


### PR DESCRIPTION
Add support to silence the status print or to skip the creation of `write_used_inputs_file` altogether. Useful in unsupervised runs, like many optimizations, where often we want to skip file creation altogether, e.g., if run with Python.