### PR TITLE
[mini] Cleanup remaining mention of the tmp_particle_container

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -123,9 +123,8 @@ void BTDiagnostics::DerivedInitData ()
     m_do_back_transformed_particles =
         ((!m_output_species_names.empty()) && (write_species == 1));
 
-    // Turn on do_back_transformed_particles in the particle containers so that
-    // the tmp_particle_data is allocated and the data of the corresponding species is
-    // copied and stored in tmp_particle_data before particles are pushed.
+    // Turn on do_back_transformed_particles in the particle containers so as
+    // the data of the corresponding species is stored in before particles are pushed.
     if (m_do_back_transformed_particles) {
         mpc.SetDoBackTransformedParticles(m_do_back_transformed_particles);
         for (auto const& species : m_output_species_names){

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.H
@@ -21,8 +21,6 @@
  */
 struct SelectParticles
 {
-    using TmpParticles = WarpXParticleContainer::TmpParticles;
-
     /**
      * \brief Constructor of SelectParticles functor.
      *
@@ -76,8 +74,6 @@ struct SelectParticles
  */
 struct LorentzTransformParticles
 {
-
-    using TmpParticles = WarpXParticleContainer::TmpParticles;
 
     /**
      * \brief Constructor of the LorentzTransformParticles functor.

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -569,9 +569,6 @@ protected:
 
 public:
     using PairIndex = std::pair<int, int>;
-    using TmpParticleTile = std::array<amrex::Gpu::DeviceVector<amrex::ParticleReal>,
-                                       TmpIdx::nattribs>;
-    using TmpParticles = amrex::Vector<std::map<PairIndex, TmpParticleTile> >;
 
     int getIonizationInitialLevel () const noexcept {return ionization_initial_level;}
 


### PR DESCRIPTION
This is a quick follow-up on https://github.com/ECP-WarpX/WarpX/pull/5571