### PR TITLE
Reduce duplication in linear Breit-Wheeler by reusing code from fusion, DSMC

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.H
@@ -65,7 +65,6 @@ namespace BinaryCollisionUtils{
 
         constexpr double c = PhysConst::c;
         constexpr double c_sq = PhysConst::c * PhysConst::c;
-        constexpr double inv_csq = 1.0 / c_sq;
 
         // Cast input parameters to double before computing collision properties
         // This is needed to avoid errors when using single-precision particles

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.H
@@ -113,7 +113,7 @@ namespace BinaryCollisionUtils{
         // p^2 = E^2/4c^2 - (m_1^2 + m_2^2)c^2/2 + (m_1^2-m_2^2)^2 c^6/4E^2
         double p_star_sq;
         if (m1_dbl + m2_dbl == 0) {
-            p_star_sq = 0.5 * E_star * inv_c;
+            p_star_sq = powi<2>( 0.5 * E_star * inv_c );
         } else {
             // The expression below is specifically written in a form that avoids returning
             // small negative numbers due to machine precision errors, for low-energy particles

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.H
@@ -49,9 +49,9 @@ namespace BinaryCollisionUtils{
      */
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
     void get_collision_parameters (
-        const amrex::ParticleReal& u1x, const amrex::ParticleReal& u1y,
-        const amrex::ParticleReal& u1z, const amrex::ParticleReal& u2x,
-        const amrex::ParticleReal& u2y, const amrex::ParticleReal& u2z,
+        const amrex::ParticleReal& p1x, const amrex::ParticleReal& p1y,
+        const amrex::ParticleReal& p1z, const amrex::ParticleReal& p2x,
+        const amrex::ParticleReal& p2y, const amrex::ParticleReal& p2z,
         const amrex::ParticleReal& m1, const amrex::ParticleReal& m2,
         amrex::ParticleReal& E_kin_COM, amrex::ParticleReal& v_rel_COM,
         amrex::ParticleReal& lab_to_COM_lorentz_factor )
@@ -70,30 +70,22 @@ namespace BinaryCollisionUtils{
         // This is needed to avoid errors when using single-precision particles
         const auto m1_dbl = static_cast<double>(m1);
         const auto m2_dbl = static_cast<double>(m2);
-        const auto u1x_dbl = static_cast<double>(u1x);
-        const auto u1y_dbl = static_cast<double>(u1y);
-        const auto u1z_dbl = static_cast<double>(u1z);
-        const auto u2x_dbl = static_cast<double>(u2x);
-        const auto u2y_dbl = static_cast<double>(u2y);
-        const auto u2z_dbl = static_cast<double>(u2z);
+        const auto p1x_dbl = static_cast<double>(p1x);
+        const auto p1y_dbl = static_cast<double>(p1y);
+        const auto p1z_dbl = static_cast<double>(p1z);
+        const auto p2x_dbl = static_cast<double>(p2x);
+        const auto p2y_dbl = static_cast<double>(p2y);
+        const auto p2z_dbl = static_cast<double>(p2z);
 
         const double m1_sq = m1_dbl*m1_dbl;
         const double m2_sq = m2_dbl*m2_dbl;
 
         // Compute Lorentz factor gamma in the lab frame
-        const double g1 = std::sqrt( 1.0 + (u1x_dbl*u1x_dbl + u1y_dbl*u1y_dbl + u1z_dbl*u1z_dbl)*inv_csq );
-        const double g2 = std::sqrt( 1.0 + (u2x_dbl*u2x_dbl + u2y_dbl*u2y_dbl + u2z_dbl*u2z_dbl)*inv_csq );
-
-        // Compute momenta
-        const double p1x = u1x_dbl * m1_dbl;
-        const double p1y = u1y_dbl * m1_dbl;
-        const double p1z = u1z_dbl * m1_dbl;
-        const double p2x = u2x_dbl * m2_dbl;
-        const double p2y = u2y_dbl * m2_dbl;
-        const double p2z = u2z_dbl * m2_dbl;
+        const double g1 = std::sqrt( 1.0 + (p1x_dbl*p1x_dbl + p1y_dbl*p1y_dbl + p1z_dbl*p1z_dbl)*inv_csq/m1_sq );
+        const double g2 = std::sqrt( 1.0 + (p2x_dbl*p2x_dbl + p2y_dbl*p2y_dbl + p2z_dbl*p2z_dbl)*inv_csq/m2_sq );
 
         // Square norm of the total (sum between the two particles) momenta in the lab frame
-        const double p_total_sq = powi<2>(p1x + p2x) + powi<2>(p1y + p2y) + powi<2>(p1z + p2z);
+        const double p_total_sq = powi<2>(p1x_dbl + p2x_dbl) + powi<2>(p1y_dbl + p2y_dbl) + powi<2>(p1z_dbl + p2z_dbl);
 
         // Total energy in the lab frame
         // Note the use of `double` for energy since this calculation is

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.H
@@ -90,7 +90,9 @@ namespace BinaryCollisionUtils{
         // Total energy in the lab frame
         // Note the use of `double` for energy since this calculation is
         // prone to error with single precision.
-        const double E_lab = (m1_dbl*g1 + m2_dbl*g2) * c_sq;
+        const double E1_lab = std::sqrt( m1_sq * c_sq + p1x_dbl*p1x_dbl + p1y_dbl*p1y_dbl + p1z_dbl*p1z_dbl ) * PhysConst::c;
+        const double E2_lab = std::sqrt( m2_sq * c_sq + p2x_dbl*p2x_dbl + p2y_dbl*p2y_dbl + p2z_dbl*p2z_dbl ) * PhysConst::c;
+        const double E_lab = E1_lab + E2_lab;
         // Total energy squared in the center of mass frame, calculated using the Lorentz invariance
         // of the four-momentum norm
         const double E_star_sq = E_lab*E_lab - c_sq*p_total_sq;
@@ -118,7 +120,7 @@ namespace BinaryCollisionUtils{
 
         // Cross sections and relative velocity are computed in the center of mass frame.
         // On the other hand, the particle densities (weight over volume) in the lab frame are used.
-        // To take this disrepancy into account, it is needed to multiply the
+        // To take this discrepancy into account, it is needed to multiply the
         // collision probability by the ratio between the Lorentz factors in the
         // COM frame and the Lorentz factors in the lab frame (see
         // Perez et al., Phys.Plasmas.19.083104 (2012)). The correction factor

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.H
@@ -63,6 +63,7 @@ namespace BinaryCollisionUtils{
         using namespace amrex::literals;
         using namespace amrex::Math;
 
+        constexpr double c = PhysConst::c;
         constexpr double c_sq = PhysConst::c * PhysConst::c;
         constexpr double inv_csq = 1.0 / c_sq;
 
@@ -80,18 +81,13 @@ namespace BinaryCollisionUtils{
         const double m1_sq = m1_dbl*m1_dbl;
         const double m2_sq = m2_dbl*m2_dbl;
 
-        // Compute Lorentz factor gamma in the lab frame
-        const double g1 = std::sqrt( 1.0 + (p1x_dbl*p1x_dbl + p1y_dbl*p1y_dbl + p1z_dbl*p1z_dbl)*inv_csq/m1_sq );
-        const double g2 = std::sqrt( 1.0 + (p2x_dbl*p2x_dbl + p2y_dbl*p2y_dbl + p2z_dbl*p2z_dbl)*inv_csq/m2_sq );
-
         // Square norm of the total (sum between the two particles) momenta in the lab frame
         const double p_total_sq = powi<2>(p1x_dbl + p2x_dbl) + powi<2>(p1y_dbl + p2y_dbl) + powi<2>(p1z_dbl + p2z_dbl);
 
         // Total energy in the lab frame
-        // Note the use of `double` for energy since this calculation is
-        // prone to error with single precision.
-        const double E1_lab = std::sqrt( m1_sq * c_sq + p1x_dbl*p1x_dbl + p1y_dbl*p1y_dbl + p1z_dbl*p1z_dbl ) * PhysConst::c;
-        const double E2_lab = std::sqrt( m2_sq * c_sq + p2x_dbl*p2x_dbl + p2y_dbl*p2y_dbl + p2z_dbl*p2z_dbl ) * PhysConst::c;
+        // Note the use of `double` for energy since this calculation is prone to error with single precision.
+        const double E1_lab = std::sqrt( m1_sq * c_sq + p1x_dbl*p1x_dbl + p1y_dbl*p1y_dbl + p1z_dbl*p1z_dbl ) * c;
+        const double E2_lab = std::sqrt( m2_sq * c_sq + p2x_dbl*p2x_dbl + p2y_dbl*p2y_dbl + p2z_dbl*p2z_dbl ) * c;
         const double E_lab = E1_lab + E2_lab;
         // Total energy squared in the center of mass frame, calculated using the Lorentz invariance
         // of the four-momentum norm
@@ -112,11 +108,11 @@ namespace BinaryCollisionUtils{
             + powi<2>(m1_dbl - m2_dbl)*c_sq/4.0 * powi<2>( E_ratio - 1.0/E_ratio);
 
         // Lorentz factors in the center of mass frame
-        const double g1_star = std::sqrt(1.0 + p_star_sq / (m1_sq*c_sq));
-        const double g2_star = std::sqrt(1.0 + p_star_sq / (m2_sq*c_sq));
+        const double E1_star = std::sqrt(m1_sq*c_sq + p_star_sq) * c;
+        const double E2_star = std::sqrt(m2_sq*c_sq + p_star_sq) * c;
 
         // relative velocity in the center of mass frame, cast back to chosen precision
-        v_rel_COM = static_cast<amrex::ParticleReal>(std::sqrt(p_star_sq) * (1.0/(m1_dbl*g1_star) + 1.0/(m2_dbl*g2_star)));
+        v_rel_COM = PhysConst::c * static_cast<amrex::ParticleReal>(std::sqrt(p_star_sq) * c * (1.0/E1_star + 1.0/E2_star));
 
         // Cross sections and relative velocity are computed in the center of mass frame.
         // On the other hand, the particle densities (weight over volume) in the lab frame are used.
@@ -125,7 +121,7 @@ namespace BinaryCollisionUtils{
         // COM frame and the Lorentz factors in the lab frame (see
         // Perez et al., Phys.Plasmas.19.083104 (2012)). The correction factor
         // is calculated here.
-        lab_to_COM_lorentz_factor = static_cast<amrex::ParticleReal>(g1_star*g2_star/(g1*g2));
+        lab_to_COM_lorentz_factor = static_cast<amrex::ParticleReal>(E1_star*E2_star/(E1_lab*E2_lab));
     }
 
     /**

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.H
@@ -65,6 +65,7 @@ namespace BinaryCollisionUtils{
 
         constexpr double c = PhysConst::c;
         constexpr double c_sq = PhysConst::c * PhysConst::c;
+        constexpr double inv_c = 1./PhysConst::c;
 
         // Cast input parameters to double before computing collision properties
         // This is needed to avoid errors when using single-precision particles
@@ -98,15 +99,30 @@ namespace BinaryCollisionUtils{
         // Cast back to chosen precision for output
         E_kin_COM = static_cast<amrex::ParticleReal>(E_star - (m1_dbl + m2_dbl)*c_sq);
 
-        // Square of the norm of the momentum of one of the particles in the center of mass frame
-        // Formula obtained by inverting E^2 = p^2*c^2 + m^2*c^4 in the COM frame for each particle
-        // The expression below is specifically written in a form that avoids returning
-        // small negative numbers due to machine precision errors, for low-energy particles
-        const double E_ratio = E_star/((m1_dbl + m2_dbl)*c_sq);
-        const double p_star_sq = m1_dbl*m2_dbl*c_sq * ( powi<2>(E_ratio) - 1.0 )
-            + powi<2>(m1_dbl - m2_dbl)*c_sq/4.0 * powi<2>( E_ratio - 1.0/E_ratio);
+        // Find the norm of the momentum of each particles in the center of mass frame
+        // This is done by solving the following system (in the COM frame)
+        // E_1^2 = p^2 c^2 + m_1^2 c^4  (for the first particle)
+        // E_2^2 = p^2 c^2 + m_2^2 c^4  (for the second particle ; same p since we are in the COM frame)
+        // to find the expression of the p as a function of E = E_1 + E_2.
+        // Here is an abbreviation derivation:
+        // - By summing the above equations
+        // E^2 = E_1^2 + E_2^2 + 2 E_1 E_2 = 2 p^2 c^2 + (m_1^2 + m_2^2) c^4 + 2 E_1 E_2
+        // - Rearranging and squaring
+        // ( E^2 - 2 p^2 c^2 - (m_1^2 + m_2^2) c^4 )^2 = 4 E_1^2 E_2^2 = 4 (p^2 c^2 + m_1^2 c^4) (p^2 c^2 + m_2^2 c^4)
+        // - By rearranging, we get:
+        // p^2 = E^2/4c^2 - (m_1^2 + m_2^2)c^2/2 + (m_1^2-m_2^2)^2 c^6/4E^2
+        double p_star_sq;
+        if (m1_dbl + m2_dbl == 0) {
+            p_star_sq = 0.5 * E_star * inv_c;
+        } else {
+            // The expression below is specifically written in a form that avoids returning
+            // small negative numbers due to machine precision errors, for low-energy particles
+            const double E_ratio = E_star/((m1_dbl + m2_dbl)*c_sq);
+            p_star_sq = m1_dbl*m2_dbl*c_sq * ( powi<2>(E_ratio) - 1.0 )
+                + powi<2>(m1_dbl - m2_dbl)*c_sq/4.0 * powi<2>( E_ratio - 1.0/E_ratio);
+        }
 
-        // Lorentz factors in the center of mass frame
+        // Energy of each particle in the center of mass frame
         const double E1_star = std::sqrt(m1_sq*c_sq + p_star_sq) * c;
         const double E2_star = std::sqrt(m2_sq*c_sq + p_star_sq) * c;
 
@@ -117,9 +133,8 @@ namespace BinaryCollisionUtils{
         // On the other hand, the particle densities (weight over volume) in the lab frame are used.
         // To take this discrepancy into account, it is needed to multiply the
         // collision probability by the ratio between the Lorentz factors in the
-        // COM frame and the Lorentz factors in the lab frame (see
-        // Perez et al., Phys.Plasmas.19.083104 (2012)). The correction factor
-        // is calculated here.
+        // COM frame and the Lorentz factors in the lab frame (see Perez et al.,
+        // Phys.Plasmas.19.083104 (2012)). The correction factor is calculated here.
         lab_to_COM_lorentz_factor = static_cast<amrex::ParticleReal>(E1_star*E2_star/(E1_lab*E2_lab));
     }
 

--- a/Source/Particles/Collision/BinaryCollision/DSMC/CollisionFilterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/CollisionFilterFunc.H
@@ -52,7 +52,7 @@ void CollisionPairFilter (const amrex::ParticleReal u1x, const amrex::ParticleRe
     amrex::ParticleReal E_coll, v_coll, lab_to_COM_factor;
 
     BinaryCollisionUtils::get_collision_parameters(
-        u1x, u1y, u1z, u2x, u2y, u2z, m1, m2,
+        m1*u1x, m1*u1y, m1*u1z, m2*u2x, m2*u2y, m2*u2z, m1, m2,
         E_coll, v_coll, lab_to_COM_factor);
 
     using namespace amrex::literals;

--- a/Source/Particles/Collision/BinaryCollision/LinearBreitWheeler/SingleLinearBreitWheelerCollisionEvent.H
+++ b/Source/Particles/Collision/BinaryCollision/LinearBreitWheeler/SingleLinearBreitWheelerCollisionEvent.H
@@ -66,71 +66,26 @@ void SingleLinearBreitWheelerCollisionEvent (const amrex::ParticleReal& u1x, con
                                        const amrex::ParticleReal& probability_target_value,
                                        const amrex::RandomEngine& engine)
 {
-    // General notations in this function:
-    //     x_sq denotes the square of x
-    //     x_star denotes the value of x in the center of mass frame
+    amrex::ParticleReal E_coll, v_coll, lab_to_COM_factor;
+
+    constexpr amrex::ParticleReal me = PhysConst::m_e;
+    BinaryCollisionUtils::get_collision_parameters(
+        me*u1x, me*u1y, me*u1z, me*u2x, me*u2y, me*u2z, 0, 0,
+        E_coll, v_coll, lab_to_COM_factor);
 
     using namespace amrex::literals;
 
     const amrex::ParticleReal w_min = amrex::min(w1, w2);
     const amrex::ParticleReal w_max = amrex::max(w1, w2);
 
-    constexpr auto one_pr = amrex::ParticleReal(1.);
-    constexpr auto two_pr = amrex::ParticleReal(2.);
-    constexpr auto one_half_pr = amrex::ParticleReal(1./2.);
-    constexpr amrex::ParticleReal c = PhysConst::c;
-    constexpr amrex::ParticleReal c_sq = c*c;
-    constexpr amrex::ParticleReal me = PhysConst::m_e;
-    auto constexpr pow2 = [](double const x) { return x*x; };
-
-    // Compute momenta in the lab frame
-    const amrex::ParticleReal p1x = u1x * me;
-    const amrex::ParticleReal p1y = u1y * me;
-    const amrex::ParticleReal p1z = u1z * me;
-    const amrex::ParticleReal p2x = u2x * me;
-    const amrex::ParticleReal p2y = u2y * me;
-    const amrex::ParticleReal p2z = u2z * me;
-    const amrex::ParticleReal p1 = std::sqrt(pow2(p1x)+pow2(p1y)+pow2(p1z));
-    const amrex::ParticleReal p2 = std::sqrt(pow2(p2x)+pow2(p2y)+pow2(p2z));
-
-    // Compute Lorentz factor gamma in the lab frame
-    const amrex::ParticleReal g1 = p1 / ( me * c );
-    const amrex::ParticleReal g2 = p2 / ( me * c );
-
-    // Compute the cosine of the angle between the two photon momenta in the lab frame
-    const amrex::ParticleReal cos_ang = (p1x*p2x+p1y*p2y+p1z*p2z)/(p1*p2);
-
-    // Energy squared of each and every particle involved in the collision
-    // (both colliding photons and the produced electron and positron)
-    // in the center of momentum frame (they are all equal),
-    // calculated using the Lorentz invariance of the total four-momentum norm
-    const amrex::ParticleReal E_star_sq = one_half_pr*c_sq*p1*p2*(one_pr - cos_ang);
-
-    // Kinetic energy of each particle in the center of momentum frame
-    const amrex::ParticleReal E_star = std::sqrt(E_star_sq);
-
     // Compute linear Breit Wheeler cross section as a function of the kinetic energy
     // in the center of momentum frame
     auto lbw_cross_section = amrex::ParticleReal(0.);
-    lbw_cross_section = LinearBreitWheelerCrossSection(E_star);
-
-    // Lorentz factors in the center of momentum frame
-    const amrex::ParticleReal g1_star = E_star / (me*c_sq);
-    const amrex::ParticleReal g2_star = g1_star;
-
-    // relative velocity in the center of momentum frame
-    const amrex::ParticleReal v_rel = two_pr*c;
-
-    // Cross section and relative velocity are computed in the center of momentum frame.
-    // On the other hand, the particle densities (weight over volume) in the lab frame are used. To
-    // take into account this discrepancy, we need to multiply the collision probability by the ratio
-    // between the Lorentz factors in the COM frame and the Lorentz factors in the lab frame
-    // (see Perez et al., Phys.Plasmas.19.083104 (2012))
-    const amrex::ParticleReal lab_to_COM_factor = g1_star*g2_star/(g1*g2);
+    lbw_cross_section = LinearBreitWheelerCrossSection(E_coll/2);
 
     // First estimate of probability to produce an electron-positron pair
     amrex::ParticleReal probability_estimate = multiplier_ratio * event_multiplier *
-                                lab_to_COM_factor * w_max * lbw_cross_section * v_rel * dt / dV;
+                                lab_to_COM_factor * w_max * lbw_cross_section * v_coll * dt / dV;
 
     // Effective event multiplier
     amrex::ParticleReal event_multiplier_eff = event_multiplier;
@@ -143,7 +98,7 @@ void SingleLinearBreitWheelerCollisionEvent (const amrex::ParticleReal& u1x, con
         // We aim for a pair-production probability of probability_target_value but take into account
         // the constraint that the event_multiplier cannot be smaller than one
         event_multiplier_eff  = amrex::max(event_multiplier *
-                                         probability_target_value / probability_estimate , one_pr);
+                                         probability_target_value / probability_estimate , 1._prt);
         probability_estimate *= event_multiplier_eff/event_multiplier;
     }
 
@@ -152,10 +107,6 @@ void SingleLinearBreitWheelerCollisionEvent (const amrex::ParticleReal& u1x, con
     // However, the computation of this quantity can fail numerically when probability_estimate is
     // too small (e.g. exp(-probability_estimate) returns 1 and the computation returns 0).
     // In this case, we simply use "probability_estimate" instead of 1 - exp(-probability_estimate)
-    // The threshold exp_threshold at which we switch between the two formulas is determined by the
-    // fact that computing the exponential is only useful if it can resolve the x^2/2 term of its
-    // Taylor expansion, i.e. the square of probability_estimate should be greater than the
-    // machine epsilon.
     const amrex::ParticleReal probability = -std::expm1(-probability_estimate);
 
     // Get a random number

--- a/Source/Particles/Collision/BinaryCollision/LinearBreitWheeler/SingleLinearBreitWheelerCollisionEvent.H
+++ b/Source/Particles/Collision/BinaryCollision/LinearBreitWheeler/SingleLinearBreitWheelerCollisionEvent.H
@@ -68,6 +68,8 @@ void SingleLinearBreitWheelerCollisionEvent (const amrex::ParticleReal& u1x, con
 {
     amrex::ParticleReal E_coll, v_coll, lab_to_COM_factor;
 
+    // By convention in WarpX, the momentum of photons is normalized by m_e
+    // i.e. `p = m_e u`.
     constexpr amrex::ParticleReal me = PhysConst::m_e;
     BinaryCollisionUtils::get_collision_parameters(
         me*u1x, me*u1y, me*u1z, me*u2x, me*u2y, me*u2z, 0, 0,

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/SingleNuclearFusionEvent.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/SingleNuclearFusionEvent.H
@@ -69,7 +69,7 @@ void SingleNuclearFusionEvent (const amrex::ParticleReal& u1x, const amrex::Part
     amrex::ParticleReal E_coll, v_coll, lab_to_COM_factor;
 
     BinaryCollisionUtils::get_collision_parameters(
-        u1x, u1y, u1z, u2x, u2y, u2z, m1, m2,
+        m1*u1x, m1*u1y, m1*u1z, m2*u2x, m2*u2y, m2*u2z, m1, m2,
         E_coll, v_coll, lab_to_COM_factor);
 
     using namespace amrex::literals;


### PR DESCRIPTION
We can reduce duplication in linear Breit-Wheeler module (collision between two photons, producing an electron-positron pair) by reusing the function `get_collision_parameters`, which is already used in the fusion and DSMC modules.

In order to do so, I had to slightly rewrite the function `get_collision_type` so that it is also valid for massless particles. In particular, this involved passing the momentum `p` to the function, rather than the normalized momentum `u`.

I also added some details about the derivation of some of the equations in the code.