### PR TITLE
[WIP] Increase CI coverage of runtime real attribute handling

### DIFF
--- a/Examples/Tests/particle_boundary_scrape/inputs_test_3d_particle_scrape_picmi.py
+++ b/Examples/Tests/particle_boundary_scrape/inputs_test_3d_particle_scrape_picmi.py
@@ -50,6 +50,10 @@ electrons = picmi.Species(
     initial_distribution=uniform_plasma_elec,
     warpx_save_particles_at_xhi=1,
     warpx_save_particles_at_eb=1,
+    warpx_add_real_attributes={
+        "r_birth": "sqrt(x*x+y*y)",
+        "z_birth": "z",
+    },
 )
 
 ##########################
@@ -135,6 +139,11 @@ scraped_steps = particle_buffer.get_particle_boundary_buffer(
 )
 for arr in scraped_steps:
     assert all(np.array(arr, copy=False) > 40)
+
+# check that the initial r-values are correctly copied to the buffer
+r_births = particle_buffer.get_particle_boundary_buffer("electrons", "eb", "r_birth", 0)
+for arr in r_births:
+    assert all(np.array(arr, copy=False) > 0)
 
 weights = particle_buffer.get_particle_boundary_buffer("electrons", "eb", "w", 0)
 n = sum(len(arr) for arr in weights)

--- a/Examples/Tests/particle_data_python/inputs_test_2d_particle_attr_access_picmi.py
+++ b/Examples/Tests/particle_data_python/inputs_test_2d_particle_attr_access_picmi.py
@@ -66,7 +66,11 @@ solver = picmi.ElectrostaticSolver(
 # physics components
 ##########################
 
-electrons = picmi.Species(particle_type="electron", name="electrons")
+electrons = picmi.Species(
+    particle_type="electron",
+    name="electrons",
+    warpx_add_real_attributes={"z_birth": "z"},
+)
 
 ##########################
 # diagnostics
@@ -151,11 +155,16 @@ sim.step(max_steps - 1)
 
 assert elec_wrapper.nps == 270 / (2 - args.unique)
 assert elec_wrapper.particle_container.get_real_comp_index("w") == 2
-assert elec_wrapper.particle_container.get_real_comp_index("newPid") == 6
+assert elec_wrapper.particle_container.get_real_comp_index("newPid") == 7
 
 new_pid_vals = elec_wrapper.get_particle_real_arrays("newPid", 0)
 for vals in new_pid_vals:
     assert np.allclose(vals, 5)
+
+z_birth_vals = elec_wrapper.get_particle_real_arrays("z_birth", 0)
+for vals in z_birth_vals:
+    print(vals)
+    assert np.all((vals >= 0.005) & (vals <= 0.025))
 
 ##########################
 # take the final sim step


### PR DESCRIPTION
This increases the CI coverage of functionality to handle runtime particle attributes.

It also serves as a demonstration of a shortcoming in the way `AddNParticles` is written. Currently, runtime attributes are passed to `AddNParticles` but in an assumed order and only attributes beyond the number of attributes passed in are populated with default values (given the user defined expression for initial values). Due to this, the Python version (`add_particles`) forces all runtime attributes that are not passed to `add_particles` to be zero. A better approach would be to have `AddNParticles` accept a list of runtime attribute indices along with the vector of values. All runtime attributes not included in the list of indices would then be initialized with default values.