### PR TITLE
[WIP] PML_RZ: remove unused functions

### DIFF
--- a/Source/BoundaryConditions/PML_RZ.H
+++ b/Source/BoundaryConditions/PML_RZ.H
@@ -44,11 +44,6 @@ public:
     void PushPSATD (int lev, ablastr::fields::MultiFabRegister& fields, SpectralSolverRZ& spec_solver);
 #endif
 
-    void FillBoundaryE (ablastr::fields::MultiFabRegister& fields,
-                        PatchType patch_type, std::optional<bool> nodal_sync=std::nullopt);
-    void FillBoundaryB (ablastr::fields::MultiFabRegister& fields,
-                        PatchType patch_type, std::optional<bool> nodal_sync=std::nullopt);
-
     void CheckPoint (ablastr::fields::MultiFabRegister& fields, std::string const& dir) const;
     void Restart (ablastr::fields::MultiFabRegister& fields, std::string const& dir);
 

--- a/Source/BoundaryConditions/PML_RZ.H
+++ b/Source/BoundaryConditions/PML_RZ.H
@@ -10,8 +10,6 @@
 
 #include "PML_RZ_fwd.H"
 
-#include "Utils/WarpXAlgorithmSelection.H"
-
 #ifdef WARPX_USE_FFT
 #   include "FieldSolver/SpectralSolver/SpectralSolverRZ.H"
 #endif
@@ -21,12 +19,9 @@
 #include <AMReX_MultiFab.H>
 #include <AMReX_BoxArray.H>
 #include <AMReX_Config.H>
-#include <AMReX_REAL.H>
 
 #include <AMReX_BaseFwd.H>
 
-#include <array>
-#include <optional>
 #include <string>
 
 class PML_RZ

--- a/Source/BoundaryConditions/PML_RZ.cpp
+++ b/Source/BoundaryConditions/PML_RZ.cpp
@@ -11,6 +11,7 @@
 #ifdef WARPX_USE_FFT
 #   include "FieldSolver/SpectralSolver/SpectralFieldDataRZ.H"
 #endif
+#include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
 
 #include <ablastr/utils/Communication.H>

--- a/Source/BoundaryConditions/PML_RZ.cpp
+++ b/Source/BoundaryConditions/PML_RZ.cpp
@@ -5,15 +5,13 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#include "PML_RZ.H"
-
 #include "BoundaryConditions/PML_RZ.H"
+
 #include "Fields.H"
 #ifdef WARPX_USE_FFT
 #   include "FieldSolver/SpectralSolver/SpectralFieldDataRZ.H"
 #endif
 #include "Utils/WarpXConst.H"
-#include "WarpX.H"
 
 #include <ablastr/utils/Communication.H>
 
@@ -128,38 +126,6 @@ PML_RZ::ApplyDamping (amrex::MultiFab* Et_fp, amrex::MultiFab* Ez_fp,
                 Bz_arr(i,j,k,icomp) *= damp_factor;
                 Ez_arr(i,j,k,icomp) *= damp_factor;
             });
-    }
-}
-
-void
-PML_RZ::FillBoundaryE (ablastr::fields::MultiFabRegister& fields, PatchType patch_type, std::optional<bool> nodal_sync)
-{
-    using ablastr::fields::Direction;
-
-    amrex::MultiFab * pml_Er = fields.get(FieldType::pml_E_fp, Direction{0}, 0);
-    amrex::MultiFab * pml_Et = fields.get(FieldType::pml_E_fp, Direction{1}, 0);
-
-    if (patch_type == PatchType::fine && pml_Er->nGrowVect().max() > 0)
-    {
-        amrex::Periodicity const& period = m_geom->periodicity();
-        const amrex::Vector<amrex::MultiFab*> mf = {pml_Er, pml_Et};
-        ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, period, nodal_sync);
-    }
-}
-
-void
-PML_RZ::FillBoundaryB (ablastr::fields::MultiFabRegister& fields, PatchType patch_type, std::optional<bool> nodal_sync)
-{
-    if (patch_type == PatchType::fine)
-    {
-        using ablastr::fields::Direction;
-
-        amrex::MultiFab * pml_Br = fields.get(FieldType::pml_B_fp, Direction{0}, 0);
-        amrex::MultiFab * pml_Bt = fields.get(FieldType::pml_B_fp, Direction{1}, 0);
-
-        amrex::Periodicity const& period = m_geom->periodicity();
-        const amrex::Vector<amrex::MultiFab*> mf = {pml_Br, pml_Bt};
-        ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, period, nodal_sync);
     }
 }
 


### PR DESCRIPTION
This PR removes `FillBoundaryE` and `FillBoundaryB` methods from `PML_RZ`, since they are (surprisingly!) unused.
This allows us to remove several include directives. 