### PR TITLE
Bug fix: Mixed precision builds fail due to conflicting types

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -121,7 +121,7 @@ jobs:
         export CC=$(which icx)
         export CXXFLAGS="-fsycl ${CXXFLAGS}"
 
-        cmake -S . -B build_sp         \
+        cmake -S . -B build_dpsp       \
           -DBUILD_SHARED_LIBS=ON       \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \
           -DWarpX_COMPUTE=SYCL         \
@@ -133,8 +133,9 @@ jobs:
           -DWarpX_PYTHON=ON            \
           -DWarpX_MPI=OFF              \
           -DWarpX_OPENPMD=ON           \
-          -DWarpX_PRECISION=SINGLE
-        cmake --build build_sp -j 4
+          -DWarpX_PRECISION=DOUBLE     \
+          -DWarpX_PARTICLE_PRECISION=SINGLE
+        cmake --build build_dpsp -j 4
 
         ccache -s
         du -hs ~/.cache/ccache

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -80,8 +80,8 @@ jobs:
         export OMP_NUM_THREADS=2
         Examples/Physics_applications/laser_acceleration/inputs_test_3d_laser_acceleration_picmi.py
 
-  build_dpcc:
-    name: oneAPI DPC++ SP
+  build_dpc:
+    name: oneAPI DPC++ DP SP
     runs-on: ubuntu-24.04
     # Since 2021.4.0, AMReX_GpuUtility.H: error: comparison with NaN always evaluates to false in fast floating point modes
     # oneAPI 2022.2.0 hangs for -O2 and higher:

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.cpp
@@ -137,7 +137,7 @@ void ParticleHistogram2D::ComputeDiags (int step)
     // resize data array
     Array<int,2> tlo{0,0}; // lower bounds
     Array<int,2> thi{m_bin_num_abs-1, m_bin_num_ord-1}; // inclusive upper bounds
-    amrex::TableData<amrex::Real,2> d_data_2D(tlo, thi);
+    amrex::TableData<amrex::ParticleReal,2> d_data_2D(tlo, thi);
     m_h_data_2D.resize(tlo, thi, The_Pinned_Arena());
     auto const& h_table_data = m_h_data_2D.table();
 
@@ -228,7 +228,7 @@ void ParticleHistogram2D::ComputeDiags (int step)
                                        // continue function if particle is not filtered out
                                        auto const f_abs = fun_partparser_abs(t, x, y, z, ux, uy, uz, w);
                                        auto const f_ord = fun_partparser_ord(t, x, y, z, ux, uy, uz, w);
-                                       auto const weight = fun_valueparser(t, x, y, z, ux, uy, uz, w);
+                                       auto const weight = static_cast<amrex::ParticleReal>(fun_valueparser(t, x, y, z, ux, uy, uz, w));
 
                                        // determine particle bin
                                        int const bin_abs = int(Math::floor((f_abs-bin_min_abs)/bin_size_abs));
@@ -237,7 +237,7 @@ void ParticleHistogram2D::ComputeDiags (int step)
                                        int const bin_ord = int(Math::floor((f_ord-bin_min_ord)/bin_size_ord));
                                        if ( bin_ord<0 || bin_ord>=num_bins_ord ) { return; } // discard if out-of-range
 
-                                       amrex::Real &data = d_table(bin_abs, bin_ord);
+                                       auto &data = d_table(bin_abs, bin_ord);
                                        amrex::HostDevice::Atomic::Add(&data, weight);
                                    });
             }

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -314,7 +314,7 @@ public:
         }
 
         amrex::Geometry const& geom_lev = WarpX::GetInstance().Geom(lev);
-        auto const dV = AMREX_D_TERM(geom_lev.CellSize(0), *geom_lev.CellSize(1), *geom_lev.CellSize(2));
+        amrex::ParticleReal const dV = AMREX_D_TERM(geom_lev.CellSize(0), *geom_lev.CellSize(1), *geom_lev.CellSize(2));
 #if defined(WARPX_DIM_RZ)
         amrex::Box const& cbx = mfi.tilebox(amrex::IntVect::TheZeroVector()); //Cell-centered box
         auto const lo = lbound(cbx);
@@ -331,18 +331,18 @@ public:
             int const ri = (i_cell - i_cell%nz)/nz;
             // rr is radius at the cell center
             amrex::ParticleReal const rr = (ri + 0.5_prt)*dr;
-            return 2.0_prt*MathConst::pi*rr;
+            return 2.0_prt*static_cast<amrex::ParticleReal>(MathConst::pi)*rr;
 #elif defined(WARPX_DIM_RCYLINDER)
             int const ri = i_cell;
             // rr is radius at the cell center
             amrex::ParticleReal const rr = (ri + 0.5_prt)*dr;
-            return 2.0_prt*MathConst::pi*rr;
+            return 2.0_prt*static_cast<amrex::ParticleReal>(MathConst::pi)*rr;
 #elif defined(WARPX_DIM_RSPHERE)
             // This needs double checking
             int const ri = i_cell;
             // rr is radius at the cell center
             amrex::ParticleReal const rr = (ri + 0.5_prt)*dr;
-            return 4.0_prt*MathConst::pi*rr*rr;
+            return 4.0_prt*static_cast<amrex::ParticleReal>(MathConst::pi)*rr*rr;
 #else
             // No factor is needed for Cartesian
             amrex::ignore_unused(i_cell);

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -408,7 +408,7 @@ public:
                 // After C is determined the momentum vectors are arranged
                 // such that the net linear momentum is zero.
 
-                const amrex::ParticleReal n_2 = std::min(E2 / E_coll, 0.5_prt * amrex::Random(engine));
+                const amrex::ParticleReal n_2 = std::min(E2 / E_coll, 0.5_prt * static_cast<amrex::ParticleReal>(amrex::Random(engine)));
 
                 // find ellipse semi-major and minor axis
                 const amrex::ParticleReal a = 0.5_prt * (1.0_prt - n_2);


### PR DESCRIPTION
This PR fixes build failures when using double precision fields but single precision particles.

Particular builds errors are:
```
/warpx/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.cpp:248:22: error: cannot convert 'amrex::TableData<double, 2>' to 'const amrex::TableData<float, 2>&'
```
and
```
BinaryCollision.H:557:29: error: no matching function for call to 'AddNoRet'
  557 |                             amrex::Gpu::Atomic::AddNoRet(&n1_in_each_cell[bins_1_ptr[ip]],
AMReX_GpuAtomic.H:281:10: note: candidate template ignored: deduced conflicting types for parameter 'T' ('amrex::ParticleReal' (aka 'float') vs. 'amrex::Real' (aka 'double'))
  281 |     void AddNoRet (T* sum, T value) noexcept
```