### PR TITLE
moving Implicit routines from WarpX class to base ImplicitSolver class

### DIFF
--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
@@ -195,9 +195,9 @@ protected:
     /**
      * \brief Perform operations needed before computing the Right Hand Side
      */
-    void PreRHSOp ( amrex::Real  a_cur_time,
-                    int          a_nl_iter,
-                    bool         a_from_jacobian );
+    void PreRHSOp ( const amrex::Real  a_cur_time,
+                    const int          a_nl_iter,
+                    const bool         a_from_jacobian );
 
     /**
      * \brief Communicate Mass Matrices used for PC and apply boundary conditions
@@ -207,7 +207,7 @@ protected:
     /**
      * \brief Scale mass matrices used for PC by c^2*mu0*theta*dt and add 1 to diagonal terms
      */
-    void SetMassMatricesForPC ( amrex::Real a_theta_dt );
+    void SetMassMatricesForPC ( const amrex::Real a_theta_dt );
 
     /**
      * \brief Convert from WarpX FieldBoundaryType to amrex::LinOpBCType

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
@@ -193,6 +193,23 @@ protected:
     void InitializeMassMatrices ();
 
     /**
+     * \brief Perform operations needed before computing the Right Hand Side
+     */
+    void PreRHSOp ( amrex::Real  a_cur_time,
+                    int          a_nl_iter,
+                    bool         a_from_jacobian );
+
+    /**
+     * \brief Communicate Mass Matrices used for PC and apply boundary conditions
+     */
+    void SyncMassMatricesPCAndApplyBCs ();
+
+    /**
+     * \brief Scale mass matrices used for PC by c^2*mu0*theta*dt and add 1 to diagonal terms
+     */
+    void SetMassMatricesForPC ( amrex::Real a_theta_dt );
+
+    /**
      * \brief Convert from WarpX FieldBoundaryType to amrex::LinOpBCType
      */
     [[nodiscard]] amrex::Array<amrex::LinOpBCType,AMREX_SPACEDIM> convertFieldBCToLinOpBC ( const amrex::Array<FieldBoundaryType,AMREX_SPACEDIM>& ) const;

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -121,3 +121,80 @@ void ImplicitSolver::InitializeMassMatrices ()
     }
 
 }
+
+void ImplicitSolver::PreRHSOp ( amrex::Real  a_cur_time,
+                                int          a_nl_iter,
+                                bool         a_from_jacobian )
+{
+    using warpx::fields::FieldType;
+    amrex::ignore_unused( a_nl_iter );
+
+    m_WarpX->ImplicitPreRHSOp();
+
+    // Advance the particle positions by 1/2 dt,
+    // particle velocities by dt, then take average of old and new v,
+    // deposit currents, giving J at n+1/2
+    // This uses Efield_fp and Bfield_fp, the field at n+1/2 from the previous iteration.
+    const PushType push_type = PushType::Implicit;
+    const bool skip_current = false;
+    bool deposit_mass_matrices = false;
+    if (m_use_mass_matrices && !a_from_jacobian) { deposit_mass_matrices = true; }
+    m_WarpX->PushParticlesandDeposit(a_cur_time, skip_current, deposit_mass_matrices, push_type);
+
+    m_WarpX->SyncCurrentAndRho();
+    if (deposit_mass_matrices) {
+        SyncMassMatricesPCAndApplyBCs();
+        const amrex::Real theta_dt = m_theta*m_dt;
+        SetMassMatricesForPC( theta_dt );
+    }
+
+}
+
+void ImplicitSolver::SyncMassMatricesPCAndApplyBCs ()
+{
+    using ablastr::fields::Direction;
+    using warpx::fields::FieldType;
+
+    // Copy mass matrices elements used for the preconditioner
+    for (int lev = 0; lev < m_num_amr_levels; ++lev) {
+        ablastr::fields::VectorField MM = m_WarpX->m_fields.get_alldirs(FieldType::MassMatrices, lev);
+        ablastr::fields::VectorField MM_PC = m_WarpX->m_fields.get_alldirs(FieldType::MassMatrices_PC, lev);
+        amrex::MultiFab::Copy(*MM_PC[0], *MM[0], 0, 0, MM[0]->nComp(), MM[0]->nGrowVect());
+        amrex::MultiFab::Copy(*MM_PC[1], *MM[1], 0, 0, MM[1]->nComp(), MM[1]->nGrowVect());
+        amrex::MultiFab::Copy(*MM_PC[2], *MM[2], 0, 0, MM[2]->nComp(), MM[2]->nGrowVect());
+    }
+
+    // Do addOp Exchange on MassMatrices_PC
+    m_WarpX->SyncMassMatricesPC();
+
+    // Apply BCs to MassMatrices_PC
+    for (int lev = 0; lev < m_num_amr_levels; ++lev) {
+        m_WarpX->ApplyJfieldBoundary(lev,
+            m_WarpX->m_fields.get(FieldType::MassMatrices_PC, Direction{0}, lev),
+            m_WarpX->m_fields.get(FieldType::MassMatrices_PC, Direction{1}, lev),
+            m_WarpX->m_fields.get(FieldType::MassMatrices_PC, Direction{2}, lev),
+            PatchType::fine);
+    }
+}
+
+void ImplicitSolver::SetMassMatricesForPC ( amrex::Real a_theta_dt )
+{
+
+    using namespace amrex::literals;
+    using ablastr::fields::Direction;
+    using warpx::fields::FieldType;
+
+    // Scale mass matrices used by preconditioner by c^2*mu0*theta*dt and add 1 to diagonal terms
+    // Note: This should be done after Sync/communication has been called
+
+    const amrex::Real pc_factor = PhysConst::c * PhysConst::c * PhysConst::mu0 * a_theta_dt;
+    const int diag_comp = 0;
+    for (int lev = 0; lev < m_num_amr_levels; ++lev) {
+        for (int dir = 0 ; dir < 3 ; dir++) {
+            amrex::MultiFab* MM_PC = m_WarpX->m_fields.get(FieldType::MassMatrices_PC, Direction{dir}, lev);
+            MM_PC->mult(pc_factor, 0, MM_PC->nComp());
+            MM_PC->plus(1.0_rt, diag_comp, 1, 0);
+        }
+    }
+
+}

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -129,7 +129,10 @@ void ImplicitSolver::PreRHSOp ( amrex::Real  a_cur_time,
     using warpx::fields::FieldType;
     amrex::ignore_unused( a_nl_iter );
 
-    m_WarpX->ImplicitPreRHSOp();
+    if (m_WarpX->use_filter) {
+        int finest_level = 0;
+        m_WarpX->ApplyFilterMF(m_WarpX->m_fields.get_mr_levels_alldirs(FieldType::Efield_fp, finest_level), 0);
+    }
 
     // Advance the particle positions by 1/2 dt,
     // particle velocities by dt, then take average of old and new v,

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -122,9 +122,9 @@ void ImplicitSolver::InitializeMassMatrices ()
 
 }
 
