### PR TITLE
CI: Remove Hard-Coded Path to Checksum Files

### DIFF
--- a/Examples/Tests/laser_injection_from_file/inputs_test_2d_laser_injection_from_binary_file_prepare.py
+++ b/Examples/Tests/laser_injection_from_file/inputs_test_2d_laser_injection_from_binary_file_prepare.py
@@ -12,7 +12,6 @@
 # injection of a laser pulse from an external binary file:
 # - Generate an input binary file with a gaussian laser pulse.
 
-import sys
 
 import matplotlib
 
@@ -21,8 +20,6 @@ import numpy as np
 import yt
 
 yt.funcs.mylog.setLevel(50)
-
-sys.path.insert(1, "../../../../warpx/Regression/Checksum/")
 
 # Maximum acceptable error for this test
 relative_error_threshold = 0.065

--- a/Examples/Tests/pass_mpi_communicator/analysis.py
+++ b/Examples/Tests/pass_mpi_communicator/analysis.py
@@ -12,9 +12,7 @@ import yt
 
 yt.funcs.mylog.setLevel(50)
 import numpy as np
-
-sys.path.insert(1, "../../../../warpx/Regression/Checksum/")
-import checksum
+from checksum import Checksum
 
 # this will be the name of the first plot file
 fn1 = "Python_pass_mpi_comm_plt1_000010"
@@ -24,10 +22,8 @@ fn2 = "Python_pass_mpi_comm_plt2_000010"
 test_name1 = fn1[:-10]
 test_name2 = fn2[:-10]
 
-
-checksum1 = checksum.Checksum(test_name1, fn1, do_fields=True, do_particles=True)
-
-checksum2 = checksum.Checksum(test_name2, fn2, do_fields=True, do_particles=True)
+checksum1 = Checksum(test_name1, fn1, do_fields=True, do_particles=True)
+checksum2 = Checksum(test_name2, fn2, do_fields=True, do_particles=True)
 
 rtol = 1.0e-9
 atol = 1.0e-40

--- a/Examples/Tests/pass_mpi_communicator/analysis.py
+++ b/Examples/Tests/pass_mpi_communicator/analysis.py
@@ -12,6 +12,8 @@ import yt
 
 yt.funcs.mylog.setLevel(50)
 import numpy as np
+
+sys.path.insert(1, "../../../Regression/Checksum/")
 from checksum import Checksum
 
 # this will be the name of the first plot file

--- a/Examples/Tests/pass_mpi_communicator/analysis.py
+++ b/Examples/Tests/pass_mpi_communicator/analysis.py
@@ -13,8 +13,8 @@ import yt
 yt.funcs.mylog.setLevel(50)
 import numpy as np
 
-sys.path.insert(1, "../../../Regression/Checksum/")
-from checksum import Checksum
+sys.path.insert(1, "../../../../warpx/Regression/Checksum/")
+import checksum
 
 # this will be the name of the first plot file
 fn1 = "Python_pass_mpi_comm_plt1_000010"
@@ -24,8 +24,10 @@ fn2 = "Python_pass_mpi_comm_plt2_000010"
 test_name1 = fn1[:-10]
 test_name2 = fn2[:-10]
 
-checksum1 = Checksum(test_name1, fn1, do_fields=True, do_particles=True)
-checksum2 = Checksum(test_name2, fn2, do_fields=True, do_particles=True)
+
+checksum1 = checksum.Checksum(test_name1, fn1, do_fields=True, do_particles=True)
+
+checksum2 = checksum.Checksum(test_name2, fn2, do_fields=True, do_particles=True)
 
 rtol = 1.0e-9
 atol = 1.0e-40

--- a/Examples/analysis_default_regression.py
+++ b/Examples/analysis_default_regression.py
@@ -2,8 +2,11 @@
 
 import argparse
 import os
+import sys
 
 import yt
+
+sys.path.insert(1, "../Regression/Checksum/")
 from checksumAPI import evaluate_checksum
 from openpmd_viewer import OpenPMDTimeSeries
 

--- a/Examples/analysis_default_regression.py
+++ b/Examples/analysis_default_regression.py
@@ -2,13 +2,10 @@
 
 import argparse
 import os
-import sys
 
 import yt
-from openpmd_viewer import OpenPMDTimeSeries
-
-sys.path.insert(1, "../../../../warpx/Regression/Checksum/")
 from checksumAPI import evaluate_checksum
+from openpmd_viewer import OpenPMDTimeSeries
 
 
 def main(args):


### PR DESCRIPTION
The hard-coded path to the checksum files in the default regression analysis script,
```py
sys.path.insert(1, "../../../../warpx/Regression/Checksum/")
```
may cause issues when running tests locally through `ctest`, due to the `warpx` directory name.

To-do:
- [x] Test locally
  - [x] by @EZoni 
  - [x] by @dpgrote (who reported the issue with the `warpx` name first) 
- [x] Test with CI
- [x] Test with IDE
  - [x] by @RemiLehe