### PR TITLE
CI: fix Open MPI bug in Azure pipelines

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -157,6 +157,8 @@ jobs:
       echo "mpirun --do-not-launch --display-allocation:"
       warpx_exec=$(find /home/vsts/work/1/s/build/bin -type f -name 'warpx.*' -executable | head -n 1)
       mpirun --do-not-launch --display-allocation ${warpx_exec}
+      echo "Open MPI environment variables:"
+      env | grep "OMPI"
       # TODO remove debugging block............................................
       # set options
       set -o nounset errexit pipefail

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -154,8 +154,9 @@ jobs:
       echo "number of processing units: $(nproc)"
       echo "mpirun --version:"
       mpirun --version
-      echo "mpirun --display-allocation:"
-      mpirun --display-allocation
+      echo "mpirun --do-not-launch --display-allocation:"
+      warpx_exec=$(find /home/vsts/work/1/s/build/bin -type f -name 'warpx.*' -executable | head -n 1)
+      mpirun --do-not-launch --display-allocation ${warpx_exec}
       # TODO remove debugging block............................................
       # set options
       set -o nounset errexit pipefail
@@ -167,7 +168,7 @@ jobs:
           -D ExperimentalTest -D ExperimentalSubmit
       else
         # run tests (exclude pytest.AMReX when running Python tests)
-        ctest --test-dir build --output-on-failure -E AMReX
+        ctest --test-dir build --verbose -E AMReX
       fi
     displayName: 'Test'
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -150,16 +150,6 @@ jobs:
     displayName: 'Build'
 
   - bash: |
-      # TODO remove debugging block............................................
-      echo "number of processing units: $(nproc)"
-      echo "mpirun --version:"
-      mpirun --version
-      echo "mpirun --do-not-launch --display-allocation:"
-      warpx_exec=$(find /home/vsts/work/1/s/build/bin -type f -name 'warpx.*' -executable | head -n 1)
-      mpirun --do-not-launch --display-allocation ${warpx_exec}
-      echo "Open MPI environment variables:"
-      env | grep "OMPI"
-      # TODO remove debugging block............................................
       # set options
       set -o nounset errexit pipefail
       # determine if the build was triggered by a push to the development branch
@@ -170,7 +160,7 @@ jobs:
           -D ExperimentalTest -D ExperimentalSubmit
       else
         # run tests (exclude pytest.AMReX when running Python tests)
-        ctest --test-dir build --verbose -E AMReX
+        ctest --test-dir build --output-on-failure -E AMReX
       fi
     displayName: 'Test'
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -150,6 +150,13 @@ jobs:
     displayName: 'Build'
 
   - bash: |
+      # TODO remove debugging block............................................
+      echo "number of processing units: $(nproc)"
+      echo "mpirun --version:"
+      mpirun --version
+      echo "mpirun --display-allocation:"
+      mpirun --display-allocation
+      # TODO remove debugging block............................................
       # set options
       set -o nounset errexit pipefail
       # determine if the build was triggered by a push to the development branch

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -112,7 +112,7 @@ function(add_warpx_test
     # Avoid the following error seen with Open MPI 4.1.6 in the Azure pipelines:
     # "There are not enough slots available in the system to satisfy the 2 slots
     # that were requested by the application"
-    set(MPI_HOST_NUMPROC "--host localhost:${nprocs}")
+    set(MPI_HOST_NUMPROC --host localhost:${nprocs})
 
     # set MPI executable
     set(THIS_MPI_TEST_EXE

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -109,11 +109,16 @@ function(add_warpx_test
         return()
     endif()
 
+    # Avoid the following error seen with Open MPI 4.1.6 in the Azure pipelines:
+    # "There are not enough slots available in the system to satisfy the 2 slots
+    # that were requested by the application"
+    set(MPI_HOST_NUMPROC "--host localhost:${nprocs}")
+
     # set MPI executable
     set(THIS_MPI_TEST_EXE
         ${MPIEXEC_EXECUTABLE}
         ${MPI_ALLOW_ROOT}
-        --host localhost:${nprocs}
+        ${MPI_HOST_NUMPROC}
         ${MPIEXEC_NUMPROC_FLAG} ${nprocs}
         ${MPIEXEC_POSTFLAGS}
         ${MPIEXEC_PREFLAGS}

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -113,6 +113,7 @@ function(add_warpx_test
     set(THIS_MPI_TEST_EXE
         ${MPIEXEC_EXECUTABLE}
         ${MPI_ALLOW_ROOT}
+        --host localhost:${nprocs}
         ${MPIEXEC_NUMPROC_FLAG} ${nprocs}
         ${MPIEXEC_POSTFLAGS}
         ${MPIEXEC_PREFLAGS}


### PR DESCRIPTION
### Goal

Resolve the following error seen in our Azure DevOps pipelines:
```
There are not enough slots available in the system to satisfy the 2
slots that were requested by the application:

  /home/vsts/work/1/s/build/bin/warpx.3d.MPI.OMP.DP.PDP.OPMD.FFT.EB.QED

Either request fewer slots for your application, or make more slots
available for use.

A "slot" is the Open MPI term for an allocatable unit where we can
launch a process.  The number of slots available are defined by the
environment in which Open MPI processes are run:

  1. Hostfile, via "slots=N" clauses (N defaults to number of
     processor cores if not provided)
  2. The --host command line parameter, via a ":N" suffix on the
     hostname (N defaults to 1 if not provided)
  3. Resource manager (e.g., SLURM, PBS/Torque, LSF, etc.)
  4. If none of a hostfile, the --host command line parameter, or an
     RM is present, Open MPI defaults to the number of processor cores

In all the above cases, if you want Open MPI to default to the number
of hardware threads instead of the number of processor cores, use the
--use-hwthread-cpus option.

Alternatively, you can use the --oversubscribe option to ignore the
number of available slots when deciding the number of processes to
launch.
```

### Workaround

The workaround consists in adding, say, `--host localhost:2` to the mpirun/mpiexec command when running with 2 processes, following the suggestion of point 2. in the error message above. Please check the comments below to see how I have debugged this so far.

### Open questions

- Why doesn't point 4. above ("Open MPI defaults to the number of processor cores") apply here?
- Do you think this is an Open MPI 4.1.6 issue or an Azure DevOps pipeline environment issue?