### PR TITLE
CI: Update PETSc Workflows

### DIFF
--- a/.github/workflows/petsc.yml
+++ b/.github/workflows/petsc.yml
@@ -1,4 +1,4 @@
-name: PETSc
+name: 🐧 PETSc
 
 on:
   push:
@@ -18,7 +18,7 @@ jobs:
 
   test_petsc_gcc:
     name: GCC
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: check_changes
     if: ${{ github.event.pull_request.draft == false && needs.check_changes.outputs.has_non_docs_changes == 'true' }}
     env:
@@ -72,7 +72,7 @@ jobs:
 
   test_petsc_mpich:
     name: GCC + MPICH
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: check_changes
     if: ${{ github.event.pull_request.draft == false && needs.check_changes.outputs.has_non_docs_changes == 'true' }}
     env:

--- a/.github/workflows/petsc.yml
+++ b/.github/workflows/petsc.yml
@@ -52,7 +52,7 @@ jobs:
         cd ${warpx_dir}
         git clone -b release https://gitlab.com/petsc/petsc.git petsc
         cd ${PETSC_DIR}
-        ./configure --with-fortran-bindings=no --with-x=no --with-mpi=0
+        ./configure --with-fortran-bindings=no --with-x=no --with-mpi=0 --with-debugging=1
         make -j 4
         # configure WarpX
         cd ${warpx_dir}
@@ -106,7 +106,7 @@ jobs:
         cd ${warpx_dir}
         git clone -b release https://gitlab.com/petsc/petsc.git petsc
         cd ${PETSC_DIR}
-        ./configure --with-fortran-bindings=no --with-x=no --with-cc=mpicc --with-fc=mpif90 --with-cxx=mpicxx
+        ./configure --with-fortran-bindings=no --with-x=no --with-cc=mpicc --with-fc=mpif90 --with-cxx=mpicxx --with-debugging=1
         make -j 4
         # configure WarpX
         cd ${warpx_dir}

--- a/.github/workflows/petsc.yml
+++ b/.github/workflows/petsc.yml
@@ -1,4 +1,4 @@
-name: w/PETSc
+name: PETSc
 
 on:
   push:
@@ -16,7 +16,7 @@ jobs:
     name: Analyze
     uses: ./.github/workflows/check_changes.yml
 
-  test-petsc-gcc:
+  test_petsc_gcc:
     name: GCC
     runs-on: ubuntu-latest
     needs: check_changes
@@ -38,25 +38,23 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get install -y --no-install-recommends libblas-dev liblapack-dev
-    - name: build WarpX w/PETSc
+    - name: Build WarpX w/ PETSc
       run: |
+        # export environment variables
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=100M
         ccache -z
-
         export warpx_dir=${PWD}
-        echo "warpx_dir is ${warpx_dir}"
         export PETSC_DIR=${warpx_dir}/petsc
-        echo "PETSC_DIR is ${PETSC_DIR}"
         export PETSC_ARCH=arch-opt
-
+        # clone and configure PETSc
         cd ${warpx_dir}
         git clone -b release https://gitlab.com/petsc/petsc.git petsc
         cd ${PETSC_DIR}
         ./configure --with-fortran-bindings=no --with-x=no --with-mpi=0
         make -j 4
-
+        # configure WarpX
         cd ${warpx_dir}
         cmake -S . -B build            \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
@@ -67,13 +65,13 @@ jobs:
           -DWarpX_EB=OFF               \
           -DWarpX_MPI=OFF              \
           -DWarpX_QED=OFF
+        # build WarpX
         cmake --build build -j 4
-
         ccache -s
         du -hs ~/.cache/ccache
 
-  test-petsc-mpich:
-    name: GCC-12 + MPICH
+  test_petsc_mpich:
+    name: GCC + MPICH
     runs-on: ubuntu-latest
     needs: check_changes
     if: ${{ github.event.pull_request.draft == false && needs.check_changes.outputs.has_non_docs_changes == 'true' }}
@@ -94,25 +92,23 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get install -y --no-install-recommends libblas-dev liblapack-dev mpich libmpich-dev
-    - name: build WarpX w/PETSc
+    - name: Build WarpX w/ PETSc
       run: |
+        # export environment variables
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
         export CCACHE_MAXSIZE=100M
         ccache -z
-
         export warpx_dir=${PWD}
-        echo "warpx_dir is ${warpx_dir}"
         export PETSC_DIR=${warpx_dir}/petsc
-        echo "PETSC_DIR is ${PETSC_DIR}"
         export PETSC_ARCH=arch-opt
-
+        # clone and configure PETSc
         cd ${warpx_dir}
         git clone -b release https://gitlab.com/petsc/petsc.git petsc
         cd ${PETSC_DIR}
         ./configure --with-fortran-bindings=no --with-x=no --with-cc=mpicc --with-fc=mpif90 --with-cxx=mpicxx
         make -j 4
-
+        # configure WarpX
         cd ${warpx_dir}
         cmake -S . -B build            \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
@@ -123,123 +119,7 @@ jobs:
           -DWarpX_EB=OFF               \
           -DWarpX_MPI=ON               \
           -DWarpX_QED=OFF
+        # build WarpX
         cmake --build build -j 4
