### PR TITLE
Doxygen: No Python

### DIFF
--- a/Docs/Doxyfile
+++ b/Docs/Doxyfile
@@ -2709,6 +2709,3 @@ GENERATE_LEGEND        = YES
 # The default value is: YES.
 
 DOT_CLEANUP            = YES
-
-# Overwrite value of WARN_AS_ERROR
-WARN_AS_ERROR = YES

--- a/Docs/Doxyfile
+++ b/Docs/Doxyfile
@@ -958,7 +958,6 @@ FILE_PATTERNS          = *.c \
                          *.c++ \
                          *.h \
                          *.H \
-                         *.py \
                          *.f90 \
                          *.f
 


### PR DESCRIPTION
Unbreak XML builds of Doxygen, following #3560.
Please do not read Python files, Doxygen. You are too eager.

See:
- https://github.com/BLAST-WarpX/warpx/pull/3560#issuecomment-3134161573