### PR TITLE
Update dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -530,7 +530,7 @@ foreach(D IN LISTS WarpX_DIMS)
                 warpx_enable_IPO(pyWarpX_${SD})
             else()
                 # conditionally defined target in pybind11
-                # https://github.com/pybind/pybind11/blob/v2.13.0/tools/pybind11Common.cmake#L407-L413
+                # https://github.com/pybind/pybind11/blob/v3.0.0/tools/pybind11Common.cmake#L420-L426
                 target_link_libraries(pyWarpX_${SD} PRIVATE pybind11::lto)
             endif()
         endif()

--- a/cmake/dependencies/pybind11.cmake
+++ b/cmake/dependencies/pybind11.cmake
@@ -37,7 +37,7 @@ function(find_pybind11)
             mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDpybind11)
         endif()
     else()
-        find_package(pybind11 2.13.0 CONFIG REQUIRED)
+        find_package(pybind11 3.0.0 CONFIG REQUIRED)
         message(STATUS "pybind11: Found version '${pybind11_VERSION}'")
     endif()
 endfunction()
@@ -52,7 +52,7 @@ option(WarpX_pybind11_internal "Download & build pybind11" ON)
 set(WarpX_pybind11_repo "https://github.com/pybind/pybind11.git"
     CACHE STRING
     "Repository URI to pull and build pybind11 from if(WarpX_pybind11_internal)")
-set(WarpX_pybind11_branch "v2.13.6"
+set(WarpX_pybind11_branch "v3.0.0"
     CACHE STRING
     "Repository branch for WarpX_pybind11_repo if(WarpX_pybind11_internal)")
 

--- a/dependencies.json
+++ b/dependencies.json
@@ -4,6 +4,6 @@
     "version_pyamrex": "25.07",
     "version_picsar": "25.06",
     "commit_amrex": "af07c6f1d7b8da7dbb2cc2073cbde17e90e681d9",
-    "commit_pyamrex": "69c5e2615700c2588fdb7d121ac88389dfd33512",
+    "commit_pyamrex": "f884dda4beebdd955aaba8f82a8a9530b8185bb5",
     "commit_picsar": "0c329e66010267662a82219f7de7abbd231463f4"
 }

--- a/dependencies.json
+++ b/dependencies.json
@@ -2,8 +2,8 @@
     "version_warpx": "25.07",
     "version_amrex": "25.07",
     "version_pyamrex": "25.07",
-    "version_picsar": "25.04",
-    "commit_amrex": "7c99975cf9090e6530125562a3288e56c9e54b6e",
-    "commit_pyamrex": "2a2587b9333d3beb6bf6d92c3470935d032f853d",
+    "version_picsar": "25.06",
+    "commit_amrex": "af07c6f1d7b8da7dbb2cc2073cbde17e90e681d9",
+    "commit_pyamrex": "69c5e2615700c2588fdb7d121ac88389dfd33512",
     "commit_picsar": "0c329e66010267662a82219f7de7abbd231463f4"
 }


### PR DESCRIPTION
Update dependencies:
- AMReX commit;
- pyAMReX commit;
- PICSAR version.

Using the better automation in #6038 I found out that we had missed the latest PICSAR version update (just the tag).

To-do:
- [x] Update after https://github.com/AMReX-Codes/pyamrex/pull/455.