### PR TITLE
For FieldEnergy, use validbox instead of tilebox for the volume factor

### DIFF
--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
@@ -164,9 +164,10 @@ FieldEnergy::ComputeNorm2(amrex::MultiFab const& field, [[maybe_unused]]int lev)
         amrex::Array4<const amrex::Real> const& field_arr = field.array(mfi);
 
         amrex::Box const tilebox = mfi.tilebox();
+        amrex::Box const validbox = mfi.validbox();
         amrex::Box const tb = convert(tilebox, is_nodal);
-        amrex::IntVect const tb_lo = tb.smallEnd();
-        amrex::IntVect const tb_hi = tb.bigEnd();
+        amrex::IntVect const tb_lo = validbox.smallEnd();
+        amrex::IntVect const tb_hi = validbox.bigEnd();
 
 #if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
         // Lower corner of tile box physical domain


### PR DESCRIPTION
The FieldEnergy diagnostic sums the field energy over all grid cells. Along directions that are nodal, the loop includes the nodes that are at the lower and upper end of the block, so those nodes get counted twice. The volume factor is set to ½ to account for this. However, when tiling is done, the upper end of the tile is not included except when it is also the upper end of the valid box. But the factor of ½ was being applied at lower and upper end of the tile. The fix is to only apply the ½ to the lower and upper end of the valid box. This PR fixes this.