### PR TITLE
Update dane scripts

### DIFF
--- a/Docs/source/install/hpc/dane.rst
+++ b/Docs/source/install/hpc/dane.rst
@@ -26,13 +26,15 @@ Preparation
 
 Use the following commands to download the WarpX source code.
 Note that these commands and the shell scripts all assume the bash shell.
+This downloads WarpX into the workspace directory, which is recommended.
+WarpX can be downloaded elsewhere if that doesn't work with your directory structure, but note that the commands shown below refer to WarpX in the workspace directory.
 
 .. code-block:: bash
 
    git clone https://github.com/BLAST-WarpX/warpx.git /usr/workspace/${USER}/dane/src/warpx
 
-We use system software modules, add environment hints and further dependencies via the file ``$HOME/dane_warpx.profile``.
-Create it now:
+The system software modules, environment hints, and further dependencies are setup via the file ``$HOME/dane_warpx.profile`` which is copied from the WarpX source.
+Set it up now:
 
 .. code-block:: bash
 
@@ -58,13 +60,18 @@ Exit the ``vi`` editor with ``Esc`` and then type ``:wq`` (write & quit).
 
 .. important::
 
-   Now, and as the first step on future logins to Dane, activate these environment settings:
+   Now, and as the first step on future logins to Dane, activate these environment settings by executing the file:
 
    .. code-block:: bash
 
       source $HOME/dane_warpx.profile
 
-Finally, since Dane does not yet provide software modules for some of our dependencies, install them once:
+Finally, since Dane does not yet provide software modules for some of our dependencies, WarpX provides a script to install them.
+This is done executed now.
+They are by default installed in the workspace directory (which is recommended), but can be installed elsewhere by setting the environment variable ``WARPX_SW_DIR``.
+The second command activates the Python virtual environment.
+This would normally be done by the ``dane_warpx.profile`` script, but the environment is created by the install script and so wasn't created yet when the profile was run above.
+So the activation needs to be done this way only this one time.
 
 .. code-block:: bash
 
@@ -85,7 +92,8 @@ Finally, since Dane does not yet provide software modules for some of our depend
 Compilation
 -----------
 
-Use the following :ref:`cmake commands <building-cmake>` to compile the application executable:
+Use the following :ref:`cmake commands <building-cmake>` to compile the application executable.
+The options should be modified to suit your needs, for example only building for the dimensions needed.
 
 .. code-block:: bash
 
@@ -125,7 +133,6 @@ If you already installed WarpX in the past and want to update it, start by getti
    git status
 
    # get the latest WarpX source code
-   git fetch
    git pull
 
    # read the output of these commands - do they look ok?

--- a/Tools/machines/dane-llnl/dane_warpx.profile.example
+++ b/Tools/machines/dane-llnl/dane_warpx.profile.example
@@ -27,7 +27,8 @@ export LD_LIBRARY_PATH=${SW_DIR}/install/blaspp-2024.10.26/lib64:$LD_LIBRARY_PAT
 export LD_LIBRARY_PATH=${SW_DIR}/install/lapackpp-2024.10.26/lib64:$LD_LIBRARY_PATH
 
 # optional: for Python bindings
-module load python/3.12.2
+#module load python/3.12.2 # Note this version breaks the adios build
+module load python/3.11.5
 
 if [ -d "${SW_DIR}/venvs/warpx-dane" ]
 then

--- a/Tools/machines/dane-llnl/dane_warpx.profile.example
+++ b/Tools/machines/dane-llnl/dane_warpx.profile.example
@@ -27,7 +27,7 @@ export LD_LIBRARY_PATH=${SW_DIR}/install/blaspp-2024.10.26/lib64:$LD_LIBRARY_PAT
 export LD_LIBRARY_PATH=${SW_DIR}/install/lapackpp-2024.10.26/lib64:$LD_LIBRARY_PATH
 
 # optional: for Python bindings
-#module load python/3.12.2 # Note this version breaks the adios build
+#module load python/3.12.2 # Note this version uses a too new GLIBCXX and breaks the adios build
 module load python/3.11.5
 
 if [ -d "${SW_DIR}/venvs/warpx-dane" ]

