### PR TITLE
PML_RZ.cpp: don't use WarpX::GetInstance()

### DIFF
--- a/Source/BoundaryConditions/PML_RZ.H
+++ b/Source/BoundaryConditions/PML_RZ.H
@@ -33,14 +33,15 @@ class PML_RZ
 {
 public:
     PML_RZ (int lev, amrex::BoxArray const& grid_ba, amrex::DistributionMapping const& grid_dm,
-            amrex::Geometry const* geom, int ncell, int do_pml_in_domain);
+            amrex::Geometry const* geom, ablastr::fields::MultiFabRegister& fields,
+            int ncell, int do_pml_in_domain);
 
     void ApplyDamping(amrex::MultiFab* Et_fp, amrex::MultiFab* Ez_fp,
                       amrex::MultiFab* Bt_fp, amrex::MultiFab* Bz_fp,
                       amrex::Real dt, ablastr::fields::MultiFabRegister& fields);
 
 #ifdef WARPX_USE_FFT
-    void PushPSATD (int lev);
+    void PushPSATD (int lev, ablastr::fields::MultiFabRegister& fields, SpectralSolverRZ& spec_solver);
 #endif
 
     void FillBoundaryE (ablastr::fields::MultiFabRegister& fields,
@@ -56,16 +57,6 @@ private:
     int m_ncell;
     int m_do_pml_in_domain;
     const amrex::Geometry* m_geom;
-
-    // The MultiFabs pml_E_fp and pml_B_fp are setup using the registry.
-    // They hold Er, Et, and Br, Bt.
-
-#ifdef WARPX_USE_FFT
-    void PushPMLPSATDSinglePatchRZ (int lev,
-                SpectralSolverRZ& solver,
-                ablastr::fields::MultiFabRegister& fields);
-#endif
-
 };
 
 #endif

