### PR TITLE
Fix Random Engine constructor for GPU compilation

### DIFF
--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -581,7 +581,11 @@ amrex::XDim3 PlasmaInjector::getMomentum (amrex::Real x,
                                           amrex::Real y,
                                           amrex::Real z) const noexcept
 {
+#ifdef AMREX_USE_GPU
+    return h_inj_mom->getMomentum(x, y, z, amrex::RandomEngine{nullptr}); // gamma*beta
+#else
     return h_inj_mom->getMomentum(x, y, z, amrex::RandomEngine{}); // gamma*beta
+#endif
 }
 
 bool PlasmaInjector::insideBounds (amrex::Real x, amrex::Real y, amrex::Real z) const noexcept

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -429,7 +429,11 @@ void ParticleBoundaryBuffer::gatherParticlesFromDomainBoundaries (MultiParticleC
                         amrex::ReduceData<int> reduce_data(reduce_op);
                         {
                           WARPX_PROFILE("ParticleBoundaryBuffer::gatherParticles::count_out_of_bounds");
+#ifdef AMREX_USE_GPU
+                          const amrex::RandomEngine rng{nullptr};
+#else
                           const amrex::RandomEngine rng{};
+#endif
                           reduce_op.eval(np, reduce_data, [=] AMREX_GPU_HOST_DEVICE (int ip)
                                          { return predicate(ptile_data, ip, rng) ? 1 : 0; });
                         }

--- a/Source/Particles/ParticleCreation/DefaultInitialization.H
+++ b/Source/Particles/ParticleCreation/DefaultInitialization.H
@@ -168,7 +168,11 @@ void DefaultInitializeRuntimeAttributes (PTile& ptile,
                 // Otherwise (e.g. particle tile allocated in pinned memory), run on CPU
                 } else {
                     for (int ip = start; ip < stop; ++ip) {
+#ifdef AMREX_USE_GPU
+                        attr_ptr[ip] = quantum_sync_get_opt(amrex::RandomEngine{nullptr});
+#else
                         attr_ptr[ip] = quantum_sync_get_opt(amrex::RandomEngine{});
+#endif
                     }
                 }
             }
@@ -191,7 +195,11 @@ void DefaultInitializeRuntimeAttributes (PTile& ptile,
                 // Otherwise (e.g. particle tile allocated in pinned memory), run on CPU
                 } else {
                     for (int ip = start; ip < stop; ++ip) {
+#ifdef AMREX_USE_GPU
+                        attr_ptr[ip] = breit_wheeler_get_opt(amrex::RandomEngine{nullptr});
+#else
                         attr_ptr[ip] = breit_wheeler_get_opt(amrex::RandomEngine{});
+#endif
                     }
                 }
             }


### PR DESCRIPTION
AMReX PR included a fix to prevent bugs with random engine definitions 
https://github.com/AMReX-Codes/amrex/pull/4443 
This resulted in the development branch breaking when compiling with GPUs

This PR fixes this compilation error
