### PR TITLE
CI: Fix Skipped Required Workflows (again)

### DIFF
--- a/.github/workflows/check_changes.yml
+++ b/.github/workflows/check_changes.yml
@@ -22,6 +22,7 @@ jobs:
               - '!Docs/**'
               - '!**.md'
               - '!**.rst'
+              - '!.github/**'  # FIXME
           predicate-quantifier: 'every'
       - id: set-output
         run: |

--- a/.github/workflows/check_changes.yml
+++ b/.github/workflows/check_changes.yml
@@ -22,7 +22,6 @@ jobs:
               - '!Docs/**'
               - '!**.md'
               - '!**.rst'
-              - '!.github/**'  # FIXME
           predicate-quantifier: 'every'
       - id: set-output
         run: |

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 250
     needs: check_changes
-    if: ${{ github.event.pull_request.draft }}
+    if: ${{ github.event.pull_request.draft == false }}
     steps:
     - uses: actions/checkout@v4
     - name: install dependencies

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -27,6 +27,7 @@ jobs:
     if: ${{ github.event.pull_request.draft == false }}
     steps:
     - uses: actions/checkout@v4
+      if: ${{ needs.check_changes.outputs.has_non_docs_changes == 'true' }}
     - name: install dependencies
       if: ${{ needs.check_changes.outputs.has_non_docs_changes == 'true' }}
       run: |

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -24,13 +24,15 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 250
     needs: check_changes
-    if: ${{ github.event.pull_request.draft == false && needs.check_changes.outputs.has_non_docs_changes == 'true' }}
+    if: ${{ github.event.pull_request.draft }}
     steps:
     - uses: actions/checkout@v4
     - name: install dependencies
+      if: ${{ needs.check_changes.outputs.has_non_docs_changes == 'true' }}
       run: |
         .github/workflows/dependencies/clang.sh 17
     - name: set up cache
+      if: ${{ needs.check_changes.outputs.has_non_docs_changes == 'true' }}
       uses: actions/cache@v4
       with:
         path: ~/.cache/ccache
@@ -38,6 +40,7 @@ jobs:
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
     - name: build WarpX & run clang-tidy
+      if: ${{ needs.check_changes.outputs.has_non_docs_changes == 'true' }}
       run: |
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
@@ -45,10 +48,8 @@ jobs:
         export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
         export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
-
         export CXX=$(which clang++-17)
         export CC=$(which clang-17)
-
         cmake -S . -B build_clang_tidy      \
           -DCMAKE_VERBOSE_MAKEFILE=ON       \
           -DWarpX_DIMS="${{ matrix.dim }}"  \
@@ -60,13 +61,10 @@ jobs:
           -DWarpX_OPENPMD=ON                \
           -DWarpX_PRECISION=SINGLE          \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-
         cmake --build build_clang_tidy -j 4
-
         ${{github.workspace}}/.github/workflows/source/makeMakefileForClangTidy.py --input ${{github.workspace}}/ccache.log.txt
         make -j4 --keep-going -f clang-tidy-ccache-misses.mak \
             CLANG_TIDY=clang-tidy-17 \
             CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
-
         ccache -s
         du -hs ~/.cache/ccache

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,8 +5,6 @@ on:
     branches: [ "development" ]
   pull_request:
     branches: [ "development" ]
-  schedule:
-    - cron: "27 3 * * 0"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-codeql

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,52 +2,52 @@ name: 🔍 CodeQL
 
 on:
   push:
-    branches: [ "development" ]
+    branches:
+      - "development"
   pull_request:
-    branches: [ "development" ]
-  schedule:
-    - cron: "27 3 * * 0"
+    branches:
+      - "development"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-codeql
   cancel-in-progress: true
 
 jobs:
+
+  check_changes:
+    name: Analyze
+    uses: ./.github/workflows/check_changes.yml
+
   analyze:
     name: Analyze
     runs-on: ubuntu-24.04
-    if: github.event.pull_request.draft == false
+    needs: check_changes
+    if: ${{ github.event.pull_request.draft == false && needs.check_changes.outputs.has_non_docs_changes == 'true' }}
     permissions:
       actions: read
       contents: read
       security-events: write
-
     strategy:
       fail-fast: false
       matrix:
         language: [ python, cpp ]
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: '3.x'
-
       - name: Install Packages (C++)
         if: ${{ matrix.language == 'cpp' }}
         run: |
           sudo apt-get update
           sudo apt-get install --yes cmake openmpi-bin libopenmpi-dev libhdf5-openmpi-dev libadios-openmpi-dev ccache
-
           python -m pip install --upgrade pip
           python -m pip install --upgrade pipx
           python -m pip install --upgrade wheel
           python -m pip install --upgrade cmake
           python -m pipx install cmake
-
       - name: Set Up Cache
         if: ${{ matrix.language == 'cpp' }}
         uses: actions/cache@v4
@@ -56,23 +56,19 @@ jobs:
           key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
           restore-keys: |
                ccache-${{ github.workflow }}-${{ github.job }}-git-
