### PR TITLE
fixed index for gmres_iter in 1d planar pinch analysis script

### DIFF
--- a/Examples/Tests/implicit/analysis_1d_pinch.py
+++ b/Examples/Tests/implicit/analysis_1d_pinch.py
@@ -12,7 +12,7 @@
 import numpy as np
 
 newton_solver = np.loadtxt("diags/reduced_files/newton_solver.txt", skiprows=1)
-gmres_iters = newton_solver[:, 5]
+gmres_iters = newton_solver[:, 6]
 
 field_energy = np.loadtxt("diags/reduced_files/field_energy.txt", skiprows=1)
 particle_energy = np.loadtxt("diags/reduced_files/particle_energy.txt", skiprows=1)


### PR DESCRIPTION
This PR fixes a bug in an analysis script introduced in PR #6013 where the index for gmres_iter in the solver diagnostic file was changed.