### PR TITLE
Add barrier after each checkpoint level

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -177,6 +177,7 @@ FlushFormatCheckpoint::WriteToFile (
             }
 #endif
         }
+        ParallelDescriptor::Barrier();
     }
 
     CheckpointParticles(checkpointname, particle_diags);


### PR DESCRIPTION
This PR adds a barrier after each checkpointing level as discussed [here](https://github.com/AMReX-Codes/amrex/pull/4426#issuecomment-2887442943).
This change, together with the AMReX PR https://github.com/AMReX-Codes/amrex/pull/4426 and the correct striping on Lustre produced checkpoints (~3 min each) on a 5200 nodes simulation on Frontier.

The striping can be given via
```
lfs setstripe -c 1 -S 16M $SLURM_SUBMIT_DIR
warpx.field_io_nfiles = $NNODES
warpx.particle_io_nfiles = $NNODES
```