### PR TITLE
Reduce kernel sizes

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICSolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICSolveE.cpp
@@ -1168,200 +1168,197 @@ void FiniteDifferenceSolver::HybridPICSolveECartesian (
         Box const& tez  = mfi.tilebox(Efield[2]->ixType().toIntVect());
 
         // Loop over the cells and update the E field
-        amrex::ParallelFor(tex, tey, tez,
+        // Ex calculation
+        amrex::ParallelFor(tex, [=] AMREX_GPU_DEVICE (int i, int j, int k){
 
-            // Ex calculation
-            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+            // Skip field update in the embedded boundaries
+            if (update_Ex_arr && update_Ex_arr(i, j, k) == 0) { return; }
 
-                // Skip field update in the embedded boundaries
-                if (update_Ex_arr && update_Ex_arr(i, j, k) == 0) { return; }
+            // Interpolate to get the appropriate charge density in space
+            const Real rho_val = Interp(rho, nodal, Ex_stag, coarsen, i, j, k, 0);
 
-                // Interpolate to get the appropriate charge density in space
-                const Real rho_val = Interp(rho, nodal, Ex_stag, coarsen, i, j, k, 0);
+            if (rho_val < rho_floor && holmstrom_vacuum_region) {
+                Ex(i, j, k) = 0._rt;
+            } else {
+                // Get the gradient of the electron pressure if the longitudinal part of
+                // the E-field should be included, otherwise ignore it since curl x (grad Pe) = 0
+                const Real grad_Pe = (!solve_for_Faraday) ?
+                    T_Algo::UpwardDx(Pe, coefs_x, n_coefs_x, i, j, k)
+                    : 0._rt;
 
-                if (rho_val < rho_floor && holmstrom_vacuum_region) {
-                    Ex(i, j, k) = 0._rt;
-                } else {
-                    // Get the gradient of the electron pressure if the longitudinal part of
-                    // the E-field should be included, otherwise ignore it since curl x (grad Pe) = 0
-                    const Real grad_Pe = (!solve_for_Faraday) ?
-                        T_Algo::UpwardDx(Pe, coefs_x, n_coefs_x, i, j, k)
-                        : 0._rt;
+                // interpolate the nodal neE values to the Yee grid
+                const auto enE_x = Interp(enE, nodal, Ex_stag, coarsen, i, j, k, 0);
 
-                    // interpolate the nodal neE values to the Yee grid
-                    const auto enE_x = Interp(enE, nodal, Ex_stag, coarsen, i, j, k, 0);
+                // safety condition since we divide by rho
+                const auto rho_val_limited = std::max(rho_val, rho_floor);
 
-                    // safety condition since we divide by rho
-                    const auto rho_val_limited = std::max(rho_val, rho_floor);
+                Ex(i, j, k) = (enE_x - grad_Pe) / rho_val_limited;
+            }
 
-                    Ex(i, j, k) = (enE_x - grad_Pe) / rho_val_limited;
+            // Add resistivity only if E field value is used to update B
+            if (solve_for_Faraday) {
+                Real jtot_val = 0._rt;
+                if (resistivity_has_J_dependence) {
+                    // Interpolate current to appropriate staggering to match E field
+                    const Real jx_val = Jx(i, j, k);
+                    const Real jy_val = Interp(Jy, Jy_stag, Ex_stag, coarsen, i, j, k, 0);
+                    const Real jz_val = Interp(Jz, Jz_stag, Ex_stag, coarsen, i, j, k, 0);
+                    jtot_val = std::sqrt(jx_val*jx_val + jy_val*jy_val + jz_val*jz_val);
                 }
 
-                // Add resistivity only if E field value is used to update B
-                if (solve_for_Faraday) {
-                    Real jtot_val = 0._rt;
-                    if (resistivity_has_J_dependence) {
-                        // Interpolate current to appropriate staggering to match E field
-                        const Real jx_val = Jx(i, j, k);
-                        const Real jy_val = Interp(Jy, Jy_stag, Ex_stag, coarsen, i, j, k, 0);
-                        const Real jz_val = Interp(Jz, Jz_stag, Ex_stag, coarsen, i, j, k, 0);
-                        jtot_val = std::sqrt(jx_val*jx_val + jy_val*jy_val + jz_val*jz_val);
+                Ex(i, j, k) += eta(rho_val, jtot_val) * Jx(i, j, k);
+
+                if (include_hyper_resistivity_term) {
+
+                    // Interpolate B field to appropriate staggering to match E field
+                    Real btot_val = 0._rt;
+                    if (hyper_resistivity_has_B_dependence) {
+                        const Real bx_val = Interp(Bx, Bx_stag, Ex_stag, coarsen, i, j, k, 0);
+                        const Real by_val = Interp(By, By_stag, Ex_stag, coarsen, i, j, k, 0);
+                        const Real bz_val = Interp(Bz, Bz_stag, Ex_stag, coarsen, i, j, k, 0);
+                        btot_val = std::sqrt(bx_val*bx_val + by_val*by_val + bz_val*bz_val);
                     }
 
-                    Ex(i, j, k) += eta(rho_val, jtot_val) * Jx(i, j, k);
+                    auto nabla2Jx = T_Algo::Dxx(Jx, coefs_x, n_coefs_x, i, j, k)
+                        + T_Algo::Dyy(Jx, coefs_y, n_coefs_y, i, j, k)
+                        + T_Algo::Dzz(Jx, coefs_z, n_coefs_z, i, j, k);
 
-                    if (include_hyper_resistivity_term) {
-
-                        // Interpolate B field to appropriate staggering to match E field
-                        Real btot_val = 0._rt;
-                        if (hyper_resistivity_has_B_dependence) {
-                            const Real bx_val = Interp(Bx, Bx_stag, Ex_stag, coarsen, i, j, k, 0);
-                            const Real by_val = Interp(By, By_stag, Ex_stag, coarsen, i, j, k, 0);
-                            const Real bz_val = Interp(Bz, Bz_stag, Ex_stag, coarsen, i, j, k, 0);
-                            btot_val = std::sqrt(bx_val*bx_val + by_val*by_val + bz_val*bz_val);
-                        }
-
-                        auto nabla2Jx = T_Algo::Dxx(Jx, coefs_x, n_coefs_x, i, j, k)
-                            + T_Algo::Dyy(Jx, coefs_y, n_coefs_y, i, j, k)
-                            + T_Algo::Dzz(Jx, coefs_z, n_coefs_z, i, j, k);
-
-                        Ex(i, j, k) -= eta_h(rho_val, btot_val) * nabla2Jx;
-                    }
-                }
-
-                if (include_external_fields && (rho_val >= rho_floor)) {
-                    Ex(i, j, k) -= Ex_ext(i, j, k);
-                }
-            },
-
-            // Ey calculation
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-
-                // Skip field update in the embedded boundaries
-                if (update_Ey_arr && update_Ey_arr(i, j, k) == 0) { return; }
-
-                // Interpolate to get the appropriate charge density in space
-                const Real rho_val = Interp(rho, nodal, Ey_stag, coarsen, i, j, k, 0);
-
-                if (rho_val < rho_floor && holmstrom_vacuum_region) {
-                    Ey(i, j, k) = 0._rt;
-                } else {
-                    // Get the gradient of the electron pressure if the longitudinal part of
-                    // the E-field should be included, otherwise ignore it since curl x (grad Pe) = 0
-                    const Real grad_Pe = (!solve_for_Faraday) ?
-                        T_Algo::UpwardDy(Pe, coefs_y, n_coefs_y, i, j, k)
-                        : 0._rt;
-
-                    // interpolate the nodal neE values to the Yee grid
-                    const auto enE_y = Interp(enE, nodal, Ey_stag, coarsen, i, j, k, 1);
-
-                    // safety condition since we divide by rho
-                    const auto rho_val_limited = std::max(rho_val, rho_floor);
-
-                    Ey(i, j, k) = (enE_y - grad_Pe) / rho_val_limited;
-                }
-
-                // Add resistivity only if E field value is used to update B
-                if (solve_for_Faraday) {
-                    Real jtot_val = 0._rt;
-                    if (resistivity_has_J_dependence) {
-                        // Interpolate current to appropriate staggering to match E field
-                        const Real jx_val = Interp(Jx, Jx_stag, Ey_stag, coarsen, i, j, k, 0);
-                        const Real jy_val = Jy(i, j, k);
-                        const Real jz_val = Interp(Jz, Jz_stag, Ey_stag, coarsen, i, j, k, 0);
-                        jtot_val = std::sqrt(jx_val*jx_val + jy_val*jy_val + jz_val*jz_val);
-                    }
-
-                    Ey(i, j, k) += eta(rho_val, jtot_val) * Jy(i, j, k);
-
-                    if (include_hyper_resistivity_term) {
-
-                        // Interpolate B field to appropriate staggering to match E field
-                        Real btot_val = 0._rt;
-                        if (hyper_resistivity_has_B_dependence) {
-                            const Real bx_val = Interp(Bx, Bx_stag, Ey_stag, coarsen, i, j, k, 0);
-                            const Real by_val = Interp(By, By_stag, Ey_stag, coarsen, i, j, k, 0);
-                            const Real bz_val = Interp(Bz, Bz_stag, Ey_stag, coarsen, i, j, k, 0);
-                            btot_val = std::sqrt(bx_val*bx_val + by_val*by_val + bz_val*bz_val);
-                        }
-
-                        auto nabla2Jy = T_Algo::Dxx(Jy, coefs_x, n_coefs_x, i, j, k)
-                            + T_Algo::Dyy(Jy, coefs_y, n_coefs_y, i, j, k)
-                            + T_Algo::Dzz(Jy, coefs_z, n_coefs_z, i, j, k);
-
-                        Ey(i, j, k) -= eta_h(rho_val, btot_val) * nabla2Jy;
-                    }
-                }
-
-                if (include_external_fields && (rho_val >= rho_floor)) {
-                    Ey(i, j, k) -= Ey_ext(i, j, k);
-                }
-            },
-
-            // Ez calculation
-            [=] AMREX_GPU_DEVICE (int i, int j, int k){
-
-                // Skip field update in the embedded boundaries
-                if (update_Ez_arr && update_Ez_arr(i, j, k) == 0) { return; }
-
-                // Interpolate to get the appropriate charge density in space
-                const Real rho_val = Interp(rho, nodal, Ez_stag, coarsen, i, j, k, 0);
-
-                if (rho_val < rho_floor && holmstrom_vacuum_region) {
-                    Ez(i, j, k) = 0._rt;
-                } else {
-                    // Get the gradient of the electron pressure if the longitudinal part of
-                    // the E-field should be included, otherwise ignore it since curl x (grad Pe) = 0
-                    const Real grad_Pe = (!solve_for_Faraday) ?
-                        T_Algo::UpwardDz(Pe, coefs_z, n_coefs_z, i, j, k)
-                        : 0._rt;
-
-                    // interpolate the nodal neE values to the Yee grid
-                    const auto enE_z = Interp(enE, nodal, Ez_stag, coarsen, i, j, k, 2);
-
-                    // safety condition since we divide by rho
-                    const auto rho_val_limited = std::max(rho_val, rho_floor);
-
-                    Ez(i, j, k) = (enE_z - grad_Pe) / rho_val_limited;
-                }
-
-                // Add resistivity only if E field value is used to update B
-                if (solve_for_Faraday) {
-                    Real jtot_val = 0._rt;
-                    if (resistivity_has_J_dependence) {
-                        // Interpolate current to appropriate staggering to match E field
-                        const Real jx_val = Interp(Jx, Jx_stag, Ez_stag, coarsen, i, j, k, 0);
-                        const Real jy_val = Interp(Jy, Jy_stag, Ez_stag, coarsen, i, j, k, 0);
-                        const Real jz_val = Jz(i, j, k);
-                        jtot_val = std::sqrt(jx_val*jx_val + jy_val*jy_val + jz_val*jz_val);
-                    }
-
-                    Ez(i, j, k) += eta(rho_val, jtot_val) * Jz(i, j, k);
-
-                    if (include_hyper_resistivity_term) {
-
-                        // Interpolate B field to appropriate staggering to match E field
-                        Real btot_val = 0._rt;
-                        if (hyper_resistivity_has_B_dependence) {
-                            const Real bx_val = Interp(Bx, Bx_stag, Ez_stag, coarsen, i, j, k, 0);
-                            const Real by_val = Interp(By, By_stag, Ez_stag, coarsen, i, j, k, 0);
-                            const Real bz_val = Interp(Bz, Bz_stag, Ez_stag, coarsen, i, j, k, 0);
-                            btot_val = std::sqrt(bx_val*bx_val + by_val*by_val + bz_val*bz_val);
-                        }
-
-                        auto nabla2Jz = T_Algo::Dxx(Jz, coefs_x, n_coefs_x, i, j, k)
-                            + T_Algo::Dyy(Jz, coefs_y, n_coefs_y, i, j, k)
-                            + T_Algo::Dzz(Jz, coefs_z, n_coefs_z, i, j, k);
-
-                        Ez(i, j, k) -= eta_h(rho_val, btot_val) * nabla2Jz;
-                    }
-                }
-
-                if (include_external_fields && (rho_val >= rho_floor)) {
-                    Ez(i, j, k) -= Ez_ext(i, j, k);
+                    Ex(i, j, k) -= eta_h(rho_val, btot_val) * nabla2Jx;
                 }
             }
-        );
+
+            if (include_external_fields && (rho_val >= rho_floor)) {
+                Ex(i, j, k) -= Ex_ext(i, j, k);
+            }
+        });
+
+        // Ey calculation
+        amrex::ParallelFor(tey, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+
+            // Skip field update in the embedded boundaries
+            if (update_Ey_arr && update_Ey_arr(i, j, k) == 0) { return; }
+
+            // Interpolate to get the appropriate charge density in space
+            const Real rho_val = Interp(rho, nodal, Ey_stag, coarsen, i, j, k, 0);
+
+            if (rho_val < rho_floor && holmstrom_vacuum_region) {
+                Ey(i, j, k) = 0._rt;
+            } else {
+                // Get the gradient of the electron pressure if the longitudinal part of
+                // the E-field should be included, otherwise ignore it since curl x (grad Pe) = 0
+                const Real grad_Pe = (!solve_for_Faraday) ?
+                    T_Algo::UpwardDy(Pe, coefs_y, n_coefs_y, i, j, k)
+                    : 0._rt;
+
+                // interpolate the nodal neE values to the Yee grid
+                const auto enE_y = Interp(enE, nodal, Ey_stag, coarsen, i, j, k, 1);
+
+                // safety condition since we divide by rho
+                const auto rho_val_limited = std::max(rho_val, rho_floor);
+
+                Ey(i, j, k) = (enE_y - grad_Pe) / rho_val_limited;
+            }
+
+            // Add resistivity only if E field value is used to update B
+            if (solve_for_Faraday) {
+                Real jtot_val = 0._rt;
+                if (resistivity_has_J_dependence) {
+                    // Interpolate current to appropriate staggering to match E field
+                    const Real jx_val = Interp(Jx, Jx_stag, Ey_stag, coarsen, i, j, k, 0);
+                    const Real jy_val = Jy(i, j, k);
+                    const Real jz_val = Interp(Jz, Jz_stag, Ey_stag, coarsen, i, j, k, 0);
+                    jtot_val = std::sqrt(jx_val*jx_val + jy_val*jy_val + jz_val*jz_val);
+                }
+
+                Ey(i, j, k) += eta(rho_val, jtot_val) * Jy(i, j, k);
+
+                if (include_hyper_resistivity_term) {
+
+                    // Interpolate B field to appropriate staggering to match E field
+                    Real btot_val = 0._rt;
+                    if (hyper_resistivity_has_B_dependence) {
+                        const Real bx_val = Interp(Bx, Bx_stag, Ey_stag, coarsen, i, j, k, 0);
+                        const Real by_val = Interp(By, By_stag, Ey_stag, coarsen, i, j, k, 0);
+                        const Real bz_val = Interp(Bz, Bz_stag, Ey_stag, coarsen, i, j, k, 0);
+                        btot_val = std::sqrt(bx_val*bx_val + by_val*by_val + bz_val*bz_val);
+                    }
+
+                    auto nabla2Jy = T_Algo::Dxx(Jy, coefs_x, n_coefs_x, i, j, k)
+                        + T_Algo::Dyy(Jy, coefs_y, n_coefs_y, i, j, k)
+                        + T_Algo::Dzz(Jy, coefs_z, n_coefs_z, i, j, k);
+
+                    Ey(i, j, k) -= eta_h(rho_val, btot_val) * nabla2Jy;
+                }
+            }
+
+            if (include_external_fields && (rho_val >= rho_floor)) {
+                Ey(i, j, k) -= Ey_ext(i, j, k);
+            }
+        });
+
+        // Ez calculation
+        amrex::ParallelFor(tez, [=] AMREX_GPU_DEVICE (int i, int j, int k){
+
+            // Skip field update in the embedded boundaries
+            if (update_Ez_arr && update_Ez_arr(i, j, k) == 0) { return; }
+
+            // Interpolate to get the appropriate charge density in space
+            const Real rho_val = Interp(rho, nodal, Ez_stag, coarsen, i, j, k, 0);
+
+            if (rho_val < rho_floor && holmstrom_vacuum_region) {
+                Ez(i, j, k) = 0._rt;
+            } else {
+                // Get the gradient of the electron pressure if the longitudinal part of
+                // the E-field should be included, otherwise ignore it since curl x (grad Pe) = 0
+                const Real grad_Pe = (!solve_for_Faraday) ?
+                    T_Algo::UpwardDz(Pe, coefs_z, n_coefs_z, i, j, k)
+                    : 0._rt;
+
+                // interpolate the nodal neE values to the Yee grid
+                const auto enE_z = Interp(enE, nodal, Ez_stag, coarsen, i, j, k, 2);
+
+                // safety condition since we divide by rho
+                const auto rho_val_limited = std::max(rho_val, rho_floor);
+
+                Ez(i, j, k) = (enE_z - grad_Pe) / rho_val_limited;
+            }
+
+            // Add resistivity only if E field value is used to update B
+            if (solve_for_Faraday) {
+                Real jtot_val = 0._rt;
+                if (resistivity_has_J_dependence) {
+                    // Interpolate current to appropriate staggering to match E field
+                    const Real jx_val = Interp(Jx, Jx_stag, Ez_stag, coarsen, i, j, k, 0);
+                    const Real jy_val = Interp(Jy, Jy_stag, Ez_stag, coarsen, i, j, k, 0);
+                    const Real jz_val = Jz(i, j, k);
+                    jtot_val = std::sqrt(jx_val*jx_val + jy_val*jy_val + jz_val*jz_val);
+                }
+
+                Ez(i, j, k) += eta(rho_val, jtot_val) * Jz(i, j, k);
+
+                if (include_hyper_resistivity_term) {
+
+                    // Interpolate B field to appropriate staggering to match E field
+                    Real btot_val = 0._rt;
+                    if (hyper_resistivity_has_B_dependence) {
+                        const Real bx_val = Interp(Bx, Bx_stag, Ez_stag, coarsen, i, j, k, 0);
+                        const Real by_val = Interp(By, By_stag, Ez_stag, coarsen, i, j, k, 0);
+                        const Real bz_val = Interp(Bz, Bz_stag, Ez_stag, coarsen, i, j, k, 0);
+                        btot_val = std::sqrt(bx_val*bx_val + by_val*by_val + bz_val*bz_val);
+                    }
+
+                    auto nabla2Jz = T_Algo::Dxx(Jz, coefs_x, n_coefs_x, i, j, k)
+                        + T_Algo::Dyy(Jz, coefs_y, n_coefs_y, i, j, k)
+                        + T_Algo::Dzz(Jz, coefs_z, n_coefs_z, i, j, k);
+
+                    Ez(i, j, k) -= eta_h(rho_val, btot_val) * nabla2Jz;
+                }
+            }
+
+            if (include_external_fields && (rho_val >= rho_floor)) {
+                Ez(i, j, k) -= Ez_ext(i, j, k);
+            }
+        });
 
         if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
         {

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveE.cpp
@@ -170,66 +170,67 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
         // starting component to interpolate macro properties to Ex, Ey, Ez locations
         const int scomp = 0;
         // Loop over the cells and update the fields
-        amrex::ParallelFor(tex, tey, tez,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+        // Ex update
+        amrex::ParallelFor(tex, [=] AMREX_GPU_DEVICE (int i, int j, int k){
 
-                // Skip field push in the embedded boundaries
-                if (update_Ex_arr && update_Ex_arr(i, j, k) == 0) { return; }
+            // Skip field push in the embedded boundaries
+            if (update_Ex_arr && update_Ex_arr(i, j, k) == 0) { return; }
 
-                // Interpolate conductivity, sigma, to Ex position on the grid
-                amrex::Real const sigma_interp = ablastr::coarsen::sample::Interp(sigma_arr, sigma_stag,
-                                                                                  Ex_stag, macro_cr, i, j, k, scomp);
-                // Interpolated permittivity, epsilon, to Ex position on the grid
-                amrex::Real const epsilon_interp = ablastr::coarsen::sample::Interp(eps_arr, epsilon_stag,
-                                                                                    Ex_stag, macro_cr, i, j, k, scomp);
-                const amrex::Real alpha = T_MacroAlgo::alpha( sigma_interp, epsilon_interp, dt);
-                const amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
-                Ex(i, j, k) = alpha * Ex(i, j, k)
-                            + beta * ( - T_Algo::DownwardDz(Hy, coefs_z, n_coefs_z, i, j, k,0)
-                                       + T_Algo::DownwardDy(Hz, coefs_y, n_coefs_y, i, j, k,0)
-                                     ) - beta * jx(i, j, k);
-            },
+            // Interpolate conductivity, sigma, to Ex position on the grid
+            amrex::Real const sigma_interp = ablastr::coarsen::sample::Interp(sigma_arr, sigma_stag,
+                                                                                Ex_stag, macro_cr, i, j, k, scomp);
+            // Interpolated permittivity, epsilon, to Ex position on the grid
+            amrex::Real const epsilon_interp = ablastr::coarsen::sample::Interp(eps_arr, epsilon_stag,
+                                                                                Ex_stag, macro_cr, i, j, k, scomp);
+            const amrex::Real alpha = T_MacroAlgo::alpha( sigma_interp, epsilon_interp, dt);
+            const amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
+            Ex(i, j, k) = alpha * Ex(i, j, k)
+                        + beta * ( - T_Algo::DownwardDz(Hy, coefs_z, n_coefs_z, i, j, k,0)
+                                    + T_Algo::DownwardDy(Hz, coefs_y, n_coefs_y, i, j, k,0)
+                                    ) - beta * jx(i, j, k);
+        });
 
-            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+        // Ey update
+        amrex::ParallelFor(tey, [=] AMREX_GPU_DEVICE (int i, int j, int k){
 
-                // Skip field push in the embedded boundaries
-                if (update_Ey_arr && update_Ey_arr(i, j, k) == 0) { return; }
+            // Skip field push in the embedded boundaries
+            if (update_Ey_arr && update_Ey_arr(i, j, k) == 0) { return; }
 
-                // Interpolate conductivity, sigma, to Ey position on the grid
-                amrex::Real const sigma_interp = ablastr::coarsen::sample::Interp(sigma_arr, sigma_stag,
-                                                                                  Ey_stag, macro_cr, i, j, k, scomp);
-                // Interpolated permittivity, epsilon, to Ey position on the grid
-                amrex::Real const epsilon_interp = ablastr::coarsen::sample::Interp(eps_arr, epsilon_stag,
-                                                                                    Ey_stag, macro_cr, i, j, k, scomp);
-                const amrex::Real alpha = T_MacroAlgo::alpha( sigma_interp, epsilon_interp, dt);
-                const amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
+            // Interpolate conductivity, sigma, to Ey position on the grid
+            amrex::Real const sigma_interp = ablastr::coarsen::sample::Interp(sigma_arr, sigma_stag,
+                                                                                Ey_stag, macro_cr, i, j, k, scomp);
+            // Interpolated permittivity, epsilon, to Ey position on the grid
+            amrex::Real const epsilon_interp = ablastr::coarsen::sample::Interp(eps_arr, epsilon_stag,
+                                                                                Ey_stag, macro_cr, i, j, k, scomp);
+            const amrex::Real alpha = T_MacroAlgo::alpha( sigma_interp, epsilon_interp, dt);
+            const amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
 
-                Ey(i, j, k) = alpha * Ey(i, j, k)
-                            + beta * ( - T_Algo::DownwardDx(Hz, coefs_x, n_coefs_x, i, j, k,0)
-                                       + T_Algo::DownwardDz(Hx, coefs_z, n_coefs_z, i, j, k,0)
-                                     ) - beta * jy(i, j, k);
-            },
+            Ey(i, j, k) = alpha * Ey(i, j, k)
+                        + beta * ( - T_Algo::DownwardDx(Hz, coefs_x, n_coefs_x, i, j, k,0)
+                                    + T_Algo::DownwardDz(Hx, coefs_z, n_coefs_z, i, j, k,0)
+                                    ) - beta * jy(i, j, k);
+        });
 
-            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+        // Ez update
+        amrex::ParallelFor(tez, [=] AMREX_GPU_DEVICE (int i, int j, int k){
 
-                // Skip field push in the embedded boundaries
-                if (update_Ez_arr && update_Ez_arr(i, j, k) == 0) { return; }
+            // Skip field push in the embedded boundaries
+            if (update_Ez_arr && update_Ez_arr(i, j, k) == 0) { return; }
 
-                // Interpolate conductivity, sigma, to Ez position on the grid
-                amrex::Real const sigma_interp = ablastr::coarsen::sample::Interp(sigma_arr, sigma_stag,
-                                                                                  Ez_stag, macro_cr, i, j, k, scomp);
-                // Interpolated permittivity, epsilon, to Ez position on the grid
-                amrex::Real const epsilon_interp = ablastr::coarsen::sample::Interp(eps_arr, epsilon_stag,
-                                                                                    Ez_stag, macro_cr, i, j, k, scomp);
-                const amrex::Real alpha = T_MacroAlgo::alpha( sigma_interp, epsilon_interp, dt);
-                const amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
+            // Interpolate conductivity, sigma, to Ez position on the grid
+            amrex::Real const sigma_interp = ablastr::coarsen::sample::Interp(sigma_arr, sigma_stag,
+                                                                                Ez_stag, macro_cr, i, j, k, scomp);
+            // Interpolated permittivity, epsilon, to Ez position on the grid
+            amrex::Real const epsilon_interp = ablastr::coarsen::sample::Interp(eps_arr, epsilon_stag,
+                                                                                Ez_stag, macro_cr, i, j, k, scomp);
+            const amrex::Real alpha = T_MacroAlgo::alpha( sigma_interp, epsilon_interp, dt);
+            const amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
 
-                Ez(i, j, k) = alpha * Ez(i, j, k)
-                            + beta * ( - T_Algo::DownwardDy(Hx, coefs_y, n_coefs_y, i, j, k,0)
-                                       + T_Algo::DownwardDx(Hy, coefs_x, n_coefs_x, i, j, k,0)
-                                     ) - beta * jz(i, j, k);
-            }
-        );
+            Ez(i, j, k) = alpha * Ez(i, j, k)
+                        + beta * ( - T_Algo::DownwardDy(Hx, coefs_y, n_coefs_y, i, j, k,0)
+                                    + T_Algo::DownwardDx(Hy, coefs_x, n_coefs_x, i, j, k,0)
+                                    ) - beta * jz(i, j, k);
+        });
     }
 }
 


### PR DESCRIPTION
The SYCL compiler on Aurora complains that these two kernels are too large so here they are split into three separate kernels each.