### PR TITLE
Python: `setuptools[core]`

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -80,7 +80,7 @@ jobs:
       python3 -m pip install --upgrade pip
       python3 -m pip install --upgrade build
       python3 -m pip install --upgrade packaging
-      python3 -m pip install --upgrade setuptools
+      python3 -m pip install --upgrade setuptools[core]
       python3 -m pip install --upgrade wheel
       python3 -m pip install --upgrade virtualenv
       python3 -m pip install --upgrade pipx

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -88,7 +88,7 @@ jobs:
         cmake --build build_sp -j 4
 
         python3 -m pip install --upgrade pip
-        python3 -m pip install --upgrade build packaging setuptools wheel
+        python3 -m pip install --upgrade build packaging setuptools[core] wheel
         export WARPX_MPI=ON
         export PYWARPX_LIB_DIR=$PWD/build_sp/lib/site-packages/pywarpx/
         python3 -m pip wheel .
@@ -191,7 +191,7 @@ jobs:
         #export CFLAGS="-noswitcherror"
 
         #python3 -m pip install --upgrade pip
-        #python3 -m pip install --upgrade build packaging setuptools wheel
+        #python3 -m pip install --upgrade build packaging setuptools[core] wheel
         #export WARPX_MPI=ON
         #export PYWARPX_LIB_DIR=$PWD/build/lib/site-packages/pywarpx/
         #python3 -m pip wheel .

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -50,7 +50,7 @@ jobs:
         export CC=$(which icc)
 
         python3 -m pip install --upgrade pip
-        python3 -m pip install --upgrade build packaging setuptools wheel
+        python3 -m pip install --upgrade build packaging setuptools[core] wheel
 
         cmake -S . -B build_dp \
           -DCMAKE_VERBOSE_MAKEFILE=ON \
@@ -118,7 +118,7 @@ jobs:
         export CC=$(which icx)
 
         python3 -m pip install --upgrade pip
-        python3 -m pip install --upgrade build packaging setuptools wheel
+        python3 -m pip install --upgrade build packaging setuptools[core] wheel
 
         cmake -S . -B build_sp         \
           -DCMAKE_CXX_FLAGS_RELEASE="-O1 -DNDEBUG" \
@@ -201,6 +201,6 @@ jobs:
 
      # Skip this as it will copy the binary artifacts and we are tight on disk space
      #   python3 -m pip install --upgrade pip
-     #   python3 -m pip install --upgrade build packaging setuptools wheel
+     #   python3 -m pip install --upgrade build packaging setuptools[core] wheel
      #   PYWARPX_LIB_DIR=$PWD/build_sp/lib/site-packages/pywarpx/ python3 -m pip wheel .
      #   python3 -m pip install *.whl

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -47,7 +47,7 @@ jobs:
     - name: install pip dependencies
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install --upgrade build packaging setuptools wheel
+        python3 -m pip install --upgrade build packaging setuptools[core] wheel
         python3 -m pip install --upgrade mpi4py
         python3 -m pip install --upgrade -r Regression/requirements.txt
     - name: CCache Cache

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -211,7 +211,7 @@ jobs:
         ccache -z
 
         python3 -m pip install --upgrade pip
-        python3 -m pip install --upgrade build packaging setuptools wheel
+        python3 -m pip install --upgrade build packaging setuptools[core] wheel
 
         export CXXFLAGS="-Werror -Wno-error=pass-failed"
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,7 +52,7 @@ jobs:
 
         python3 -m pip install --upgrade pip
         if(!$?) { Exit $LASTEXITCODE }
-        python3 -m pip install --upgrade build packaging setuptools wheel
+        python3 -m pip install --upgrade build packaging setuptools[core] wheel
         if(!$?) { Exit $LASTEXITCODE }
         cmake --build build --config Debug --target install
         if(!$?) { Exit $LASTEXITCODE }
@@ -113,7 +113,7 @@ jobs:
 
         python3 -m pip install --upgrade pip
         if errorlevel 1 exit 1
-        python3 -m pip install --upgrade build packaging setuptools wheel
+        python3 -m pip install --upgrade build packaging setuptools[core] wheel
         if errorlevel 1 exit 1
         python3 -m pip install --upgrade -r requirements.txt
         if errorlevel 1 exit 1

--- a/Docs/source/install/cmake.rst
+++ b/Docs/source/install/cmake.rst
@@ -222,7 +222,7 @@ PICMI Python Bindings
    .. code-block:: bash
 
       python3 -m pip install -U pip
