### PR TITLE
Fix DSMC typo for non-product producing processes

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -88,7 +88,7 @@ public:
         );
 
         amrex::Vector<int> num_added_vec(m_num_product_species, 0);
-        for (int i = 0; i < m_num_product_species; i++)
+        for (int i = 0; i < 2; i++)
         {
             // Record the number of non product producing events lead to new
             // particles for species1 and 2. Only 1 particle is created for


### PR DESCRIPTION
The DSMC kernel performs several types of collisions:
- non-product producing collisions: elastic scattering, charge exchange, etc.
- product producing collisions: ionization

The first types of collisions (non-product producing collisions) still creates new macroparticles (because the high-weight macroparticle in a collision can be split into a lower weight "scattered" particles, and another "unscattered" particle).

However, these non-product producing collisions only involve the first 2 "products".