### PR TITLE
Update install direction in dane_warpx.profile.example

### DIFF
--- a/Tools/machines/dane-llnl/dane_warpx.profile.example
+++ b/Tools/machines/dane-llnl/dane_warpx.profile.example
@@ -15,24 +15,27 @@ module load boost/1.80.0
 # optional: for openPMD support
 module load hdf5-parallel/1.14.0
 
-SW_DIR="/usr/workspace/${USER}/dane"
-export CMAKE_PREFIX_PATH=${SW_DIR}/install/c-blosc-1.21.6:$CMAKE_PREFIX_PATH
-export CMAKE_PREFIX_PATH=${SW_DIR}/install/adios2-2.10.2:$CMAKE_PREFIX_PATH
-export PATH=${SW_DIR}/install/adios2-2.10.2/bin:${PATH}
+if [ -z "${WARPX_SW_DIR+x}" ]; then
+    WARPX_SW_DIR="/usr/workspace/${USER}/dane"
+fi
+
+export CMAKE_PREFIX_PATH=${WARPX_SW_DIR}/install/c-blosc-1.21.6:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=${WARPX_SW_DIR}/install/adios2-2.10.2:$CMAKE_PREFIX_PATH
+export PATH=${WARPX_SW_DIR}/install/adios2-2.10.2/bin:${PATH}
 
 # optional: for PSATD in RZ geometry support
-export CMAKE_PREFIX_PATH=${SW_DIR}/install/blaspp-2024.10.26:$CMAKE_PREFIX_PATH
-export CMAKE_PREFIX_PATH=${SW_DIR}/install/lapackpp-2024.10.26:$CMAKE_PREFIX_PATH
-export LD_LIBRARY_PATH=${SW_DIR}/install/blaspp-2024.10.26/lib64:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=${SW_DIR}/install/lapackpp-2024.10.26/lib64:$LD_LIBRARY_PATH
+export CMAKE_PREFIX_PATH=${WARPX_SW_DIR}/install/blaspp-2024.10.26:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=${WARPX_SW_DIR}/install/lapackpp-2024.10.26:$CMAKE_PREFIX_PATH
+export LD_LIBRARY_PATH=${WARPX_SW_DIR}/install/blaspp-2024.10.26/lib64:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${WARPX_SW_DIR}/install/lapackpp-2024.10.26/lib64:$LD_LIBRARY_PATH
 
 # optional: for Python bindings
 #module load python/3.12.2 # Note this version uses a too new GLIBCXX and breaks the adios build
 module load python/3.11.5
 
-if [ -d "${SW_DIR}/venvs/warpx-dane" ]
+if [ -d "${WARPX_SW_DIR}/venvs/warpx-dane" ]
 then
-    source ${SW_DIR}/venvs/warpx-dane/bin/activate
+    source ${WARPX_SW_DIR}/venvs/warpx-dane/bin/activate
 fi
 
 # optional: an alias to request an interactive node for two hours


### PR DESCRIPTION
This makes the same change in `update_dane_scripts_fix` that was done in `dane-llnl/install_dependencies.sh` for the software install directory.

Follow-up to #6009