-      python3 -m pip install -U build packaging setuptools wheel
+      python3 -m pip install -U build packaging setuptools[core] wheel
       python3 -m pip install -U cmake
       python3 -m pip install -r requirements.txt
 

--- a/Docs/source/install/hpc/lawrencium.rst
+++ b/Docs/source/install/hpc/lawrencium.rst
@@ -83,7 +83,7 @@ Optionally, download and install Python packages for :ref:`PICMI <usage-picmi>` 
    python3 -m pip install --upgrade build
    python3 -m pip install --upgrade packaging
    python3 -m pip install --upgrade wheel
-   python3 -m pip install --upgrade setuptools
+   python3 -m pip install --upgrade setuptools[core]
    python3 -m pip install --upgrade cython
    python3 -m pip install --upgrade numpy
    python3 -m pip install --upgrade pandas

--- a/Docs/source/install/hpc/lxplus.rst
+++ b/Docs/source/install/hpc/lxplus.rst
@@ -148,7 +148,7 @@ Now, ensure Python tooling is up-to-date:
 .. code-block:: bash
 
    python3 -m pip install -U pip
-   python3 -m pip install -U build packaging setuptools wheel
+   python3 -m pip install -U build packaging setuptools[core] wheel
    python3 -m pip install -U cmake
 
 Then we compile WarpX as in the previous section (with or without CUDA) adding ``-DWarpX_PYTHON=ON`` and then we install it into our Python:

--- a/Docs/source/install/users.rst
+++ b/Docs/source/install/users.rst
@@ -109,7 +109,7 @@ Given that you have the :ref:`WarpX dependencies <install-dependencies>` install
 .. code-block:: bash
 
    python3 -m pip install -U pip
-   python3 -m pip install -U build packaging setuptools wheel
+   python3 -m pip install -U build packaging setuptools[core] wheel
    python3 -m pip install -U cmake
 
    python3 -m pip wheel -v git+https://github.com/ECP-WarpX/WarpX.git

--- a/Tools/machines/adastra-cines/install_dependencies.sh
+++ b/Tools/machines/adastra-cines/install_dependencies.sh
@@ -104,7 +104,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
-python3 -m pip install --upgrade setuptools
+python3 -m pip install --upgrade setuptools[core]
 python3 -m pip install --upgrade cython
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas

--- a/Tools/machines/crusher-olcf/install_dependencies.sh
+++ b/Tools/machines/crusher-olcf/install_dependencies.sh
@@ -87,7 +87,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
-python3 -m pip install --upgrade setuptools
+python3 -m pip install --upgrade setuptools[core]
 python3 -m pip install --upgrade cython
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas

--- a/Tools/machines/dane-llnl/install_dependencies.sh
+++ b/Tools/machines/dane-llnl/install_dependencies.sh
@@ -100,7 +100,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
-python3 -m pip install --upgrade setuptools
+python3 -m pip install --upgrade setuptools[core]
 python3 -m pip install --upgrade cython
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas

--- a/Tools/machines/frontier-olcf/install_dependencies.sh
+++ b/Tools/machines/frontier-olcf/install_dependencies.sh
@@ -86,7 +86,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
-python3 -m pip install --upgrade setuptools
+python3 -m pip install --upgrade setuptools[core]
 python3 -m pip install --upgrade "cython>=3.0"
 # cupy for ROCm
 #   https://docs.cupy.dev/en/stable/install.html#building-cupy-for-rocm-from-source

--- a/Tools/machines/greatlakes-umich/install_v100_dependencies.sh
+++ b/Tools/machines/greatlakes-umich/install_v100_dependencies.sh
@@ -118,7 +118,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
-python3 -m pip install --upgrade setuptools
+python3 -m pip install --upgrade setuptools[core]
 python3 -m pip install --upgrade cython
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas

--- a/Tools/machines/hpc3-uci/install_gpu_dependencies.sh
+++ b/Tools/machines/hpc3-uci/install_gpu_dependencies.sh
@@ -117,7 +117,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
-python3 -m pip install --upgrade setuptools
+python3 -m pip install --upgrade setuptools[core]
 python3 -m pip install --upgrade pipx
 python3 -m pip install --upgrade cython
 python3 -m pip install --upgrade numpy

