### PR TITLE
Fix new bug in particle BTD

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -1459,8 +1459,8 @@ BTDiagnostics::InitializeParticleBuffer ()
         m_totalParticles_in_buffer[i].resize(m_output_species_names.size());
         for (int isp = 0; isp < m_particles_buffer[i].size(); ++isp) {
             m_totalParticles_in_buffer[i][isp] = 0;
-            m_particles_buffer[i][isp] = std::make_unique<PinnedMemoryParticleContainer>(mpc.GetParticleContainer(isp).make_alike<amrex::PinnedArenaAllocator>());
             const int idx = mpc.getSpeciesID(m_output_species_names[isp]);
+            m_particles_buffer[i][isp] = std::make_unique<PinnedMemoryParticleContainer>(mpc.GetParticleContainer(idx).make_alike<amrex::PinnedArenaAllocator>());
 
             // SoA component names
             {


### PR DESCRIPTION
This fixes a new issue in the back-transformed diagnostics for particles that was introduced in #5571. The problem affected runs where not all particle species were written into the diagnostic. In that case, the index of the particle buffer and the index of the species in the `MultiParticleContainer` are not the same.