### PR TITLE
Remove inclusion of  unused header ablastr/parallelization/KernelTimer.H

### DIFF
--- a/Source/Particles/Deposition/ChargeDeposition.H
+++ b/Source/Particles/Deposition/ChargeDeposition.H
@@ -9,7 +9,6 @@
 #define WARPX_CHARGEDEPOSITION_H_
 
 #include "Particles/Deposition/SharedDepositionUtils.H"
-#include "ablastr/parallelization/KernelTimer.H"
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/ShapeFactors.H"
 #include "Utils/WarpXAlgorithmSelection.H"

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -9,7 +9,6 @@
 #define WARPX_CURRENTDEPOSITION_H_
 
 #include "Particles/Deposition/SharedDepositionUtils.H"
-#include "ablastr/parallelization/KernelTimer.H"
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/ShapeFactors.H"
 #include "Utils/TextMsg.H"

--- a/Source/Particles/Deposition/MassMatricesDeposition.H
+++ b/Source/Particles/Deposition/MassMatricesDeposition.H
@@ -9,7 +9,6 @@
 #define WARPX_MASS_MATRICES_DEPOSITION_H_
 
 #include "Particles/Deposition/SharedDepositionUtils.H"
-#include "ablastr/parallelization/KernelTimer.H"
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/Gather/FieldGather.H"
 #include "Particles/ShapeFactors.H"

--- a/Source/Particles/Deposition/TemperatureDeposition.H
+++ b/Source/Particles/Deposition/TemperatureDeposition.H
@@ -12,7 +12,6 @@
 
 #include "Particles/Deposition/VarianceAccumulationBuffer.H"
 #include "Particles/Deposition/SharedDepositionUtils.H"
-#include "ablastr/parallelization/KernelTimer.H"
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/ShapeFactors.H"
 #include "Utils/TextMsg.H"


### PR DESCRIPTION
It seems that we are not currently using the KernelTimer. Therefore this PR removes the inclusions of `ablastr/parallelization/KernelTimer.H` from the code.