### PR TITLE
Check if implicit diagnostics file exist before writing the header

### DIFF
--- a/Source/NonlinearSolvers/NewtonSolver.H
+++ b/Source/NonlinearSolvers/NewtonSolver.H
@@ -204,7 +204,9 @@ void NewtonSolver<Vec,Ops>::Define ( const Vec&  a_U,
     this->m_is_defined = true;
 
     // Create diagnostic file and write header
-    if (!this->m_diagnostic_file.empty() && amrex::ParallelDescriptor::IOProcessor()) {
+    if (amrex::ParallelDescriptor::IOProcessor()
+        && !this->m_diagnostic_file.empty()
+        && !amrex::FileExists(this->m_diagnostic_file)) {
 
         std::filesystem::path const diagnostic_path(this->m_diagnostic_file);
         std::filesystem::path const diagnostic_dir = diagnostic_path.parent_path();

--- a/Source/NonlinearSolvers/PicardSolver.H
+++ b/Source/NonlinearSolvers/PicardSolver.H
@@ -118,7 +118,9 @@ void PicardSolver<Vec,Ops>::Define ( const Vec&  a_U,
     this->m_is_defined = true;
 
     // Create diagnostic file and write header
-    if (!this->m_diagnostic_file.empty() && amrex::ParallelDescriptor::IOProcessor()) {
+    if (amrex::ParallelDescriptor::IOProcessor()
+        && !this->m_diagnostic_file.empty()
+        && !amrex::FileExists(this->m_diagnostic_file)) {
 
         std::filesystem::path const diagnostic_path(this->m_diagnostic_file);
         std::filesystem::path const diagnostic_dir = diagnostic_path.parent_path();


### PR DESCRIPTION
This is a small fix to prevent the implicit diagnostics file from being overwritten during a restart.