### PR TITLE
Check that species involved in linear Breit-Wheeler are photons

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
@@ -11,7 +11,6 @@
 #include "Particles/WarpXParticleContainer.H"
 
 #include <AMReX_ParmParse.H>
-#include <AMReX_Parser.H>
 #include <AMReX_Vector.H>
 
 #include <string>

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
@@ -11,6 +11,7 @@
 #include "Particles/WarpXParticleContainer.H"
 
 #include <AMReX_ParmParse.H>
+#include <AMReX_Parser.H>
 #include <AMReX_Vector.H>
 
 #include <string>
@@ -37,6 +38,18 @@ namespace BinaryCollisionUtils{
             return CollisionType::DSMC;
         }
         else if (type == "linear_breit_wheeler") {
+            amrex::Vector<std::string> species_name;
+            // Check that incoming species are photons
+            pp_collision_name.getarr("species", species_name);
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                species_name.size() == 2u,
+                "Linear Breit-Wheeler collisions must involve exactly two species");
+            auto& species1 = mypc->GetParticleContainerFromName(species_name[0]);
+            auto& species2 = mypc->GetParticleContainerFromName(species_name[1]);
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                species1.AmIA<PhysicalSpecies::photon>() && species2.AmIA<PhysicalSpecies::photon>(),
+                "Species involved in linear Breit-Wheeler collisions must be of type photon.");
+            // Check that product species are electron and positron
             amrex::Vector<std::string> product_species_name;
             pp_collision_name.getarr("product_species", product_species_name);
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(


### PR DESCRIPTION
When using the linear Breit-Wheeler package, we check that the product species are electron and positrons, but we did not yet check that the reactant are photons.

This PR fixes the issue.