### PR TITLE
Fix parser function string in MCCCollision

### DIFF
--- a/Source/Particles/Collision/BackgroundMCC/BackgroundMCCCollision.cpp
+++ b/Source/Particles/Collision/BackgroundMCC/BackgroundMCCCollision.cpp
@@ -40,7 +40,7 @@ BackgroundMCCCollision::BackgroundMCCCollision (std::string const& collision_nam
     }
     else {
         std::string background_density_str;
-        pp_collision_name.get("background_density(x,y,z,t)", background_density_str);
+        utils::parser::Store_parserString(pp_collision_name, "background_density(x,y,z,t)", background_density_str);
         m_background_density_parser =
             utils::parser::makeParser(background_density_str, {"x", "y", "z", "t"});
     }
@@ -55,7 +55,7 @@ BackgroundMCCCollision::BackgroundMCCCollision (std::string const& collision_nam
     }
     else {
         std::string background_temperature_str;
-        pp_collision_name.get("background_temperature(x,y,z,t)", background_temperature_str);
+        utils::parser::Store_parserString(pp_collision_name, "background_temperature(x,y,z,t)", background_temperature_str);
         m_background_temperature_parser =
             utils::parser::makeParser(background_temperature_str, {"x", "y", "z", "t"});
     }


### PR DESCRIPTION
We should use `utils::parser::Store_parserString` instead of `amrex::Parser::get` to obtain the parser function string because the latter treats spaces as separators for different strings.

Fix #5741