-
-        ccache -s
-        du -hs ~/.cache/ccache
-
-  test-petsc-gcc-debug:
-    name: GCC [Debug]
-    runs-on: ubuntu-latest
-    needs: check_changes
-    if: ${{ github.event.pull_request.draft == false && needs.check_changes.outputs.has_non_docs_changes == 'true' }}
-    env:
-      CXXFLAGS: "-Werror"
-    steps:
-    - uses: actions/checkout@v4
-    - name: Dependencies
-      run: |
-        .github/workflows/dependencies/gcc.sh
-    - name: CCache Cache
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/ccache
-        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
-        restore-keys: |
-             ccache-${{ github.workflow }}-${{ github.job }}-git-
-    - name: Install Dependencies
-      run: |
-        sudo apt-get install -y --no-install-recommends libblas-dev liblapack-dev
-    - name: build WarpX w/PETSc
-      run: |
-        export CCACHE_COMPRESS=1
-        export CCACHE_COMPRESSLEVEL=10
-        export CCACHE_MAXSIZE=100M
-        ccache -z
-
-        export warpx_dir=${PWD}
-        echo "warpx_dir is ${warpx_dir}"
-        export PETSC_DIR=${warpx_dir}/petsc
-        echo "PETSC_DIR is ${PETSC_DIR}"
-        export PETSC_ARCH=arch-opt
-        export AMREX_DIR=${warpx_dir}/amrex
-        echo "AMREX_DIR is ${AMREX_DIR}"
-
-        cd ${warpx_dir}
-        git clone -b release https://gitlab.com/petsc/petsc.git petsc
-        cd ${PETSC_DIR}
-        ./configure --with-fortran-bindings=no --with-x=no --with-mpi=0 --with-debugging=1
-        make -j 4
-
-        cd ${warpx_dir}
-        cmake -S . -B build            \
-          -DCMAKE_VERBOSE_MAKEFILE=ON  \
-          -DWarpX_DIMS="1;2;RZ;3"      \
-          -DAMReX_PETSC=YES            \
-          -DCMAKE_BUILD_TYPE=Debug     \
-          -DPETSC_DIR=${PETSC_DIR}     \
-          -DPETSC_ARCH=${PETSC_ARCH}   \
-          -DWarpX_EB=OFF               \
-          -DWarpX_MPI=OFF              \
-          -DWarpX_QED=OFF
-        cmake --build build -j 4
-
-        ccache -s
-        du -hs ~/.cache/ccache
-
-  test-petsc-mpich-debug:
-    name: GCC-12 + MPICH [Debug]
-    runs-on: ubuntu-latest
-    needs: check_changes
-    if: ${{ github.event.pull_request.draft == false && needs.check_changes.outputs.has_non_docs_changes == 'true' }}
-    env:
-      CXXFLAGS: "-Werror"
-    steps:
-    - uses: actions/checkout@v4
-    - name: Dependencies
-      run: |
-        .github/workflows/dependencies/gcc12.sh
-    - name: CCache Cache
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/ccache
-        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
-        restore-keys: |
-             ccache-${{ github.workflow }}-${{ github.job }}-git-
-    - name: Install Dependencies
-      run: |
-        sudo apt-get install -y --no-install-recommends libblas-dev liblapack-dev mpich libmpich-dev
-    - name: build WarpX w/PETSc
-      run: |
-        export CCACHE_COMPRESS=1
-        export CCACHE_COMPRESSLEVEL=10
-        export CCACHE_MAXSIZE=100M
-        ccache -z
-
-        export warpx_dir=${PWD}
-        echo "warpx_dir is ${warpx_dir}"
-        export PETSC_DIR=${warpx_dir}/petsc
-        echo "PETSC_DIR is ${PETSC_DIR}"
-        export PETSC_ARCH=arch-opt
-
-        cd ${warpx_dir}
-        git clone -b release https://gitlab.com/petsc/petsc.git petsc
-        cd ${PETSC_DIR}
-        ./configure --with-fortran-bindings=no --with-x=no --with-cc=mpicc --with-fc=mpif90 --with-cxx=mpicxx --with-debugging=1
-        make -j 4
-
-        cd ${warpx_dir}
-        cmake -S . -B build            \
-          -DCMAKE_VERBOSE_MAKEFILE=ON  \
-          -DWarpX_DIMS="1;2;RZ;3"      \
-          -DCMAKE_BUILD_TYPE=Debug     \
-          -DAMReX_PETSC=YES            \
-          -DPETSC_DIR=${PETSC_DIR}     \
-          -DPETSC_ARCH=${PETSC_ARCH}   \
-          -DWarpX_EB=OFF               \
-          -DWarpX_MPI=ON               \
-          -DWarpX_QED=OFF
-        cmake --build build -j 4
-
         ccache -s
         du -hs ~/.cache/ccache


### PR DESCRIPTION
This removes the two PETSc workflows labeled as "debug", which I think differed from the other ones by
- the `--with-debugging=1` flag for the PETSc configuration, and
- the `-DCMAKE_BUILD_TYPE=Debug` flag for the WarpX configuration.

Note that `CXXFLAGS: "-Werror"` was set for all workflows and is maintained for the workflows that are kept.

Note also that none of the workflows is running WarpX at this point - this isn't changed in this PR.

@RemiLehe @debog @atmyers 
We can still choose to keep only the "debug" ones instead - please feel free to comment if you have new opinions on this.

To-do:
- [x] Run on `ubuntu-24.04` instead of `ubuntu-latest` (we usually fix the Ubuntu version for these complex workflows)
- [ ] Flag workflows as required in the repository's settings (must be done by contributors with admin/owner access)