### PR TITLE
SYCL: Turn on AOT in CI and Update MKL

### DIFF
--- a/.github/workflows/dependencies/dpcpp.sh
+++ b/.github/workflows/dependencies/dpcpp.sh
@@ -29,16 +29,16 @@ df -h
 # https://github.com/BLAST-WarpX/warpx/pull/1566#issuecomment-790934878
 
 # try apt install up to five times, to avoid connection splits
-# FIXME install latest version of IntelLLVM, Intel MKL
-#       after conflicts with openPMD are resolved
 status=1
 for itry in {1..5}
 do
     sudo apt-get install -y --no-install-recommends \
         build-essential \
         cmake           \
-        intel-oneapi-compiler-dpcpp-cpp=2024.2.1-1079 \
-        intel-oneapi-mkl-devel=2024.2.1-103 \
+        intel-oneapi-compiler-dpcpp-cpp \
+        intel-oneapi-mkl-devel \
+        intel-ocloc \
+        libigc-dev  \
         g++ gfortran    \
         libopenmpi-dev  \
         openmpi-bin     \

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -129,6 +129,8 @@ jobs:
           -DBUILD_SHARED_LIBS=ON       \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DWarpX_COMPUTE=SYCL         \
+          -DAMReX_SYCL_AOT=ON          \
+          -DAMReX_INTEL_ARCH=pvc       \
           -DWarpX_EB=ON                \
           -DWarpX_FFT=ON               \
           -DWarpX_PYTHON=ON            \

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -53,7 +53,6 @@ jobs:
         set +e
         source /opt/intel/oneapi/setvars.sh
         set -e
-        export PATH=$PATH:/opt/intel/oneapi/compiler/2024.2/bin  # FIXME
         export CXX=$(which icpx)
         export CC=$(which icx)
 
@@ -61,7 +60,6 @@ jobs:
         python3 -m pip install --upgrade build packaging setuptools[core] wheel
 
         cmake -S . -B build_sp         \
-          -DCMAKE_CXX_FLAGS_RELEASE="-O1 -DNDEBUG" \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DWarpX_EB=OFF               \
           -DWarpX_PYTHON=ON            \
@@ -119,13 +117,11 @@ jobs:
         set +e
         source /opt/intel/oneapi/setvars.sh
         set -e
-        export PATH=$PATH:/opt/intel/oneapi/compiler/2024.2/bin  # FIXME
         export CXX=$(which icpx)
         export CC=$(which icx)
         export CXXFLAGS="-fsycl ${CXXFLAGS}"
 
         cmake -S . -B build_sp         \
-          -DCMAKE_CXX_FLAGS_RELEASE="-O1 -DNDEBUG" \
           -DBUILD_SHARED_LIBS=ON       \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DWarpX_COMPUTE=SYCL         \

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -131,6 +131,7 @@ jobs:
           -DWarpX_COMPUTE=SYCL         \
           -DAMReX_SYCL_AOT=ON          \
           -DAMReX_INTEL_ARCH=pvc       \
+          -DAMReX_PARALLEL_LINK_JOBS=4 \
           -DWarpX_EB=ON                \
           -DWarpX_FFT=ON               \
           -DWarpX_PYTHON=ON            \

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -280,7 +280,8 @@ void ImplicitSolver::ComputeJfromMassMatrices ()
                 }
 
                 Jx(i,j,k,n) = Jx0(i,j,k,n) + SxxdEx + SxydEy + SxzdEz;
-            },
+            });
+            amrex::ParallelFor(
             Jby, ncomps, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 const int idx[3] = {i, j, k};
@@ -342,7 +343,8 @@ void ImplicitSolver::ComputeJfromMassMatrices ()
                 }
 
                 Jy(i,j,k,n) = Jy0(i,j,k,n) + SyxdEx + SyydEy + SyzdEz;
-            },
+            });
+            amrex::ParallelFor(
             Jbz, ncomps, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 const int idx[3] = {i, j, k};

--- a/Source/ablastr/math/fft/AnyFFT.H
+++ b/Source/ablastr/math/fft/AnyFFT.H
@@ -24,7 +24,7 @@
 #       endif
 #       include <hip/hip_complex.h>
 #   elif defined(AMREX_USE_SYCL)
-#       include <oneapi/mkl/dfti.hpp>
+#       include <oneapi/mkl/dft.hpp>
 #   else
 #       include <fftw3.h>
 #   endif

--- a/Source/ablastr/math/fft/WrapMklFFT.cpp
+++ b/Source/ablastr/math/fft/WrapMklFFT.cpp
@@ -10,6 +10,7 @@
 #include "ablastr/utils/TextMsg.H"
 #include "ablastr/profiler/ProfilerWrapper.H"
 
+#include <complex>
 #include <cstdint>
 
 namespace ablastr::math::anyfft
@@ -53,9 +54,9 @@ namespace ablastr::math::anyfft
         }
 
         fft_plan.m_plan->set_value(oneapi::mkl::dft::config_param::PLACEMENT,
-                                   DFTI_NOT_INPLACE);
+                                   oneapi::mkl::dft::config_value::NOT_INPLACE);
         fft_plan.m_plan->set_value(oneapi::mkl::dft::config_param::FWD_STRIDES,
-                                   strides.data());
+                                   strides);
         fft_plan.m_plan->commit(amrex::Gpu::Device::streamQueue());
 
         // Store meta-data in fft_plan


### PR DESCRIPTION
- AOT can help expose issues earlier.
- A header we use has been deprecated  by Intel.
- A big kernel has been split into three so that their kernel parameter size can be less than 2KB.