### PR TITLE
Add `--release` option to script for update of dependencies

### DIFF
--- a/Docs/source/maintenance/release.rst
+++ b/Docs/source/maintenance/release.rst
@@ -19,6 +19,7 @@ The script ``update_dependencies.py`` from `Tools/Release/update_dependencies.py
        --pyamrex   Update pyAMReX only
        --picsar    Update PICSAR only
        --warpx     Update WarpX only
+       --release   New release
 
 Create a new WarpX release
 --------------------------
@@ -34,6 +35,7 @@ In order to create a GitHub release, you need to:
     The script above can be used to update the core dependencies of WarpX and the WarpX version.
 
     For a WarpX release, ideally a *git tag* of AMReX & PICSAR shall be used instead of an unnamed commit.
+    This can be done by running the script above with the command line option ``--release``.
 
     Then open a PR, wait for tests to pass and then merge.
 

--- a/Tools/Release/releasePR.py
+++ b/Tools/Release/releasePR.py
@@ -74,7 +74,11 @@ AMReX_version = f"{datetime.now().strftime('%y')}.{datetime.now().strftime('%m')
 answers = concat_answers(["y", AMReX_version, AMReX_version, "y"])
 
 process = subprocess.Popen(
-    [Path(REPO_DIR).joinpath("Tools/Release/update_dependencies.py"), "--amrex"],
+    [
+        Path(REPO_DIR).joinpath("Tools/Release/update_dependencies.py"),
+        "--amrex",
+        "--release",
+    ],
     stdin=subprocess.PIPE,
     stdout=subprocess.PIPE,
     stderr=subprocess.PIPE,
@@ -97,7 +101,11 @@ PICSAR_version = "25.04"
 answers = concat_answers(["y", PICSAR_version, PICSAR_version, "y"])
 
 process = subprocess.Popen(
-    [Path(REPO_DIR).joinpath("Tools/Release/update_dependencies.py"), "--picsar"],
+    [
+        Path(REPO_DIR).joinpath("Tools/Release/update_dependencies.py"),
+        "--picsar",
+        "--release",
+    ],
     stdin=subprocess.PIPE,
     stdout=subprocess.PIPE,
     stderr=subprocess.PIPE,
@@ -120,7 +128,11 @@ pyAMReX_version = f"{datetime.now().strftime('%y')}.{datetime.now().strftime('%m
 answers = concat_answers(["y", pyAMReX_version, pyAMReX_version, "y"])
 
 process = subprocess.Popen(
-    [Path(REPO_DIR).joinpath("Tools/Release/update_dependencies.py"), "--pyamrex"],
+    [
+        Path(REPO_DIR).joinpath("Tools/Release/update_dependencies.py"),
+        "--pyamrex",
+        "--release",
+    ],
     stdin=subprocess.PIPE,
     stdout=subprocess.PIPE,
     stderr=subprocess.PIPE,
@@ -142,7 +154,11 @@ subprocess.run(
 answers = concat_answers(["y", WarpX_version_yr, WarpX_version_mn, "", "", "y"])
 
 process = subprocess.Popen(
-    [Path(REPO_DIR).joinpath("Tools/Release/update_dependencies.py"), "--warpx"],
+    [
+        Path(REPO_DIR).joinpath("Tools/Release/update_dependencies.py"),
+        "--warpx",
+        "--release",
+    ],
     stdin=subprocess.PIPE,
     stdout=subprocess.PIPE,
     stderr=subprocess.PIPE,
@@ -174,11 +190,11 @@ subprocess.run(
         f"""Prepare the {datetime.now().strftime("%B")} release of WarpX:
 ```bash
 # update dependencies
-./Tools/Release/update_dependencies.py --amrex
-./Tools/Release/update_dependencies.py --picsar # no changes, still {PICSAR_version}
-./Tools/Release/update_dependencies.py --pyamrex
+./Tools/Release/update_dependencies.py --amrex --release
+./Tools/Release/update_dependencies.py --picsar --release # no changes, still {PICSAR_version}
+./Tools/Release/update_dependencies.py --pyamrex --release
 # bump version number
-./Tools/Release/update_dependencies.py --warpx
+./Tools/Release/update_dependencies.py --warpx --release
 ```
 
 Following this workflow: https://warpx.readthedocs.io/en/latest/maintenance/release.html

--- a/Tools/Release/releasePR.py
+++ b/Tools/Release/releasePR.py
@@ -197,7 +197,8 @@ subprocess.run(
 ./Tools/Release/update_dependencies.py --warpx --release
 ```
 
-Following this workflow: https://warpx.readthedocs.io/en/latest/maintenance/release.html
+This pull request was created with the script `./Tools/Release/releasePR.py`,
+following the instructions described in https://warpx.readthedocs.io/en/latest/maintenance/release.html#create-a-new-warpx-release.
 """,
         "--label",
         "component: documentation",

--- a/Tools/Release/update_dependencies.py
+++ b/Tools/Release/update_dependencies.py
@@ -63,16 +63,18 @@ def update(args):
         repo_commit = repo_gh.json()["sha"]
         # set new repository version
         repo_version = datetime.date.today().strftime("%y.%m")
+        # use version tag for new release
+        new_commit = repo_version if args.release else repo_commit
         # update repository commit
         if repo_name != "warpx":
             print(f"- old commit: {dependencies_data[commit_key]}")
-            print(f"- new commit: {repo_commit}")
+            print(f"- new commit: {new_commit}")
             proceed = input("Do you want to continue? [y/n] ")
             if proceed not in ["y", "Y"]:
                 print("Skipping commit update...")
             else:
                 print("Updating commit...")
-                dependencies_data[f"commit_{repo_name}"] = repo_commit
+                dependencies_data[f"commit_{repo_name}"] = new_commit
         # update repository version
         print(f"- old version: {dependencies_data[version_key]}")
         print(f"- new version: {repo_version}")
@@ -122,6 +124,14 @@ if __name__ == "__main__":
         help="Update WarpX only",
         action="store_true",
         dest="warpx",
+    )
+
+    # add arguments: release option
+    parser.add_argument(
+        "--release",
+        help="New release",
+        action="store_true",
+        dest="release",
     )
 
     # parse arguments

--- a/Tools/Release/weeklyUpdate.py
+++ b/Tools/Release/weeklyUpdate.py
@@ -168,7 +168,8 @@ Weekly update to latest PICSAR{picsar_changes}.
 ./Tools/Release/update_dependencies.py --picsar
 ```
 
-This pull request was created with this script: `./Tools/Release/weeklyUpdate.py`
+This pull request was created with the script `./Tools/Release/weeklyUpdate.py`,
+following the instructions described in https://warpx.readthedocs.io/en/latest/maintenance/release.html#update-warpx-core-dependencies.
 """,
         "--label",
         "component: documentation",


### PR DESCRIPTION
Added the new command line option `--release` to the script `update_dependencies.py` which automatically uses the version tag (e.g., `25.07`) instead of the commit hash to replace the commit field in the dependencies file.

Requested by @ax3l on Slack:

> Can we slightly update the version script to support to put tags into commit fields, when we have a tag?
I added this in the last commit. Whenever we can add a tag it is just more readable for this field, so I used tags instead of hashes for releases usually in the past. In between, of course we use hashes for weekly/intermediate updates.

@ax3l 
Does this implementation work for you?