### PR TITLE
CI: Fix Post-Job Ccache Error

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -19,7 +19,6 @@ jobs:
 - job:
   # FIXME remove unused variables
   variables:
-    CCACHE_DIR: $(Pipeline.Workspace)/ccache
     BLASPP_HOME: '/usr/local'
     CEI_SUDO: 'sudo'
     CEI_TMP: '/tmp/cei'
@@ -53,18 +52,12 @@ jobs:
   timeoutInMinutes: 240
 
   steps:
-  - bash: |
-      set -o nounset errexit pipefail
-      sudo apt update
-      sudo apt install -y ccache
-      ccache --set-config=max_size=10.0G
-      # update PATH to use linked versions of gcc, cc, etc.
-      echo "##vso[task.prependpath]/usr/lib/ccache"
-      displayName: 'Install ccache'
-
   # Ccache caching:
   # - once stored under a key, they become immutable (even if cache content changes)
   # - for a refresh the key has to change, e.g., hash of a tracked file in the key
+  - bash: |
+      mkdir -p /home/vsts/.ccache
+    displayName: 'Create Ccache Directory'
   - task: Cache@2
     continueOnError: true
     inputs:
@@ -72,9 +65,9 @@ jobs:
       restoreKeys: |
          Ccache | "$(System.JobName)" | .azure-pipelines.yml | cmake/dependencies/AMReX.cmake
          Ccache | "$(System.JobName)" | .azure-pipelines.yml
-      path: $(CCACHE_DIR)
+      path: /home/vsts/.ccache
       cacheHitVar: CCACHE_CACHE_RESTORED
-    displayName: Ccache Caching
+    displayName: 'Cache Ccache Objects'
 
   - bash: |
       set -o nounset errexit pipefail
@@ -82,10 +75,11 @@ jobs:
       df -h
       echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
       sudo apt update
-      sudo apt install -y curl gcc gfortran git g++ ninja-build \
+      sudo apt install -y ccache curl gcc gfortran git g++ ninja-build \
         openmpi-bin libopenmpi-dev \
         libfftw3-dev libfftw3-mpi-dev libhdf5-openmpi-dev pkg-config make \
         python3 python3-pandas python3-pip python3-venv python3-setuptools libblas-dev liblapack-dev
+      ccache --set-config=max_size=10.0G
       python3 -m pip install --upgrade pip
       python3 -m pip install --upgrade build
       python3 -m pip install --upgrade packaging

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -19,6 +19,7 @@ jobs:
 - job:
   # FIXME remove unused variables
   variables:
+    CCACHE_DIR: $(Pipeline.Workspace)/ccache
     BLASPP_HOME: '/usr/local'
     CEI_SUDO: 'sudo'
     CEI_TMP: '/tmp/cei'
@@ -52,7 +53,16 @@ jobs:
   timeoutInMinutes: 240
 
   steps:
-  # set up caches:
+  - bash: |
+      set -o nounset errexit pipefail
+      sudo apt update
+      sudo apt install -y ccache
+      ccache --set-config=max_size=10.0G
+      # update PATH to use linked versions of gcc, cc, etc.
+      echo "##vso[task.prependpath]/usr/lib/ccache"
+      displayName: 'Install ccache'
+
+  # Ccache caching:
   # - once stored under a key, they become immutable (even if cache content changes)
   # - for a refresh the key has to change, e.g., hash of a tracked file in the key
   - task: Cache@2
@@ -62,9 +72,9 @@ jobs:
       restoreKeys: |
          Ccache | "$(System.JobName)" | .azure-pipelines.yml | cmake/dependencies/AMReX.cmake
          Ccache | "$(System.JobName)" | .azure-pipelines.yml
-      path: /home/vsts/.ccache
+      path: $(CCACHE_DIR)
       cacheHitVar: CCACHE_CACHE_RESTORED
-    displayName: Cache Ccache Objects
+    displayName: Ccache Caching
 
   - bash: |
       set -o nounset errexit pipefail
@@ -72,11 +82,10 @@ jobs:
       df -h
       echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
       sudo apt update
-      sudo apt install -y ccache curl gcc gfortran git g++ ninja-build \
+      sudo apt install -y curl gcc gfortran git g++ ninja-build \
         openmpi-bin libopenmpi-dev \
         libfftw3-dev libfftw3-mpi-dev libhdf5-openmpi-dev pkg-config make \
         python3 python3-pandas python3-pip python3-venv python3-setuptools libblas-dev liblapack-dev
-      ccache --set-config=max_size=10.0G
       python3 -m pip install --upgrade pip
       python3 -m pip install --upgrade build
       python3 -m pip install --upgrade packaging


### PR DESCRIPTION
Trying to fix a recurrent Ccache error found in our CI Azure pipelines (for example, [here](https://dev.azure.com/BLAST-WarpX/WarpX/_build/results?buildId=279&view=logs&j=7ec3750d-56ea-5cbe-d508-4a6ff7a212d2&t=02414252-bae9-4c9c-b628-e0dec3b06210)):
```
tar: /home/vsts/.ccache: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
```
Attempts so far:
- ~Integrate the example at https://learn.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops#ccache-cc within our workflow file~
- [x] Create custom .ccache directory before caching