### PR TITLE
CI: Remove Obsolete `geometry.is_periodic` from Input File

### DIFF
--- a/Examples/Tests/ionization_dsmc/inputs_base_3d
+++ b/Examples/Tests/ionization_dsmc/inputs_base_3d
@@ -30,7 +30,6 @@ amr.max_grid_size = 4
 #################################
 ###### BOUNDARY CONDITIONS ######
 #################################
-geometry.is_periodic = 1 1 1
 boundary.field_hi = periodic periodic periodic
 boundary.field_lo = periodic periodic periodic
 boundary.particle_hi = periodic periodic periodic


### PR DESCRIPTION
@oshapoval pointed out that we have one input file where `geometry.is_periodic` is set, even though we comment in the source code that this parameter is used only internally and should not be set by the user:
https://github.com/BLAST-WarpX/warpx/blob/2e895d5bcbceacd64617660c48aae12351d88536/Source/Utils/WarpXUtil.cpp#L386-L394

This PR removes the parameter from the input file, to avoid confusion for developers and users who look at examples.