### PR TITLE
Move RelativeCellPosition.H/cpp from Utils to ablastr/utils

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -12,12 +12,12 @@
 #include "Particles/Filter/FilterFunctors.H"
 #include "Utils/TextMsg.H"
 #include "Utils/Parser/ParserUtils.H"
-#include "Utils/RelativeCellPosition.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXProfilerWrapper.H"
 #include "WarpX.H"
 #include "OpenPMDHelpFunction.H"
 
+#include <ablastr/utils/RelativeCellPosition.H>
 #include <ablastr/warn_manager/WarnManager.H>
 
 #include <AMReX.H>
@@ -1312,7 +1312,7 @@ WarpXOpenPMDPlot::SetupMeshComp (openPMD::Mesh& mesh,
     mesh_comp.resetDataset(dataset);
 
     ::detail::setOpenPMDUnit( mesh, field_name );
-    auto relative_cell_pos = utils::getRelativeCellPosition(mf);     // AMReX Fortran index order
+    auto relative_cell_pos = ablastr::utils::getRelativeCellPosition(mf);     // AMReX Fortran index order
     std::reverse( relative_cell_pos.begin(), relative_cell_pos.end() ); // now in C order
     mesh_comp.setPosition( relative_cell_pos );
 }

--- a/Source/Utils/CMakeLists.txt
+++ b/Source/Utils/CMakeLists.txt
@@ -5,7 +5,6 @@ foreach(D IN LISTS WarpX_DIMS)
         Interpolate.cpp
         ParticleUtils.cpp
         SpeciesUtils.cpp
-        RelativeCellPosition.cpp
         WarpXMovingWindow.cpp
         WarpXTagging.cpp
         WarpXUtil.cpp

--- a/Source/Utils/Make.package
+++ b/Source/Utils/Make.package
@@ -4,7 +4,6 @@ CEXE_sources += WarpXUtil.cpp
 CEXE_sources += WarpXVersion.cpp
 CEXE_sources += Interpolate.cpp
 CEXE_sources += IntervalsParser.cpp
-CEXE_sources += RelativeCellPosition.cpp
 CEXE_sources += ParticleUtils.cpp
 CEXE_sources += SpeciesUtils.cpp
 

--- a/Source/ablastr/utils/CMakeLists.txt
+++ b/Source/ablastr/utils/CMakeLists.txt
@@ -3,6 +3,7 @@ foreach(D IN LISTS WarpX_DIMS)
     target_sources(ablastr_${SD}
       PRIVATE
         Communication.cpp
+        RelativeCellPosition.cpp
         SignalHandling.cpp
         TextMsg.cpp
         UsedInputsFile.cpp

--- a/Source/ablastr/utils/Make.package
+++ b/Source/ablastr/utils/Make.package
@@ -1,4 +1,5 @@
 CEXE_sources += Communication.cpp
+CEXE_sources += RelativeCellPosition.cpp
 CEXE_sources += SignalHandling.cpp
 CEXE_sources += TextMsg.cpp
 CEXE_sources += UsedInputsFile.cpp

--- a/Source/ablastr/utils/RelativeCellPosition.H
+++ b/Source/ablastr/utils/RelativeCellPosition.H
@@ -4,14 +4,15 @@
  *
  * License: BSD-3-Clause-LBNL
  */
-#ifndef WARPX_RELATIVE_CELL_POSITION_H_
-#define WARPX_RELATIVE_CELL_POSITION_H_
+
+#ifndef ABLASTR_UTILS_RELATIVE_CELL_POSITION_H_
+#define ABLASTR_UTILS_RELATIVE_CELL_POSITION_H_
 
 #include <AMReX_BaseFwd.H>
 
 #include <vector>
 
-namespace utils
+namespace ablastr::utils
 {
     /** Get the Relative Cell Position of Values in an MultiFab
      *
@@ -21,8 +22,8 @@ namespace utils
      * @param[in] mf the amrex::MultiFab to get relative cell positions for
      * @return relative position to the lower corner, scaled to cell size [0.0:1.0)
      */
-    std::vector< double >
+    [[nodiscard]] std::vector< double >
     getRelativeCellPosition (amrex::MultiFab const& mf);
 }
 
-#endif // WARPX_RELATIVE_CELL_POSITION_H_
+#endif // ABLASTR_UTILS_RELATIVE_CELL_POSITION_H_

--- a/Source/ablastr/utils/RelativeCellPosition.cpp
+++ b/Source/ablastr/utils/RelativeCellPosition.cpp
@@ -4,14 +4,15 @@
  *
  * License: BSD-3-Clause-LBNL
  */
+
 #include "RelativeCellPosition.H"
 
 #include <AMReX_Config.H>
 #include <AMReX_IndexType.H>
 #include <AMReX_MultiFab.H>
 
-std::vector< double >
-utils::getRelativeCellPosition(amrex::MultiFab const& mf)
+[[nodiscard]] std::vector< double >
+ablastr::utils::getRelativeCellPosition(amrex::MultiFab const& mf)
 {
     amrex::IndexType const idx_type = mf.ixType();
 


### PR DESCRIPTION
I think that the `getRelativeCellPosition` function is sufficiently general to be moved to ablastr. With this PR I would like to propose to do that.