### PR TITLE
CuPY not compatible with cython 3.1

### DIFF
--- a/Tools/machines/frontier-olcf/install_dependencies.sh
+++ b/Tools/machines/frontier-olcf/install_dependencies.sh
@@ -87,7 +87,7 @@ python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
 python3 -m pip install --upgrade setuptools[core]
-python3 -m pip install --upgrade "cython>=3.0"
+python3 -m pip install --upgrade "cython>=3.0,<3.1"
 # cupy for ROCm
 #   https://docs.cupy.dev/en/stable/install.html#building-cupy-for-rocm-from-source
 #   https://github.com/cupy/cupy/issues/7830

--- a/Tools/machines/frontier-olcf/install_dependencies.sh
+++ b/Tools/machines/frontier-olcf/install_dependencies.sh
@@ -87,7 +87,7 @@ python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
 python3 -m pip install --upgrade setuptools[core]
-python3 -m pip install --upgrade "cython>=3.0,<3.1"
+python3 -m pip install --upgrade "cython>=3.0"
 # cupy for ROCm
 #   https://docs.cupy.dev/en/stable/install.html#building-cupy-for-rocm-from-source
 #   https://github.com/cupy/cupy/issues/7830

--- a/Tools/machines/tuolumne-llnl/install_mi300a_dependencies.sh
+++ b/Tools/machines/tuolumne-llnl/install_mi300a_dependencies.sh
@@ -158,7 +158,7 @@ python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
 python3 -m pip install --upgrade setuptools[core]
-python3 -m pip install --upgrade cython
+python3 -m pip install --upgrade "cython>=3.0,<3.1"
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas
 python3 -m pip install --upgrade scipy

--- a/Tools/machines/tuolumne-llnl/install_mi300a_dependencies.sh
+++ b/Tools/machines/tuolumne-llnl/install_mi300a_dependencies.sh
@@ -158,7 +158,7 @@ python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel
 python3 -m pip install --upgrade setuptools[core]
-python3 -m pip install --upgrade "cython>=3.0,<3.1"
+python3 -m pip install --upgrade "cython>=3.0"
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade pandas
 python3 -m pip install --upgrade scipy


### PR DESCRIPTION
It seems that cython 3.1 is not compatible with cupy. With cython 3.1 installed on FRONTIER, I get the error
```
----> 1 import cupy

File ~/sw/frontier/gpu/venvs/warpx-frontier/lib/python3.11/site-packages/cupy/__init__.py:16
     12 _environment._preload_library('cutensor')  # NOQA
     15 try:
---> 16     from cupy import _core  # NOQA
     17 except ImportError as exc:
     18     raise ImportError(f'''
     19 ================================================================
     20 {_environment._diagnose_import_error()}
   (...)     24 ================================================================
     25 ''') from exc

File ~/sw/frontier/gpu/venvs/warpx-frontier/lib/python3.11/site-packages/cupy/_core/__init__.py:3
      1 # mypy: ignore-errors
----> 3 from cupy._core import core  # NOQA
      4 from cupy._core import fusion  # NOQA
      5 from cupy._core import internal  # NOQA

File cupy/_core/core.pyx:1, in init cupy._core.core()

File ~/sw/frontier/gpu/venvs/warpx-frontier/lib/python3.11/site-packages/cupy/cuda/__init__.py:9
      7 from cupy._environment import get_rocm_path  # NOQA
      8 from cupy._environment import get_hipcc_path  # NOQA
----> 9 from cupy.cuda import compiler  # NOQA
     10 from cupy.cuda import device  # NOQA
     11 from cupy.cuda import function  # NOQA

File ~/sw/frontier/gpu/venvs/warpx-frontier/lib/python3.11/site-packages/cupy/cuda/compiler.py:14
     11 from typing import Optional
     12 import warnings
---> 14 from cupy.cuda import device
     15 from cupy.cuda import function
     16 from cupy.cuda import get_rocm_path

File cupy/cuda/device.pyx:105, in init cupy.cuda.device()

File cupy/_util.pyx:52, in cupy._util.memoize.decorator()

File /opt/cray/pe/python/3.11.5/lib/python3.11/functools.py:56, in update_wrapper(wrapper, wrapped, assigned, updated)
     54         pass
     55     else:
---> 56         setattr(wrapper, attr, value)
     57 for attr in updated:
     58     getattr(wrapper, attr).update(getattr(wrapped, attr, {}))

AttributeError: attribute '__name__' of 'builtin_function_or_method' objects is not writable
```

The incompatibility is reported in cupy/cupy#9128.

For me, forcing cython 3.0 solves the issue.