--- a/Source/BoundaryConditions/PML_RZ.cpp
+++ b/Source/BoundaryConditions/PML_RZ.cpp
@@ -38,34 +38,33 @@ using warpx::fields::FieldType;
 using ablastr::fields::Direction;
 
 PML_RZ::PML_RZ (int lev, amrex::BoxArray const& grid_ba, amrex::DistributionMapping const& grid_dm,
-                amrex::Geometry const* geom, int ncell, int do_pml_in_domain)
+                amrex::Geometry const* geom, ablastr::fields::MultiFabRegister& fields,
+                int ncell, int do_pml_in_domain)
     : m_ncell(ncell),
       m_do_pml_in_domain(do_pml_in_domain),
       m_geom(geom)
 {
     using ablastr::fields::Direction;
 
-    auto & warpx = WarpX::GetInstance();
-
     bool const remake = false;
     bool const redistribute_on_remake = false;
 
-    amrex::MultiFab const& Er_fp = *warpx.m_fields.get(FieldType::Efield_fp, Direction{0}, lev);
-    amrex::MultiFab const& Et_fp = *warpx.m_fields.get(FieldType::Efield_fp, Direction{1}, lev);
+    amrex::MultiFab const& Er_fp = *fields.get(FieldType::Efield_fp, Direction{0}, lev);
+    amrex::MultiFab const& Et_fp = *fields.get(FieldType::Efield_fp, Direction{1}, lev);
     amrex::BoxArray const ba_Er = amrex::convert(grid_ba, Er_fp.ixType().toIntVect());
     amrex::BoxArray const ba_Et = amrex::convert(grid_ba, Et_fp.ixType().toIntVect());
-    warpx.m_fields.alloc_init(FieldType::pml_E_fp, Direction{0}, lev, ba_Er, grid_dm, Er_fp.nComp(), Er_fp.nGrowVect(), 0.0_rt,
+    fields.alloc_init(FieldType::pml_E_fp, Direction{0}, lev, ba_Er, grid_dm, Er_fp.nComp(), Er_fp.nGrowVect(), 0.0_rt,
                               remake, redistribute_on_remake);
-    warpx.m_fields.alloc_init(FieldType::pml_E_fp, Direction{1}, lev, ba_Et, grid_dm, Et_fp.nComp(), Et_fp.nGrowVect(), 0.0_rt,
+    fields.alloc_init(FieldType::pml_E_fp, Direction{1}, lev, ba_Et, grid_dm, Et_fp.nComp(), Et_fp.nGrowVect(), 0.0_rt,
                               remake, redistribute_on_remake);
 
-    amrex::MultiFab const& Br_fp = *warpx.m_fields.get(FieldType::Bfield_fp,Direction{0},lev);
-    amrex::MultiFab const& Bt_fp = *warpx.m_fields.get(FieldType::Bfield_fp,Direction{1},lev);
+    amrex::MultiFab const& Br_fp = *fields.get(FieldType::Bfield_fp,Direction{0},lev);
+    amrex::MultiFab const& Bt_fp = *fields.get(FieldType::Bfield_fp,Direction{1},lev);
     amrex::BoxArray const ba_Br = amrex::convert(grid_ba, Br_fp.ixType().toIntVect());
     amrex::BoxArray const ba_Bt = amrex::convert(grid_ba, Bt_fp.ixType().toIntVect());
-    warpx.m_fields.alloc_init(FieldType::pml_B_fp, Direction{0}, lev, ba_Br, grid_dm, Br_fp.nComp(), Br_fp.nGrowVect(), 0.0_rt,
+    fields.alloc_init(FieldType::pml_B_fp, Direction{0}, lev, ba_Br, grid_dm, Br_fp.nComp(), Br_fp.nGrowVect(), 0.0_rt,
                               remake, redistribute_on_remake);
-    warpx.m_fields.alloc_init(FieldType::pml_B_fp, Direction{1}, lev, ba_Bt, grid_dm, Bt_fp.nComp(), Bt_fp.nGrowVect(), 0.0_rt,
+    fields.alloc_init(FieldType::pml_B_fp, Direction{1}, lev, ba_Bt, grid_dm, Bt_fp.nComp(), Bt_fp.nGrowVect(), 0.0_rt,
                               remake, redistribute_on_remake);
 
 }
@@ -192,38 +191,27 @@ PML_RZ::Restart (ablastr::fields::MultiFabRegister& fields, std::string const& d
 
 #ifdef WARPX_USE_FFT
 void
-PML_RZ::PushPSATD (int lev)
-{
-    // Update the fields on the fine and coarse patch
-    WarpX& warpx = WarpX::GetInstance();
-    SpectralSolverRZ& solver = warpx.get_spectral_solver_fp(lev);
-    PushPMLPSATDSinglePatchRZ(lev, solver, warpx.m_fields);
-}
-
-void
-PML_RZ::PushPMLPSATDSinglePatchRZ (
-    int lev,
-    SpectralSolverRZ& solver,
-    ablastr::fields::MultiFabRegister& fields)
+PML_RZ::PushPSATD (int lev, ablastr::fields::MultiFabRegister& fields, SpectralSolverRZ& spec_solver)
 {
     using ablastr::fields::Direction;
 
-    SpectralFieldIndex const& Idx = solver.m_spectral_index;
+    SpectralFieldIndex const& Idx = spec_solver.m_spectral_index;
     amrex::MultiFab * pml_Er = fields.get(FieldType::pml_E_fp, Direction{0}, 0);
     amrex::MultiFab * pml_Et = fields.get(FieldType::pml_E_fp, Direction{1}, 0);
     amrex::MultiFab * pml_Br = fields.get(FieldType::pml_B_fp, Direction{0}, 0);
     amrex::MultiFab * pml_Bt = fields.get(FieldType::pml_B_fp, Direction{1}, 0);
 
     // Perform forward Fourier transforms
-    solver.ForwardTransform(lev, *pml_Er, Idx.Er_pml, *pml_Et, Idx.Et_pml);
-    solver.ForwardTransform(lev, *pml_Br, Idx.Br_pml, *pml_Bt, Idx.Bt_pml);
+    spec_solver.ForwardTransform(lev, *pml_Er, Idx.Er_pml, *pml_Et, Idx.Et_pml);
+    spec_solver.ForwardTransform(lev, *pml_Br, Idx.Br_pml, *pml_Bt, Idx.Bt_pml);
 
     // Advance fields in spectral space
     bool const doing_pml = true;
-    solver.pushSpectralFields(doing_pml);
+    spec_solver.pushSpectralFields(doing_pml);
 
     // Perform backward Fourier transforms
-    solver.BackwardTransform(lev, *pml_Er, Idx.Er_pml, *pml_Et, Idx.Et_pml);
-    solver.BackwardTransform(lev, *pml_Br, Idx.Br_pml, *pml_Bt, Idx.Bt_pml);
+    spec_solver.BackwardTransform(lev, *pml_Er, Idx.Er_pml, *pml_Et, Idx.Et_pml);
+    spec_solver.BackwardTransform(lev, *pml_Br, Idx.Br_pml, *pml_Bt, Idx.Bt_pml);
 }
+
 #endif

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -903,7 +903,8 @@ WarpX::PushPSATD (amrex::Real start_time)
     PSATDForwardTransformEB();
 
 #ifdef WARPX_DIM_RZ
-    if (pml_rz[0]) { pml_rz[0]->PushPSATD(0); }
+    constexpr auto lev0 = 0;
+    if (pml_rz[lev0]) { pml_rz[lev0]->PushPSATD(lev0, m_fields, get_spectral_solver_fp(lev0)); }
 #endif
 
     // FFT of F and G

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -800,7 +800,7 @@ WarpX::InitPML ()
         bool const eb_enabled = EB::enabled();
 #if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
         do_pml_Lo[0][0] = 0; // no PML at r=0, in cylindrical geometry
-        pml_rz[0] = std::make_unique<PML_RZ>(0, boxArray(0), DistributionMap(0), &Geom(0), pml_ncell, do_pml_in_domain);
+        pml_rz[0] = std::make_unique<PML_RZ>(0, boxArray(0), DistributionMap(0), &Geom(0), m_fields, pml_ncell, do_pml_in_domain);
 #else
         // Note: fill_guards_fields and fill_guards_current are both set to
         // zero (amrex::IntVect(0)) (what we do with damping BCs does not apply


### PR DESCRIPTION
This PR removes the occurrences of `WarpX::GetInstance()` from `PML_RZ.cpp`. This is achieved by passing `m_fields` and the spectral solver object as function parameters. 

The PR also moves the code of the function `PML_RZ::PushPMLPSATDSinglePatchRZ`  inside `PML_RZ::PushPSATD` in order to avoid an unnecessary intermediate layer (without `WarpX::GetInstance()`, `PML_RZ::PushPSATD` would have directly called `PML_RZ::PushPMLPSATDSinglePatchRZ`).