### PR TITLE
Fix GCC 8: `stdc++fs`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,17 @@ include(CTest)
 # Dependencies ################################################################
 #
 
+# Old GCCs: std::filesystem as a separate library
+try_compile(CXX_HAS_STD_FS "${WarpX_BINARY_DIR}/temp"
+    "${WarpX_SOURCE_DIR}/cmake/has_filesystem.cpp"
+    CMAKE_FLAGS -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON
+)
+try_compile(CXX_HAS_STD_FS_WITH_LINK "${WarpX_BINARY_DIR}/temp"
+    "${WarpX_SOURCE_DIR}/cmake/has_filesystem.cpp"
+    CMAKE_FLAGS -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON
+    LINK_LIBRARIES stdc++fs
+)
+
 # AMReX
 #   builds AMReX from source (default) or finds an existing install
 set(WarpX_amrex_dim ${WarpX_DIMS})  # RZ is AMReX 2D
@@ -293,6 +304,16 @@ foreach(D IN LISTS WarpX_DIMS)
                 # Number must be more than the number of .cpp files in WarpX
                 UNITY_BUILD_BATCH_SIZE 10000
             )
+        endif()
+
+        # GCC < 9 need to manually link std::filesystem
+        if(NOT CXX_HAS_STD_FS)
+            if(CXX_HAS_STD_FS_WITH_LINK)
+                target_link_libraries(ablastr_${SD} PUBLIC stdc++fs)
+            else()
+                message(FATAL_ERROR "Your compiler does not support C++17 "
+                        "<filesystem> Please use a newer C++ compiler.")
+            endif()
         endif()
     endif()
 

--- a/cmake/has_filesystem.cpp
+++ b/cmake/has_filesystem.cpp
@@ -1,0 +1,12 @@
+#include <filesystem>
+
+
+int main()
+{
+    namespace fs = std::filesystem;
+
+    fs::path dir{"./mkdir_test"};
+    fs::create_directories(dir);
+
+    return 0;
+}


### PR DESCRIPTION
In order GCC (we officially only support GCC 9.1+, but GCC 8 is still around), one needs to manually link `stdc++fs` for `<filesystem>` support in C++17.

This adds this work around, mostly for older RHEL.

Fix #5947