-void ImplicitSolver::PreRHSOp ( amrex::Real  a_cur_time,
-                                int          a_nl_iter,
-                                bool         a_from_jacobian )
+void ImplicitSolver::PreRHSOp ( const amrex::Real  a_cur_time,
+                                const int          a_nl_iter,
+                                const bool         a_from_jacobian )
 {
     using warpx::fields::FieldType;
     amrex::ignore_unused( a_nl_iter );
@@ -180,7 +180,7 @@ void ImplicitSolver::SyncMassMatricesPCAndApplyBCs ()
     }
 }
 
-void ImplicitSolver::SetMassMatricesForPC ( amrex::Real a_theta_dt )
+void ImplicitSolver::SetMassMatricesForPC ( const amrex::Real a_theta_dt )
 {
 
     using namespace amrex::literals;

--- a/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
@@ -125,7 +125,7 @@ void SemiImplicitEM::ComputeRHS ( WarpXSolverVec&  a_RHS,
 
     // Update particle positions and velocities using the current state
     // of Eg and Bg. Deposit current density at time n+1/2
-    m_WarpX->ImplicitPreRHSOp( half_time, m_theta, m_dt, a_nl_iter, a_from_jacobian, m_use_mass_matrices );
+    PreRHSOp( half_time, a_nl_iter, a_from_jacobian );
 
     // RHS = cvac^2*0.5*dt*( curl(Bg^{n+1/2}) - mu0*Jg^{n+1/2} )
     m_WarpX->ImplicitComputeRHSE(0.5_rt*m_dt, a_RHS);

--- a/Source/FieldSolver/ImplicitSolvers/StrangImplicitSpectralEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/StrangImplicitSpectralEM.cpp
@@ -116,7 +116,7 @@ void StrangImplicitSpectralEM::ComputeRHS ( WarpXSolverVec& a_RHS,
 
     // Self consistently update particle positions and velocities using the
     // current state of the fields E and B. Deposit current density at time n+1/2.
-    m_WarpX->ImplicitPreRHSOp( half_time, m_theta, m_dt, a_nl_iter, a_from_jacobian, m_use_mass_matrices );
+    PreRHSOp( half_time, a_nl_iter, a_from_jacobian );
 
     // For Strang split implicit PSATD, the RHS = -dt*mu*c**2*J
     bool const allow_type_mismatch = true;

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
@@ -146,7 +146,7 @@ void ThetaImplicitEM::ComputeRHS ( WarpXSolverVec&  a_RHS,
     // Update particle positions and velocities using the current state
     // of Eg and Bg. Deposit current density at time n+1/2
     const amrex::Real theta_time = start_time + m_theta*m_dt;
-    m_WarpX->ImplicitPreRHSOp( theta_time, m_theta, m_dt, a_nl_iter, a_from_jacobian, m_use_mass_matrices );
+    PreRHSOp( theta_time, a_nl_iter, a_from_jacobian );
 
     // RHS = cvac^2*m_theta*dt*( curl(Bg^{n+theta}) - mu0*Jg^{n+1/2} )
     m_WarpX->ImplicitComputeRHSE( m_theta*m_dt, a_RHS);

--- a/Source/FieldSolver/ImplicitSolvers/WarpXImplicitOps.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXImplicitOps.cpp
@@ -46,16 +46,6 @@
 #include <vector>
 
 void
-WarpX::ImplicitPreRHSOp ()
-{
-    // ApplyFilterMF() is protected and can't be called using m_WarpX-> from ImplicitSolver::PreRHSOp()
-    if (use_filter) {
-        using warpx::fields::FieldType;
-        ApplyFilterMF(m_fields.get_mr_levels_alldirs(FieldType::Efield_fp, finest_level), 0);
-    }
-}
-
-void
 WarpX::SetElectricFieldAndApplyBCs ( const WarpXSolverVec& a_E, amrex::Real a_time )
 {
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(

--- a/Source/FieldSolver/ImplicitSolvers/WarpXImplicitOps.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXImplicitOps.cpp
@@ -46,86 +46,13 @@
 #include <vector>
 
 void
-WarpX::ImplicitPreRHSOp ( amrex::Real  a_cur_time,
-                          amrex::Real  a_theta,
-                          amrex::Real  a_full_dt,
-                          int          a_nl_iter,
-                          bool         a_from_jacobian,
-                          bool         a_use_mass_matrices )
+WarpX::ImplicitPreRHSOp ()
 {
-    using warpx::fields::FieldType;
-    amrex::ignore_unused( a_full_dt, a_nl_iter, a_from_jacobian );
-
-    if (use_filter) { ApplyFilterMF(m_fields.get_mr_levels_alldirs(FieldType::Efield_fp, finest_level), 0); }
-
-    // Advance the particle positions by 1/2 dt,
-    // particle velocities by dt, then take average of old and new v,
-    // deposit currents, giving J at n+1/2
-    // This uses Efield_fp and Bfield_fp, the field at n+1/2 from the previous iteration.
-    const PushType push_type = PushType::Implicit;
-    const bool skip_current = false;
-    bool deposit_mass_matrices = false;
-    if (a_use_mass_matrices && !a_from_jacobian) { deposit_mass_matrices = true; }
-    PushParticlesandDeposit(a_cur_time, skip_current, deposit_mass_matrices, push_type);
-
-    SyncCurrentAndRho();
-    if (deposit_mass_matrices) {
-        SyncMassMatricesAndApplyBCs();
-        const amrex::Real theta_dt = a_theta*a_full_dt;
-        SetMassMatricesForPC( theta_dt );
+    // ApplyFilterMF() is protected and can't be called using m_WarpX-> from ImplicitSolver::PreRHSOp()
+    if (use_filter) {
+        using warpx::fields::FieldType;
+        ApplyFilterMF(m_fields.get_mr_levels_alldirs(FieldType::Efield_fp, finest_level), 0);
     }
-
-}
-
-void
-WarpX::SyncMassMatricesAndApplyBCs ()
-{
-    using ablastr::fields::Direction;
-    using warpx::fields::FieldType;
-
-    // Copy mass matrices elements used for the preconditioner
-    for (int lev = 0; lev <= finest_level; ++lev) {
-        ablastr::fields::VectorField MM = m_fields.get_alldirs(FieldType::MassMatrices, lev);
-        ablastr::fields::VectorField MM_PC = m_fields.get_alldirs(FieldType::MassMatrices_PC, lev);
-        amrex::MultiFab::Copy(*MM_PC[0], *MM[0], 0, 0, MM[0]->nComp(), MM[0]->nGrowVect());
-        amrex::MultiFab::Copy(*MM_PC[1], *MM[1], 0, 0, MM[1]->nComp(), MM[1]->nGrowVect());
-        amrex::MultiFab::Copy(*MM_PC[2], *MM[2], 0, 0, MM[2]->nComp(), MM[2]->nGrowVect());
-    }
-
-    // Do addOp Exchange on MassMatrices_PC
-    SyncMassMatrices();
-
-    // Apply BCs to MassMatrices_PC
-    for (int lev = 0; lev <= finest_level; ++lev) {
-        ApplyJfieldBoundary(lev,
-            m_fields.get(FieldType::MassMatrices_PC, Direction{0}, lev),
-            m_fields.get(FieldType::MassMatrices_PC, Direction{1}, lev),
-            m_fields.get(FieldType::MassMatrices_PC, Direction{2}, lev),
-            PatchType::fine);
-    }
-}
-
-void
-WarpX::SetMassMatricesForPC ( amrex::Real a_theta_dt )
-{
-
-    using namespace amrex::literals;
-    using ablastr::fields::Direction;
-    using warpx::fields::FieldType;
-
-    // Scale mass matrices used by preconditioner by c^2*mu0*theta*dt and add 1 to diagonal terms
-    // Note: This should be done after Sync/communication has been called
-
-    const amrex::Real pc_factor = PhysConst::c * PhysConst::c * PhysConst::mu0 * a_theta_dt;
-    const int diag_comp = 0;
-    for (int lev = 0; lev <= finest_level; ++lev) {
-        for (int idir = 0 ; idir < 3 ; idir++) {
-            amrex::MultiFab* mass_matrix = m_fields.get(FieldType::MassMatrices_PC, Direction{idir}, lev);
-            mass_matrix->mult(pc_factor, 0, mass_matrix->nComp());
-            mass_matrix->plus(1.0_rt, diag_comp, 1, 0);
-        }
-    }
-
 }
 
 void

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -1268,9 +1268,9 @@ WarpX::SyncCurrent (const std::string& current_fp_string)
 }
 
 void
-WarpX::SyncMassMatrices ()
+WarpX::SyncMassMatricesPC ()
 {
-    WARPX_PROFILE("WarpX::SyncMassMatrices()");
+    WARPX_PROFILE("WarpX::SyncMassMatricesPC()");
 
     ablastr::fields::MultiLevelVectorField const& Sigma_fp = m_fields.get_mr_levels_alldirs("MassMatrices_PC", finest_level);
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -137,7 +137,6 @@ public:
     //
     // Functions used by implicit solvers
     //
-    void ImplicitPreRHSOp ();
     void SyncMassMatricesPC ();
     void SaveParticlesAtImplicitStepStart ();
     void FinishImplicitParticleUpdate ();
@@ -883,6 +882,15 @@ public:
 
     void ApplyFilterandSumBoundaryRho (int lev, int glev, amrex::MultiFab& rho, int icomp, int ncomp);
 
+    void ApplyFilterMF (
+        const ablastr::fields::MultiLevelVectorField& mfvec,
+        int lev,
+        int idim);
+
+    void ApplyFilterMF (
+        const ablastr::fields::MultiLevelVectorField& mfvec,
+        int lev);
+
     // Device vectors of stencil coefficients used for finite-order centering of fields
     amrex::Gpu::DeviceVector<amrex::Real> device_field_centering_stencil_coeffs_x;
     amrex::Gpu::DeviceVector<amrex::Real> device_field_centering_stencil_coeffs_y;
@@ -1056,13 +1064,6 @@ private:
         const ablastr::fields::MultiLevelVectorField& J_fp,
         const ablastr::fields::MultiLevelVectorField& J_cp,
         const ablastr::fields::MultiLevelVectorField& J_buffer,
-        int lev);
-    void ApplyFilterMF (
-        const ablastr::fields::MultiLevelVectorField& mfvec,
-        int lev,
-        int idim);
-    void ApplyFilterMF (
-        const ablastr::fields::MultiLevelVectorField& mfvec,
         int lev);
     void SumBoundaryJ (
         const ablastr::fields::MultiLevelVectorField& current,

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -137,15 +137,8 @@ public:
     //
     // Functions used by implicit solvers
     //
-    void ImplicitPreRHSOp ( amrex::Real cur_time,
-                            amrex::Real a_theta,
-                            amrex::Real a_full_dt,
-                            int         a_nl_iter,
-                            bool        a_from_jacobian,
-                            bool        a_use_mass_matrices );
-    void SyncMassMatricesAndApplyBCs ();
-    void SyncMassMatrices ();
-    void SetMassMatricesForPC ( amrex::Real a_theta_dt );
+    void ImplicitPreRHSOp ();
+    void SyncMassMatricesPC ();
     void SaveParticlesAtImplicitStepStart ();
     void FinishImplicitParticleUpdate ();
     void SetElectricFieldAndApplyBCs ( const WarpXSolverVec& a_E, amrex::Real a_time );


### PR DESCRIPTION
This PR is in preparation for future PRs to incorporate the full mass matrices into the implicit solvers.