--- a/Tools/machines/dane-llnl/install_dependencies.sh
+++ b/Tools/machines/dane-llnl/install_dependencies.sh
@@ -17,18 +17,22 @@ set -eu -o pipefail
 #   Was dane_warpx.profile sourced and configured correctly?
 if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in your dane_warpx.profile file! Please edit its line 2 to continue!"; exit 1; fi
 
-
-# The src directory should have already been created when cloning WarpX #######
-#
-SW_DIR="/usr/workspace/${USER}/dane"
-rm -rf ${SW_DIR}/install
-mkdir -p ${SW_DIR}/install
+# Make sure that a virtual environment is not already activated
+if declare -F deactivate &>/dev/null; then
+  deactivate
+fi
 
 # remove common user mistakes in python, located in .local instead of a venv
 python3 -m pip uninstall -qq -y pywarpx
 python3 -m pip uninstall -qq -y warpx
 python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 
+# Setup the directories where the packages will be installed
+if [ -z "${WARPX_SW_DIR+x}" ]; then
+    WARPX_SW_DIR="/usr/workspace/${USER}/dane"
+fi
+rm -rf ${WARPX_SW_DIR}/install
+mkdir -p ${WARPX_SW_DIR}/install
 
 # General extra dependencies ##################################################
 #
@@ -37,64 +41,64 @@ python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 build_dir=$(mktemp -d)
 
 # c-blosc (I/O compression)
-if [ -d ${SW_DIR}/src/c-blosc ]
+if [ -d ${WARPX_SW_DIR}/src/c-blosc ]
 then
-  cd ${SW_DIR}/src/c-blosc
+  cd ${WARPX_SW_DIR}/src/c-blosc
   git fetch --prune
   git checkout v1.21.6
   cd -
 else
-  git clone -b v1.21.6 https://github.com/Blosc/c-blosc.git ${SW_DIR}/src/c-blosc
+  git clone -b v1.21.6 https://github.com/Blosc/c-blosc.git ${WARPX_SW_DIR}/src/c-blosc
 fi
-cmake -S ${SW_DIR}/src/c-blosc -B ${build_dir}/c-blosc-dane-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/install/c-blosc-1.21.6
+cmake -S ${WARPX_SW_DIR}/src/c-blosc -B ${build_dir}/c-blosc-dane-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${WARPX_SW_DIR}/install/c-blosc-1.21.6
 cmake --build ${build_dir}/c-blosc-dane-build --target install --parallel 6
 
 # ADIOS2
-if [ -d ${SW_DIR}/src/adios2 ]
+if [ -d ${WARPX_SW_DIR}/src/adios2 ]
 then
-  cd ${SW_DIR}/src/adios2
+  cd ${WARPX_SW_DIR}/src/adios2
   git fetch --prune
   git checkout v2.10.2
   cd -
 else
-  git clone -b v2.10.2 https://github.com/ornladios/ADIOS2.git ${SW_DIR}/src/adios2
+  git clone -b v2.10.2 https://github.com/ornladios/ADIOS2.git ${WARPX_SW_DIR}/src/adios2
 fi
-cmake -S ${SW_DIR}/src/adios2 -B ${build_dir}/adios2-dane-build -DBUILD_TESTING=OFF -DADIOS2_BUILD_EXAMPLES=OFF -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_SST=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/install/adios2-2.10.2
+cmake -S ${WARPX_SW_DIR}/src/adios2 -B ${build_dir}/adios2-dane-build -DBUILD_TESTING=OFF -DADIOS2_BUILD_EXAMPLES=OFF -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_SST=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${WARPX_SW_DIR}/install/adios2-2.10.2
 cmake --build ${build_dir}/adios2-dane-build --target install -j 6
 
 # BLAS++ (for PSATD+RZ)
-if [ -d ${SW_DIR}/src/blaspp ]
+if [ -d ${WARPX_SW_DIR}/src/blaspp ]
 then
