### PR TITLE
WarpX.cpp: remove some superfluous preprocessor directives

### DIFF
--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -280,9 +280,7 @@ void WarpX::MakeWarpX ()
     ConvertLabParamsToBoost();
     ReadBCParams();
 
-#ifdef WARPX_DIM_RZ
     CheckGriddingForRZSpectral();
-#endif
 
     m_instance = new WarpX();
 }


### PR DESCRIPTION
`CheckGriddingForRZSpectral();` is already a no-op if `WARPX_DIM_RZ` is not defined. So these pre-processor directives are superfluous here.