### PR TITLE
PoissonBoundaryHandler.H: remove #include "WarpX.H"

### DIFF
--- a/Source/FieldSolver/ElectrostaticSolvers/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolvers/ElectrostaticSolver.cpp
@@ -10,6 +10,7 @@
 #include "ElectrostaticSolver.H"
 #include "EmbeddedBoundary/Enabled.H"
 #include "Fields.H"
+#include "WarpX.H"
 
 #include <ablastr/fields/PoissonSolver.H>
 

--- a/Source/FieldSolver/ElectrostaticSolvers/PoissonBoundaryHandler.H
+++ b/Source/FieldSolver/ElectrostaticSolvers/PoissonBoundaryHandler.H
@@ -10,7 +10,6 @@
 #define WARPX_BOUNDARYHANDLER_H_
 
 #include "Utils/Parser/ParserUtils.H"
-#include "WarpX.H"
 
 #include <AMReX_Array.H>
 #include <AMReX_Geometry.H>

--- a/Source/FieldSolver/ElectrostaticSolvers/PoissonBoundaryHandler.cpp
+++ b/Source/FieldSolver/ElectrostaticSolvers/PoissonBoundaryHandler.cpp
@@ -9,6 +9,8 @@
 
 #include "PoissonBoundaryHandler.H"
 
+#include "WarpX.H"
+
 using namespace amrex;
 
 PoissonBoundaryHandler::PoissonBoundaryHandler ()


### PR DESCRIPTION
This PR removes `#include "WarpX.H` from the header file `PoissonBoundaryHandler.H`, and adds it to `PoissonBoundaryHandler.cpp` (where it is needed), in order to avoid including the WarpX header transitively whenever we include  `PoissonBoundaryHandler.H`. Note that adding `#include "WarpX.H`  is now required also in `ElectrostaticSolver.cpp` (`ElectrostaticSolver.H` includes `PoissonBoundaryHandler.H`, which, before this PR, included `WarpX.H`.