### PR TITLE
Run test_2d_theta_implicit_strang_psatd test on one processor

### DIFF
--- a/Examples/Tests/implicit/CMakeLists.txt
+++ b/Examples/Tests/implicit/CMakeLists.txt
@@ -75,7 +75,7 @@ if(WarpX_FFT)
     add_warpx_test(
         test_2d_theta_implicit_strang_psatd  # name
         2  # dims
-        2  # nprocs
+        1  # nprocs
         inputs_test_2d_theta_implicit_strang_psatd  # inputs
         "analysis_2d_psatd.py"  # analysis
         "analysis_default_regression.py --path diags/diag1000020"  # checksum


### PR DESCRIPTION
This test uses `psatd.periodic_single_box_fft = 1` and so only works on one processor. This change avoids the warning `Too many resources / too little work!` that was arising during the CI tests.