### PR TITLE
adding limit_verbose_step flag.

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3955,6 +3955,11 @@ When developing, testing and :ref:`debugging WarpX <debugging_warpx>`, the follo
 * ``warpx.verbose`` (``0`` or ``1``; default is ``1`` for true)
     Controls how much information is printed to the terminal, when running WarpX.
 
+* ``warpx.limit_verbose_step`` (`bool`, default: false)
+    If set to true, the information normally printed to the terminal at every time step
+    is limited: it prints every step for the first 10 steps, every 10 steps for steps between 10 and 100,
+    and once every 100 steps for steps greater than 100.
+
 * ``warpx.always_warn_immediately`` (``0`` or ``1``; default is ``0`` for false)
     If set to ``1``, WarpX immediately prints every warning message as soon as
     it is generated. It is mainly intended for debug purposes, in case a simulation

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -171,8 +171,21 @@ WarpX::Evolve (int numsteps)
 
         multi_diags->NewIteration();
 
+        bool verbose_step = (bool)verbose;
+        if (verbose && m_limit_verbose_step) {
+
+            int verbose_step_interval = 1;
+            if (step<10) { verbose_step_interval = 1; }
+            else if (step<100) { verbose_step_interval = 10; }
+            else { verbose_step_interval = 100; }
+
+            if ((step+1)%verbose_step_interval==0) { verbose_step = true; }
+            else { verbose_step = false; }
+
+        }
+
         // Start loop on time steps
