### PR TITLE
PML_RZ: don't use warpx static variables directly

### DIFF
--- a/Source/BoundaryConditions/PML_RZ.H
+++ b/Source/BoundaryConditions/PML_RZ.H
@@ -44,10 +44,10 @@ public:
     void PushPSATD (int lev, ablastr::fields::MultiFabRegister& fields, SpectralSolverRZ& spec_solver);
 #endif
 
-    void FillBoundaryE (ablastr::fields::MultiFabRegister& fields,
-                        PatchType patch_type, std::optional<bool> nodal_sync=std::nullopt);
-    void FillBoundaryB (ablastr::fields::MultiFabRegister& fields,
-                        PatchType patch_type, std::optional<bool> nodal_sync=std::nullopt);
+    void FillBoundaryE (ablastr::fields::MultiFabRegister& fields, PatchType patch_type,
+        bool do_single_precision_comms, std::optional<bool> nodal_sync=std::nullopt);
+    void FillBoundaryB (ablastr::fields::MultiFabRegister& fields, PatchType patch_type,
+        bool do_single_precision_comms, std::optional<bool> nodal_sync=std::nullopt);
 
     void CheckPoint (ablastr::fields::MultiFabRegister& fields, std::string const& dir) const;
     void Restart (ablastr::fields::MultiFabRegister& fields, std::string const& dir);

--- a/Source/BoundaryConditions/PML_RZ.cpp
+++ b/Source/BoundaryConditions/PML_RZ.cpp
@@ -13,7 +13,6 @@
 #   include "FieldSolver/SpectralSolver/SpectralFieldDataRZ.H"
 #endif
 #include "Utils/WarpXConst.H"
-#include "WarpX.H"
 
 #include <ablastr/utils/Communication.H>
 
@@ -132,7 +131,8 @@ PML_RZ::ApplyDamping (amrex::MultiFab* Et_fp, amrex::MultiFab* Ez_fp,
 }
 
 void
-PML_RZ::FillBoundaryE (ablastr::fields::MultiFabRegister& fields, PatchType patch_type, std::optional<bool> nodal_sync)
+PML_RZ::FillBoundaryE (ablastr::fields::MultiFabRegister& fields, PatchType patch_type,
+    const bool do_single_precision_comms, const std::optional<bool> nodal_sync)
 {
     using ablastr::fields::Direction;
 
@@ -143,12 +143,13 @@ PML_RZ::FillBoundaryE (ablastr::fields::MultiFabRegister& fields, PatchType patc
     {
         amrex::Periodicity const& period = m_geom->periodicity();
         const amrex::Vector<amrex::MultiFab*> mf = {pml_Er, pml_Et};
-        ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, period, nodal_sync);
+        ablastr::utils::communication::FillBoundary(mf, do_single_precision_comms, period, nodal_sync);
     }
 }
 
 void
-PML_RZ::FillBoundaryB (ablastr::fields::MultiFabRegister& fields, PatchType patch_type, std::optional<bool> nodal_sync)
+PML_RZ::FillBoundaryB (ablastr::fields::MultiFabRegister& fields, PatchType patch_type,
+    const bool do_single_precision_comms, const std::optional<bool> nodal_sync)
 {
     if (patch_type == PatchType::fine)
     {
@@ -159,7 +160,7 @@ PML_RZ::FillBoundaryB (ablastr::fields::MultiFabRegister& fields, PatchType patc
 
         amrex::Periodicity const& period = m_geom->periodicity();
         const amrex::Vector<amrex::MultiFab*> mf = {pml_Br, pml_Bt};
-        ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, period, nodal_sync);
+        ablastr::utils::communication::FillBoundary(mf, do_single_precision_comms, period, nodal_sync);
     }
 }
 

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -760,7 +760,7 @@ WarpX::FillBoundaryE (const int lev, const PatchType patch_type, const amrex::In
 #if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
         if (pml_rz[lev])
         {
-            pml_rz[lev]->FillBoundaryE(m_fields, patch_type, nodal_sync);
+            pml_rz[lev]->FillBoundaryE(m_fields, patch_type, do_single_precision_comms, nodal_sync);
         }
 #endif
     }
@@ -773,7 +773,7 @@ WarpX::FillBoundaryE (const int lev, const PatchType patch_type, const amrex::In
             "Error: in FillBoundaryE, requested more guard cells than allocated");
 
         const amrex::IntVect nghost = (m_safe_guard_cells) ? mf[i]->nGrowVect() : ng;
-        ablastr::utils::communication::FillBoundary(*mf[i], nghost, WarpX::do_single_precision_comms, period, nodal_sync);
+        ablastr::utils::communication::FillBoundary(*mf[i], nghost, do_single_precision_comms, period, nodal_sync);
     }
 }
 
@@ -825,7 +825,7 @@ WarpX::FillBoundaryB (const int lev, const PatchType patch_type, const amrex::In
 #if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
         if (pml_rz[lev])
         {
-            pml_rz[lev]->FillBoundaryB(m_fields, patch_type, nodal_sync);
+            pml_rz[lev]->FillBoundaryB(m_fields, patch_type, do_single_precision_comms, nodal_sync);
         }
 #endif
     }
@@ -838,7 +838,7 @@ WarpX::FillBoundaryB (const int lev, const PatchType patch_type, const amrex::In
             "Error: in FillBoundaryB, requested more guard cells than allocated");
 
         const amrex::IntVect nghost = (m_safe_guard_cells) ? mf[i]->nGrowVect() : ng;
-        ablastr::utils::communication::FillBoundary(*mf[i], nghost, WarpX::do_single_precision_comms, period, nodal_sync);
+        ablastr::utils::communication::FillBoundary(*mf[i], nghost, do_single_precision_comms, period, nodal_sync);
     }
 }
 


### PR DESCRIPTION
This PR avoids accessing directly `WarpX::do_single_precision_comms` inside `PML_RZ.cpp` . Instead, this variable is passes as an argument.