### PR TITLE
Tools: improve automated dependencies update

### DIFF
--- a/Tools/Release/update_dependencies.py
+++ b/Tools/Release/update_dependencies.py
@@ -100,7 +100,7 @@ def update(args):
             # current date version for the WarpX release update
             repo_version_tag = datetime.date.today().strftime("%y.%m")
         else:
-            # last available tag (index 0) for all other dependencies
+            # latest available tag (index 0) for all other dependencies
             repo_version_tag = tags_list_filtered[0]["name"]
         # use version tag instead of commit sha for a release update
         new_commit_sha = repo_version_tag if args.release else repo_commit_sha

--- a/Tools/Release/update_dependencies.py
+++ b/Tools/Release/update_dependencies.py
@@ -18,20 +18,36 @@ def update(args):
     # list of repositories to update
     repo_dict = {}
     if args.all or args.amrex:
-        repo_dict["amrex"] = (
+        repo_dict["amrex"] = {}
+        repo_dict["amrex"]["commit"] = (
             "https://api.github.com/repos/AMReX-Codes/amrex/commits/development"
         )
+        repo_dict["amrex"]["tags"] = (
+            "https://api.github.com/repos/AMReX-Codes/amrex/tags"
+        )
     if args.all or args.pyamrex:
-        repo_dict["pyamrex"] = (
+        repo_dict["pyamrex"] = {}
+        repo_dict["pyamrex"]["commit"] = (
             "https://api.github.com/repos/AMReX-Codes/pyamrex/commits/development"
         )
+        repo_dict["pyamrex"]["tags"] = (
+            "https://api.github.com/repos/AMReX-Codes/pyamrex/tags"
+        )
     if args.all or args.picsar:
-        repo_dict["picsar"] = (
+        repo_dict["picsar"] = {}
+        repo_dict["picsar"]["commit"] = (
             "https://api.github.com/repos/ECP-WarpX/picsar/commits/development"
         )
+        repo_dict["picsar"]["tags"] = (
+            "https://api.github.com/repos/ECP-WarpX/picsar/tags"
+        )
     if args.all or args.warpx:
-        repo_dict["warpx"] = (
+        repo_dict["warpx"] = {}
+        repo_dict["warpx"]["commit"] = (
             "https://api.github.com/repos/BLAST-WarpX/warpx/commits/development"
+        )
+        repo_dict["warpx"]["tags"] = (
+            "https://api.github.com/repos/BLAST-WarpX/warpx/tags"
         )
 
     # list of repositories labels for logging convenience
@@ -53,35 +69,56 @@ def update(args):
         sys.exit()
 
     # loop over repositories and update dependencies data
-    for repo_name, repo_url in repo_dict.items():
+    for repo_name, repo_subdict in repo_dict.items():
         print(f"\nUpdating {repo_labels[repo_name]}...")
         # set keys to access dependencies data
         commit_key = f"commit_{repo_name}"
         version_key = f"version_{repo_name}"
-        # set new repository commit
-        repo_gh = requests.get(repo_url)
-        repo_commit = repo_gh.json()["sha"]
-        # set new repository version
-        repo_version = datetime.date.today().strftime("%y.%m")
-        # update repository commit
+        # get new commit information
+        commit_response = requests.get(repo_subdict["commit"])
+        commit_dict = commit_response.json()
+        # set new commit
+        repo_commit_sha = commit_dict["sha"]
+        # get new version tag information
+        tags_response = requests.get(repo_subdict["tags"])
+        tags_list = tags_response.json()
+        # filter out old-format tags for specific repositories
+        if repo_name == "amrex":
+            tags_list_filtered = [
+                tag_dict
+                for tag_dict in tags_list
+                if (tag_dict["name"] != "boxlib" and tag_dict["name"] != "v2024")
+            ]
+        elif repo_name == "picsar":
+            tags_list_filtered = [
+                tag_dict
+                for tag_dict in tags_list
+                if (tag_dict["name"] != "PICSARlite-0.1")
+            ]
+        # set new version tag
+        if repo_name == "warpx":
+            # current date version for the WarpX release update
+            repo_version_tag = datetime.date.today().strftime("%y.%m")
+        else:
+            # last available tag (index 0) for all other dependencies
+            repo_version_tag = tags_list_filtered[0]["name"]
+        # update commit
         if repo_name != "warpx":
             print(f"- old commit: {dependencies_data[commit_key]}")
-            print(f"- new commit: {repo_commit}")
-            proceed = input("Do you want to continue? [y/n] ")
-            if proceed not in ["y", "Y"]:
+            print(f"- new commit: {repo_commit_sha}")
+            if dependencies_data[commit_key] == repo_commit_sha:
                 print("Skipping commit update...")
             else:
                 print("Updating commit...")
-                dependencies_data[f"commit_{repo_name}"] = repo_commit
-        # update repository version
+                dependencies_data[f"commit_{repo_name}"] = repo_commit_sha
+        # update version
         print(f"- old version: {dependencies_data[version_key]}")
-        print(f"- new version: {repo_version}")
-        proceed = input("Do you want to continue? [y/n] ")
-        if proceed not in ["y", "Y"]:
+        print(f"- new version: {repo_version_tag}")
+        if dependencies_data[version_key] == repo_version_tag:
             print("Skipping version update...")
         else:
             print("Updating version...")
-            dependencies_data[f"version_{repo_name}"] = repo_version
+            dependencies_data[f"version_{repo_name}"] = repo_version_tag
 
     # write to JSON file with dependencies data
     with open(dependencies_file, "w") as file:


### PR DESCRIPTION
### Overview

Follow up on #5965 and improve further the automated update of dependencies:
- The script chooses whether to update or skip the update automatically, user input (`[y/n]`) not requested anymore.
- The script fetches both the latest commit and the list of available version tags (to be used for a new release update).
- For dependencies, we use the latest available version tag (instead of the current date YY.MM), as not all dependencies publish regular monthly releases (e.g., PICSAR). The script takes care of filtering out old-format tags as well.

### To do

- [x] Rebase after #6033 

### Coming next

Try setting up a GitHub Actions workflow for fully automated weekly update and monthly release, using GitHub CLI as in https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-what-your-workflow-does/using-github-cli-in-workflows.