### PR TITLE
CI: Fix Bugs with `lasy` 0.6.1

### DIFF
--- a/Examples/Tests/laser_injection_from_file/inputs_test_rz_laser_injection_from_RZ_lasy_file_prepare.py
+++ b/Examples/Tests/laser_injection_from_file/inputs_test_rz_laser_injection_from_RZ_lasy_file_prepare.py
@@ -36,9 +36,9 @@ t_c = 20.0 * fs
 profile = CombinedLongitudinalTransverseProfile(
     wavelength,
     pol,
-    laser_energy,
     GaussianLongitudinalProfile(wavelength, tt, t_peak=0),
-    LaguerreGaussianTransverseProfile(w0, p=0, m=1),
+    LaguerreGaussianTransverseProfile(w0, p=0, m=1, wavelength=wavelength),
+    laser_energy,
 )
 dim = "rt"
 lo = (0e-6, -20e-15)


### PR DESCRIPTION
`lasy` 0.6.1 is available after https://github.com/LASY-org/lasy/pull/393 and it is now downloaded automatically when we install dependencies for our CI tests. This PR fixes a couple of bugs in our test scripts, occurring with the new version.