### PR TITLE
ensure time solver-dependent alpha is set correctly in the curl-curl PC.

### DIFF
--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
@@ -106,6 +106,7 @@ public:
 
     // This parameter is used for the time-step fraction in the PC for implicit
     // treatment of light waves in the curl-curl MLMG solver.
+    // This function should return zero if light waves are not treated implicitly
     [[nodiscard]] virtual amrex::Real  GetThetaForPC () const = 0;
 
     void ComputeJfromMassMatrices ();

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
@@ -104,7 +104,9 @@ public:
         else { return nullptr; }
     }
 
-    [[nodiscard]] amrex::Real  GetTheta () const { return m_theta; }
+    // This parameter is used for the time-step fraction in the PC for implicit
+    // treatment of light waves in the curl-curl MLMG solver.
+    [[nodiscard]] virtual amrex::Real  GetThetaForPC () const = 0;
 
     void ComputeJfromMassMatrices ();
 

--- a/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.H
+++ b/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.H
@@ -67,6 +67,9 @@ public:
                       int              a_nl_iter,
                       bool             a_from_jacobian ) override;
 
+    // This function should return zero if light waves are not treated implicitly
+    [[nodiscard]] amrex::Real  GetThetaForPC () const override { return 0.; }
+
 private:
 
     /**

--- a/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.H
+++ b/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.H
@@ -67,6 +67,8 @@ public:
                       int              a_nl_iter,
                       bool             a_from_jacobian ) override;
 
+    // This parameter is used for the time-step fraction in the PC for implicit
+    // treatment of light waves in the curl-curl MLMG solver.
     // This function should return zero if light waves are not treated implicitly
     [[nodiscard]] amrex::Real  GetThetaForPC () const override { return 0.; }
 

--- a/Source/FieldSolver/ImplicitSolvers/StrangImplicitSpectralEM.H
+++ b/Source/FieldSolver/ImplicitSolvers/StrangImplicitSpectralEM.H
@@ -68,6 +68,8 @@ public:
                       int              a_nl_iter,
                       bool             a_from_jacobian ) override;
 
+    // This parameter is used for the time-step fraction in the PC for implicit
+    // treatment of light waves in the curl-curl MLMG solver.
     // This function should return zero if light waves are not treated implicitly
     [[nodiscard]] amrex::Real  GetThetaForPC () const override { return 0.; }
 

--- a/Source/FieldSolver/ImplicitSolvers/StrangImplicitSpectralEM.H
+++ b/Source/FieldSolver/ImplicitSolvers/StrangImplicitSpectralEM.H
@@ -68,6 +68,9 @@ public:
                       int              a_nl_iter,
                       bool             a_from_jacobian ) override;
 
+    // This function should return zero if light waves are not treated implicitly
+    [[nodiscard]] amrex::Real  GetThetaForPC () const override { return 0.; }
+
 private:
 
     /**

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.H
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.H
@@ -84,6 +84,10 @@ public:
                       int              a_nl_iter,
                       bool             a_from_jacobian ) override;
 
+    // This parameter is used for the time-step fraction in the PC for implicit
+    // treatment of light waves in the curl-curl MLMG solver.
+    [[nodiscard]] virtual amrex::Real  GetThetaForPC () const override { return m_theta; }
+
 private:
 
     /**

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.H
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.H
@@ -86,6 +86,7 @@ public:
 
     // This parameter is used for the time-step fraction in the PC for implicit
     // treatment of light waves in the curl-curl MLMG solver.
+    // This function should return zero if light waves are not treated implicitly
     [[nodiscard]] virtual amrex::Real  GetThetaForPC () const override { return m_theta; }
 
 private:

--- a/Source/NonlinearSolvers/CurlCurlMLMGPC.H
+++ b/Source/NonlinearSolvers/CurlCurlMLMGPC.H
@@ -278,7 +278,14 @@ void CurlCurlMLMGPC<T,Ops>::Update (const T& a_U)
     amrex::ignore_unused(a_U);
 
     // set the alpha coefficient for the curl-curl op
-    const RT thetaDt = m_ops->GetTheta()*this->m_dt;
+    const RT thetaDt = m_ops->GetThetaForPC()*this->m_dt;
+    if (thetaDt==0.) {
+        std::stringstream convergenceMsg;
+        convergenceMsg << "Light waves are not treated implicitly with the chosen time solver.\n";
+        convergenceMsg << "Use jacobian.pc_type = pc_jacobi for better performance.\n";
+        ablastr::warn_manager::WMRecordWarning("CurlCurlMLMGPC", convergenceMsg.str());
+    }
+
     const RT alpha = (thetaDt*PhysConst::c) * (thetaDt*PhysConst::c);
     m_curl_curl->setScalars(alpha, RT(1.0));
 


### PR DESCRIPTION
The curl curl PC solves the following equation:
curl ( alpha * curl ( Eg ) ) + beta * Eg = b

This PC should not be used with a non-zero alpha for time solvers that do not treat light waves implicitly. This PR makes it such that the alpha coefficient is set to zero for the semi-implicit and strang-implicit time solvers.

Also, a Warning is returned if one is using this PC with time solvers that do not treat light waves implicitly. The Warning message tells the user to use the Jacobi PC instead for potentially better performance.