### PR TITLE
Unify user-input names between nuclear fusion and linear Breit-Wheeler

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2125,7 +2125,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
     that approaches 1 (for a given collision between two macroparticles), then
     there is a risk of underestimating the total yield. In these cases,
     WarpX reduces the event multiplier used in that given collision.
-    ``m_probability_threshold`` is the probability threshold above
+    ``probability_threshold`` is the probability threshold above
     which WarpX reduces the event multiplier.
 
 * ``<collision_name>.probability_target_value`` (`float`) optional.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2107,44 +2107,32 @@ Details about the collision models can be found in the :ref:`theory section <mul
     of each species. By default, this is turned off. Note that if ``<collision_name>.CoulombLog``
     is specified, this Debye length is not used.
 
-* ``<collision_name>.fusion_multiplier`` (`float`) optional.
-    Only for ``nuclearfusion``.
-    Increasing ``fusion_multiplier`` creates more macroparticles of fusion
-    products, but with lower weight (in such a way that the corresponding
-    total number of physical particle remains the same). This can improve
-    the statistics of the simulation, in the case where fusion reactions are very rare.
-    More specifically, in a fusion reaction between two macroparticles with weight ``w_1`` and ``w_2``,
-    the weight of the product macroparticles will be ``min(w_1,w_2)/fusion_multiplier``.
-    (And the weights of the reactant macroparticles are reduced correspondingly after the reaction.)
-    See :cite:t:`param-HigginsonJCP2019` for more details.
-    The default value of ``fusion_multiplier`` is 1.
-
-* ``<collision_name>.fusion_probability_threshold`` (`float`) optional.
-    Only for ``nuclearfusion``.
-    If the fusion multiplier is too high and results in a fusion probability
-    that approaches 1 (for a given collision between two macroparticles), then
-    there is a risk of underestimating the total fusion yield. In these cases,
-    WarpX reduces the fusion multiplier used in that given collision.
-    ``m_probability_threshold`` is the fusion probability threshold above
-    which WarpX reduces the fusion multiplier.
-
-* ``<collision_name>.fusion_probability_target_value`` (`float`) optional.
-    Only for ``nuclearfusion``.
-    When the probability of fusion for a given collision exceeds
-    ``fusion_probability_threshold``, WarpX reduces the fusion multiplier for
-    that collisions such that the fusion probability approches ``fusion_probability_target_value``.
-
 * ``<collision_name>.event_multiplier`` (`float`) optional.
-    Only for ``linear_breit_wheeler``.
-    Works in the same way as ``<collision_name>.fusion_probability_target_value`` for fusion reactions.
+    Only for ``nuclearfusion`` and ``linear_breit_wheeler`` (LBW).
+    Increasing ``event_multiplier`` creates more macroparticles products,
+    but with lower weight (in such a way that the corresponding
+    total number of physical particle remains the same). This can improve
+    the statistics of the simulation, in the case where the collision events are very rare.
+    More specifically, in a collision between two macroparticles with weight ``w_1`` and ``w_2``,
+    the weight of the product macroparticles will be ``min(w_1,w_2)/event_multiplier``.
+    (And the weights of the reactant macroparticles are reduced correspondingly after the collision.)
+    See :cite:t:`param-HigginsonJCP2019` for more details.
+    The default value of ``event_multiplier`` is 1.
 
 * ``<collision_name>.probability_threshold`` (`float`) optional.
-    Only for ``linear_breit_wheeler``.
-    Works in the same way as ``<collision_name>.fusion_probability_threshold`` for fusion reactions.
+    Only for ``nuclearfusion`` and ``linear_breit_wheeler``.
+    If the event multiplier is too high and results in a probability
+    that approaches 1 (for a given collision between two macroparticles), then
+    there is a risk of underestimating the total yield. In these cases,
+    WarpX reduces the event multiplier used in that given collision.
+    ``m_probability_threshold`` is the probability threshold above
+    which WarpX reduces the event multiplier.
 
 * ``<collision_name>.probability_target_value`` (`float`) optional.
-    Only for ``linear_breit_wheeler``.
-    Works in the same way as ``<collision_name>.fusion_probability_target_value`` for fusion reactions.
+    Only for ``nuclearfusion`` and ``linear_breit_wheeler``.
+    When the probability of fusion or linear Breit-Wheeler for a given collision exceeds
+    ``probability_threshold``, WarpX reduces the event multiplier for
+    that collisions such that the probability approches ``probability_target_value``.
 
 * ``<collision_name>.background_density`` (`float`)
     Only for ``background_mcc`` and ``background_stopping``. The density of the background in :math:`m^{-3}`.

--- a/Examples/Tests/nuclear_fusion/inputs_test_2d_proton_boron_fusion
+++ b/Examples/Tests/nuclear_fusion/inputs_test_2d_proton_boron_fusion
@@ -180,29 +180,29 @@ collisions.collision_names = PBF1 PBF2 PBF3 PBF4 PBF5
 PBF1.species = proton1 boron1
 PBF1.product_species = alpha1
 PBF1.type = nuclearfusion
-PBF1.fusion_multiplier = 1.e50
+PBF1.event_multiplier = 1.e50
 
 PBF2.species = proton2 boron2
 PBF2.product_species = alpha2
 PBF2.type = nuclearfusion
-PBF2.fusion_multiplier = 1.e15
-PBF2.fusion_probability_target_value = 0.02
+PBF2.event_multiplier = 1.e15
+PBF2.probability_target_value = 0.02
 
 PBF3.species = proton3 boron3
 PBF3.product_species = alpha3
 PBF3.type = nuclearfusion
-PBF3.fusion_multiplier = 1.e15
+PBF3.event_multiplier = 1.e15
 
 PBF4.species = proton4 boron4
 PBF4.product_species = alpha4
 PBF4.type = nuclearfusion
-PBF4.fusion_multiplier = 1.e21
+PBF4.event_multiplier = 1.e21
 
 PBF5.species = proton5 boron5
 PBF5.product_species = alpha5
 PBF5.type = nuclearfusion
-PBF5.fusion_multiplier = 1.e21
-PBF5.fusion_probability_threshold = 1e123
+PBF5.event_multiplier = 1.e21
+PBF5.probability_threshold = 1e123
 
 # Diagnostics
 diagnostics.diags_names = diag1

--- a/Examples/Tests/nuclear_fusion/inputs_test_3d_deuterium_deuterium_fusion
+++ b/Examples/Tests/nuclear_fusion/inputs_test_3d_deuterium_deuterium_fusion
@@ -74,7 +74,7 @@ collisions.collision_names = DDNHeF1
 DDNHeF1.species = deuterium_1 hydrogen2_1
 DDNHeF1.product_species = helium3_1 neutron_1
 DDNHeF1.type = nuclearfusion
-DDNHeF1.fusion_multiplier = 1.e50
+DDNHeF1.event_multiplier = 1.e50
 
 # Diagnostics
 diagnostics.diags_names = diag1

--- a/Examples/Tests/nuclear_fusion/inputs_test_3d_deuterium_deuterium_fusion_intraspecies
+++ b/Examples/Tests/nuclear_fusion/inputs_test_3d_deuterium_deuterium_fusion_intraspecies
@@ -25,7 +25,7 @@ boundary.field_lo = periodic periodic periodic
 collisions.collision_names = dd_collision
 
 # dd_collision
-dd_collision.fusion_multiplier = 1e10
+dd_collision.event_multiplier = 1e10
 dd_collision.product_species = helium3 neutron
 dd_collision.species = deuterium deuterium
 dd_collision.type = nuclearfusion

--- a/Examples/Tests/nuclear_fusion/inputs_test_3d_deuterium_tritium_fusion
+++ b/Examples/Tests/nuclear_fusion/inputs_test_3d_deuterium_tritium_fusion
@@ -120,13 +120,13 @@ collisions.collision_names = DTF1 DTF2
 DTF1.species = deuterium_1 tritium_1
 DTF1.product_species = helium4_1 neutron_1
 DTF1.type = nuclearfusion
-DTF1.fusion_multiplier = 1.e50
+DTF1.event_multiplier = 1.e50
 
 DTF2.species = deuterium_2 tritium_2
 DTF2.product_species = helium4_2 neutron_2
 DTF2.type = nuclearfusion
-DTF2.fusion_multiplier = 1.e15
-DTF2.fusion_probability_target_value = 0.02
+DTF2.event_multiplier = 1.e15
+DTF2.probability_target_value = 0.02
 
 # Diagnostics
 diagnostics.diags_names = diag1

--- a/Examples/Tests/nuclear_fusion/inputs_test_3d_proton_boron_fusion
+++ b/Examples/Tests/nuclear_fusion/inputs_test_3d_proton_boron_fusion
@@ -180,29 +180,29 @@ collisions.collision_names = PBF1 PBF2 PBF3 PBF4 PBF5
 PBF1.species = proton1 boron1
 PBF1.product_species = alpha1
 PBF1.type = nuclearfusion
-PBF1.fusion_multiplier = 1.e50
+PBF1.event_multiplier = 1.e50
 
 PBF2.species = proton2 boron2
 PBF2.product_species = alpha2
 PBF2.type = nuclearfusion
-PBF2.fusion_multiplier = 1.e15
-PBF2.fusion_probability_target_value = 0.02
+PBF2.event_multiplier = 1.e15
+PBF2.probability_target_value = 0.02
 
 PBF3.species = proton3 boron3
 PBF3.product_species = alpha3
 PBF3.type = nuclearfusion
-PBF3.fusion_multiplier = 1.e15
+PBF3.event_multiplier = 1.e15
 
 PBF4.species = proton4 boron4
 PBF4.product_species = alpha4
 PBF4.type = nuclearfusion
-PBF4.fusion_multiplier = 1.e21
+PBF4.event_multiplier = 1.e21
 
 PBF5.species = proton5 boron5
 PBF5.product_species = alpha5
 PBF5.type = nuclearfusion
-PBF5.fusion_multiplier = 1.e21
-PBF5.fusion_probability_threshold = 1e123
+PBF5.event_multiplier = 1.e21
+PBF5.probability_threshold = 1e123
 
 # Diagnostics
 diagnostics.diags_names = diag1

--- a/Examples/Tests/nuclear_fusion/inputs_test_rz_deuterium_tritium_fusion
+++ b/Examples/Tests/nuclear_fusion/inputs_test_rz_deuterium_tritium_fusion
@@ -114,13 +114,13 @@ collisions.collision_names = DTF1 DTF2
 DTF1.species = deuterium_1 tritium_1
 DTF1.product_species = helium4_1 neutron_1
 DTF1.type = nuclearfusion
-DTF1.fusion_multiplier = 1.e50
+DTF1.event_multiplier = 1.e50
 
 DTF2.species = deuterium_2 tritium_2
 DTF2.product_species = helium4_2 neutron_2
 DTF2.type = nuclearfusion
-DTF2.fusion_multiplier = 1.e15
-DTF2.fusion_probability_target_value = 0.02
+DTF2.event_multiplier = 1.e15
+DTF2.probability_target_value = 0.02
 
 # Diagnostics
 diagnostics.diags_names = diag1

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
@@ -70,11 +70,11 @@ public:
 
         const amrex::ParmParse pp_collision_name(collision_name);
         utils::parser::queryWithParser(
-            pp_collision_name, "fusion_multiplier", m_fusion_multiplier);
+            pp_collision_name, "event_multiplier", m_fusion_multiplier);
         utils::parser::queryWithParser(
-            pp_collision_name, "fusion_probability_threshold", m_probability_threshold);
+            pp_collision_name, "probability_threshold", m_probability_threshold);
         utils::parser::queryWithParser(
-            pp_collision_name, "fusion_probability_target_value",
+            pp_collision_name, "probability_target_value",
             m_probability_target_value);
 
         m_exe.m_fusion_multiplier = m_fusion_multiplier;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -2070,6 +2070,19 @@ WarpX::BackwardCompatibility ()
             ablastr::warn_manager::WarnPriority::low);
     }
 
+    std::vector<std::string> backward_coll_names;
+    pp_collisions.queryarr("collision_names", backward_coll_names);
+    for(const std::string& coll_name : backward_coll_names){
+        const ParmParse pp_coll(coll_name);
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+            !pp_coll.query("fusion_multiplier", backward_Real) &&
+            !pp_coll.query("fusion_probability_threshold", backward_Real) &&
+            !pp_coll.query("fusion_probability_target_value", backward_Real),
+            "Inputs fusion_multiplier, fusion_probability_threshold & fusion_probability_target_value "
+            "are deprecated. Please use event_multiplier, probability_threshold & probability_target_value."
+        );
+    }
+
     const ParmParse pp_lasers("lasers");
     int nlasers;
     if (pp_lasers.query("nlasers", nlasers)){


### PR DESCRIPTION
This PR removes the tag/word `fusion` from three user inputs: 
* `fusion_multiplier` becomes `event_multiplier`
* `fusion_probability_threshold` becomes `probability_threshold`
* `fusion_probability_target_value` becomes `probability_target_value`

This makes the user interfaces of the nuclear fusion and linear Breit-Wheeler modules match. 