-  cd ${SW_DIR}/src/blaspp
+  cd ${WARPX_SW_DIR}/src/blaspp
   git fetch --prune
   git checkout v2024.10.26
   cd -
 else
-  git clone -b v2024.10.26 https://github.com/icl-utk-edu/blaspp.git ${SW_DIR}/src/blaspp
+  git clone -b v2024.10.26 https://github.com/icl-utk-edu/blaspp.git ${WARPX_SW_DIR}/src/blaspp
 fi
-cmake -S ${SW_DIR}/src/blaspp -B ${build_dir}/blaspp-dane-build -Duse_openmp=ON -Duse_cmake_find_blas=ON -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/install/blaspp-2024.10.26
+cmake -S ${WARPX_SW_DIR}/src/blaspp -B ${build_dir}/blaspp-dane-build -Duse_openmp=ON -Duse_cmake_find_blas=ON -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${WARPX_SW_DIR}/install/blaspp-2024.10.26
 cmake --build ${build_dir}/blaspp-dane-build --target install --parallel 6
 
 # LAPACK++ (for PSATD+RZ)
-if [ -d ${SW_DIR}/src/lapackpp ]
+if [ -d ${WARPX_SW_DIR}/src/lapackpp ]
 then
-  cd ${SW_DIR}/src/lapackpp
+  cd ${WARPX_SW_DIR}/src/lapackpp
   git fetch --prune
   git checkout v2024.10.26
   cd -
 else
-  git clone -b v2024.10.26 https://github.com/icl-utk-edu/lapackpp.git ${SW_DIR}/src/lapackpp
+  git clone -b v2024.10.26 https://github.com/icl-utk-edu/lapackpp.git ${WARPX_SW_DIR}/src/lapackpp
 fi
-CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S ${SW_DIR}/src/lapackpp -B ${build_dir}/lapackpp-dane-build -Duse_cmake_find_lapack=ON -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/install/lapackpp-2024.10.26
+CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S ${WARPX_SW_DIR}/src/lapackpp -B ${build_dir}/lapackpp-dane-build -Duse_cmake_find_lapack=ON -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${WARPX_SW_DIR}/install/lapackpp-2024.10.26
 cmake --build ${build_dir}/lapackpp-dane-build --target install --parallel 6
 
 
 # Python ######################################################################
 #
-python3 -m pip install --upgrade --user virtualenv
-rm -rf ${SW_DIR}/venvs/warpx-dane
-python3 -m venv ${SW_DIR}/venvs/warpx-dane
-source ${SW_DIR}/venvs/warpx-dane/bin/activate
+# Create a virtual environment and install the Python packages there.
+rm -rf ${WARPX_SW_DIR}/venvs/warpx-dane
+python3 -m venv ${WARPX_SW_DIR}/venvs/warpx-dane
+source ${WARPX_SW_DIR}/venvs/warpx-dane/bin/activate
 python3 -m pip install --upgrade pip
 #python3 -m pip cache purge
 python3 -m pip install --upgrade build
@@ -111,7 +115,9 @@ python3 -m pip install --upgrade matplotlib
 python3 -m pip install --upgrade yt
 
 # install or update WarpX dependencies such as picmistandard
-python3 -m pip install --upgrade -r ${SW_DIR}/src/warpx/requirements.txt
+SCRIPT_PATH="$(realpath ${BASH_SOURCE[0]})"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+python3 -m pip install --upgrade -r ${SCRIPT_DIR}/../../../requirements.txt
 
 # ML dependencies
 python3 -m pip install --upgrade torch


### PR DESCRIPTION
This updates the script for setting up WarpX on Dane. Here is a list of the changes:

- Use an older version of Python. The newer version, 3.12.2 breaks the build of Adios2 because of a reference to a too new version of GLIBCXX.
- Makes the software installation directory user settable, in the variable WARPX_SW_DIR
- Executes the deactivate function if it is defined in case a Python virtual environment was already activated.
- Removes the install of virtualenv in user space so that the installation is completely contained in the install directory.
- The install script uses its own location to find the requirements.txt file. This allows that user to download WarpX anywhere.
- Update the instructions in the doc accordingly