### PR TITLE
Add memory usage info reduced diagnostic

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -4797,28 +4797,42 @@ This shifts analysis from post-processing to runtime calculation of reduction op
         ``2``, since costs are not recorded until step ``1``.
 
     * ``MemoryPerRank``
-        This diagnostic uses ``amrex::Arena::PrintUsageToFiles`` to write detailed memory
-        usage information for each MPI rank. It logs, per rank:
+        This diagnostic writes detailed memory usage information for each MPI rank
+        as a YAML file. Each participating rank produces one file named
+        ``<path>/<file_prefix>.<zero-padded MPI rank>.yaml``, and every entry in it
+        is a self-contained YAML document (separated by ``---``), so readers can
+        stream them with e.g. ``yaml.safe_load_all()`` in Python.
 
-        * Total/free GPU memory (when applicable)
-        * Memory usage statistics for the ``Main``, ``Device``, ``Managed``, ``Pinned`` and
-          ``Comms`` Arena memory pools (allocated/used MB, alloc/busy/free block counts).
-          The ``Comms`` Arena holds MPI staging buffers; it is only reported as a separate
-          block when it is distinct from the ``Device`` and ``Pinned`` Arenas, which typically
-          happens on GPU-aware MPI builds.
-        * Host-process memory usage (``VmPeak``, ``VmSize``, ``VmHWM``, ``VmRSS`` on Linux)
-        * MPI rank, host name and GPU device id
+        Per rank and per interval, each YAML document records:
 
-        This is primarily useful for debugging out-of-memory (OOM) crashes on large,
-        multi-GPU runs. A typical workflow is to restart from a checkpoint and enable this
-        diagnostic without otherwise changing the input file, so the crash signature is
-        preserved while detailed per-rank memory information is captured right up until the
-        failure. The data is saved into separate text files (one per MPI rank) in the
-        specified output directory (``<reduced_diags_name>.path``).
+        * Simulation ``step`` and ``time`` (s)
+        * ``mpi.rank`` and ``mpi.size``
+        * ``host.name`` (MPI processor name or the Linux hostname)
+        * ``gpu.device_id`` and total/free global memory in MB (when built with a GPU backend)
+        * ``arenas.{main, device, managed, pinned, comms}`` allocated and used MB, for the
+          AMReX ``Arena`` memory pools. ``device``/``managed``/``comms`` are only emitted
+          when they are distinct allocators from ``main``/``device``/``pinned`` respectively
+          (e.g. the ``comms`` arena is typically a separate block only on GPU-aware MPI builds).
+        * ``process.{vm_peak, vm_size, vm_hwm, vm_rss}_mb`` read from ``/proc/self/status`` on
+          Linux, capturing the total resident set and high-water mark of the process — including
+          allocations that AMReX arenas do not track (MPI buffers, I/O libraries, Python,
+          plugin libraries, ...). This is often the first thing that matters when chasing
+          out-of-memory (OOM) crashes.
+
+        All memory values in the YAML are reported in **MB as floating-point numbers with
+        3-decimal precision**, regardless of the underlying source unit (bytes from AMReX,
+        kB from ``/proc/self/status``).
+
+        This is primarily useful for debugging OOM crashes on large, multi-GPU runs. A
+        typical workflow is to restart from a checkpoint and enable this diagnostic without
+        otherwise changing the input file, so the crash signature is preserved while
+        detailed per-rank memory information is captured right up until the failure.
 
         * ``<reduced_diags_name>.file_prefix`` (`string`)
