### PR TITLE
Fix setAlwaysUseBNorm deprecation warning

### DIFF
--- a/Source/Initialization/DivCleaner/ProjectionDivCleaner.H
+++ b/Source/Initialization/DivCleaner/ProjectionDivCleaner.H
@@ -97,7 +97,7 @@ private:
         mlmg.setBottomSolver(m_bottom_solver);
         mlmg.setVerbose(m_verbose);
         mlmg.setBottomVerbose(m_bottom_verbose);
-        mlmg.setAlwaysUseBNorm(false);
+        mlmg.setConvergenceNormType(amrex::MLMGNormType::greater);
         mlmg.solve({m_solution[lev].get()}, {m_source[lev].get()}, m_rtol, m_atol);
     }
 

--- a/Source/ablastr/fields/EffectivePotentialPoissonSolver.H
+++ b/Source/ablastr/fields/EffectivePotentialPoissonSolver.H
@@ -229,7 +229,7 @@ computeEffectivePotentialPhi (
         amrex::MLMG mlmg(*linop); // actual solver defined here
         mlmg.setVerbose(verbosity);
         mlmg.setMaxIter(max_iters);
-        mlmg.setAlwaysUseBNorm((max_norm_b > 0));
+        mlmg.setConvergenceNormType((max_norm_b > 0 ? amrex::MLMGNormType::bnorm : amrex::MLMGNormType::greater));
 
         const int ng = int(grid_type == utils::enums::GridType::Collocated); // ghost cells
         if (ng) {

--- a/Source/ablastr/fields/PoissonSolver.H
+++ b/Source/ablastr/fields/PoissonSolver.H
@@ -399,7 +399,7 @@ computePhi (
         amrex::MLMG mlmg(*linop); // actual solver defined here
         mlmg.setVerbose(verbosity);
         mlmg.setMaxIter(max_iters);
-        mlmg.setAlwaysUseBNorm((max_norm_b > 0));
+        mlmg.setConvergenceNormType((max_norm_b > 0 ? amrex::MLMGNormType::bnorm : amrex::MLMGNormType::greater));
 
         const int ng = int(grid_type == utils::enums::GridType::Collocated); // ghost cells
         if (ng) {

--- a/Source/ablastr/fields/VectorPoissonSolver.H
+++ b/Source/ablastr/fields/VectorPoissonSolver.H
@@ -205,7 +205,7 @@ computeVectorPotential   (  amrex::Vector<amrex::Array<amrex::MultiFab*, 3> > co
 
             mlmg[adim]->setVerbose(verbosity);
             mlmg[adim]->setMaxIter(max_iters);
-            mlmg[adim]->setAlwaysUseBNorm(always_use_bnorm);
+            mlmg[adim]->setConvergenceNormType(always_use_bnorm ? amrex::MLMGNormType::bnorm : amrex::MLMGNormType::greater);
 
             // Solve Poisson equation at lev
             mlmg[adim]->solve( {A[lev][adim]}, {curr[lev][adim]},


### PR DESCRIPTION
This fixes the warning from amrex of a deprecated routine that appears in the development version. The CI tests should pass once the version of amrex has been updated.

```
warpx_ECP4/Source/Initialization/DivCleaner/ProjectionDivCleaner.H:100:14: warning: 'setAlwaysUseBNorm' is deprecated: Use MLMG::setConvergenceNormType() instead. [-Wdeprecated-declarations]
```