### PR TITLE
ParticlesBoundaries.cpp: remove unnecessary #include "WarpX.H"

### DIFF
--- a/Source/Particles/ParticleBoundaries.cpp
+++ b/Source/Particles/ParticleBoundaries.cpp
@@ -6,7 +6,6 @@
  */
 
 #include "ParticleBoundaries.H"
-#include "WarpX.H"
 
 #include "Utils/Parser/ParserUtils.H"
 


### PR DESCRIPTION
This PR removes an unnecessary `#include "WarpX.H"`