### PR TITLE
[WIP] Impose that the target species in DSMC impact ionization is always the second species

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2080,6 +2080,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
 * ``<collision_name>.species`` (`strings`)
     If using ``dsmc``, ``pairwisecoulomb`` or ``nuclearfusion``, this should be the name(s) of the species,
     between which the collision will be considered. (Provide only one name for intra-species collisions.)
+    When using ``dsmc`` with impact ionization, the second species is the one that gets ionized.
     If using ``background_mcc`` or ``background_stopping`` type this should be the name of the
     species for which collisions with a background will be included.
     In this case, only one species name should be given.
@@ -2216,10 +2217,6 @@ Details about the collision models can be found in the :ref:`theory section <mul
     Only for ``background_mcc``. If the scattering process is ``ionization`` the
     produced species must also be given. For example if argon properties is used
     for the background gas, a species of argon ions should be specified here.
-
-* ``<collision_name>.ionization_target_species`` (`string`)
-    Only for ``dsmc`` with impact ionization. This specifies which one of the
-    colliding particles is ionized.
 
 .. _running-cpp-parameters-numerics:
 

--- a/Examples/Tests/ionization_dsmc/inputs_base_3d
+++ b/Examples/Tests/ionization_dsmc/inputs_base_3d
@@ -89,7 +89,6 @@ collisions.collision_names = ioniz
 
 ioniz.ionization_energy = 13.59844
 ioniz.product_species = ions electrons
-ioniz.ionization_target_species = neutrals
 ioniz.ndt = 1
 ioniz.scattering_processes = ionization
 ioniz.type = dsmc

--- a/Examples/Tests/ionization_dsmc/inputs_test_1d_ionization_neutral_dsmc
+++ b/Examples/Tests/ionization_dsmc/inputs_test_1d_ionization_neutral_dsmc
@@ -94,7 +94,6 @@ collisions.collision_names = neutral_to_ion
 neutral_to_ion.type = dsmc
 neutral_to_ion.scattering_processes = ionization
 neutral_to_ion.species = H2 Hneutral
-neutral_to_ion.ionization_target_species = Hneutral
 neutral_to_ion.product_species = Hplus electrons
 neutral_to_ion.ionization_cross_section = ../../../../warpx-data/MCC_cross_sections/H/H_on_H2_ionization.dat
 neutral_to_ion.ionization_energy = 13.6 # eV

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -108,22 +108,6 @@ public:
         // If DSMC the colliding species are also product species.
         // Therefore, we insert the colliding species at the beginning of `m_product_species`.
         if (collision_type == CollisionType::DSMC) {
-            // If the scattering process is ionization ensure that the
-            // explicitly specified "target" species, i.e., the species that
-            // undergoes ionization, is second in the species list for this
-            // collision set. The reason for this is that during the collision
-            // operation, an outgoing particle of the first species type will
-            // be created.
-            std::string target_species;
-            pp_collision_name.query("ionization_target_species", target_species);
-            if (!target_species.empty()) {
-                if (m_species_names[0] == target_species) {
-                    std::swap(m_species_names[0], m_species_names[1]);
-                } else if (m_species_names[1] != target_species) {
-                    WARPX_ABORT_WITH_MESSAGE("DSMC: Ionization target species, " + target_species + " must be one of the colliding species.");
-                }
-            }
-
             m_product_species.insert( m_product_species.begin(), m_species_names.begin(), m_species_names.end() );
 
             // During an ionization event, the non-ionizing target species could

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.cpp
@@ -31,19 +31,8 @@ SplitAndScatterFunc::SplitAndScatterFunc (const std::string& collision_name,
             // grab the colliding species
             amrex::Vector<std::string> colliding_species;
             pp_collision_name.getarr("species", colliding_species);
-            // grab the target species (i.e., the species that looses an
-            // electron during the collision)
-            std::string target_species;
-            pp_collision_name.query("ionization_target_species", target_species);
-            // find the index of the non-target species (the one that could
-            // also be used as a product species)
-            int non_target_idx = 0;
-            if (colliding_species[0] == target_species) {
-                non_target_idx = 1;
-            }
-
-            // check if the non-target species is in ``product_species``
-            auto it = std::find(product_species.begin(), product_species.end(), colliding_species[non_target_idx]);
+            // check if the non-target species (which is always the first species) is in ``product_species``
+            auto it = std::find(product_species.begin(), product_species.end(), colliding_species[0]);
 
             if (it != product_species.end()) {
                 m_num_product_species = 3;


### PR DESCRIPTION
The code in `SplitAndScatterFunc.cpp` is somewhat confusing because:
- This line seems to indicate that we do not know which of the two colliding species is the target species: https://github.com/BLAST-WarpX/warpx/blob/development/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.cpp#L41
- While this line seems to indicate that we do know which one it is:
https://github.com/BLAST-WarpX/warpx/blob/development/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.cpp#L50

In reality, these lines are consistent, because the first part refers to the list of products as entered by the user, while the second part refers to the order in the WarpX internal list of products, which has been modified by this line:
https://github.com/BLAST-WarpX/warpx/blob/2e242f8aa2c39914df9c06420b70f862992953c7/Source/Particles/Collision/BinaryCollision/BinaryCollision.H#L121
However, it is difficult to know this from just reading the code.

Instead I would suggest that we always impose that the second species that the user passes is the target species (the one that gets ionized). In this case, the user also does not need to pass `ionization_target_species` as a separate argument.


TODO: 
- [ ] Add checks that the ionized species is consistent with the products
- [ ] Impose that the user enters the electron species as the first species + check the species type in the code.
- [ ] Consolidate checks in only one file