--- a/Tools/machines/lassen-llnl/install_v100_dependencies_toss3.sh
+++ b/Tools/machines/lassen-llnl/install_v100_dependencies_toss3.sh
@@ -118,7 +118,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
-python3 -m pip install --upgrade setuptools
+python3 -m pip install --upgrade setuptools[core]
 python3 -m pip install --upgrade cython
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas

--- a/Tools/machines/leonardo-cineca/install_gpu_dependencies.sh
+++ b/Tools/machines/leonardo-cineca/install_gpu_dependencies.sh
@@ -85,7 +85,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
-python3 -m pip install --upgrade setuptools
+python3 -m pip install --upgrade setuptools[core]
 python3 -m pip install --upgrade cython
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas

--- a/Tools/machines/lonestar6-tacc/install_a100_dependencies.sh
+++ b/Tools/machines/lonestar6-tacc/install_a100_dependencies.sh
@@ -108,7 +108,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
-python3 -m pip install --upgrade setuptools
+python3 -m pip install --upgrade setuptools[core]
 python3 -m pip install --upgrade cython
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas

--- a/Tools/machines/lumi-csc/install_dependencies.sh
+++ b/Tools/machines/lumi-csc/install_dependencies.sh
@@ -154,7 +154,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
-python3 -m pip install --upgrade setuptools
+python3 -m pip install --upgrade setuptools[core]
 python3 -m pip install --upgrade cython
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas

--- a/Tools/machines/perlmutter-nersc/Containerfile
+++ b/Tools/machines/perlmutter-nersc/Containerfile
@@ -155,7 +155,7 @@ RUN python3 -m venv /opt/venv && \
     cython \
     packaging \
     build \
-    setuptools
+    setuptools[core]
 
 # Set up the environment for the virtual environment
 ENV PATH="/opt/venv/bin:${PATH}"

--- a/Tools/machines/perlmutter-nersc/install_cpu_dependencies.sh
+++ b/Tools/machines/perlmutter-nersc/install_cpu_dependencies.sh
@@ -139,7 +139,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
-python3 -m pip install --upgrade setuptools
+python3 -m pip install --upgrade setuptools[core]
 python3 -m pip install --upgrade cython
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas

--- a/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
+++ b/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
@@ -139,7 +139,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
-python3 -m pip install --upgrade setuptools
+python3 -m pip install --upgrade setuptools[core]
 python3 -m pip install --upgrade cython
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas

--- a/Tools/machines/pitzer-osc/install_cpu_dependencies.sh
+++ b/Tools/machines/pitzer-osc/install_cpu_dependencies.sh
@@ -139,7 +139,7 @@ python3 -m pip cache purge
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
-python3 -m pip install --upgrade setuptools
+python3 -m pip install --upgrade setuptools[core]
 python3 -m pip install --upgrade cython
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas

--- a/Tools/machines/pitzer-osc/install_v100_dependencies.sh
+++ b/Tools/machines/pitzer-osc/install_v100_dependencies.sh
@@ -139,7 +139,7 @@ python3 -m pip cache purge
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
-python3 -m pip install --upgrade setuptools
+python3 -m pip install --upgrade setuptools[core]
 python3 -m pip install --upgrade cython
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas

--- a/Tools/machines/polaris-alcf/install_gpu_dependencies.sh
+++ b/Tools/machines/polaris-alcf/install_gpu_dependencies.sh
@@ -102,7 +102,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
-python3 -m pip install --upgrade setuptools
+python3 -m pip install --upgrade setuptools[core]
 python3 -m pip install --upgrade cython
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas

--- a/Tools/machines/summit-olcf/install_gpu_dependencies.sh
+++ b/Tools/machines/summit-olcf/install_gpu_dependencies.sh
@@ -100,7 +100,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
-python3 -m pip install --upgrade setuptools
+python3 -m pip install --upgrade setuptools[core]
 python3 -m pip install --upgrade cython
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas

--- a/Tools/machines/tioga-llnl/install_mi300a_dependencies.sh
+++ b/Tools/machines/tioga-llnl/install_mi300a_dependencies.sh
@@ -158,7 +158,7 @@ python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
-python3 -m pip install --upgrade setuptools
+python3 -m pip install --upgrade setuptools[core]
 python3 -m pip install --upgrade cython
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas


### PR DESCRIPTION
The pip instructions for setuptools require now to specify the `[core]` argument, otherwise dependent packages are used from the system and are usually outdated, which causes errors.

X-ref:
- https://setuptools.pypa.io/en/latest/userguide/quickstart.html
- https://github.com/pypa/setuptools/issues/4483#issuecomment-2236528158