-
       - name: Configure (C++)
         if: ${{ matrix.language == 'cpp' }}
         run: |
           cmake -S . -B build -DWarpX_OPENPMD=ON
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           config-file: ./.github/codeql/warpx-codeql.yml
           languages: ${{ matrix.language }}
           queries: +security-and-quality
-
       - name: Build (py)
         uses: github/codeql-action/autobuild@v3
         if: ${{ matrix.language == 'python' }}
-
       - name: Build (C++)
         if: ${{ matrix.language == 'cpp' }}
         run: |
@@ -80,24 +76,19 @@ jobs:
           export CCACHE_COMPRESSLEVEL=10
           export CCACHE_MAXSIZE=100M
           ccache -z
-
           cmake --build build -j 4
-
           ccache -s
           du -hs ~/.cache/ccache
-
           # Make sure CodeQL has something to do
           touch Source/Utils/WarpXVersion.cpp
           export CCACHE_DISABLE=1
           cmake --build build -j 4
-
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"
           upload: False
           output: sarif-results
-
       - name: filter-sarif
         uses: advanced-security/filter-sarif@v1
         with:
@@ -111,7 +102,6 @@ jobs:
             -build/_deps/*/*/*/*/*/*/*/*
           input: sarif-results/${{ matrix.language }}.sarif
           output: sarif-results/${{ matrix.language }}.sarif
-
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,52 +2,52 @@ name: 🔍 CodeQL
 
 on:
   push:
-    branches:
-      - "development"
+    branches: [ "development" ]
   pull_request:
-    branches:
-      - "development"
+    branches: [ "development" ]
+  schedule:
+    - cron: "27 3 * * 0"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-codeql
   cancel-in-progress: true
 
 jobs:
-
-  check_changes:
-    name: Analyze
-    uses: ./.github/workflows/check_changes.yml
-
   analyze:
     name: Analyze
     runs-on: ubuntu-24.04
-    needs: check_changes
-    if: ${{ github.event.pull_request.draft == false && needs.check_changes.outputs.has_non_docs_changes == 'true' }}
+    if: github.event.pull_request.draft == false
     permissions:
       actions: read
       contents: read
       security-events: write
+
     strategy:
       fail-fast: false
       matrix:
         language: [ python, cpp ]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: '3.x'
+
       - name: Install Packages (C++)
         if: ${{ matrix.language == 'cpp' }}
         run: |
           sudo apt-get update
           sudo apt-get install --yes cmake openmpi-bin libopenmpi-dev libhdf5-openmpi-dev libadios-openmpi-dev ccache
+
           python -m pip install --upgrade pip
           python -m pip install --upgrade pipx
           python -m pip install --upgrade wheel
           python -m pip install --upgrade cmake
           python -m pipx install cmake
+
       - name: Set Up Cache
         if: ${{ matrix.language == 'cpp' }}
         uses: actions/cache@v4
@@ -56,19 +56,23 @@ jobs:
           key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
           restore-keys: |
                ccache-${{ github.workflow }}-${{ github.job }}-git-
+
       - name: Configure (C++)
         if: ${{ matrix.language == 'cpp' }}
         run: |
           cmake -S . -B build -DWarpX_OPENPMD=ON
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           config-file: ./.github/codeql/warpx-codeql.yml
           languages: ${{ matrix.language }}
           queries: +security-and-quality
+
       - name: Build (py)
         uses: github/codeql-action/autobuild@v3
         if: ${{ matrix.language == 'python' }}
+
       - name: Build (C++)
         if: ${{ matrix.language == 'cpp' }}
         run: |
@@ -76,19 +80,24 @@ jobs:
           export CCACHE_COMPRESSLEVEL=10
           export CCACHE_MAXSIZE=100M
           ccache -z
+
           cmake --build build -j 4
+
           ccache -s
           du -hs ~/.cache/ccache
+
           # Make sure CodeQL has something to do
           touch Source/Utils/WarpXVersion.cpp
           export CCACHE_DISABLE=1
           cmake --build build -j 4
+
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"
           upload: False
           output: sarif-results
+
       - name: filter-sarif
         uses: advanced-security/filter-sarif@v1
         with:
@@ -102,6 +111,7 @@ jobs:
             -build/_deps/*/*/*/*/*/*/*/*
           input: sarif-results/${{ matrix.language }}.sarif
           output: sarif-results/${{ matrix.language }}.sarif
+
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@v3
         with:


### PR DESCRIPTION
Follow up on #5889 and fix the issue that appeared in #5883, related to the fact that we add the `clang-tidy` checks automatically from a matrix, rather than manually as separate jobs in the workflow file.

Note that I had managed to fix a similar issue in the alternative in-house implementation I had proposed in #5469.

To-do:
- [x] Fix main issue by applying the `if` condition at the `step` level (rather than the `job` level)
- [x] Remove `cron` schedule for CodeQL workflows (on Sundays at 3:27 AM...?)
- [x] Revert change in .github/workflows/check_changes.yml (implemented only to test the PR)

Future PRs:
- Skip also CodeQL workflows (C++ and Python files analysis) - not working yet...