### PR TITLE
Fix string concatenation in assert

### DIFF
--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -251,14 +251,14 @@ LaserParticleContainer::LaserParticleContainer (AmrCore* amr_core, int ispecies,
             (m_nvec[0]-windir[0])*(m_nvec[0]-windir[0]) +
             (m_nvec[1]-windir[1])*(m_nvec[1]-windir[1]) +
             (m_nvec[2]-windir[2])*(m_nvec[2]-windir[2]) < 1.e-12,
-            "do_continous_injection for laser particle only works" +
+            "do_continous_injection for laser particle only works"
             " if moving window direction and laser propagation direction are the same");
         if ( WarpX::gamma_boost>1 ){
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
                 (WarpX::boost_direction[0]-0)*(WarpX::boost_direction[0]-0) +
                 (WarpX::boost_direction[1]-0)*(WarpX::boost_direction[1]-0) +
                 (WarpX::boost_direction[2]-1)*(WarpX::boost_direction[2]-1) < 1.e-12,
-                "do_continous_injection for laser particle only works if " +
+                "do_continous_injection for laser particle only works if "
                 "warpx.boost_direction = z. TODO: all directions.");
         }
     }


### PR DESCRIPTION
In https://github.com/AMReX-Codes/amrex/pull/4581 I would like to change how `AMREX_ALWAYS_ASSERT_WITH_MESSAGE` works. Currently it encloses everything in a string so that expressions containing errors go unnoticed, like concatenating two `const char *` with `+` instead of just putting them after one another like done here. The AMReX PR proposes to change this to interpret the message as a `const char *` or string directly, exposing this error.