### PR TITLE
Run sanitizer test in double precision

### DIFF
--- a/.github/workflows/clang_sanitizers.yml
+++ b/.github/workflows/clang_sanitizers.yml
@@ -57,9 +57,7 @@ jobs:
           -DWarpX_FFT=ON                    \
           -DWarpX_QED=ON                    \
           -DWarpX_QED_TABLE_GEN=ON          \
-          -DWarpX_OPENPMD=ON                \
-          -DWarpX_PRECISION=SINGLE          \
-          -DWarpX_PARTICLE_PRECISION=SINGLE
+          -DWarpX_OPENPMD=ON
         cmake --build build -j 4
 
         ccache -s


### PR DESCRIPTION
The sanitizer test include a run with the implicit solver (`inputs_test_2d_theta_implicit_jfnk_vandb`). 
However, as pointed out offline by @dpgrote, the implicit solver fails to converge to the required precision when run with single precision. This doesn't actually result in an error, but instead in very long runs (because the solver reaches the maximum number of iterations, when trying to converge) and in many warnings.

Therefore, it would make more sense to run this in double precision.

@lucafedeli88 It seems that this test was added in this PR: https://github.com/BLAST-WarpX/warpx/pull/4783. Do you remember if there was a good reason to use single precision here?