### PR TITLE
AcceleratorLattice.cpp: fix typo in a comment

### DIFF
--- a/Source/AcceleratorLattice/AcceleratorLattice.cpp
+++ b/Source/AcceleratorLattice/AcceleratorLattice.cpp
@@ -97,7 +97,7 @@ AcceleratorLattice::InitElementFinder (
 
 void
 AcceleratorLattice::UpdateElementFinder (int const lev, const amrex::Vector<amrex::Real>& time) // NOLINT(readability-make-member-function-const)
-{                                                       // Techniquely clang-tidy is correct because
+{                                                       // Technically clang-tidy is correct because
                                                         // m_element_finder is unique_ptr, not const*.
     if (m_lattice_defined) {
         for (amrex::MFIter mfi(*m_element_finder); mfi.isValid(); ++mfi)


### PR DESCRIPTION
I believe that the correct spelling is `Technically` here.