### PR TITLE
OpenPMDHelpFunction.H: remove superfluous #include

### DIFF
--- a/Source/Diagnostics/OpenPMDHelpFunction.cpp
+++ b/Source/Diagnostics/OpenPMDHelpFunction.cpp
@@ -9,8 +9,6 @@
 
 #include "Utils/TextMsg.H"
 
-#include <map>
-
 std::string
 WarpXOpenPMDFileType ()
 {


### PR DESCRIPTION
This PR removes a superfluous include directive