### PR TITLE
ElectrostaticSolver.H: remove superfluous include of the WarpX header

### DIFF
--- a/Source/FieldSolver/ElectrostaticSolvers/ElectrostaticSolver.H
+++ b/Source/FieldSolver/ElectrostaticSolvers/ElectrostaticSolver.H
@@ -13,7 +13,6 @@
 #include "Fluids/MultiFluidContainer.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Utils/WarpXProfilerWrapper.H"
-#include "WarpX.H"
 
 #include <AMReX_Array.H>
 


### PR DESCRIPTION
This PR removes a superfluous `include "WarpX.H"`