### PR TITLE
Simplify logic in the DSMC code

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2086,8 +2086,9 @@ Details about the collision models can be found in the :ref:`theory section <mul
     If using ``linear_breit_wheeler`` these should be two photon species.
 
 * ``<collision_name>.product_species`` (`strings`)
-    Only for ``dsmc`` and ``nuclearfusion``. The name(s) of the species in which to add
+    Only for ``dsmc``, ``linear_breit_wheeler``, and ``nuclearfusion``. The name(s) of the species in which to add
     the new macroparticles created by the reaction.
+    If using ``dsmc`` with ionization reactions, the first species in this list must be an electron.
     If using ``linear_breit_wheeler`` these should be two species: one of electrons and one of positrons.
 
 * ``<collision_name>.ndt`` (`int`) optional

--- a/Examples/Physics_applications/capacitive_discharge/inputs_base_1d_picmi.py
+++ b/Examples/Physics_applications/capacitive_discharge/inputs_base_1d_picmi.py
@@ -292,7 +292,7 @@ class CapacitiveDischargeExample(object):
             electron_colls_dsmc = picmi.DSMCCollisions(
                 name="coll_elec_dsmc",
                 species=[self.electrons, self.neutrals],
-                product_species=[self.ions, self.electrons],
+                product_species=[self.electrons, self.ions],
                 ndt=4,
                 scattering_processes=ionization,
             )

--- a/Examples/Tests/ionization_dsmc/inputs_base_3d
+++ b/Examples/Tests/ionization_dsmc/inputs_base_3d
@@ -88,7 +88,7 @@ neutrals.uz_th = sqrt(q_e * Tn / m_p) / clight
 collisions.collision_names = ioniz
 
 ioniz.ionization_energy = 13.59844
-ioniz.product_species = ions electrons
+ioniz.product_species = electrons ions
 ioniz.ionization_target_species = neutrals
 ioniz.ndt = 1
 ioniz.scattering_processes = ionization

--- a/Examples/Tests/ionization_dsmc/inputs_base_3d
+++ b/Examples/Tests/ionization_dsmc/inputs_base_3d
@@ -40,11 +40,10 @@ boundary.particle_lo = periodic periodic periodic
 #################################
 particles.species_names = electrons ions neutrals
 
-electrons.charge = -q_e
+electrons.species_type = electron
 electrons.density = 1e+14
 electrons.initialize_self_fields = 0
 electrons.injection_style = nuniformpercell
-electrons.mass = m_e
 electrons.momentum_distribution_type = gaussian
 electrons.num_particles_per_cell_each_dim = 5 5 5
 electrons.profile = constant

--- a/Examples/Tests/ionization_dsmc/inputs_base_3d
+++ b/Examples/Tests/ionization_dsmc/inputs_base_3d
@@ -40,10 +40,11 @@ boundary.particle_lo = periodic periodic periodic
 #################################
 particles.species_names = electrons ions neutrals
 
-electrons.species_type = electron
+electrons.charge = -q_e
 electrons.density = 1e+14
 electrons.initialize_self_fields = 0
 electrons.injection_style = nuniformpercell
+electrons.mass = m_e
 electrons.momentum_distribution_type = gaussian
 electrons.num_particles_per_cell_each_dim = 5 5 5
 electrons.profile = constant

--- a/Examples/Tests/ionization_dsmc/inputs_test_1d_ionization_neutral_dsmc
+++ b/Examples/Tests/ionization_dsmc/inputs_test_1d_ionization_neutral_dsmc
@@ -95,6 +95,6 @@ neutral_to_ion.type = dsmc
 neutral_to_ion.scattering_processes = ionization
 neutral_to_ion.species = H2 Hneutral
 neutral_to_ion.ionization_target_species = Hneutral
-neutral_to_ion.product_species = Hplus electrons
+neutral_to_ion.product_species = electrons Hplus
 neutral_to_ion.ionization_cross_section = ../../../../warpx-data/MCC_cross_sections/H/H_on_H2_ionization.dat
 neutral_to_ion.ionization_energy = 13.6 # eV

--- a/Examples/Tests/ionization_dsmc/inputs_test_1d_ionization_neutral_dsmc
+++ b/Examples/Tests/ionization_dsmc/inputs_test_1d_ionization_neutral_dsmc
@@ -74,9 +74,8 @@ H2.uz = 0
 H2.zmin = 0
 H2.zmax = gas_length
 
+electrons.species_type = electron
 electrons.injection_style = none
-electrons.mass = m_e
-electrons.charge = -q_e
 
 #############################
 # Add diagnostics

--- a/Examples/Tests/ionization_dsmc/inputs_test_1d_ionization_neutral_dsmc
+++ b/Examples/Tests/ionization_dsmc/inputs_test_1d_ionization_neutral_dsmc
@@ -74,8 +74,9 @@ H2.uz = 0
 H2.zmin = 0
 H2.zmax = gas_length
 
-electrons.species_type = electron
 electrons.injection_style = none
+electrons.mass = m_e
+electrons.charge = -q_e
 
 #############################
 # Add diagnostics

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -125,20 +125,9 @@ public:
             }
 
             m_product_species.insert( m_product_species.begin(), m_species_names.begin(), m_species_names.end() );
-
-            // During an ionization event, the non-ionizing target species could
-            // also be a product (for example, electron impact ionization producing another
-            // electron). We check that if this is the case, the product species is
-            // only listed once. The number of product particles is appropriately
-            // handled in `SplitAndScatterFunc` in that case.
-            if (m_product_species.size() > 2) {
-                if (m_product_species[2] == m_product_species[0]) {
-                    m_product_species.erase(m_product_species.begin() + 2);
-                }
-                else if (m_product_species[3] == m_product_species[0]) {
-                    m_product_species.erase(m_product_species.begin() + 3);
-                }
-            }
+            // Note that, if a species is both a colliding species and a product species
+            // (e.g., e- in e- + H -> 2 e- + H+) then it will be listed twice in `m_product_species`.
+            // The code for ionization in `SplitAndScatterFunc` handles this case correctly.
         }
         m_have_product_species = !m_product_species.empty();
 

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -127,6 +127,7 @@ public:
             m_product_species.insert( m_product_species.begin(), m_species_names.begin(), m_species_names.end() );
             // Note that, if a species is both a colliding species and a product species
             // (e.g., e- in e- + H -> 2 e- + H+) then it will be listed twice in `m_product_species`.
+            // (e.g., m_product_species = [e-, H, e-, H+])
             // The code for ionization in `SplitAndScatterFunc` handles this case correctly.
         }
         m_have_product_species = !m_product_species.empty();

--- a/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
@@ -70,10 +70,11 @@ DSMCFunc::DSMCFunc (
             // during the scattering operation).
             amrex::Vector<std::string> product_species_names;
             pp_collision_name.getarr("product_species", product_species_names);
+            // Check that the charge and mass of the species is consistent with an electron species
             auto& species1 = mypc->GetParticleContainerFromName(product_species_names[0]);
-            if(species1.AmIA<PhysicalSpecies::electron>() == false) {
-                amrex::Abort("The first species in " + collision_name + ".product_species must be an electron, " +
-                "and must be marked as such with species_type=electron.");
+            if( abs( species1.getCharge() - PhysConst::q_e ) > 1e-6*PhysConst::q_e   ||
+                abs( species1.getMass() - PhysConst::m_e ) > 1e-6*PhysConst::m_e ) {
+                amrex::Abort("The first species in " + collision_name + ".product_species must be an electron.");
             }
 
             // TODO: add a check that the ionization species has the same mass

--- a/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
@@ -70,10 +70,9 @@ DSMCFunc::DSMCFunc (
             // during the scattering operation).
             amrex::Vector<std::string> product_species_names;
             pp_collision_name.getarr("product_species", product_species_names);
-            // Check that the charge and mass of the species is consistent with an electron species
+            // Check that the charge is consistent with an electron species
             auto& species1 = mypc->GetParticleContainerFromName(product_species_names[0]);
-            if( std::abs(  species1.getCharge() + PhysConst::q_e ) > 1e-6*PhysConst::q_e   ||
-                std::abs( species1.getMass() - PhysConst::m_e ) > 1e-6*PhysConst::m_e ) {
+            if( species1.getCharge() < 0._prt ) {
                 amrex::Abort("The first species in " + collision_name + ".product_species must be an electron.");
             }
 

--- a/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
@@ -56,16 +56,27 @@ DSMCFunc::DSMCFunc (
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(process.type() != ScatteringProcessType::INVALID,
                                         "Cannot add an unknown scattering process type");
 
-        // Only one ionization process is currently supported as part of a given
-        // collision set.
         if (process.type() == ScatteringProcessType::IONIZATION) {
-            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                !ionization_flag,
-                "DSMC only supports a single ionization process"
-            );
+
+            // Only one ionization process is currently supported as part of a given
+            // collision set.
+            if (ionization_flag) {
+                amrex::Abort("Multiple ionization processes were specified in " + collision_name +
+                ".scattering_processes, but DSMC only supports a single ionization process.");
+            }
             ionization_flag = true;
 
-            // And add a check that the ionization species has the same mass
+            // Ensure that the first product species is always an electron (which is assumed
+            // during the scattering operation).
+            amrex::Vector<std::string> product_species_names;
+            pp_collision_name.getarr("product_species", product_species_names);
+            auto& species1 = mypc->GetParticleContainerFromName(product_species_names[0]);
+            if(species1.AmIA<PhysicalSpecies::electron>() == false) {
+                amrex::Abort("The first species in " + collision_name + ".product_species must be an electron, " +
+                "and must be marked as such with species_type=electron.");
+            }
+
+            // TODO: add a check that the ionization species has the same mass
             // (and a positive charge), compared to the target species
         }
         m_scattering_processes.push_back(std::move(process));

--- a/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
@@ -72,7 +72,7 @@ DSMCFunc::DSMCFunc (
             pp_collision_name.getarr("product_species", product_species_names);
             // Check that the charge is consistent with an electron species
             auto& species1 = mypc->GetParticleContainerFromName(product_species_names[0]);
-            if( species1.getCharge() < 0._prt ) {
+            if( species1.getCharge() >= 0._prt ) {
                 amrex::Abort("The first species in " + collision_name + ".product_species must be an electron.");
             }
 

--- a/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
@@ -72,7 +72,7 @@ DSMCFunc::DSMCFunc (
             pp_collision_name.getarr("product_species", product_species_names);
             // Check that the charge and mass of the species is consistent with an electron species
             auto& species1 = mypc->GetParticleContainerFromName(product_species_names[0]);
-            if( std::abs(  species1.getCharge() - PhysConst::q_e ) > 1e-6*PhysConst::q_e   ||
+            if( std::abs(  species1.getCharge() + PhysConst::q_e ) > 1e-6*PhysConst::q_e   ||
                 std::abs( species1.getMass() - PhysConst::m_e ) > 1e-6*PhysConst::m_e ) {
                 amrex::Abort("The first species in " + collision_name + ".product_species must be an electron.");
             }

--- a/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
@@ -72,8 +72,8 @@ DSMCFunc::DSMCFunc (
             pp_collision_name.getarr("product_species", product_species_names);
             // Check that the charge and mass of the species is consistent with an electron species
             auto& species1 = mypc->GetParticleContainerFromName(product_species_names[0]);
-            if( abs( species1.getCharge() - PhysConst::q_e ) > 1e-6*PhysConst::q_e   ||
-                abs( species1.getMass() - PhysConst::m_e ) > 1e-6*PhysConst::m_e ) {
+            if( std::abs(  species1.getCharge() - PhysConst::q_e ) > 1e-6*PhysConst::q_e   ||
+                std::abs( species1.getMass() - PhysConst::m_e ) > 1e-6*PhysConst::m_e ) {
                 amrex::Abort("The first species in " + collision_name + ".product_species must be an electron.");
             }
 

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -170,10 +170,6 @@ public:
         if (num_product_species > 2) {
             m_ioniz_product1 = pc_products[2]->getMass();
             m_ioniz_product2 = pc_products[3]->getMass();
-            // Ensure that the first product species is always an electron (which is assumed
-            // during the scattering operation).
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(pc_products[2]->getCharge() < 0.0,
-                "The first product species must be an electron.");
         }
 
         // First perform all non-product producing collisions

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -164,16 +164,16 @@ public:
         const int num_product_species = m_num_product_species;
         const auto ionization_energy = m_ionization_energy;
 
-        // Ensure that the first product species is always an electron (which is assumed
-        // during the scattering operation).
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(pc_products[2]->getCharge() < 0.0,
-            "The first product species must be an electron.");
         // Grab the masses of ionization products
         amrex::ParticleReal m_ioniz_product1 = 0;
         amrex::ParticleReal m_ioniz_product2 = 0;
         if (num_product_species > 2) {
             m_ioniz_product1 = pc_products[2]->getMass();
             m_ioniz_product2 = pc_products[3]->getMass();
+            // Ensure that the first product species is always an electron (which is assumed
+            // during the scattering operation).
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(pc_products[2]->getCharge() < 0.0,
+                "The first product species must be an electron.");
         }
 
         // First perform all non-product producing collisions

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -121,13 +121,13 @@ public:
             num_added_vec[i] += static_cast<int>(num_added);
         }
 
-        // resize the particle tiles to accomodate the new particles, for the colliding species
-        for (int i = 0; i < 2; i++)
-        {
-            tile_products[i]->resize(products_np[i] + num_added_vec[i]);
-        }
-        // resize the particle tiles to accomodate the new particles, for the product species
-        for (int i = 2; i < m_num_product_species; i++)
+        // resize the particle tiles to accomodate the new particles
+        // The code works correctly, even if the same species appears
+        // several times in the product species list.
+        // (e.g., for e- + H -> 2 e- + H+, the product species list is [e-, H, e-, H+])
+        // In that case, the species that appears multiple times is resized several times ;
+        // `products_np` keeps track of array positions at which it has been resized.
+        for (int i = 0; i < m_num_product_species; i++)
         {
             products_np[i] = tile_products[i]->numParticles();
             tile_products[i]->resize(products_np[i] + num_added_vec[i]);

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -341,7 +341,7 @@ public:
                 * there is a corresponding assert statement at initialization.)
                 */
                 amrex::ParticleReal const theta = (
-                    soa_products_data[0].m_rdata[PIdx::theta][product1_index]
+                    soa_products_data[2].m_rdata[PIdx::theta][product1_index]
                     - soa_products_data[0].m_rdata[PIdx::theta][species1_index]
                 );
                 amrex::ParticleReal const ux1buf = ux1;

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -323,12 +323,12 @@ public:
                 auto& ux1 = soa_products_data[0].m_rdata[PIdx::ux][species1_index];
                 auto& uy1 = soa_products_data[0].m_rdata[PIdx::uy][species1_index];
                 auto& uz1 = soa_products_data[0].m_rdata[PIdx::uz][species1_index];
-                auto& ux_p1 = soa_products_data[0].m_rdata[PIdx::ux][product1_index];
-                auto& uy_p1 = soa_products_data[0].m_rdata[PIdx::uy][product1_index];
-                auto& uz_p1 = soa_products_data[0].m_rdata[PIdx::uz][product1_index];
-                auto& ux_p2 = soa_products_data[1].m_rdata[PIdx::ux][product2_index];
-                auto& uy_p2 = soa_products_data[1].m_rdata[PIdx::uy][product2_index];
-                auto& uz_p2 = soa_products_data[1].m_rdata[PIdx::uz][product2_index];
+                auto& ux_p1 = soa_products_data[2].m_rdata[PIdx::ux][product1_index];
+                auto& uy_p1 = soa_products_data[2].m_rdata[PIdx::uy][product1_index];
+                auto& uz_p1 = soa_products_data[2].m_rdata[PIdx::uz][product1_index];
+                auto& ux_p2 = soa_products_data[3].m_rdata[PIdx::ux][product2_index];
+                auto& uy_p2 = soa_products_data[3].m_rdata[PIdx::uy][product2_index];
+                auto& uz_p2 = soa_products_data[3].m_rdata[PIdx::uz][product2_index];
 
 #if (defined WARPX_DIM_RZ)
                 /* In RZ geometry, macroparticles can collide with other macroparticles

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -305,17 +305,17 @@ public:
 
                 // create a copy of the first product species at the location of species 2
                 const auto product1_index = products_np_data[2] + with_product_p_offsets[i];
-                copy_species1[0](soa_products_data[0], soa_2, static_cast<int>(p_pair_indices_2[i]),
+                copy_species1[2](soa_products_data[2], soa_2, static_cast<int>(p_pair_indices_2[i]),
                                 static_cast<int>(product1_index), engine);
                 // Set the weight of the new particle to p_pair_reaction_weight[i]
-                soa_products_data[0].m_rdata[PIdx::w][product1_index] = p_pair_reaction_weight[i];
+                soa_products_data[2].m_rdata[PIdx::w][product1_index] = p_pair_reaction_weight[i];
 
                 // create a copy of the other product species at the location of species 2
                 const auto product2_index = products_np_data[3] + with_product_p_offsets[i];
-                copy_species1[0](soa_products_data[1], soa_2, static_cast<int>(p_pair_indices_2[i]),
+                copy_species1[3](soa_products_data[3], soa_2, static_cast<int>(p_pair_indices_2[i]),
                                 static_cast<int>(product2_index), engine);
                 // Set the weight of the new particle to p_pair_reaction_weight[i]
-                soa_products_data[0].m_rdata[PIdx::w][product2_index] = p_pair_reaction_weight[i];
+                soa_products_data[3].m_rdata[PIdx::w][product2_index] = p_pair_reaction_weight[i];
 
                 // Grab the colliding particle velocities to calculate the COM
                 // Note that the two product particles currently have the same

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -58,7 +58,7 @@ public:
         const amrex::ParticleReal m1, const amrex::ParticleReal m2,
         const amrex::Vector<amrex::ParticleReal>& /*products_mass*/,
         const index_type* AMREX_RESTRICT mask,
-        const amrex::Vector<index_type>& products_np,
+        amrex::Vector<index_type>& products_np,
         const SmartCopy* AMREX_RESTRICT copy_species1,
         const SmartCopy* AMREX_RESTRICT copy_species2,
         const index_type* AMREX_RESTRICT p_pair_indices_1,
@@ -121,9 +121,15 @@ public:
             num_added_vec[i] += static_cast<int>(num_added);
         }
 
-        // resize the particle tiles to accomodate the new particles
-        for (int i = 0; i < m_num_product_species; i++)
+        // resize the particle tiles to accomodate the new particles, for the colliding species
+        for (int i = 0; i < 2; i++)
         {
+            tile_products[i]->resize(products_np[i] + num_added_vec[i]);
+        }
+        // resize the particle tiles to accomodate the new particles, for the product species
+        for (int i = 2; i < m_num_product_species; i++)
+        {
+            products_np[i] = tile_products[i]->numParticles();
             tile_products[i]->resize(products_np[i] + num_added_vec[i]);
         }
 
@@ -158,47 +164,16 @@ public:
         const int num_product_species = m_num_product_species;
         const auto ionization_energy = m_ionization_energy;
 
-        // Store the list indices for ionization products, ensuring that
-        // the first product species is always an electron (which is assumed
+        // Ensure that the first product species is always an electron (which is assumed
         // during the scattering operation).
-        // Also, get the starting index for the first ionization product (if ionization
-        // is present). If species1 is also a product, this would start the
-        // indexing for product particles after the particles created from
-        // fragmentation.
-        int ioniz_product1_list_index = 0, ioniz_product2_list_index = 0;
-        index_type ioniz_product1_offset = 0, ioniz_product2_offset = 0;
-        if (num_product_species == 3) {
-            if (pc_products[0]->getCharge() < 0.0) {
-                ioniz_product1_list_index = 0;
-                ioniz_product2_list_index = 2;
-                ioniz_product1_offset = products_np[0] + no_product_total + with_product_total;
-                ioniz_product2_offset = products_np[2];
-            } else {
-                ioniz_product1_list_index = 2;
-                ioniz_product2_list_index = 0;
-                ioniz_product1_offset = products_np[2];
-                ioniz_product2_offset = products_np[0] + no_product_total + with_product_total;
-            }
-        } else if (num_product_species == 4) {
-            if (pc_products[2]->getCharge() < 0.0) {
-                ioniz_product1_list_index = 2;
-                ioniz_product2_list_index = 3;
-                ioniz_product1_offset = products_np[2];
-                ioniz_product2_offset = products_np[3];
-            } else {
-                ioniz_product1_list_index = 3;
-                ioniz_product2_list_index = 2;
-                ioniz_product1_offset = products_np[3];
-                ioniz_product2_offset = products_np[2];
-            }
-        }
-
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(pc_products[0]->getCharge() < 0.0,
+            "The first product species must be an electron.");
         // Grab the masses of ionization products
         amrex::ParticleReal m_ioniz_product1 = 0;
         amrex::ParticleReal m_ioniz_product2 = 0;
         if (num_product_species > 2) {
-            m_ioniz_product1 = pc_products[ioniz_product1_list_index]->getMass();
-            m_ioniz_product2 = pc_products[ioniz_product2_list_index]->getMass();
+            m_ioniz_product1 = pc_products[2]->getMass();
+            m_ioniz_product2 = pc_products[3]->getMass();
         }
 
         // First perform all non-product producing collisions
@@ -329,18 +304,18 @@ public:
                 soa_products_data[0].m_rdata[PIdx::w][species1_index] = p_pair_reaction_weight[i];
 
                 // create a copy of the first product species at the location of species 2
-                const auto product1_index = ioniz_product1_offset + with_product_p_offsets[i];
-                copy_species1[ioniz_product1_list_index](soa_products_data[ioniz_product1_list_index], soa_2, static_cast<int>(p_pair_indices_2[i]),
+                const auto product1_index = products_np_data[2] + with_product_p_offsets[i];
+                copy_species1[0](soa_products_data[0], soa_2, static_cast<int>(p_pair_indices_2[i]),
                                 static_cast<int>(product1_index), engine);
                 // Set the weight of the new particle to p_pair_reaction_weight[i]
-                soa_products_data[ioniz_product1_list_index].m_rdata[PIdx::w][product1_index] = p_pair_reaction_weight[i];
+                soa_products_data[0].m_rdata[PIdx::w][product1_index] = p_pair_reaction_weight[i];
 
                 // create a copy of the other product species at the location of species 2
-                const auto product2_index = ioniz_product2_offset + with_product_p_offsets[i];
-                copy_species1[ioniz_product2_list_index](soa_products_data[ioniz_product2_list_index], soa_2, static_cast<int>(p_pair_indices_2[i]),
+                const auto product2_index = products_np_data[3] + with_product_p_offsets[i];
+                copy_species1[0](soa_products_data[1], soa_2, static_cast<int>(p_pair_indices_2[i]),
                                 static_cast<int>(product2_index), engine);
                 // Set the weight of the new particle to p_pair_reaction_weight[i]
-                soa_products_data[ioniz_product2_list_index].m_rdata[PIdx::w][product2_index] = p_pair_reaction_weight[i];
+                soa_products_data[0].m_rdata[PIdx::w][product2_index] = p_pair_reaction_weight[i];
 
                 // Grab the colliding particle velocities to calculate the COM
                 // Note that the two product particles currently have the same
@@ -348,12 +323,12 @@ public:
                 auto& ux1 = soa_products_data[0].m_rdata[PIdx::ux][species1_index];
                 auto& uy1 = soa_products_data[0].m_rdata[PIdx::uy][species1_index];
                 auto& uz1 = soa_products_data[0].m_rdata[PIdx::uz][species1_index];
-                auto& ux_p1 = soa_products_data[ioniz_product1_list_index].m_rdata[PIdx::ux][product1_index];
-                auto& uy_p1 = soa_products_data[ioniz_product1_list_index].m_rdata[PIdx::uy][product1_index];
-                auto& uz_p1 = soa_products_data[ioniz_product1_list_index].m_rdata[PIdx::uz][product1_index];
-                auto& ux_p2 = soa_products_data[ioniz_product2_list_index].m_rdata[PIdx::ux][product2_index];
-                auto& uy_p2 = soa_products_data[ioniz_product2_list_index].m_rdata[PIdx::uy][product2_index];
-                auto& uz_p2 = soa_products_data[ioniz_product2_list_index].m_rdata[PIdx::uz][product2_index];
+                auto& ux_p1 = soa_products_data[0].m_rdata[PIdx::ux][product1_index];
+                auto& uy_p1 = soa_products_data[0].m_rdata[PIdx::uy][product1_index];
+                auto& uz_p1 = soa_products_data[0].m_rdata[PIdx::uz][product1_index];
+                auto& ux_p2 = soa_products_data[1].m_rdata[PIdx::ux][product2_index];
+                auto& uy_p2 = soa_products_data[1].m_rdata[PIdx::uy][product2_index];
+                auto& uz_p2 = soa_products_data[1].m_rdata[PIdx::uz][product2_index];
 
 #if (defined WARPX_DIM_RZ)
                 /* In RZ geometry, macroparticles can collide with other macroparticles
@@ -366,7 +341,7 @@ public:
                 * there is a corresponding assert statement at initialization.)
                 */
                 amrex::ParticleReal const theta = (
-                    soa_products_data[ioniz_product1_list_index].m_rdata[PIdx::theta][product1_index]
+                    soa_products_data[0].m_rdata[PIdx::theta][product1_index]
                     - soa_products_data[0].m_rdata[PIdx::theta][species1_index]
                 );
                 amrex::ParticleReal const ux1buf = ux1;

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -166,7 +166,7 @@ public:
 
         // Ensure that the first product species is always an electron (which is assumed
         // during the scattering operation).
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(pc_products[0]->getCharge() < 0.0,
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(pc_products[2]->getCharge() < 0.0,
             "The first product species must be an electron.");
         // Grab the masses of ionization products
         amrex::ParticleReal m_ioniz_product1 = 0;

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.cpp
@@ -25,8 +25,6 @@ SplitAndScatterFunc::SplitAndScatterFunc (const std::string& collision_name,
 
         const bool ionization_flag = (!product_species.empty());
 
-        // if ionization is one of the processes, check if one of the colliding
-        // species is also used as a product species
         if (ionization_flag) {
             m_num_product_species = 4;
             m_num_products_host.push_back(1); // the non-target species

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.cpp
@@ -28,35 +28,11 @@ SplitAndScatterFunc::SplitAndScatterFunc (const std::string& collision_name,
         // if ionization is one of the processes, check if one of the colliding
         // species is also used as a product species
         if (ionization_flag) {
-            // grab the colliding species
-            amrex::Vector<std::string> colliding_species;
-            pp_collision_name.getarr("species", colliding_species);
-            // grab the target species (i.e., the species that looses an
-            // electron during the collision)
-            std::string target_species;
-            pp_collision_name.query("ionization_target_species", target_species);
-            // find the index of the non-target species (the one that could
-            // also be used as a product species)
-            int non_target_idx = 0;
-            if (colliding_species[0] == target_species) {
-                non_target_idx = 1;
-            }
-
-            // check if the non-target species is in ``product_species``
-            auto it = std::find(product_species.begin(), product_species.end(), colliding_species[non_target_idx]);
-
-            if (it != product_species.end()) {
-                m_num_product_species = 3;
-                m_num_products_host.push_back(2); // the non-target species: one particle for the product ; one particle for the fact that the incident particle loses energy
-                m_num_products_host.push_back(0); // the target species
-                m_num_products_host.push_back(1); // the other product of the reaction
-            } else {
-                m_num_product_species = 4;
-                m_num_products_host.push_back(1); // the non-target species
-                m_num_products_host.push_back(0); // the target species
-                m_num_products_host.push_back(1); // first product species
-                m_num_products_host.push_back(1); // second product species
-            }
+            m_num_product_species = 4;
+            m_num_products_host.push_back(1); // the non-target species
+            m_num_products_host.push_back(0); // the target species
+            m_num_products_host.push_back(1); // first product species
+            m_num_products_host.push_back(1); // second product species
 
             // get the ionization energy
             pp_collision_name.get("ionization_energy", m_ionization_energy);


### PR DESCRIPTION
This PR simplifies the logic in the DSMC code, esp. in the case where the same species is both in the colliding species and in the products of an ionization reaction, such as in the following case:
$e^- + H \rightarrow 2 e^- + H^+$
`species = electron H`
`product_species = electron Hplus`

- Previously: we were careful to list this species only once in `m_product_species` (e.g., `m_product_species = electron H Hplus`), but this resulted in complicated logic to make sure that the array allocation and offsets were properly calculated.
- With this PR: the species can be listed several times in `m_product_species` (e.g., `m_product_species = electron H electron Hplus`). The corresponding logic is more streamlined (see comments in the code).

In addition, the new code forces the first species in `product_species` to be an electron in the case where ionization is used, as this also simplifies some of the logic. 
This check is more strict that the previous `if` condition (which was used to swap indices internally so that the electron species is indeed the first product): instead of simply checking for the sign of the charge, we now explicitly check the charge and mass of the species.

This will likely raise error messages in existing user code, but the error message should hopefully be clear enough for the user to make the required change.