### PR TITLE
HankelTransform : remove unnecessary #include "WarpX.H"

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
@@ -9,7 +9,6 @@
 #include "BesselRoots.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXConst.H"
-#include "WarpX.H"
 
 #include "Utils/WarpXProfilerWrapper.H"
 


### PR DESCRIPTION
This PR removes an unnecessary include.