### PR TITLE
CI: improve paths exclusion filters

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -7,6 +7,10 @@ trigger:
   branches:
     include:
     - development
+  paths:
+    exclude:
+    - Docs
+    - '**/*.rst'
 pr:
   autoCancel: true
   drafts: false

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -9,15 +9,19 @@ trigger:
     - development
   paths:
     exclude:
-    - Docs
+    - 'Docs/**'
+    - 'Tools/machines/**'
     - '**/*.rst'
+    - '**/*.md'
 pr:
   autoCancel: true
   drafts: false
   paths:
     exclude:
-    - Docs
+    - 'Docs/**'
+    - 'Tools/machines/**'
     - '**/*.rst'
+    - '**/*.md'
 
 jobs:
 - job:

--- a/.github/workflows/check_changes.yml
+++ b/.github/workflows/check_changes.yml
@@ -20,8 +20,9 @@ jobs:
           filters: |
             non_docs:
               - '!Docs/**'
-              - '!**.md'
+              - '!Tools/machines/**'
               - '!**.rst'
+              - '!**.md'
           predicate-quantifier: 'every'
       - id: set-output
         run: |


### PR DESCRIPTION
This improves the paths exclusion filters that we use in our CI workflows, from GitHub Actions to Azure pipelines:
- Anything inside `Docs/`
- Anything inside `Tools/machines/`
- Anything ending in `.rst`
- Anything ending in `.md`