### PR TITLE
permit CurlCurlMLMG with PEC and SilverMueller BCs.

### DIFF
--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -67,11 +67,14 @@ Array<LinOpBCType,AMREX_SPACEDIM> ImplicitSolver::convertFieldBCToLinOpBC (const
         } else if (a_fbc[i] == FieldBoundaryType::Periodic) {
             lbc[i] = LinOpBCType::Periodic;
         } else if (a_fbc[i] == FieldBoundaryType::PEC) {
-            WARPX_ABORT_WITH_MESSAGE("LinOpBCType not set for this FieldBoundaryType");
+            lbc[i] = LinOpBCType::Dirichlet;
         } else if (a_fbc[i] == FieldBoundaryType::Damped) {
             WARPX_ABORT_WITH_MESSAGE("LinOpBCType not set for this FieldBoundaryType");
         } else if (a_fbc[i] == FieldBoundaryType::Absorbing_SilverMueller) {
-            WARPX_ABORT_WITH_MESSAGE("LinOpBCType not set for this FieldBoundaryType");
+            ablastr::warn_manager::WMRecordWarning("Implicit solver",
+                "With SilverMueller, in the Curl-Curl preconditioner Neumann boundary will be used since the full boundary is not yet implemented.",
+                ablastr::warn_manager::WarnPriority::medium);
+            lbc[i] = LinOpBCType::symmetry;
         } else if (a_fbc[i] == FieldBoundaryType::Neumann) {
             // Also for FieldBoundaryType::PMC
             lbc[i] = LinOpBCType::symmetry;


### PR DESCRIPTION
With PEC, the curl curl mlmg solver uses the Dirichlet BC.

With SilverMueller, the curl curl mlmd solver uses symmetry BC same as for PEC_Insulator.