### PR TITLE
Fix docstrings in WarpXEvolve and WarpXComm : /brief -> \brief

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -384,10 +384,11 @@ WarpX::Evolve (int numsteps)
         ablastr::warn_manager::GetWMInstance().PrintGlobalWarnings("THE END");
 }
 
-/* /brief Perform one PIC iteration, without subcycling
-*  i.e. all levels/patches use the same timestep (that of the finest level)
-*  for the field advance and particle pusher.
-*/
+/**
+ * \brief Perform one PIC iteration, without subcycling
+ * i.e. all levels/patches use the same timestep (that of the finest level)
+ * for the field advance and particle pusher.
+ */
 void
 WarpX::OneStep_nosub (Real cur_time)
 {
@@ -869,21 +870,22 @@ WarpX::OneStep_multiJ (const amrex::Real cur_time)
 #endif // WARPX_USE_FFT
 }
 
-/* /brief Perform one PIC iteration, with subcycling
-*  i.e. The fine patch uses a smaller timestep (and steps more often)
-*  than the coarse patch, for the field advance and particle pusher.
-*
-* This version of subcycling only works for 2 levels and with a refinement
-* ratio of 2.
-* The particles and fields of the fine patch are pushed twice
-* (with dt[coarse]/2) in this routine.
-* The particles of the coarse patch and mother grid are pushed only once
-* (with dt[coarse]). The fields on the coarse patch and mother grid
-* are pushed in a way which is equivalent to pushing once only, with
-* a current which is the average of the coarse + fine current at the 2
-* steps of the fine grid.
-*
-*/
+/**
+ *  \brief Perform one PIC iteration, with subcycling
+ *  i.e. The fine patch uses a smaller timestep (and steps more often)
+ *  than the coarse patch, for the field advance and particle pusher.
+ *
+ * This version of subcycling only works for 2 levels and with a refinement
+ * ratio of 2.
+ * The particles and fields of the fine patch are pushed twice
+ * (with dt[coarse]/2) in this routine.
+ * The particles of the coarse patch and mother grid are pushed only once
+ * (with dt[coarse]). The fields on the coarse patch and mother grid
+ * are pushed in a way which is equivalent to pushing once only, with
+ * a current which is the average of the coarse + fine current at the 2
+ * steps of the fine grid.
+ *
+ */
 void
 WarpX::OneStep_sub1 (Real cur_time)
 {

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -1463,19 +1463,20 @@ void WarpX::SumBoundaryJ (
     }
 }
 
-/* /brief Update the currents of `lev` by adding the currents from particles
-*         that are in the mesh refinement patches at `lev+1`
-*
-* More precisely, apply filter and sum boundaries for the current of:
-* - the fine patch of `lev`
-* - the coarse patch of `lev+1` (same resolution)
-* - the buffer regions of the coarse patch of `lev+1` (i.e. for particules
-* that are within the mesh refinement patch, but do not deposit on the
-* mesh refinement patch because they are too close to the boundary)
-*
-* Then update the fine patch of `lev` by adding the currents for the coarse
-* patch (and buffer region) of `lev+1`
-*/
+/**
+ * \brief Update the currents of `lev` by adding the currents from particles
+ *         that are in the mesh refinement patches at `lev+1`
+ *
+ * More precisely, apply filter and sum boundaries for the current of:
+ * - the fine patch of `lev`
+ * - the coarse patch of `lev+1` (same resolution)
+ * - the buffer regions of the coarse patch of `lev+1` (i.e. for particules
+ * that are within the mesh refinement patch, but do not deposit on the
+ * mesh refinement patch because they are too close to the boundary)
+ *
+ * Then update the fine patch of `lev` by adding the currents for the coarse
+ * patch (and buffer region) of `lev+1`
+ */
 void WarpX::AddCurrentFromFineLevelandSumBoundary (
     const ablastr::fields::MultiLevelVectorField& J_fp,
     const ablastr::fields::MultiLevelVectorField& J_cp,
@@ -1596,19 +1597,20 @@ void WarpX::ApplyFilterandSumBoundaryRho (int /*lev*/, int glev, amrex::MultiFab
     }
 }
 
-/* /brief Update the charge density of `lev` by adding the charge density from particles
-*         that are in the mesh refinement patches at `lev+1`
-*
-* More precisely, apply filter and sum boundaries for the charge density of:
-* - the fine patch of `lev`
-* - the coarse patch of `lev+1` (same resolution)
-* - the buffer regions of the coarse patch of `lev+1` (i.e. for particules
-* that are within the mesh refinement patch, but do not deposit on the
-* mesh refinement patch because they are too close to the boundary)
-*
-* Then update the fine patch of `lev` by adding the charge density for the coarse
-* patch (and buffer region) of `lev+1`
-*/
+/**
+ *  \brief Update the charge density of `lev` by adding the charge density from particles
+ *         that are in the mesh refinement patches at `lev+1`
+ *
+ * More precisely, apply filter and sum boundaries for the charge density of:
+ * - the fine patch of `lev`
+ * - the coarse patch of `lev+1` (same resolution)
+ * - the buffer regions of the coarse patch of `lev+1` (i.e. for particules
+ * that are within the mesh refinement patch, but do not deposit on the
+ * mesh refinement patch because they are too close to the boundary)
+ *
+ * Then update the fine patch of `lev` by adding the charge density for the coarse
+ * patch (and buffer region) of `lev+1`
+ */
 void WarpX::AddRhoFromFineLevelandSumBoundary (
     const ablastr::fields::MultiLevelScalarField& charge_fp,
     const ablastr::fields::MultiLevelScalarField& charge_cp,


### PR DESCRIPTION
This PR fixes some minor issues with some docstrings.