-            The basename of the per-rank output files, to which ``.<MPI rank>`` is appended.
-            The default is ``"<reduced_diags_name>"``.
+            The basename of the per-rank YAML files, to which ``.<zero-padded MPI rank>.yaml``
+            is appended. The default is ``"<reduced_diags_name>"``. The rank is padded to a
+            constant width per run (minimum 4 digits) so that filenames sort lexicographically
+            in rank order.
 
         * ``<reduced_diags_name>.rank_stride`` (`int`, default ``1``)
             Only every ``rank_stride``-th MPI rank writes a file (i.e. ranks for which
@@ -4826,39 +4840,54 @@ This shifts analysis from post-processing to runtime calculation of reduction op
             on very large runs a larger stride can be used to reduce the number of files
             created on the shared filesystem.
 
-        Example output (``MPR.0``)::
+        Example output (``MPR.0000.yaml``)::
 
-            Memory usage at step 0, time = 0.00000000000000e+00
-                Total GPU global memory (MB): 7966
-                Free  GPU global memory (MB): 1571
-                [The         Arena] space allocated (MB): 2987
-                [The         Arena] space used      (MB): 53
-                [The         Arena]: 1 allocs, 261 busy blocks, 2 free blocks
-                [The Managed Arena] space allocated (MB): 8
-                [The Managed Arena] space used      (MB): 0
-                [The Managed Arena]: 1 allocs, 0 busy blocks, 1 free blocks
-                [The  Pinned Arena] space allocated (MB): 24
-                [The  Pinned Arena] space used      (MB): 0
-                [The  Pinned Arena]: 3 allocs, 64 busy blocks, 6 free blocks
-                [The   Comms Arena] space allocated (MB): 8
-                [The   Comms Arena] space used      (MB): 0
-                [The   Comms Arena]: 1 allocs, 0 busy blocks, 1 free blocks
-                [Rank] MPI rank: 0
-                [Rank] MPI size: 4
-                [Rank] hostname: host-123
-                [Rank] GPU device id: 0
-                [Process] VmPeak: 7632384 kB
-                [Process] VmSize: 7632384 kB
-                [Process] VmHWM:  1024512 kB
-                [Process] VmRSS:  1024512 kB
+            ---
+            step: 0
+            time: 0.00000000000000e+00
+            mpi:
+              rank: 0
+              size: 4
+            host:
+              name: 'nid002112'
+            gpu:
+              device_id: 0
+              total_mb: 40441.438
+              free_mb: 9058.688
+            arenas:
+              main:
+                allocated_mb: 30330.500
+                used_mb: 51.125
+              managed:
+                allocated_mb: 8.000
+                used_mb: 0.250
+              pinned:
+                allocated_mb: 8.000
+                used_mb: 0.000
+              comms:
+                allocated_mb: 8.000
+                used_mb: 0.000
+            process:
+              vm_peak_mb: 73430.281
+              vm_size_mb: 73430.281
+              vm_hwm_mb: 419.633
+              vm_rss_mb: 419.633
+            ---
+            step: 100
+            time: 1.08306469330691e-14
+            ...
+
+        See :ref:`MemoryPerRank reading and plotting <memoryperrank-plotting>` for a
+        small Python helper that loads these files into a ``pandas.DataFrame`` and a plotting
+        example showing total arena usage and host-process memory per rank over time.
 
         .. note::
 
             Use sparingly on larger production runs.
-            The diagnostic produces one text file per (participating) rank and appends to it
-            at each timestep in ``<reduced_diags_name>.intervals``. For very large rank counts,
-            combine with ``rank_stride`` and/or point ``<reduced_diags_name>.path`` to a
-            filesystem with good small-file performance.
+            The diagnostic produces one YAML file per (participating) rank and appends one
+            YAML document to it at each timestep in ``<reduced_diags_name>.intervals``.
+            For very large rank counts, combine with ``rank_stride`` and/or point
+            ``<reduced_diags_name>.path`` to a filesystem with good small-file performance.
 
     * ``ParticleHistogram``
         This type computes a user defined particle histogram.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -4840,7 +4840,9 @@ This shifts analysis from post-processing to runtime calculation of reduction op
             on very large runs a larger stride can be used to reduce the number of files
             created on the shared filesystem.
 
-        Example output (``MPR.0000.yaml``)::
+        Example output (``MPR.0000.yaml``):
+
+        .. code-block:: yaml
 
             ---
             step: 0

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -4837,7 +4837,8 @@ This shifts analysis from post-processing to runtime calculation of reduction op
                 [The  Pinned Arena] space allocated (MB): 24
                 [The  Pinned Arena] space used      (MB): 0
                 [The  Pinned Arena]: 3 allocs, 64 busy blocks, 6 free blocks
-                [Rank] MPI rank: 0 / 4
+                [Rank] MPI rank: 0
+                [Rank] MPI size: 4
                 [Rank] hostname: host-123
                 [Rank] GPU device id: 0
                 [Process] VmPeak: 7632384 kB

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -4797,24 +4797,61 @@ This shifts analysis from post-processing to runtime calculation of reduction op
         ``2``, since costs are not recorded until step ``1``.
 
     * ``MemoryPerRank``
-        This diagnostic uses ``AMReX::Arena::PrintUsageToFiles`` to output detailed memory
-        usage information for each MPI rank. It logs information including:
+        This diagnostic uses ``amrex::Arena::PrintUsageToFiles`` to write detailed memory
+        usage information for each MPI rank. It logs, per rank:
 
-        * Total/free GPU memory when applicable
-        * Memory usage statistics for different Arena memory pools (Main, Device, Managed, Pinned, Comms)
-        * Per-rank memory allocation and usage details
+        * Total/free GPU memory (when applicable)
+        * Memory usage statistics for the ``Main``, ``Device``, ``Managed`` and ``Pinned``
+          Arena memory pools (allocated/used MB, alloc/busy/free block counts)
+        * Host-process memory usage (``VmPeak``, ``VmSize``, ``VmHWM``, ``VmRSS`` on Linux)
+        * MPI rank, host name and GPU device id
 
-        This is useful for tracking memory consumption patterns throughout simulation runs,
-        particularly when debugging memory usage issues or optimizing performance on GPUs.
-        The data is saved into separate text files (one per MPI rank) in the specified output directory.
+        This is primarily useful for debugging out-of-memory (OOM) crashes on large,
+        multi-GPU runs. A typical workflow is to restart from a checkpoint and enable this
+        diagnostic without otherwise changing the input file, so the crash signature is
+        preserved while detailed per-rank memory information is captured right up until the
+        failure. The data is saved into separate text files (one per MPI rank) in the
+        specified output directory (``<reduced_diags_name>.path``).
 
         * ``<reduced_diags_name>.file_prefix`` (`string`)
-            The prefix for the output files. The default is `"<reduced_diags_name>"`.
+            The basename of the per-rank output files, to which ``.<MPI rank>`` is appended.
+            The default is ``"<reduced_diags_name>"``.
+
+        * ``<reduced_diags_name>.rank_stride`` (`int`, default ``1``)
+            Only every ``rank_stride``-th MPI rank writes a file (i.e. ranks for which
+            ``MyProc() % rank_stride == 0``). The default ``1`` writes one file per rank;
+            on very large runs a larger stride can be used to reduce the number of files
+            created on the shared filesystem.
+
+        Example output (``MPR.0``)::
+
+            Memory usage at step 0, time = 0.00000000000000e+00
+                Total GPU global memory (MB): 7966
+                Free  GPU global memory (MB): 1571
+                [The         Arena] space allocated (MB): 2987
+                [The         Arena] space used      (MB): 53
+                [The         Arena]: 1 allocs, 261 busy blocks, 2 free blocks
+                [The Managed Arena] space allocated (MB): 8
+                [The Managed Arena] space used      (MB): 0
+                [The Managed Arena]: 1 allocs, 0 busy blocks, 1 free blocks
+                [The  Pinned Arena] space allocated (MB): 24
+                [The  Pinned Arena] space used      (MB): 0
+                [The  Pinned Arena]: 3 allocs, 64 busy blocks, 6 free blocks
+                [Rank] MPI rank: 0 / 4
+                [Rank] hostname: host-123
+                [Rank] GPU device id: 0
+                [Process] VmPeak: 7632384 kB
+                [Process] VmSize: 7632384 kB
+                [Process] VmHWM:  1024512 kB
+                [Process] VmRSS:  1024512 kB
 
         .. note::
 
             Use sparingly on larger production runs.
-            The diagnostic produces one text file per rank and appends to it at each timestep according to ``<reduced_diags_name>.intervals``.
+            The diagnostic produces one text file per (participating) rank and appends to it
+            at each timestep in ``<reduced_diags_name>.intervals``. For very large rank counts,
+            combine with ``rank_stride`` and/or point ``<reduced_diags_name>.path`` to a
+            filesystem with good small-file performance.
 
     * ``ParticleHistogram``
         This type computes a user defined particle histogram.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -4796,6 +4796,26 @@ This shifts analysis from post-processing to runtime calculation of reduction op
         at earliest, the load balance efficiency can be output starting at step
         ``2``, since costs are not recorded until step ``1``.
 
+    * ``MemoryPerRank``
+        This diagnostic uses ``AMReX::Arena::PrintUsageToFiles`` to output detailed memory
+        usage information for each MPI rank. It logs information including:
+
+        * Total/free GPU memory when applicable
+        * Memory usage statistics for different Arena memory pools (Main, Device, Managed, Pinned, Comms)
+        * Per-rank memory allocation and usage details
+
+        This is useful for tracking memory consumption patterns throughout simulation runs,
+        particularly when debugging memory usage issues or optimizing performance on GPUs.
+        The data is saved into separate text files (one per MPI rank) in the specified output directory.
+
+        * ``<reduced_diags_name>.file_prefix`` (`string`)
+            The prefix for the output files. The default is `"<reduced_diags_name>"`.
+
+        .. note::
+
+            Use sparingly on larger production runs.
+            The diagnostic produces one text file per rank and appends to it at each timestep according to ``<reduced_diags_name>.intervals``.
+
     * ``ParticleHistogram``
         This type computes a user defined particle histogram.
 

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -4801,8 +4801,11 @@ This shifts analysis from post-processing to runtime calculation of reduction op
         usage information for each MPI rank. It logs, per rank:
 
         * Total/free GPU memory (when applicable)
-        * Memory usage statistics for the ``Main``, ``Device``, ``Managed`` and ``Pinned``
-          Arena memory pools (allocated/used MB, alloc/busy/free block counts)
+        * Memory usage statistics for the ``Main``, ``Device``, ``Managed``, ``Pinned`` and
+          ``Comms`` Arena memory pools (allocated/used MB, alloc/busy/free block counts).
+          The ``Comms`` Arena holds MPI staging buffers; it is only reported as a separate
+          block when it is distinct from the ``Device`` and ``Pinned`` Arenas, which typically
+          happens on GPU-aware MPI builds.
         * Host-process memory usage (``VmPeak``, ``VmSize``, ``VmHWM``, ``VmRSS`` on Linux)
         * MPI rank, host name and GPU device id
 
@@ -4837,6 +4840,9 @@ This shifts analysis from post-processing to runtime calculation of reduction op
                 [The  Pinned Arena] space allocated (MB): 24
                 [The  Pinned Arena] space used      (MB): 0
                 [The  Pinned Arena]: 3 allocs, 64 busy blocks, 6 free blocks
+                [The   Comms Arena] space allocated (MB): 8
+                [The   Comms Arena] space used      (MB): 0
+                [The   Comms Arena]: 1 allocs, 0 busy blocks, 1 free blocks
                 [Rank] MPI rank: 0
                 [Rank] MPI size: 4
                 [Rank] hostname: host-123

--- a/Docs/source/usage/workflows.rst
+++ b/Docs/source/usage/workflows.rst
@@ -12,6 +12,7 @@ This section collects typical user workflows and best practices for WarpX.
    workflows/python_extend
    workflows/domain_decomposition
    workflows/plot_distribution_mapping
+   workflows/memory_per_rank
    workflows/debugging
    workflows/generate_lookup_tables_with_tools
    workflows/plot_timestep_duration

--- a/Docs/source/usage/workflows/memory_per_rank.rst
+++ b/Docs/source/usage/workflows/memory_per_rank.rst
@@ -1,0 +1,127 @@
+.. _memoryperrank-plotting:
+
+Reading and plotting ``MemoryPerRank`` output
+==============================================
+
+WarpX provides via :ref:`reduced diagnostics <dataanalysis-formats-reduced>` an
+output :ref:`MemoryPerRank <running-cpp-parameters-diagnostics>`, which
+captures detailed per-rank memory usage over time (AMReX arenas, host-process
+memory, hostname, and GPU device id).
+
+Each participating MPI rank writes one YAML file
+``<path>/<file_prefix>.<zero-padded rank>.yaml``. Every diagnostic interval
+appends a new self-contained YAML document (separated by ``---``), so the
+output can be streamed cheaply with ``yaml.safe_load_all()``.
+
+
+Generating the data
+-------------------
+
+To enable the diagnostic, add the following lines to your input file
+(``MPR`` is an arbitrary name, ``100`` is the step interval):
+
+.. code-block:: text
+
+    warpx.reduced_diags_names = MPR
+    MPR.type        = MemoryPerRank
+    MPR.intervals   = 100
+    MPR.path        = "diags/reducedfiles/MemoryPerRank/"
+    MPR.file_prefix = "MPR"
+    # Optional: only every 4th rank writes a file (useful on large runs).
+    # MPR.rank_stride = 4
+
+Or from a PICMI script:
+
+.. code-block:: python
+
+    mpr = picmi.ReducedDiagnostic(
+        diag_type="MemoryPerRank",
+        name="MPR",
+        period=100,
+        path="diags/reducedfiles/MemoryPerRank/",
+        file_prefix="MPR",
+    )
+    sim.add_diagnostic(mpr)
+
+
+Loading the data
+----------------
+
+A small Python helper in
+:download:`read_memory_per_rank.py <../../../../Tools/PostProcessing/read_memory_per_rank.py>`
+collects all per-rank YAML files in a directory into a tidy
+``pandas.DataFrame``. Each row corresponds to one ``(rank, step)`` snapshot:
+
+.. code-block:: python
+
+    import read_memory_per_rank as mpr
+
+    df = mpr.load("diags/reducedfiles/MemoryPerRank/", prefix="MPR")
+    print(df.columns.tolist())
+    # ['file', 'step', 'time', 'rank', 'nprocs', 'hostname',
+    #  'gpu_device_id', 'gpu_total_mb', 'gpu_free_mb',
+    #  'arena_main_allocated_mb', 'arena_main_used_mb',
+    #  'arena_managed_allocated_mb', 'arena_managed_used_mb',
+    #  'arena_pinned_allocated_mb', 'arena_pinned_used_mb',
+    #  'arena_comms_allocated_mb', 'arena_comms_used_mb',
+    #  'vm_peak_mb', 'vm_size_mb', 'vm_hwm_mb', 'vm_rss_mb']
+
+    # All memory columns are in MB (float, 3-decimal precision).
+    # Max resident-set size over all ranks at each step:
+    df.groupby("step")[["vm_rss_mb", "vm_hwm_mb"]].max()
+
+
+Plotting per-rank memory over time
+----------------------------------
+
+The same helper exposes a one-line plotting function:
+
+.. code-block:: python
+
+    import matplotlib.pyplot as plt
+    import read_memory_per_rank as mpr
+
+    df = mpr.load("diags/reducedfiles/MemoryPerRank/", prefix="MPR")
+    fig = mpr.plot(df, output="mpr_timeline.png")
+    plt.show()
+
+It produces two stacked panels:
+
+* **Top** -- total AMReX arena memory *allocated* per rank (MB), one line per rank.
+  This is the memory AMReX explicitly reserved across all arenas (Main / Device /
+  Managed / Pinned / Comms, summed).
+* **Bottom** -- host-process resident memory (``VmRSS``, solid) and high-water mark
+  (``VmHWM``, dashed) per rank, in MB. This captures *everything*: AMReX arenas,
+  MPI buffers, I/O libraries, Python, plugin ``.so``\s, CUDA runtime internals.
+  When the bottom panel diverges from the top one, the difference is the memory
+  that AMReX does not see -- often the key information when chasing OOM crashes.
+
+You can also run the helper as a script:
+
+.. code-block:: bash
+
+    python3 Tools/PostProcessing/read_memory_per_rank.py \\
+        diags/reducedfiles/MemoryPerRank/ \\
+        --prefix MPR \\
+        --output mpr_timeline.png \\
+        --csv    mpr_timeline.csv
+
+
+Spotting imbalance between ranks
+--------------------------------
+
+For a quick per-rank spread at any given step:
+
+.. code-block:: python
+
+    at_step = df[df["step"] == df["step"].max()]
+    print(at_step[["rank", "hostname", "gpu_device_id",
+                   "arena_main_allocated_mb", "vm_rss_mb"]]
+          .sort_values("vm_rss_mb", ascending=False)
+          .head(10))
+
+A rank whose ``arena_main_allocated_mb`` is an outlier is carrying a larger
+domain chunk; a rank whose ``vm_rss_mb`` is an outlier but whose arena size is
+not typically indicates memory consumed outside AMReX (MPI staging, Python, ...).
+Correlating with the :ref:`LoadBalanceCosts <running-cpp-parameters-diagnostics>`
+diagnostic is often useful when both are enabled.

--- a/Docs/source/usage/workflows/memory_per_rank.rst
+++ b/Docs/source/usage/workflows/memory_per_rank.rst
@@ -85,16 +85,15 @@ The same helper exposes a one-line plotting function:
     fig = mpr.plot(df, output="mpr_timeline.png")
     plt.show()
 
-It produces two stacked panels:
+The figure adapts to the run: on GPU builds the headline panel shows GPU
+memory used per rank (the quantity that drives device OOM); on CPU-only
+builds it shows total AMReX arena allocation. A host-process ``VmRSS`` /
+``VmHWM`` panel is always included.
 
-* **Top** -- total AMReX arena memory *allocated* per rank (MB), one line per rank.
-  This is the memory AMReX explicitly reserved across all arenas (Main / Device /
-  Managed / Pinned / Comms, summed).
-* **Bottom** -- host-process resident memory (``VmRSS``, solid) and high-water mark
-  (``VmHWM``, dashed) per rank, in MB. This captures *everything*: AMReX arenas,
-  MPI buffers, I/O libraries, Python, plugin ``.so``\s, CUDA runtime internals.
-  When the bottom panel diverges from the top one, the difference is the memory
-  that AMReX does not see -- often the key information when chasing OOM crashes.
+The per-rank rendering mode is auto-selected from the rank count (one
+curve per rank for small runs, an envelope of min/median/max for medium
+runs, a rank x step heatmap for very large runs). See the script's
+module docstring and ``--help`` for the available modes and overrides.
 
 You can also run the helper as a script:
 
@@ -104,7 +103,8 @@ You can also run the helper as a script:
         diags/reducedfiles/MemoryPerRank/ \\
         --prefix MPR \\
         --output mpr_timeline.png \\
-        --csv    mpr_timeline.csv
+        --csv    mpr_timeline.csv \\
+        --mode   auto
 
 
 Spotting imbalance between ranks

--- a/Examples/Physics_applications/laser_ion/analysis_test_laser_ion.py
+++ b/Examples/Physics_applications/laser_ion/analysis_test_laser_ion.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
 
-import glob
 import os
 import sys
 
 import numpy as np
 import openpmd_api as io
-import yaml
 
 
 def load_field_from_iteration(
@@ -65,51 +63,6 @@ def compare_time_avg_with_instantaneous_diags(dir_inst: str, dir_avg: str):
         sys.exit(1)
 
 
-def check_memory_per_rank_yaml(mpr_dir: str, prefix: str = "MPR"):
-    """Smoke test for the MemoryPerRank YAML output.
-
-    Validates that one file per rank exists, that every YAML document in each
-    file parses cleanly to a plain dict, and that the key fields we document
-    are present with the expected types. This catches YAML format regressions
-    in the C++ emitter.
-    """
-    files = sorted(glob.glob(os.path.join(mpr_dir, f"{prefix}.*.yaml")))
-    if not files:
-        print(
-            f"Test failed: no MemoryPerRank YAML files found in {mpr_dir} "
-            f"(prefix={prefix})."
-        )
-        sys.exit(1)
-
-    required_top_level = {"step", "time", "mpi", "host", "arenas"}
-
-    for fpath in files:
-        with open(fpath) as fh:
-            docs = [d for d in yaml.safe_load_all(fh) if d is not None]
-        if not docs:
-            print(f"Test failed: {fpath} contains no YAML documents.")
-            sys.exit(1)
-        for d in docs:
-            if not isinstance(d, dict):
-                print(f"Test failed: {fpath} document is not a dict: {type(d)}.")
-                sys.exit(1)
-            missing = required_top_level - d.keys()
-            if missing:
-                print(
-                    f"Test failed: {fpath} is missing required keys {missing}. "
-                    f"Got keys: {sorted(d.keys())}"
-                )
-                sys.exit(1)
-            if "main" not in (d.get("arenas") or {}):
-                print(f"Test failed: {fpath} is missing arenas.main.")
-                sys.exit(1)
-
-    print(
-        f"Test passed: MemoryPerRank YAML is valid across {len(files)} "
-        f"rank files in {mpr_dir}."
-    )
-
-
 if __name__ == "__main__":
     # TODO: implement intervals parser for PICMI that allows more complex output periods
     test_name = os.path.split(os.getcwd())[1]
@@ -119,6 +72,3 @@ if __name__ == "__main__":
             dir_inst=sys.argv[1],
             dir_avg="diags/diagTimeAvg/",
         )
-
-    # Smoke test for MemoryPerRank YAML output (present in both variants).
-    check_memory_per_rank_yaml("diags/reducedfiles/MemoryPerRank/", prefix="MPR")

--- a/Examples/Physics_applications/laser_ion/analysis_test_laser_ion.py
+++ b/Examples/Physics_applications/laser_ion/analysis_test_laser_ion.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 
+import glob
 import os
 import sys
 
 import numpy as np
 import openpmd_api as io
+import yaml
 
 
 def load_field_from_iteration(
@@ -63,6 +65,51 @@ def compare_time_avg_with_instantaneous_diags(dir_inst: str, dir_avg: str):
         sys.exit(1)
 
 
+def check_memory_per_rank_yaml(mpr_dir: str, prefix: str = "MPR"):
+    """Smoke test for the MemoryPerRank YAML output.
+
+    Validates that one file per rank exists, that every YAML document in each
+    file parses cleanly to a plain dict, and that the key fields we document
+    are present with the expected types. This catches YAML format regressions
+    in the C++ emitter.
+    """
+    files = sorted(glob.glob(os.path.join(mpr_dir, f"{prefix}.*.yaml")))
+    if not files:
+        print(
+            f"Test failed: no MemoryPerRank YAML files found in {mpr_dir} "
+            f"(prefix={prefix})."
+        )
+        sys.exit(1)
+
+    required_top_level = {"step", "time", "mpi", "host", "arenas"}
+
+    for fpath in files:
+        with open(fpath) as fh:
+            docs = [d for d in yaml.safe_load_all(fh) if d is not None]
+        if not docs:
+            print(f"Test failed: {fpath} contains no YAML documents.")
+            sys.exit(1)
+        for d in docs:
+            if not isinstance(d, dict):
+                print(f"Test failed: {fpath} document is not a dict: {type(d)}.")
+                sys.exit(1)
+            missing = required_top_level - d.keys()
+            if missing:
+                print(
+                    f"Test failed: {fpath} is missing required keys {missing}. "
+                    f"Got keys: {sorted(d.keys())}"
+                )
+                sys.exit(1)
+            if "main" not in (d.get("arenas") or {}):
+                print(f"Test failed: {fpath} is missing arenas.main.")
+                sys.exit(1)
+
+    print(
+        f"Test passed: MemoryPerRank YAML is valid across {len(files)} "
+        f"rank files in {mpr_dir}."
+    )
+
+
 if __name__ == "__main__":
     # TODO: implement intervals parser for PICMI that allows more complex output periods
     test_name = os.path.split(os.getcwd())[1]
@@ -72,3 +119,6 @@ if __name__ == "__main__":
             dir_inst=sys.argv[1],
             dir_avg="diags/diagTimeAvg/",
         )
+
+    # Smoke test for MemoryPerRank YAML output (present in both variants).
+    check_memory_per_rank_yaml("diags/reducedfiles/MemoryPerRank/", prefix="MPR")

--- a/Examples/Physics_applications/laser_ion/inputs_test_2d_laser_ion_acc
+++ b/Examples/Physics_applications/laser_ion/inputs_test_2d_laser_ion_acc
@@ -322,7 +322,7 @@ LBC.intervals = 100
 # NOTE: use sparingly for large-scale runs as it produces a text file per rank
 MPR.type = MemoryPerRank
 MPR.intervals = 100
-MPR.path = "diags/reducedfiles/MemoryPerRank"
+MPR.path = "diags/reducedfiles/MemoryPerRank/"
 MPR.file_prefix = "MPR"
 
 PhaseSpaceIons.type                                 = ParticleHistogram2D

--- a/Examples/Physics_applications/laser_ion/inputs_test_2d_laser_ion_acc
+++ b/Examples/Physics_applications/laser_ion/inputs_test_2d_laser_ion_acc
@@ -257,7 +257,7 @@ openPMDbw.hydrogen.plot_filter_function(t,x,y,z,ux,uy,uz) = (uz<0)
 # histograms with 2.0 degree acceptance angle in fw direction
 # 2 deg * pi / 180 : 0.03490658503 rad
 # half-angle +/-   : 0.017453292515 rad
-warpx.reduced_diags_names                   = histuH histue histuzAll FieldProbe_Z FieldProbe_ScatPoint FieldProbe_ScatLine LBC PhaseSpaceIons PhaseSpaceElectrons
+warpx.reduced_diags_names                   = histuH histue histuzAll FieldProbe_Z FieldProbe_ScatPoint FieldProbe_ScatLine LBC MPR PhaseSpaceIons PhaseSpaceElectrons
 
 histuH.type                                 = ParticleHistogram
 histuH.intervals                            = 100
@@ -317,6 +317,13 @@ FieldProbe_ScatLine.resolution = 201
 # check computational load per box
 LBC.type = LoadBalanceCosts
 LBC.intervals = 100
+
+# check memory usage per rank
+# NOTE: use sparingly for large-scale runs as it produces a text file per rank
+MPR.type = MemoryPerRank
+MPR.intervals = 100
+MPR.path = "diags/reducedfiles/MemoryPerRank"
+MPR.file_prefix = "MPR"
 
 PhaseSpaceIons.type                                 = ParticleHistogram2D
 PhaseSpaceIons.intervals                            = 100

--- a/Examples/Physics_applications/laser_ion/inputs_test_2d_laser_ion_acc_picmi.py
+++ b/Examples/Physics_applications/laser_ion/inputs_test_2d_laser_ion_acc_picmi.py
@@ -265,6 +265,19 @@ load_balance_costs_rdiag = picmi.ReducedDiagnostic(
     name="LBC",
 )
 
+# Per-rank memory diagnostic: one text file per MPI rank, containing AMReX
+# arena usage, host-process memory (VmRSS etc. on Linux), hostname and
+# GPU device id. Use sparingly on large production runs; see
+# <rd_name>.rank_stride to thin out the number of files.
+# NOTE: use sparingly for large-scale runs as it produces a text file per rank
+memory_per_rank_rdiag = picmi.ReducedDiagnostic(
+    diag_type="MemoryPerRank",
+    name="MPR",
+    period=100,
+    path="diags/reducedfiles/MemoryPerRank/",
+    file_prefix="MPR",
+)
+
 # Set up simulation
 sim = picmi.Simulation(
     solver=solver,
@@ -311,6 +324,7 @@ sim.add_diagnostic(field_probe_z_rdiag)
 sim.add_diagnostic(field_probe_scat_point_rdiag)
 sim.add_diagnostic(field_probe_scat_line_rdiag)
 sim.add_diagnostic(load_balance_costs_rdiag)
+sim.add_diagnostic(memory_per_rank_rdiag)
 # TODO: make ParticleHistogram2D available
 
 # Write input file that can be used to run with the compiled version

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -4584,6 +4584,17 @@ class ReducedDiagnostic(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
     weighting_function: string, optional
         For diagnostic type 'ChargeOnEB', the function to weight contributions to the total charge
 
+    file_prefix: string, optional
+        For diagnostic type 'MemoryPerRank', the basename of the per-rank output
+        files. The MPI rank is appended automatically, producing files named
+        ``<path>/<file_prefix>.<rank>``. Defaults to the diagnostic name.
+
+    rank_stride: integer, optional
+        For diagnostic type 'MemoryPerRank', only every ``rank_stride``-th MPI rank
+        writes a file (i.e. ranks for which ``MyProc() % rank_stride == 0``). The
+        default ``1`` writes one file per rank; on very large runs a larger stride
+        can be used to reduce the number of files on the shared filesystem.
+
     reduction_type: {'Maximum', 'Minimum', or 'Integral'}
         For diagnostic type 'FieldReduction', the type of reduction
 
@@ -4642,6 +4653,8 @@ class ReducedDiagnostic(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
         # different reduced diagnostic types.
 
         # The simple diagnostics do not require any additional arguments
+        # (any extra kwargs such as file_prefix/rank_stride for MemoryPerRank
+        # are set on the diagnostic instance directly via handle_init).
         self._simple_reduced_diagnostics = [
             "ParticleEnergy",
             "ParticleMomentum",
@@ -4653,6 +4666,7 @@ class ReducedDiagnostic(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
             "ParticleNumber",
             "LoadBalanceCosts",
             "LoadBalanceEfficiency",
+            "MemoryPerRank",
             "Timestep",
         ]
         # The species diagnostics require a species to be provided
@@ -4664,7 +4678,8 @@ class ReducedDiagnostic(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
         ]
 
         if self.type in self._simple_reduced_diagnostics:
-            pass
+            if self.type == "MemoryPerRank":
+                kw = self._handle_memory_per_rank(**kw)
         elif self.type in self._species_reduced_diagnostics:
             species = kw.pop("species")
             self.species = species.name
@@ -4801,6 +4816,12 @@ class ReducedDiagnostic(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
                 self.user_defined_kw[k] = kw[k]
                 del kw[k]
 
+        return kw
+
+    def _handle_memory_per_rank(self, **kw):
+        """Utility function to pop MemoryPerRank-specific kwargs."""
+        self.file_prefix = kw.pop("file_prefix", None)
+        self.rank_stride = kw.pop("rank_stride", None)
         return kw
 
     def _handle_charge_on_eb(self, **kw):

--- a/Source/Diagnostics/ReducedDiags/CMakeLists.txt
+++ b/Source/Diagnostics/ReducedDiags/CMakeLists.txt
@@ -17,6 +17,7 @@ foreach(D IN LISTS WarpX_DIMS)
         FieldProbe.cpp
         LoadBalanceCosts.cpp
         LoadBalanceEfficiency.cpp
+        MemoryPerRank.cpp
         MultiReducedDiags.cpp
         ParticleEnergy.cpp
         ParticleExtrema.cpp

--- a/Source/Diagnostics/ReducedDiags/Make.package
+++ b/Source/Diagnostics/ReducedDiags/Make.package
@@ -14,6 +14,7 @@ CEXE_sources += FieldProbeParticleContainer.cpp
 CEXE_sources += FieldReduction.cpp
 CEXE_sources += LoadBalanceCosts.cpp
 CEXE_sources += LoadBalanceEfficiency.cpp
+CEXE_sources += MemoryPerRank.cpp
 CEXE_sources += ParticleEnergy.cpp
 CEXE_sources += ParticleExtrema.cpp
 CEXE_sources += ParticleHistogram.cpp

--- a/Source/Diagnostics/ReducedDiags/MemoryPerRank.H
+++ b/Source/Diagnostics/ReducedDiags/MemoryPerRank.H
@@ -5,21 +5,27 @@
  * License: BSD-3-Clause-LBNL
  */
 
-#ifndef WARPX_DIAGNOSTICS_REDUCEDDIAGS_MEMORYDIAGS_H_
-#define WARPX_DIAGNOSTICS_REDUCEDDIAGS_MEMORYDIAGS_H_
+#ifndef WARPX_DIAGNOSTICS_REDUCEDDIAGS_MEMORYPERRANK_H_
+#define WARPX_DIAGNOSTICS_REDUCEDDIAGS_MEMORYPERRANK_H_
 
 #include "ReducedDiags.H"
 
 #include <string>
 
 /**
- * \brief Reduced diagnostic for tracking memory usage from AMReX memory arenas.
+ * \brief Reduced diagnostic for tracking memory usage on each MPI rank.
  *
- * This diagnostic uses AMReX::Arena::PrintUsageToFiles to output detailed memory
- * usage information including:
- * - Total/free GPU memory when applicable
- * - Main/device/managed/pinned/comms arena memory usage
- * - Per-rank memory statistics
+ * This diagnostic uses amrex::Arena::PrintUsageToFiles to write detailed
+ * memory usage information, one text file per MPI rank, and appends extra
+ * context that is useful when debugging out-of-memory (OOM) errors, such as:
+ * - Total/free GPU memory (when applicable)
+ * - Main/device/managed/pinned arena memory usage
+ * - Host process memory (VmRSS/VmHWM/VmPeak/VmSize on Linux)
+ * - MPI rank, host name and GPU device id
+ *
+ * The main use case is to inspect the state of a large, multi-GPU run
+ * (typically from a checkpoint) right before an OOM crash, without
+ * otherwise modifying the input file.
  */
 class MemoryPerRank : public ReducedDiags
 {
@@ -32,17 +38,28 @@ public:
     explicit MemoryPerRank (const std::string& rd_name);
 
     /**
-     * \brief This function computes memory diagnostics by calling
-     * AMReX::Arena::PrintUsageToFiles at the specified intervals.
+     * \brief Compute memory diagnostics at the specified intervals by calling
+     * amrex::Arena::PrintUsageToFiles and appending additional per-rank
+     * information (process memory, host name, GPU device id).
      *
      * \param[in] step current time step
      */
     void ComputeDiags (int step) override;
 
 private:
-    // The base filename for memory usage output files
+    //! Basename for per-rank files (the final file name is
+    //! ``<m_path><m_filename>.<MPI rank>``).
     std::string m_filename;
+
+    //! Write a file only from every ``m_rank_stride``-th MPI rank.
+    //! The default ``1`` writes one file per rank; on very large runs
+    //! setting this to e.g. ``8`` reduces the number of files by 8x.
+    int m_rank_stride = 1;
+
+    //! Whether this rank participates in writing (derived from
+    //! ``m_rank_stride`` in the constructor).
+    bool m_rank_participates = true;
 
 };
 
-#endif // WARPX_DIAGNOSTICS_REDUCEDDIAGS_MEMORYDIAGS_H_
+#endif // WARPX_DIAGNOSTICS_REDUCEDDIAGS_MEMORYPERRANK_H_

--- a/Source/Diagnostics/ReducedDiags/MemoryPerRank.H
+++ b/Source/Diagnostics/ReducedDiags/MemoryPerRank.H
@@ -46,4 +46,3 @@ private:
 };
 
 #endif // WARPX_DIAGNOSTICS_REDUCEDDIAGS_MEMORYDIAGS_H_
-

--- a/Source/Diagnostics/ReducedDiags/MemoryPerRank.H
+++ b/Source/Diagnostics/ReducedDiags/MemoryPerRank.H
@@ -1,0 +1,49 @@
+/* Copyright 2025 Marco Garten
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#ifndef WARPX_DIAGNOSTICS_REDUCEDDIAGS_MEMORYDIAGS_H_
+#define WARPX_DIAGNOSTICS_REDUCEDDIAGS_MEMORYDIAGS_H_
+
+#include "ReducedDiags.H"
+
+#include <string>
+
+/**
+ * \brief Reduced diagnostic for tracking memory usage from AMReX memory arenas.
+ *
+ * This diagnostic uses AMReX::Arena::PrintUsageToFiles to output detailed memory
+ * usage information including:
+ * - Total/free GPU memory when applicable
+ * - Main/device/managed/pinned/comms arena memory usage
+ * - Per-rank memory statistics
+ */
+class MemoryPerRank : public ReducedDiags
+{
+public:
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] rd_name name of the reduced diagnostic
+     */
+    explicit MemoryPerRank (const std::string& rd_name);
+
+    /**
+     * \brief This function computes memory diagnostics by calling
+     * AMReX::Arena::PrintUsageToFiles at the specified intervals.
+     *
+     * \param[in] step current time step
+     */
+    void ComputeDiags (int step) override;
+
+private:
+    // The base filename for memory usage output files
+    std::string m_filename;
+
+};
+
+#endif // WARPX_DIAGNOSTICS_REDUCEDDIAGS_MEMORYDIAGS_H_
+

--- a/Source/Diagnostics/ReducedDiags/MemoryPerRank.cpp
+++ b/Source/Diagnostics/ReducedDiags/MemoryPerRank.cpp
@@ -35,17 +35,17 @@
 
 namespace {
 
-#ifdef __linux__
     /** Read a named field (e.g. "VmRSS") from /proc/self/status and return its
-     *  numeric part as an integer kB value, or -1 on failure. All Vm* fields in
-     *  /proc/self/status are reported in kB with a trailing " kB" unit.
+     *  numeric part as an integer kB value, or -1 on failure. All Vm* fields
+     *  in /proc/self/status are reported in kB with a trailing " kB" unit.
      *
-     *  The [[maybe_unused]] attribute silences a CodeQL
-     *  `cpp/unused-static-function` false positive: the function is defined and
-     *  used only inside `#ifdef __linux__` blocks, and the rule does not match
-     *  references across conditional-compilation boundaries reliably.
+     *  The function is defined unconditionally so it (and its sole caller) are
+     *  visible to CodeQL on every platform. On platforms without `/proc`
+     *  (macOS, Windows, ...) the file simply does not open and the function
+     *  returns -1 for every field; callers must treat -1 as "unavailable" and
+     *  skip emitting the corresponding output.
      */
-    [[maybe_unused]] long ReadProcStatusKB (const std::string& key)
+    long ReadProcStatusKB (const std::string& key)
     {
         std::ifstream ifs("/proc/self/status");
         if (!ifs.is_open()) { return -1; }
@@ -64,7 +64,6 @@ namespace {
         }
         return -1;
     }
-#endif
 
     /** Get a human-readable host name (MPI processor name if available,
      *  otherwise gethostname on Linux, otherwise "unknown").
@@ -243,28 +242,35 @@ void MemoryPerRank::ComputeDiags (int step)
         EmitArenaBlock(ofs, "comms", amrex::The_Comms_Arena());
     }
 
-#ifdef __linux__
-    // Host-process memory as reported by the kernel. The kernel emits kB in
-    // /proc/self/status; we convert to MB to keep the YAML unit-consistent
-    // with the arena and GPU values. This captures allocations that are not
-    // tracked by AMReX arenas (MPI buffers, I/O libraries, Python, plugin
-    // libraries, ...) and is often the first thing that matters when chasing
-    // OOM errors.
+    // Host-process memory as reported by the kernel. On Linux these come from
+    // /proc/self/status (kB) and are converted to MB to keep the YAML
+    // unit-consistent with the arena and GPU values. They capture allocations
+    // that AMReX arenas do not track (MPI buffers, I/O libraries, Python,
+    // plugin libraries, ...) and are often the first thing that matters when
+    // chasing OOM errors.
+    //
+    // The call is unconditional (no `#ifdef __linux__`) so CodeQL can see the
+    // reference to ReadProcStatusKB regardless of preprocessor configuration.
+    // On platforms without /proc, every field reads as -1, no entries are
+    // staged, and the `process:` block is omitted entirely.
     const std::pair<const char*, const char*> vm_fields[] = {
         {"VmPeak", "vm_peak_mb"},
         {"VmSize", "vm_size_mb"},
         {"VmHWM",  "vm_hwm_mb"},
         {"VmRSS",  "vm_rss_mb"},
     };
-    ofs << "process:\n";
+    std::ostringstream proc_buf;
+    proc_buf << std::fixed << std::setprecision(3);
     for (const auto& [field, yaml_key] : vm_fields) {
         const long kb = ReadProcStatusKB(field);
         if (kb >= 0) {
-            ofs << "  " << yaml_key << ": "
-                << (static_cast<double>(kb) / 1024.0) << "\n";
+            proc_buf << "  " << yaml_key << ": "
+                     << (static_cast<double>(kb) / 1024.0) << "\n";
         }
     }
-#endif
+    if (!proc_buf.str().empty()) {
+        ofs << "process:\n" << proc_buf.str();
+    }
 
     ofs.flush();
 }

--- a/Source/Diagnostics/ReducedDiags/MemoryPerRank.cpp
+++ b/Source/Diagnostics/ReducedDiags/MemoryPerRank.cpp
@@ -1,0 +1,67 @@
+/* Copyright 2025 Marco Garten
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#include "MemoryPerRank.H"
+
+#include "WarpX.H"
+
+#include <AMReX_Arena.H>
+#include <AMReX_ParmParse.H>
+
+#include <utility>
+#include <iomanip>
+#include <sstream>
+
+
+namespace {
+    constexpr int permission_flag_rwxrxrx = 0755;
+}
+
+// Constructor
+MemoryPerRank::MemoryPerRank (const std::string& rd_name)
+        : ReducedDiags{std::move(rd_name)}
+{
+    // Initialize filename for memory usage files
+    m_filename = m_rd_name;
+
+    // Get parameters from input file
+    amrex::ParmParse pp_name(m_rd_name);
+
+    // Allow customizing the output filename
+    pp_name.queryAdd("file_prefix", m_filename);
+
+    // We don't need the WriteToFile functionality as AMReX::Arena::PrintUsageToFiles
+    // handles the file output directly
+    m_write_header = false;
+
+    // Create the output directory if it doesn't exist
+    if (amrex::ParallelDescriptor::IOProcessor()) {
+        if (!amrex::UtilCreateDirectory(m_path, permission_flag_rwxrxrx)) {
+            amrex::CreateDirectoryFailed(m_path);
+        }
+    }
+
+}
+
+// Compute diagnostics - this calls AMReX's memory usage reporting function
+void MemoryPerRank::ComputeDiags (int step)
+{
+    // Only proceed if this step is included in our intervals
+    if (!m_intervals.contains(step+1)) { return; }
+
+    // Create a message with the current step and time (with scientific notation)
+    std::stringstream time_ss;
+    time_ss << std::scientific << std::setprecision(14) << WarpX::GetInstance().gett_new(0);
+
+    std::string message = std::string("Memory usage") +
+                          std::string(" at step ") + std::to_string(step+1) +
+                          std::string(", time = ") + time_ss.str();
+
+    // Call AMReX's memory usage reporting function
+    // This will create one file per MPI rank in the specified directory
+    amrex::Arena::PrintUsageToFiles(m_path + m_filename, message);
+}

--- a/Source/Diagnostics/ReducedDiags/MemoryPerRank.cpp
+++ b/Source/Diagnostics/ReducedDiags/MemoryPerRank.cpp
@@ -39,8 +39,13 @@ namespace {
     /** Read a named field (e.g. "VmRSS") from /proc/self/status and return its
      *  numeric part as an integer kB value, or -1 on failure. All Vm* fields in
      *  /proc/self/status are reported in kB with a trailing " kB" unit.
+     *
+     *  The [[maybe_unused]] attribute silences a CodeQL
+     *  `cpp/unused-static-function` false positive: the function is defined and
+     *  used only inside `#ifdef __linux__` blocks, and the rule does not match
+     *  references across conditional-compilation boundaries reliably.
      */
-    long ReadProcStatusKB (const std::string& key)
+    [[maybe_unused]] long ReadProcStatusKB (const std::string& key)
     {
         std::ifstream ifs("/proc/self/status");
         if (!ifs.is_open()) { return -1; }

--- a/Source/Diagnostics/ReducedDiags/MemoryPerRank.cpp
+++ b/Source/Diagnostics/ReducedDiags/MemoryPerRank.cpp
@@ -10,58 +10,148 @@
 #include "WarpX.H"
 
 #include <AMReX_Arena.H>
+#include <AMReX_GpuDevice.H>
+#include <AMReX_ParallelDescriptor.H>
 #include <AMReX_ParmParse.H>
 
-#include <utility>
+#ifdef AMREX_USE_MPI
+#   include <mpi.h>
+#endif
+
+#ifdef __linux__
+#   include <unistd.h>
+#endif
+
+#include <fstream>
 #include <iomanip>
 #include <sstream>
+#include <string>
 
 
 namespace {
-    constexpr int permission_flag_rwxrxrx = 0755;
-}
+
+#ifdef __linux__
+    /** Read a named field (e.g. "VmRSS") from /proc/self/status.
+     *  Returns the trimmed value (including unit) or an empty string on failure.
+     */
+    std::string ReadProcStatusField (const std::string& key)
+    {
+        std::ifstream ifs("/proc/self/status");
+        if (!ifs.is_open()) { return {}; }
+        std::string line;
+        const std::string prefix = key + ":";
+        while (std::getline(ifs, line)) {
+            if (line.rfind(prefix, 0) == 0) {
+                const auto pos = line.find_first_not_of(" \t", prefix.size());
+                return (pos == std::string::npos) ? std::string{} : line.substr(pos);
+            }
+        }
+        return {};
+    }
+#endif
+
+    /** Get a human-readable host name (MPI processor name if available,
+     *  otherwise gethostname on Linux, otherwise "unknown").
+     */
+    std::string GetHostName ()
+    {
+#ifdef AMREX_USE_MPI
+        char hostname[MPI_MAX_PROCESSOR_NAME] = {0};
+        int length = 0;
+        if (MPI_Get_processor_name(hostname, &length) == MPI_SUCCESS) {
+            return {hostname, static_cast<std::size_t>(length)};
+        }
+#elif defined(__linux__)
+        char hostname[256] = {0};
+        if (gethostname(hostname, sizeof(hostname)) == 0) {
+            hostname[sizeof(hostname)-1] = '\0';
+            return {hostname};
+        }
+#endif
+        return {"unknown"};
+    }
+
+} // namespace
 
 // Constructor
 MemoryPerRank::MemoryPerRank (const std::string& rd_name)
-        : ReducedDiags{std::move(rd_name)}
+    : ReducedDiags{rd_name}
 {
-    // Initialize filename for memory usage files
+    // Default basename for the per-rank files (the MPI rank is appended by
+    // amrex::Arena::PrintUsageToFiles, giving "<m_path><m_filename>.<rank>").
     m_filename = m_rd_name;
 
-    // Get parameters from input file
-    amrex::ParmParse pp_name(m_rd_name);
+    // Read per-diagnostic parameters
+    const amrex::ParmParse pp_name(m_rd_name);
 
-    // Allow customizing the output filename
-    pp_name.queryAdd("file_prefix", m_filename);
+    // Optional custom basename
+    pp_name.query("file_prefix", m_filename);
 
-    // We don't need the WriteToFile functionality as AMReX::Arena::PrintUsageToFiles
-    // handles the file output directly
+    // Optional: only every m_rank_stride-th MPI rank writes a file.
+    // This is useful on very large runs where one file per rank would
+    // create too many files on the shared filesystem.
+    pp_name.query("rank_stride", m_rank_stride);
+    if (m_rank_stride < 1) { m_rank_stride = 1; }
+    m_rank_participates =
+        (amrex::ParallelDescriptor::MyProc() % m_rank_stride == 0);
+
+    // We do not use ReducedDiags::WriteToFile: per-rank files are written
+    // directly from ComputeDiags via amrex::Arena::PrintUsageToFiles, and
+    // additional per-rank information is appended there.
     m_write_header = false;
 
-    // Create the output directory if it doesn't exist
-    if (amrex::ParallelDescriptor::IOProcessor()) {
-        if (!amrex::UtilCreateDirectory(m_path, permission_flag_rwxrxrx)) {
-            amrex::CreateDirectoryFailed(m_path);
-        }
-    }
-
+    // Note: the output directory (m_path) is already created by the
+    // ReducedDiags base class constructor on the IOProcessor.
 }
 
-// Compute diagnostics - this calls AMReX's memory usage reporting function
+// Compute diagnostics - writes one file per participating MPI rank
 void MemoryPerRank::ComputeDiags (int step)
 {
-    // Only proceed if this step is included in our intervals
+    // Only proceed on requested intervals
     if (!m_intervals.contains(step+1)) { return; }
 
-    // Create a message with the current step and time (with scientific notation)
+    // Optionally thin out the set of ranks that write a file
+    if (!m_rank_participates) { return; }
+
+    // Header line printed at the top of each block
     std::stringstream time_ss;
-    time_ss << std::scientific << std::setprecision(14) << WarpX::GetInstance().gett_new(0);
+    time_ss << std::scientific << std::setprecision(14)
+            << WarpX::GetInstance().gett_new(0);
+    const std::string message =
+        "Memory usage at step " + std::to_string(step+1) +
+        ", time = " + time_ss.str();
 
-    std::string message = std::string("Memory usage") +
-                          std::string(" at step ") + std::to_string(step+1) +
-                          std::string(", time = ") + time_ss.str();
+    // Let AMReX print arena usage for this rank into <file_basename>.<rank>
+    const std::string file_basename = m_path + m_filename;
+    amrex::Arena::PrintUsageToFiles(file_basename, message);
 
-    // Call AMReX's memory usage reporting function
-    // This will create one file per MPI rank in the specified directory
-    amrex::Arena::PrintUsageToFiles(m_path + m_filename, message);
+    // Append additional per-rank context that AMReX does not emit
+    const std::string per_rank_file =
+        file_basename + "." +
+        std::to_string(amrex::ParallelDescriptor::MyProc());
+    std::ofstream ofs(per_rank_file, std::ios_base::app);
+    if (!ofs.is_open()) { return; }
+
+    ofs << "    [Rank] MPI rank: " << amrex::ParallelDescriptor::MyProc()
+        << " / " << amrex::ParallelDescriptor::NProcs() << "\n";
+    ofs << "    [Rank] hostname: " << GetHostName() << "\n";
+#ifdef AMREX_USE_GPU
+    ofs << "    [Rank] GPU device id: "
+        << amrex::Gpu::Device::deviceId() << "\n";
+#endif
+
+#ifdef __linux__
+    // Host-process memory (in kB, as reported by the kernel). This captures
+    // allocations that are not tracked by AMReX arenas (MPI buffers, I/O
+    // libraries, Python, plugin libraries, ...) and is often the first
+    // thing that matters when chasing OOM errors.
+    for (const auto& field : {"VmPeak", "VmSize", "VmHWM", "VmRSS"}) {
+        const std::string v = ReadProcStatusField(field);
+        if (!v.empty()) {
+            ofs << "    [Process] " << field << ": " << v << "\n";
+        }
+    }
+#endif
+
+    ofs << "\n";
 }

--- a/Source/Diagnostics/ReducedDiags/MemoryPerRank.cpp
+++ b/Source/Diagnostics/ReducedDiags/MemoryPerRank.cpp
@@ -10,6 +10,7 @@
 #include "WarpX.H"
 
 #include <AMReX_Arena.H>
+#include <AMReX_CArena.H>
 #include <AMReX_GpuDevice.H>
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_ParmParse.H>
@@ -22,31 +23,41 @@
 #   include <unistd.h>
 #endif
 
+#include <algorithm>
+#include <cstddef>
 #include <fstream>
 #include <iomanip>
+#include <ios>
 #include <sstream>
 #include <string>
+#include <utility>
 
 
 namespace {
 
 #ifdef __linux__
-    /** Read a named field (e.g. "VmRSS") from /proc/self/status.
-     *  Returns the trimmed value (including unit) or an empty string on failure.
+    /** Read a named field (e.g. "VmRSS") from /proc/self/status and return its
+     *  numeric part as an integer kB value, or -1 on failure. All Vm* fields in
+     *  /proc/self/status are reported in kB with a trailing " kB" unit.
      */
-    std::string ReadProcStatusField (const std::string& key)
+    long ReadProcStatusKB (const std::string& key)
     {
         std::ifstream ifs("/proc/self/status");
-        if (!ifs.is_open()) { return {}; }
+        if (!ifs.is_open()) { return -1; }
         std::string line;
         const std::string prefix = key + ":";
         while (std::getline(ifs, line)) {
             if (line.rfind(prefix, 0) == 0) {
                 const auto pos = line.find_first_not_of(" \t", prefix.size());
-                return (pos == std::string::npos) ? std::string{} : line.substr(pos);
+                if (pos == std::string::npos) { return -1; }
+                try {
+                    return std::stol(line.substr(pos));
+                } catch (...) {
+                    return -1;
+                }
             }
         }
-        return {};
+        return -1;
     }
 #endif
 
@@ -71,15 +82,52 @@ namespace {
         return {"unknown"};
     }
 
+    /** Width (in decimal digits) required to represent any rank in [0, nprocs-1].
+     *  Uses a minimum width of 4 so small-rank runs still produce constant-length
+     *  filenames like MPR.0000.yaml / MPR.0001.yaml.
+     */
+    int RankFilenameWidth (int nprocs)
+    {
+        int width = 1;
+        for (int n = std::max(nprocs - 1, 0); n >= 10; n /= 10) { ++width; }
+        return std::max(width, 4);
+    }
+
+    /** Bytes → MB (float). Used throughout the YAML output so every memory
+     *  quantity is reported in the same unit at the same precision.
+     */
+    constexpr double bytes_per_mib = 1024.0 * 1024.0;
+    double BytesToMb (std::size_t bytes)
+    {
+        return static_cast<double>(bytes) / bytes_per_mib;
+    }
+
+    /** Emit one YAML "arena" block for a CArena-derived pool. No-op for non-CArena
+     *  (e.g. BArena) since those do not track usage. Numbers are written as
+     *  floating-point MB with 3-decimal precision — the caller is expected to
+     *  have set `std::fixed << std::setprecision(3)` on the stream already.
+     */
+    void EmitArenaBlock (std::ofstream& ofs, const std::string& key, amrex::Arena* arena)
+    {
+        if (arena == nullptr) { return; }
+        auto* const carena = dynamic_cast<amrex::CArena*>(arena);
+        if (carena == nullptr) { return; }
+        ofs << "  " << key << ":\n";
+        ofs << "    allocated_mb: "
+            << BytesToMb(carena->heap_space_used()) << "\n";
+        ofs << "    used_mb: "
+            << BytesToMb(carena->heap_space_actually_used()) << "\n";
+    }
+
 } // namespace
 
 // Constructor
 MemoryPerRank::MemoryPerRank (const std::string& rd_name)
     : ReducedDiags{rd_name},
-      // Default basename for the per-rank files (the MPI rank is appended
-      // by amrex::Arena::PrintUsageToFiles, giving
-      // "<m_path><m_filename>.<MPI rank>"). m_rd_name is initialized by the
-      // base ReducedDiags ctor above and is already usable here.
+      // Default basename for the per-rank YAML files (the MPI rank is appended
+      // with zero padding, giving "<m_path><m_filename>.<rank>.yaml").
+      // m_rd_name is initialized by the base ReducedDiags ctor above and is
+      // already usable here.
       m_filename{m_rd_name}
 {
     // Read per-diagnostic parameters
@@ -96,16 +144,16 @@ MemoryPerRank::MemoryPerRank (const std::string& rd_name)
     m_rank_participates =
         (amrex::ParallelDescriptor::MyProc() % m_rank_stride == 0);
 
-    // We do not use ReducedDiags::WriteToFile: per-rank files are written
-    // directly from ComputeDiags via amrex::Arena::PrintUsageToFiles, and
-    // additional per-rank information is appended there.
+    // We do not use ReducedDiags::WriteToFile: per-rank YAML files are written
+    // directly from ComputeDiags below.
     m_write_header = false;
 
     // Note: the output directory (m_path) is already created by the
     // ReducedDiags base class constructor on the IOProcessor.
 }
 
-// Compute diagnostics - writes one file per participating MPI rank
+// Compute diagnostics - writes/appends one YAML document per participating MPI
+// rank into <m_path><m_filename>.<zero-padded-rank>.yaml.
 void MemoryPerRank::ComputeDiags (int step)
 {
     // Only proceed on requested intervals
@@ -114,47 +162,104 @@ void MemoryPerRank::ComputeDiags (int step)
     // Optionally thin out the set of ranks that write a file
     if (!m_rank_participates) { return; }
 
-    // Header line printed at the top of each block
-    std::stringstream time_ss;
-    time_ss << std::scientific << std::setprecision(14)
-            << WarpX::GetInstance().gett_new(0);
-    const std::string message =
-        "Memory usage at step " + std::to_string(step+1) +
-        ", time = " + time_ss.str();
+    // Build per-rank filename with a zero-padded rank so every file has the
+    // same name length in a given run (easier globbing / sorting).
+    const int nprocs = amrex::ParallelDescriptor::NProcs();
+    const int myproc = amrex::ParallelDescriptor::MyProc();
+    const int width = RankFilenameWidth(nprocs);
+    std::ostringstream rank_ss;
+    rank_ss << std::setw(width) << std::setfill('0') << myproc;
 
-    // Let AMReX print arena usage for this rank into <file_basename>.<rank>
-    const std::string file_basename = m_path + m_filename;
-    amrex::Arena::PrintUsageToFiles(file_basename, message);
-
-    // Append additional per-rank context that AMReX does not emit
     const std::string per_rank_file =
-        file_basename + "." +
-        std::to_string(amrex::ParallelDescriptor::MyProc());
+        m_path + m_filename + "." + rank_ss.str() + ".yaml";
+
     std::ofstream ofs(per_rank_file, std::ios_base::app);
     if (!ofs.is_open()) { return; }
 
-    ofs << "    [Rank] MPI rank: "
-        << amrex::ParallelDescriptor::MyProc() << "\n";
-    ofs << "    [Rank] MPI size: "
-        << amrex::ParallelDescriptor::NProcs() << "\n";
-    ofs << "    [Rank] hostname: " << GetHostName() << "\n";
+    // Start a new YAML document for this snapshot. Every snapshot in a given
+    // file is a self-contained dict; readers can use e.g. PyYAML's
+    // `yaml.safe_load_all()` to stream them.
+    ofs << "---\n";
+
+    ofs << "step: " << (step+1) << "\n";
+
+    // Time in scientific notation (YAML accepts this as a native float).
+    ofs << "time: "
+        << std::scientific << std::setprecision(14)
+        << WarpX::GetInstance().gett_new(0) << "\n";
+    ofs.unsetf(std::ios_base::floatfield);
+
+    ofs << "mpi:\n";
+    ofs << "  rank: " << myproc << "\n";
+    ofs << "  size: " << nprocs << "\n";
+
+    // Host name is single-quoted to be safe against characters (e.g. ':') that
+    // would otherwise need YAML escaping.
+    ofs << "host:\n";
+    ofs << "  name: '" << GetHostName() << "'\n";
+
+    // From here on every memory value is emitted as floating-point MB with
+    // 3-decimal precision. Integer fields (rank, step, device_id, ...) are
+    // unaffected by `std::fixed`/`setprecision`.
+    ofs << std::fixed << std::setprecision(3);
+
 #ifdef AMREX_USE_GPU
-    ofs << "    [Rank] GPU device id: "
-        << amrex::Gpu::Device::deviceId() << "\n";
+    ofs << "gpu:\n";
+    ofs << "  device_id: " << amrex::Gpu::Device::deviceId() << "\n";
+    ofs << "  total_mb: "
+        << BytesToMb(amrex::Gpu::Device::totalGlobalMem()) << "\n";
+    ofs << "  free_mb: "
+        << BytesToMb(amrex::Gpu::Device::freeMemAvailable()) << "\n";
 #endif
 
+    // AMReX arena usage. We walk the arenas ourselves (rather than using
+    // amrex::Arena::PrintUsageToFiles) so we can emit structured YAML. We match
+    // AMReX's "only emit when distinct" logic so aliased arenas (e.g. Comms
+    // aliased to Device/Pinned) do not appear twice.
+    ofs << "arenas:\n";
+    EmitArenaBlock(ofs, "main", amrex::The_Arena());
+    if (amrex::The_Device_Arena() != nullptr &&
+        amrex::The_Device_Arena() != amrex::The_Arena())
+    {
+        EmitArenaBlock(ofs, "device", amrex::The_Device_Arena());
+    }
+    if (amrex::The_Managed_Arena() != nullptr &&
+        amrex::The_Managed_Arena() != amrex::The_Arena())
+    {
+        EmitArenaBlock(ofs, "managed", amrex::The_Managed_Arena());
+    }
+    if (amrex::The_Pinned_Arena() != nullptr) {
+        EmitArenaBlock(ofs, "pinned", amrex::The_Pinned_Arena());
+    }
+    if (amrex::The_Comms_Arena() != nullptr &&
+        amrex::The_Comms_Arena() != amrex::The_Device_Arena() &&
+        amrex::The_Comms_Arena() != amrex::The_Pinned_Arena())
+    {
+        EmitArenaBlock(ofs, "comms", amrex::The_Comms_Arena());
+    }
+
 #ifdef __linux__
-    // Host-process memory (in kB, as reported by the kernel). This captures
-    // allocations that are not tracked by AMReX arenas (MPI buffers, I/O
-    // libraries, Python, plugin libraries, ...) and is often the first
-    // thing that matters when chasing OOM errors.
-    for (const auto& field : {"VmPeak", "VmSize", "VmHWM", "VmRSS"}) {
-        const std::string v = ReadProcStatusField(field);
-        if (!v.empty()) {
-            ofs << "    [Process] " << field << ": " << v << "\n";
+    // Host-process memory as reported by the kernel. The kernel emits kB in
+    // /proc/self/status; we convert to MB to keep the YAML unit-consistent
+    // with the arena and GPU values. This captures allocations that are not
+    // tracked by AMReX arenas (MPI buffers, I/O libraries, Python, plugin
+    // libraries, ...) and is often the first thing that matters when chasing
+    // OOM errors.
+    const std::pair<const char*, const char*> vm_fields[] = {
+        {"VmPeak", "vm_peak_mb"},
+        {"VmSize", "vm_size_mb"},
+        {"VmHWM",  "vm_hwm_mb"},
+        {"VmRSS",  "vm_rss_mb"},
+    };
+    ofs << "process:\n";
+    for (const auto& [field, yaml_key] : vm_fields) {
+        const long kb = ReadProcStatusKB(field);
+        if (kb >= 0) {
+            ofs << "  " << yaml_key << ": "
+                << (static_cast<double>(kb) / 1024.0) << "\n";
         }
     }
 #endif
 
-    ofs << "\n";
+    ofs.flush();
 }

--- a/Source/Diagnostics/ReducedDiags/MemoryPerRank.cpp
+++ b/Source/Diagnostics/ReducedDiags/MemoryPerRank.cpp
@@ -75,12 +75,13 @@ namespace {
 
 // Constructor
 MemoryPerRank::MemoryPerRank (const std::string& rd_name)
-    : ReducedDiags{rd_name}
+    : ReducedDiags{rd_name},
+      // Default basename for the per-rank files (the MPI rank is appended
+      // by amrex::Arena::PrintUsageToFiles, giving
+      // "<m_path><m_filename>.<MPI rank>"). m_rd_name is initialized by the
+      // base ReducedDiags ctor above and is already usable here.
+      m_filename{m_rd_name}
 {
-    // Default basename for the per-rank files (the MPI rank is appended by
-    // amrex::Arena::PrintUsageToFiles, giving "<m_path><m_filename>.<rank>").
-    m_filename = m_rd_name;
-
     // Read per-diagnostic parameters
     const amrex::ParmParse pp_name(m_rd_name);
 

--- a/Source/Diagnostics/ReducedDiags/MemoryPerRank.cpp
+++ b/Source/Diagnostics/ReducedDiags/MemoryPerRank.cpp
@@ -133,8 +133,10 @@ void MemoryPerRank::ComputeDiags (int step)
     std::ofstream ofs(per_rank_file, std::ios_base::app);
     if (!ofs.is_open()) { return; }
 
-    ofs << "    [Rank] MPI rank: " << amrex::ParallelDescriptor::MyProc()
-        << " / " << amrex::ParallelDescriptor::NProcs() << "\n";
+    ofs << "    [Rank] MPI rank: "
+        << amrex::ParallelDescriptor::MyProc() << "\n";
+    ofs << "    [Rank] MPI size: "
+        << amrex::ParallelDescriptor::NProcs() << "\n";
     ofs << "    [Rank] hostname: " << GetHostName() << "\n";
 #ifdef AMREX_USE_GPU
     ofs << "    [Rank] GPU device id: "

--- a/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/MultiReducedDiags.cpp
@@ -19,6 +19,7 @@
 #include "FieldReduction.H"
 #include "LoadBalanceCosts.H"
 #include "LoadBalanceEfficiency.H"
+#include "MemoryPerRank.H"
 #include "ParticleEnergy.H"
 #include "ParticleExtrema.H"
 #include "ParticleHistogram.H"
@@ -74,6 +75,7 @@ MultiReducedDiags::MultiReducedDiags ()
             {"FieldReduction",        [](CS s){return std::make_unique<FieldReduction>(s);}},
             {"LoadBalanceCosts",      [](CS s){return std::make_unique<LoadBalanceCosts>(s);}},
             {"LoadBalanceEfficiency", [](CS s){return std::make_unique<LoadBalanceEfficiency>(s);}},
+            {"MemoryPerRank",         [](CS s){return std::make_unique<MemoryPerRank>(s);}},
             {"RhoMaximum",            [](CS s){return std::make_unique<RhoMaximum>(s);}},
             {"Timestep",              [](CS s){return std::make_unique<Timestep>(s);}}
     };

--- a/Tools/PostProcessing/read_memory_per_rank.py
+++ b/Tools/PostProcessing/read_memory_per_rank.py
@@ -172,8 +172,9 @@ def _pick_mode(n_ranks: int) -> str:
     return "heatmap"
 
 
-def _draw_panel(ax, df: pd.DataFrame, x: str, y: str, ylabel: str,
-                mode: str, n_ranks: int):
+def _draw_panel(
+    ax, df: pd.DataFrame, x: str, y: str, ylabel: str, mode: str, n_ranks: int
+):
     """Render a single per-rank time-series panel in the requested mode.
 
     The panel renders a quantity ``y`` over an axis ``x`` (typically
@@ -195,25 +196,33 @@ def _draw_panel(ax, df: pd.DataFrame, x: str, y: str, ylabel: str,
         # Bold min/median/max envelopes across ranks at each x.
         agg = df.groupby(x)[y].agg(["min", "median", "max"]).dropna()
         if not agg.empty:
-            ax.plot(agg.index, agg["max"], color="red",
-                    linewidth=2, label="max")
-            ax.plot(agg.index, agg["median"], color="black",
-                    linewidth=1.5, label="median")
-            ax.plot(agg.index, agg["min"], color="blue",
-                    linewidth=1, alpha=0.7, label="min")
+            ax.plot(agg.index, agg["max"], color="red", linewidth=2, label="max")
+            ax.plot(
+                agg.index, agg["median"], color="black", linewidth=1.5, label="median"
+            )
+            ax.plot(
+                agg.index, agg["min"], color="blue", linewidth=1, alpha=0.7, label="min"
+            )
             ax.legend(loc="best", fontsize=8)
         ax.set_ylabel(ylabel)
     elif mode == "heatmap":
         pivot = df.pivot_table(index="rank", columns=x, values=y, aggfunc="last")
         if pivot.empty:
-            ax.text(0.5, 0.5, "no data", ha="center", va="center",
-                    transform=ax.transAxes)
+            ax.text(
+                0.5, 0.5, "no data", ha="center", va="center", transform=ax.transAxes
+            )
             ax.set_ylabel("rank")
             return
         im = ax.imshow(
-            pivot.values, aspect="auto", origin="lower",
-            extent=[float(pivot.columns.min()), float(pivot.columns.max()),
-                    float(pivot.index.min()), float(pivot.index.max())],
+            pivot.values,
+            aspect="auto",
+            origin="lower",
+            extent=[
+                float(pivot.columns.min()),
+                float(pivot.columns.max()),
+                float(pivot.index.min()),
+                float(pivot.index.max()),
+            ],
         )
         plt.colorbar(im, ax=ax, label=ylabel)
         ax.set_ylabel("rank")
@@ -272,54 +281,62 @@ def plot(
     if mode == "auto":
         mode = _pick_mode(n_ranks)
 
-    has_gpu = (
-        "gpu_total_mb" in df.columns and df["gpu_total_mb"].notna().any()
-    )
+    has_gpu = "gpu_total_mb" in df.columns and df["gpu_total_mb"].notna().any()
 
     # Build the list of panels to draw, top to bottom.
     panels: list[dict] = []
 
     if has_gpu:
         df["gpu_used_mb"] = df["gpu_total_mb"] - df["gpu_free_mb"]
-        panels.append({
-            "y": "gpu_used_mb",
-            "ylabel": "GPU memory used (MB)\n(total \u2212 free)",
-            "ceiling_col": "gpu_total_mb",
-        })
+        panels.append(
+            {
+                "y": "gpu_used_mb",
+                "ylabel": "GPU memory used (MB)\n(total \u2212 free)",
+                "ceiling_col": "gpu_total_mb",
+            }
+        )
         device_cols = [c for c in _GPU_SIDE_ARENAS if c in df.columns]
         if device_cols:
             df["gpu_arena_total_mb"] = df[device_cols].sum(axis=1, min_count=1)
-            panels.append({
-                "y": "gpu_arena_total_mb",
-                "ylabel": "Device-side AMReX arenas\nallocated (MB)",
-            })
+            panels.append(
+                {
+                    "y": "gpu_arena_total_mb",
+                    "ylabel": "Device-side AMReX arenas\nallocated (MB)",
+                }
+            )
     else:
         alloc_cols = [
-            c for c in df.columns
+            c
+            for c in df.columns
             if c.startswith("arena_") and c.endswith("_allocated_mb")
         ]
         df["arena_total_allocated_mb"] = df[alloc_cols].sum(axis=1, min_count=1)
-        panels.append({
-            "y": "arena_total_allocated_mb",
-            "ylabel": "AMReX arenas total\nallocated (MB)",
-        })
+        panels.append(
+            {
+                "y": "arena_total_allocated_mb",
+                "ylabel": "AMReX arenas total\nallocated (MB)",
+            }
+        )
 
     # Host-process panel: always last when present.
     has_rss = "vm_rss_mb" in df.columns and df["vm_rss_mb"].notna().any()
     has_hwm = "vm_hwm_mb" in df.columns and df["vm_hwm_mb"].notna().any()
     if has_rss:
-        panels.append({
-            "y": "vm_rss_mb",
-            "ylabel": (
-                "Process memory (MB)\nsolid = VmRSS, dashed = VmHWM"
-                if has_hwm and mode == "spaghetti"
-                else "Process VmRSS (MB)"
-            ),
-            "extra_y": "vm_hwm_mb" if (has_hwm and mode == "spaghetti") else None,
-        })
+        panels.append(
+            {
+                "y": "vm_rss_mb",
+                "ylabel": (
+                    "Process memory (MB)\nsolid = VmRSS, dashed = VmHWM"
+                    if has_hwm and mode == "spaghetti"
+                    else "Process VmRSS (MB)"
+                ),
+                "extra_y": "vm_hwm_mb" if (has_hwm and mode == "spaghetti") else None,
+            }
+        )
 
     fig, axes = plt.subplots(
-        len(panels), 1,
+        len(panels),
+        1,
         figsize=(10, 3 + 2.5 * len(panels)),
         sharex=(mode != "heatmap"),
         squeeze=False,
@@ -327,8 +344,7 @@ def plot(
     axes = axes[:, 0]
 
     for ax, panel in zip(axes, panels):
-        _draw_panel(ax, df, "step", panel["y"], panel["ylabel"],
-                    mode, n_ranks)
+        _draw_panel(ax, df, "step", panel["y"], panel["ylabel"], mode, n_ranks)
         ax.grid(True, alpha=0.3)
 
         # Optional ceiling line (e.g. GPU total memory). Only meaningful in
@@ -336,8 +352,13 @@ def plot(
         ceiling_col = panel.get("ceiling_col")
         if ceiling_col and ceiling_col in df.columns and mode != "heatmap":
             ceiling = df[ceiling_col].median()
-            ax.axhline(ceiling, color="grey", linestyle="--", linewidth=1,
-                       label=f"GPU total ({ceiling:.0f} MB)")
+            ax.axhline(
+                ceiling,
+                color="grey",
+                linestyle="--",
+                linewidth=1,
+                label=f"GPU total ({ceiling:.0f} MB)",
+            )
             # Re-draw legend so the ceiling line shows up alongside any
             # per-rank / band labels.
             handles, labels = ax.get_legend_handles_labels()
@@ -348,8 +369,7 @@ def plot(
         extra_y = panel.get("extra_y")
         if extra_y and extra_y in df.columns and mode == "spaghetti":
             for _, g in df.groupby("rank"):
-                ax.plot(g["step"], g[extra_y], linestyle="--",
-                        alpha=0.5, linewidth=0.8)
+                ax.plot(g["step"], g[extra_y], linestyle="--", alpha=0.5, linewidth=0.8)
 
     # In heatmap mode the X axis on every panel shows step; in others only
     # the bottom panel labels it (sharex collapses the rest).

--- a/Tools/PostProcessing/read_memory_per_rank.py
+++ b/Tools/PostProcessing/read_memory_per_rank.py
@@ -6,7 +6,26 @@ Each participating MPI rank writes one file named
 ``<path>/<file_prefix>.<zero-padded rank>.yaml`` containing a stream of YAML
 documents (one per diagnostic interval). This helper loads all rank files
 from a directory into a tidy ``pandas.DataFrame`` and optionally produces
-summary plots of total arena usage and host-process memory over time.
+summary plots tailored to the run type:
+
+* On GPU builds the headline panel is **GPU memory used per rank**
+  (``gpu_total_mb - gpu_free_mb``), the quantity that actually drives OOM
+  on production GPU clusters. A second panel breaks down the device-resident
+  AMReX arenas (``main`` + ``device`` + ``managed``), so a divergence
+  between the two panels means memory pressure outside AMReX (CUDA runtime,
+  MPI staging, plugin libraries, ...).
+* On CPU-only builds the headline panel is the total AMReX arena
+  allocation per rank.
+* Both build types also get a host-process panel (``VmRSS`` / ``VmHWM``).
+
+The per-rank rendering mode is auto-detected from the rank count and can
+be overridden via the ``mode`` parameter / ``--mode`` flag:
+
+* ``spaghetti`` -- one labelled curve per rank (good for <= 32 ranks).
+* ``band`` -- faint per-rank background, with bold min/median/max
+  envelopes overlaid (good for ~32-256 ranks).
+* ``heatmap`` -- rank on the Y axis, step on the X axis, value encoded as
+  color (good for >256 ranks; one heatmap per panel).
 
 Requires: pyyaml, pandas, matplotlib.
 
@@ -14,12 +33,13 @@ Usage (as a library)::
 
     import read_memory_per_rank as mpr
     df = mpr.load("diags/reducedfiles/MemoryPerRank/", prefix="MPR")
-    fig = mpr.plot(df)
+    fig = mpr.plot(df)              # mode="auto"
+    fig = mpr.plot(df, mode="band") # force a specific mode
 
 Usage (as a script)::
 
     python3 read_memory_per_rank.py diags/reducedfiles/MemoryPerRank/ \\
-        --prefix MPR --output mpr_timeline.png
+        --prefix MPR --output mpr_timeline.png --mode auto
 """
 
 from __future__ import annotations
@@ -133,30 +153,111 @@ def load(directory: str, prefix: str = "MPR") -> pd.DataFrame:
     return df
 
 
+# Arenas that are device-resident on a GPU build (i.e. their allocations
+# count toward GPU memory pressure). `pinned` and `comms` are host-side
+# staging buffers and intentionally excluded from this list.
+_GPU_SIDE_ARENAS = (
+    "arena_main_allocated_mb",
+    "arena_device_allocated_mb",
+    "arena_managed_allocated_mb",
+)
+
+
+def _pick_mode(n_ranks: int) -> str:
+    """Auto-pick a rendering mode based on rank count."""
+    if n_ranks <= 32:
+        return "spaghetti"
+    if n_ranks <= 256:
+        return "band"
+    return "heatmap"
+
+
+def _draw_panel(ax, df: pd.DataFrame, x: str, y: str, ylabel: str,
+                mode: str, n_ranks: int):
+    """Render a single per-rank time-series panel in the requested mode.
+
+    The panel renders a quantity ``y`` over an axis ``x`` (typically
+    ``"step"``). The Y axis (or colorbar in heatmap mode) is labelled
+    with ``ylabel``.
+    """
+    import matplotlib.pyplot as plt  # local: keeps module import headless
+
+    if mode == "spaghetti":
+        for rank, g in df.groupby("rank"):
+            ax.plot(g[x], g[y], label=f"rank {rank}", linewidth=1)
+        if n_ranks <= 16:
+            ax.legend(loc="best", fontsize=8, ncol=2)
+        ax.set_ylabel(ylabel)
+    elif mode == "band":
+        # Faint per-rank background lines.
+        for _, g in df.groupby("rank"):
+            ax.plot(g[x], g[y], color="grey", alpha=0.15, linewidth=0.7)
+        # Bold min/median/max envelopes across ranks at each x.
+        agg = df.groupby(x)[y].agg(["min", "median", "max"]).dropna()
+        if not agg.empty:
+            ax.plot(agg.index, agg["max"], color="red",
+                    linewidth=2, label="max")
+            ax.plot(agg.index, agg["median"], color="black",
+                    linewidth=1.5, label="median")
+            ax.plot(agg.index, agg["min"], color="blue",
+                    linewidth=1, alpha=0.7, label="min")
+            ax.legend(loc="best", fontsize=8)
+        ax.set_ylabel(ylabel)
+    elif mode == "heatmap":
+        pivot = df.pivot_table(index="rank", columns=x, values=y, aggfunc="last")
+        if pivot.empty:
+            ax.text(0.5, 0.5, "no data", ha="center", va="center",
+                    transform=ax.transAxes)
+            ax.set_ylabel("rank")
+            return
+        im = ax.imshow(
+            pivot.values, aspect="auto", origin="lower",
+            extent=[float(pivot.columns.min()), float(pivot.columns.max()),
+                    float(pivot.index.min()), float(pivot.index.max())],
+        )
+        plt.colorbar(im, ax=ax, label=ylabel)
+        ax.set_ylabel("rank")
+    else:
+        raise ValueError(
+            f"Unknown mode {mode!r}; expected one of: auto, spaghetti, band, heatmap."
+        )
+
+
 def plot(
     df: pd.DataFrame,
     output: str | None = None,
     show: bool = False,
+    mode: str = "auto",
 ):
-    """Plot ``MemoryPerRank`` time series for all ranks.
+    """Plot ``MemoryPerRank`` time series, with panels picked from the data.
 
-    Creates two stacked panels:
+    On a **GPU build** (when the YAML carries a ``gpu:`` block):
 
-    * Top: per-rank total AMReX arena memory *allocated* (MB), with one curve
-      per rank. This is the device/host memory that AMReX explicitly reserved.
-    * Bottom: per-rank host-process resident memory (``VmRSS`` in MB) and its
-      high-water mark (``VmHWM``). This captures everything including things
-      AMReX arenas don't track.
+    * Top: per-rank GPU memory used (``gpu_total_mb - gpu_free_mb``) with
+      a dashed line at the (median) device total. This is the panel that
+      actually answers "how close are we to OOM?".
+    * Middle: per-rank device-resident AMReX arenas, summed
+      (``main + device + managed``). Diverging from the top panel means
+      memory pressure that AMReX does not see (CUDA runtime, MPI staging,
+      plugin libraries, ...).
+    * Bottom: per-rank host-process memory (``VmRSS`` / ``VmHWM``).
+
+    On a **CPU-only build** the GPU panels are skipped and the figure has
+    only the total-arena and host-process panels.
 
     Parameters
     ----------
     df
         DataFrame as returned by :func:`load`.
     output
-        If given, write the figure to this path (png/pdf/svg). Otherwise only
-        return the Figure object.
+        If given, write the figure to this path (png/pdf/svg). Otherwise
+        only return the Figure object.
     show
         If True, call ``plt.show()`` at the end.
+    mode
+        Rendering mode for per-rank curves:
+        ``"auto"`` (default) picks ``spaghetti``, ``band``, or ``heatmap``
+        based on rank count; or pass one of those names directly.
 
     Returns
     -------
@@ -166,57 +267,102 @@ def plot(
     # be imported in headless contexts without pulling GUI deps.
     import matplotlib.pyplot as plt
 
-    alloc_cols = [
-        c for c in df.columns if c.startswith("arena_") and c.endswith("_allocated_mb")
-    ]
     df = df.copy()
-    df["arena_total_allocated_mb"] = df[alloc_cols].sum(axis=1, min_count=1)
+    n_ranks = df["rank"].nunique()
+    if mode == "auto":
+        mode = _pick_mode(n_ranks)
 
-    fig, (ax_arena, ax_proc) = plt.subplots(2, 1, figsize=(10, 7), sharex=True)
+    has_gpu = (
+        "gpu_total_mb" in df.columns and df["gpu_total_mb"].notna().any()
+    )
 
-    # Top: AMReX arenas, one line per rank.
-    for rank, g in df.groupby("rank"):
-        ax_arena.plot(g["step"], g["arena_total_allocated_mb"], label=f"rank {rank}")
-    ax_arena.set_ylabel("AMReX arenas total\nallocated (MB)")
-    ax_arena.grid(True, alpha=0.3)
-    if df["rank"].nunique() <= 16:
-        ax_arena.legend(loc="best", fontsize=8, ncol=2)
+    # Build the list of panels to draw, top to bottom.
+    panels: list[dict] = []
 
-    # Bottom: process memory (RSS solid, HWM dashed). Values already in MB.
+    if has_gpu:
+        df["gpu_used_mb"] = df["gpu_total_mb"] - df["gpu_free_mb"]
+        panels.append({
+            "y": "gpu_used_mb",
+            "ylabel": "GPU memory used (MB)\n(total \u2212 free)",
+            "ceiling_col": "gpu_total_mb",
+        })
+        device_cols = [c for c in _GPU_SIDE_ARENAS if c in df.columns]
+        if device_cols:
+            df["gpu_arena_total_mb"] = df[device_cols].sum(axis=1, min_count=1)
+            panels.append({
+                "y": "gpu_arena_total_mb",
+                "ylabel": "Device-side AMReX arenas\nallocated (MB)",
+            })
+    else:
+        alloc_cols = [
+            c for c in df.columns
+            if c.startswith("arena_") and c.endswith("_allocated_mb")
+        ]
+        df["arena_total_allocated_mb"] = df[alloc_cols].sum(axis=1, min_count=1)
+        panels.append({
+            "y": "arena_total_allocated_mb",
+            "ylabel": "AMReX arenas total\nallocated (MB)",
+        })
+
+    # Host-process panel: always last when present.
     has_rss = "vm_rss_mb" in df.columns and df["vm_rss_mb"].notna().any()
     has_hwm = "vm_hwm_mb" in df.columns and df["vm_hwm_mb"].notna().any()
+    if has_rss:
+        panels.append({
+            "y": "vm_rss_mb",
+            "ylabel": (
+                "Process memory (MB)\nsolid = VmRSS, dashed = VmHWM"
+                if has_hwm and mode == "spaghetti"
+                else "Process VmRSS (MB)"
+            ),
+            "extra_y": "vm_hwm_mb" if (has_hwm and mode == "spaghetti") else None,
+        })
 
-    if has_rss or has_hwm:
-        for rank, g in df.groupby("rank"):
-            color = None
-            if has_rss:
-                (line,) = ax_proc.plot(
-                    g["step"], g["vm_rss_mb"], label=f"rank {rank} VmRSS"
-                )
-                color = line.get_color()
-            if has_hwm:
-                ax_proc.plot(
-                    g["step"],
-                    g["vm_hwm_mb"],
-                    linestyle="--",
-                    color=color,
-                    alpha=0.7,
-                )
-        ax_proc.set_ylabel("Process memory (MB)\nsolid = VmRSS, dashed = VmHWM")
+    fig, axes = plt.subplots(
+        len(panels), 1,
+        figsize=(10, 3 + 2.5 * len(panels)),
+        sharex=(mode != "heatmap"),
+        squeeze=False,
+    )
+    axes = axes[:, 0]
+
+    for ax, panel in zip(axes, panels):
+        _draw_panel(ax, df, "step", panel["y"], panel["ylabel"],
+                    mode, n_ranks)
+        ax.grid(True, alpha=0.3)
+
+        # Optional ceiling line (e.g. GPU total memory). Only meaningful in
+        # spaghetti / band modes; in heatmap the colorbar already shows scale.
+        ceiling_col = panel.get("ceiling_col")
+        if ceiling_col and ceiling_col in df.columns and mode != "heatmap":
+            ceiling = df[ceiling_col].median()
+            ax.axhline(ceiling, color="grey", linestyle="--", linewidth=1,
+                       label=f"GPU total ({ceiling:.0f} MB)")
+            # Re-draw legend so the ceiling line shows up alongside any
+            # per-rank / band labels.
+            handles, labels = ax.get_legend_handles_labels()
+            if handles:
+                ax.legend(handles, labels, loc="best", fontsize=8)
+
+        # Spaghetti VmHWM overlay (dashed).
+        extra_y = panel.get("extra_y")
+        if extra_y and extra_y in df.columns and mode == "spaghetti":
+            for _, g in df.groupby("rank"):
+                ax.plot(g["step"], g[extra_y], linestyle="--",
+                        alpha=0.5, linewidth=0.8)
+
+    # In heatmap mode the X axis on every panel shows step; in others only
+    # the bottom panel labels it (sharex collapses the rest).
+    if mode == "heatmap":
+        for ax in axes:
+            ax.set_xlabel("step")
     else:
-        ax_proc.text(
-            0.5,
-            0.5,
-            "No /proc/self/status data (non-Linux run?)",
-            ha="center",
-            va="center",
-            transform=ax_proc.transAxes,
-        )
+        axes[-1].set_xlabel("step")
 
-    ax_proc.set_xlabel("step")
-    ax_proc.grid(True, alpha=0.3)
-
-    fig.suptitle("WarpX MemoryPerRank diagnostic", y=0.995)
+    fig.suptitle(
+        f"WarpX MemoryPerRank \u2014 {n_ranks} ranks, mode={mode}",
+        y=0.995,
+    )
     fig.tight_layout()
 
     if output:
@@ -255,12 +401,24 @@ def _cli(argv: list[str]) -> int:
         action="store_true",
         help="Open the plot in an interactive window.",
     )
+    parser.add_argument(
+        "--mode",
+        choices=("auto", "spaghetti", "band", "heatmap"),
+        default="auto",
+        help=(
+            "Per-rank rendering mode. 'auto' picks: spaghetti for <=32 ranks, "
+            "band for <=256 ranks, heatmap above. 'spaghetti' = one labelled "
+            "curve per rank. 'band' = faint per-rank lines plus bold "
+            "min/median/max envelopes. 'heatmap' = rank x step image with "
+            "value encoded as color (one heatmap per panel)."
+        ),
+    )
     args = parser.parse_args(argv)
 
     df = load(args.directory, prefix=args.prefix)
     if args.csv:
         df.to_csv(args.csv, index=False)
-    plot(df, output=args.output, show=args.show)
+    plot(df, output=args.output, show=args.show, mode=args.mode)
     return 0
 
 

--- a/Tools/PostProcessing/read_memory_per_rank.py
+++ b/Tools/PostProcessing/read_memory_per_rank.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""
+Read and visualize WarpX ``MemoryPerRank`` reduced-diagnostic output.
+
+Each participating MPI rank writes one file named
+``<path>/<file_prefix>.<zero-padded rank>.yaml`` containing a stream of YAML
+documents (one per diagnostic interval). This helper loads all rank files
+from a directory into a tidy ``pandas.DataFrame`` and optionally produces
+summary plots of total arena usage and host-process memory over time.
+
+Requires: pyyaml, pandas, matplotlib.
+
+Usage (as a library)::
+
+    import read_memory_per_rank as mpr
+    df = mpr.load("diags/reducedfiles/MemoryPerRank/", prefix="MPR")
+    fig = mpr.plot(df)
+
+Usage (as a script)::
+
+    python3 read_memory_per_rank.py diags/reducedfiles/MemoryPerRank/ \\
+        --prefix MPR --output mpr_timeline.png
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import sys
+from typing import Any, Iterable
+
+import pandas as pd
+import yaml
+
+
+# Columns we want to pull up to top-level for easy plotting. All MemoryPerRank
+# memory values are emitted as float MB with 3-decimal precision.
+_PROCESS_KEYS = ["vm_peak_mb", "vm_size_mb", "vm_hwm_mb", "vm_rss_mb"]
+# Arenas that AMReX may or may not emit as a distinct block. Missing arenas
+# are simply not present in the DataFrame column list.
+_ARENA_KEYS = ["main", "device", "managed", "pinned", "comms"]
+
+
+def _flatten_snapshot(snap: dict[str, Any], rank_file: str) -> dict[str, Any]:
+    """Flatten one YAML snapshot into a single-row dict suitable for a DataFrame."""
+    row: dict[str, Any] = {
+        "file": os.path.basename(rank_file),
+        "step": snap.get("step"),
+        "time": snap.get("time"),
+    }
+
+    mpi = snap.get("mpi", {}) or {}
+    row["rank"] = mpi.get("rank")
+    row["nprocs"] = mpi.get("size")
+
+    host = snap.get("host", {}) or {}
+    row["hostname"] = host.get("name")
+
+    gpu = snap.get("gpu", {}) or {}
+    row["gpu_device_id"] = gpu.get("device_id")
+    row["gpu_total_mb"] = gpu.get("total_mb")
+    row["gpu_free_mb"] = gpu.get("free_mb")
+
+    arenas = snap.get("arenas", {}) or {}
+    for name in _ARENA_KEYS:
+        a = arenas.get(name)
+        if isinstance(a, dict):
+            row[f"arena_{name}_allocated_mb"] = a.get("allocated_mb")
+            row[f"arena_{name}_used_mb"] = a.get("used_mb")
+
+    proc = snap.get("process", {}) or {}
+    for k in _PROCESS_KEYS:
+        row[k] = proc.get(k)
+
+    return row
+
+
+def _iter_rank_files(directory: str, prefix: str) -> Iterable[str]:
+    """All ``<directory>/<prefix>.*.yaml`` files in numeric-rank order."""
+    pattern = os.path.join(directory, f"{prefix}.*.yaml")
+    files = glob.glob(pattern)
+    # Filenames are zero-padded, so a lexicographic sort is rank-order too.
+    files.sort()
+    return files
+
+
+def load(directory: str, prefix: str = "MPR") -> pd.DataFrame:
+    """Load all ``MemoryPerRank`` YAML files in *directory* into a DataFrame.
+
+    Parameters
+    ----------
+    directory
+        Path to the directory containing the per-rank files, typically
+        ``diags/reducedfiles/<reduced_diags_name>/``.
+    prefix
+        File prefix used by the diagnostic, matching ``<rd>.file_prefix``
+        (default ``"MPR"``).
+
+    Returns
+    -------
+    pandas.DataFrame
+        One row per (rank, step). Columns include ``step``, ``time``, ``rank``,
+        ``hostname``, ``gpu_device_id``, ``gpu_total_mb``, ``gpu_free_mb``,
+        ``arena_<name>_allocated_mb`` / ``arena_<name>_used_mb`` for each arena
+        reported, and ``vm_peak_mb`` / ``vm_size_mb`` / ``vm_hwm_mb`` /
+        ``vm_rss_mb`` (Linux only). All memory values are in MB.
+    """
+    rows: list[dict[str, Any]] = []
+    n_files = 0
+    for f in _iter_rank_files(directory, prefix):
+        n_files += 1
+        with open(f) as fh:
+            for snap in yaml.safe_load_all(fh):
+                if snap is None:
+                    # Empty document (can happen if a file ends with `---\n`).
+                    continue
+                rows.append(_flatten_snapshot(snap, f))
+
+    if n_files == 0:
+        raise FileNotFoundError(
+            f"No files match {os.path.join(directory, prefix)}.*.yaml; "
+            "check the directory and prefix."
+        )
+    if not rows:
+        raise ValueError(
+            f"Found {n_files} MemoryPerRank files in {directory} but no YAML "
+            "documents inside them; was the diagnostic ever triggered?"
+        )
+
+    df = pd.DataFrame(rows)
+    # Stable ordering helps anyone iterating per-rank time series.
+    df = df.sort_values(["rank", "step"]).reset_index(drop=True)
+    return df
+
+
+def plot(
+    df: pd.DataFrame,
+    output: str | None = None,
+    show: bool = False,
+):
+    """Plot ``MemoryPerRank`` time series for all ranks.
+
+    Creates two stacked panels:
+
+    * Top: per-rank total AMReX arena memory *allocated* (MB), with one curve
+      per rank. This is the device/host memory that AMReX explicitly reserved.
+    * Bottom: per-rank host-process resident memory (``VmRSS`` in MB) and its
+      high-water mark (``VmHWM``). This captures everything including things
+      AMReX arenas don't track.
+
+    Parameters
+    ----------
+    df
+        DataFrame as returned by :func:`load`.
+    output
+        If given, write the figure to this path (png/pdf/svg). Otherwise only
+        return the Figure object.
+    show
+        If True, call ``plt.show()`` at the end.
+
+    Returns
+    -------
+    matplotlib.figure.Figure
+    """
+    # Keep the matplotlib import inside the function so the module itself can
+    # be imported in headless contexts without pulling GUI deps.
+    import matplotlib.pyplot as plt
+
+    alloc_cols = [c for c in df.columns if c.startswith("arena_") and c.endswith("_allocated_mb")]
+    df = df.copy()
+    df["arena_total_allocated_mb"] = df[alloc_cols].sum(axis=1, min_count=1)
+
+    fig, (ax_arena, ax_proc) = plt.subplots(2, 1, figsize=(10, 7), sharex=True)
+
+    # Top: AMReX arenas, one line per rank.
+    for rank, g in df.groupby("rank"):
+        ax_arena.plot(g["step"], g["arena_total_allocated_mb"], label=f"rank {rank}")
+    ax_arena.set_ylabel("AMReX arenas total\nallocated (MB)")
+    ax_arena.grid(True, alpha=0.3)
+    if df["rank"].nunique() <= 16:
+        ax_arena.legend(loc="best", fontsize=8, ncol=2)
+
+    # Bottom: process memory (RSS solid, HWM dashed). Values already in MB.
+    has_rss = "vm_rss_mb" in df.columns and df["vm_rss_mb"].notna().any()
+    has_hwm = "vm_hwm_mb" in df.columns and df["vm_hwm_mb"].notna().any()
+
+    if has_rss or has_hwm:
+        for rank, g in df.groupby("rank"):
+            color = None
+            if has_rss:
+                (line,) = ax_proc.plot(
+                    g["step"], g["vm_rss_mb"], label=f"rank {rank} VmRSS"
+                )
+                color = line.get_color()
+            if has_hwm:
+                ax_proc.plot(
+                    g["step"],
+                    g["vm_hwm_mb"],
+                    linestyle="--",
+                    color=color,
+                    alpha=0.7,
+                )
+        ax_proc.set_ylabel("Process memory (MB)\nsolid = VmRSS, dashed = VmHWM")
+    else:
+        ax_proc.text(
+            0.5,
+            0.5,
+            "No /proc/self/status data (non-Linux run?)",
+            ha="center",
+            va="center",
+            transform=ax_proc.transAxes,
+        )
+
+    ax_proc.set_xlabel("step")
+    ax_proc.grid(True, alpha=0.3)
+
+    fig.suptitle("WarpX MemoryPerRank diagnostic", y=0.995)
+    fig.tight_layout()
+
+    if output:
+        fig.savefig(output, dpi=150, bbox_inches="tight")
+    if show:
+        plt.show()
+    return fig
+
+
+def _cli(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Read WarpX MemoryPerRank YAML output and plot per-rank memory over time."
+    )
+    parser.add_argument(
+        "directory",
+        help="Path to the MemoryPerRank output directory "
+        "(typically diags/reducedfiles/<reduced_diags_name>/).",
+    )
+    parser.add_argument(
+        "--prefix",
+        default="MPR",
+        help="File prefix used by the diagnostic (default: MPR).",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Write the figure to this path instead of only returning it.",
+    )
+    parser.add_argument(
+        "--csv",
+        default=None,
+        help="Also export the flattened DataFrame to this CSV path.",
+    )
+    parser.add_argument(
+        "--show",
+        action="store_true",
+        help="Open the plot in an interactive window.",
+    )
+    args = parser.parse_args(argv)
+
+    df = load(args.directory, prefix=args.prefix)
+    if args.csv:
+        df.to_csv(args.csv, index=False)
+    plot(df, output=args.output, show=args.show)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_cli(sys.argv[1:]))

--- a/Tools/PostProcessing/read_memory_per_rank.py
+++ b/Tools/PostProcessing/read_memory_per_rank.py
@@ -33,7 +33,6 @@ from typing import Any, Iterable
 import pandas as pd
 import yaml
 
-
 # Columns we want to pull up to top-level for easy plotting. All MemoryPerRank
 # memory values are emitted as float MB with 3-decimal precision.
 _PROCESS_KEYS = ["vm_peak_mb", "vm_size_mb", "vm_hwm_mb", "vm_rss_mb"]
@@ -167,7 +166,9 @@ def plot(
     # be imported in headless contexts without pulling GUI deps.
     import matplotlib.pyplot as plt
 
-    alloc_cols = [c for c in df.columns if c.startswith("arena_") and c.endswith("_allocated_mb")]
+    alloc_cols = [
+        c for c in df.columns if c.startswith("arena_") and c.endswith("_allocated_mb")
+    ]
     df = df.copy()
     df["arena_total_allocated_mb"] = df[alloc_cols].sum(axis=1, min_count=1)
 


### PR DESCRIPTION
This PR adds a new reduced diagnostic that uses AMReX's `PrintUsageToFiles` and produces a text file for each rank with detailed memory usage information.

A demonstration of the new diagnostic was added to the laser-ion acceleration example, where it can become helpful in debugging given that the computational load imbalance is high and on larger production cases one might see local out-of-memory errors.


The output looks like this, e.g. in `MPR.0000` from the laser-ion example. It is in YAML format and fully parseable.
```
---
step: 0
time: 0.00000000000000e+00
mpi:
  rank: 0
  size: 4
host:
  name: 'nid002112'
gpu:
  device_id: 0
  total_mb: 40441.438
  free_mb: 9058.688
arenas:
  main:
    allocated_mb: 30330.500
    used_mb: 51.125
  managed:
    allocated_mb: 8.000
    used_mb: 0.250
  pinned:
    allocated_mb: 8.000
    used_mb: 0.000
  comms:
    allocated_mb: 8.000
    used_mb: 0.000
process:
  vm_peak_mb: 73430.281
  vm_size_mb: 73430.281
  vm_hwm_mb: 419.633
  vm_rss_mb: 419.633
---
step: 100
time: 1.08306469330691e-14
...
```