-        if (verbose) {
+        if (verbose_step) {
             amrex::Print() << "STEP " << step+1 << " starts ...\n";
         }
         ExecutePythonCallback("beforestep");
@@ -183,7 +196,7 @@ WarpX::Evolve (int numsteps)
         // This first synchronizes the position and velocity before setting the new timestep
         if (electromagnetic_solver_id == ElectromagneticSolverAlgo::None &&
             !m_const_dt.has_value() && m_dt_update_interval.contains(step+1)) {
-            if (verbose) {
+            if (verbose_step) {
                 amrex::Print() << Utils::TextMsg::Info("updating timestep");
             }
             SynchronizeVelocityWithPosition();
@@ -261,7 +274,7 @@ WarpX::Evolve (int numsteps)
         // Resample particles
         // +1 is necessary here because value of step seen by user (first step is 1) is different than
         // value of step in code (first step is 0)
-        mypc->doResampling(Geom(), istep[0]+1, verbose);
+        mypc->doResampling(Geom(), istep[0]+1, verbose_step);
 
         if (evolve_scheme == EvolveScheme::Explicit) {
             applyMirrors(cur_time);
@@ -374,7 +387,7 @@ WarpX::Evolve (int numsteps)
 
         HandleSignals();
 
-        if (verbose) {
+        if (verbose_step) {
             amrex::Print()<< "STEP " << step+1 << " ends." << " TIME = " << cur_time
                         << " DT = " << dt[0] << "\n";
             amrex::Print()<< "Evolve time = " << evolve_time

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -179,8 +179,7 @@ WarpX::Evolve (int numsteps)
             else if (step<100) { verbose_step_interval = 10; }
             else { verbose_step_interval = 100; }
 
-            if ((step+1)%verbose_step_interval==0) { verbose_step = true; }
-            else { verbose_step = false; }
+            verbose_step = !((step+1)%verbose_step_interval);
 
         }
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1339,6 +1339,7 @@ private:
 
     // Other runtime parameters
     int verbose = 1;
+    bool m_limit_verbose_step = false;
 
     bool use_hybrid_QED = false;
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -656,6 +656,7 @@ WarpX::ReadParameters ()
 
         utils::parser::queryWithParser(pp_warpx, "cfl", cfl);
         pp_warpx.query("verbose", verbose);
+        pp_warpx.query("limit_verbose_step", m_limit_verbose_step);
         utils::parser::queryWithParser(pp_warpx, "regrid_int", regrid_int);
         pp_warpx.query("do_subcycling", m_do_subcycling);
         pp_warpx.query("use_hybrid_QED", use_hybrid_QED);


### PR DESCRIPTION
This PR adds a boolean flag to WarpX that can be used to limit the time step verbosity in the Evolve routine by dynamically increasing the step interval for printing. The step interval for printing is one for steps < 10, ten for steps < 100, and 100 otherwise.

Example output when this flag is true:

````
STEP 1 ends. TIME = 1e-12 DT = 1e-12
Evolve time = 0.097061303 s; This step = 0.097061303 s; Avg. per step = 0.097061303 s

STEP 2 starts ...
STEP 2 ends. TIME = 2e-12 DT = 1e-12
Evolve time = 0.1794752 s; This step = 0.082413897 s; Avg. per step = 0.0897376 s

STEP 3 starts ...
STEP 3 ends. TIME = 3e-12 DT = 1e-12
Evolve time = 0.264203125 s; This step = 0.084727925 s; Avg. per step = 0.08806770833 s

STEP 4 starts ...
STEP 4 ends. TIME = 4e-12 DT = 1e-12
Evolve time = 0.353372399 s; This step = 0.089169274 s; Avg. per step = 0.08834309975 s

STEP 5 starts ...
STEP 5 ends. TIME = 5e-12 DT = 1e-12
Evolve time = 0.437916334 s; This step = 0.084543935 s; Avg. per step = 0.0875832668 s

STEP 6 starts ...
STEP 6 ends. TIME = 6e-12 DT = 1e-12
Evolve time = 0.520766539 s; This step = 0.082850205 s; Avg. per step = 0.08679442317 s

STEP 7 starts ...
STEP 7 ends. TIME = 7e-12 DT = 1e-12
Evolve time = 0.605351227 s; This step = 0.084584688 s; Avg. per step = 0.08647874671 s

STEP 8 starts ...
STEP 8 ends. TIME = 8e-12 DT = 1e-12
Evolve time = 0.692963985 s; This step = 0.087612758 s; Avg. per step = 0.08662049813 s

STEP 9 starts ...
STEP 9 ends. TIME = 9e-12 DT = 1e-12
Evolve time = 0.775941135 s; This step = 0.08297715 s; Avg. per step = 0.08621568167 s

STEP 10 starts ...
STEP 10 ends. TIME = 1e-11 DT = 1e-12
Evolve time = 0.85883038 s; This step = 0.082889245 s; Avg. per step = 0.085883038 s

STEP 20 starts ...
STEP 20 ends. TIME = 2e-11 DT = 1e-12
Evolve time = 1.712082326 s; This step = 0.084826014 s; Avg. per step = 0.0856041163 s

STEP 30 starts ...
STEP 30 ends. TIME = 3e-11 DT = 1e-12
Evolve time = 2.561648666 s; This step = 0.08491593 s; Avg. per step = 0.08538828887 s

STEP 40 starts ...
STEP 40 ends. TIME = 4e-11 DT = 1e-12
Evolve time = 3.423001782 s; This step = 0.083581545 s; Avg. per step = 0.08557504455 s

STEP 50 starts ...
STEP 50 ends. TIME = 5e-11 DT = 1e-12
Evolve time = 4.274986048 s; This step = 0.085187583 s; Avg. per step = 0.08549972096 s

STEP 60 starts ...
STEP 60 ends. TIME = 6e-11 DT = 1e-12
Evolve time = 5.11891441 s; This step = 0.084928299 s; Avg. per step = 0.08531524017 s

STEP 70 starts ...
STEP 70 ends. TIME = 7e-11 DT = 1e-12
Evolve time = 5.96381336 s; This step = 0.084958207 s; Avg. per step = 0.08519733371 s

STEP 80 starts ...
STEP 80 ends. TIME = 8e-11 DT = 1e-12
Evolve time = 6.814137797 s; This step = 0.08497195 s; Avg. per step = 0.08517672246 s

STEP 90 starts ...
STEP 90 ends. TIME = 9e-11 DT = 1e-12
Evolve time = 7.65153128 s; This step = 0.084132666 s; Avg. per step = 0.08501701422 s

STEP 100 starts ...
STEP 100 ends. TIME = 1e-10 DT = 1e-12
Evolve time = 8.502485652 s; This step = 0.091003074 s; Avg. per step = 0.08502485652 s

STEP 200 starts ...
STEP 200 ends. TIME = 2e-10 DT = 1e-12
Evolve time = 16.96620295 s; This step = 0.088188 s; Avg. per step = 0.08483101474 s

STEP 300 starts ...
STEP 300 ends. TIME = 3e-10 DT = 1e-12
Evolve time = 25.44802304 s; This step = 0.084051843 s; Avg. per step = 0.08482674348 s

STEP 400 starts ...
STEP 400 ends. TIME = 4e-10 DT = 1e-12
Evolve time = 33.93437035 s; This step = 0.085563184 s; Avg. per step = 0.08483592588 s

STEP 500 starts ...
STEP 500 ends. TIME = 5e-10 DT = 1e-12
Evolve time = 42.43260393 s; This step = 0.08560758 s; Avg. per step = 0.08486520787 s

STEP 600 starts ...
STEP 600 ends. TIME = 6e-10 DT = 1e-12
Evolve time = 50.94823959 s; This step = 0.086835283 s; Avg. per step = 0.08491373266 s

STEP 700 starts ...
STEP 700 ends. TIME = 7e-10 DT = 1e-12
Evolve time = 59.52822963 s; This step = 0.085494549 s; Avg. per step = 0.08504032805 s

STEP 800 starts ...
STEP 800 ends. TIME = 8e-10 DT = 1e-12
Evolve time = 68.13886403 s; This step = 0.086334161 s; Avg. per step = 0.08517358004 s

STEP 900 starts ...
STEP 900 ends. TIME = 9e-10 DT = 1e-12
Evolve time = 76.7887484 s; This step = 0.086209944 s; Avg. per step = 0.08532083155 s

STEP 1000 starts ...
STEP 1000 ends. TIME = 1e-09 DT = 1e-12
Evolve time = 85.41984831 s; This step = 0.08705983 s; Avg. per step = 0.08541984831 s

STEP 1100 starts ...
STEP 1100 ends. TIME = 1.1e-09 DT = 1e-12
Evolve time = 94.10704904 s; This step = 0.089692752 s; Avg. per step = 0.08555186276 s

STEP 1200 starts ...
STEP 1200 ends. TIME = 1.2e-09 DT = 1e-12
Evolve time = 102.8065307 s; This step = 0.085702888 s; Avg. per step = 0.08567210893 s
````

