### PR TITLE
openPMD: Species Temperature Dimensionality

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -371,6 +371,10 @@ namespace detail
                                           {openPMD::UnitDimension::I,  1},
                                           {openPMD::UnitDimension::T,  1},
                                   });
+        } else if (field_name.substr(0,2) == "T_"){ // temperature in eV
+            mesh.setUnitDimension({
+                                          {openPMD::UnitDimension::theta,  1},
+                                  });
         }
     }
 #endif // WARPX_USE_OPENPMD

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -1471,6 +1471,9 @@ WarpXOpenPMDPlot::WriteOpenPMDFieldsAll ( //const std::string& filename,
                                         field_name,
                                         mf[lev],
                                         var_in_theta_mode );
+                        if (field_name.substr(0,2) == "T_") {
+                            mesh.setUnitSI(11604.5);  // temperature in eV -> K
+                        }
                     }
                 } else {
                     auto mesh = meshes[field_name];


### PR DESCRIPTION
- [x] Properly add the meta data for thermodynamic temperature to the `T_<species>` field outputs.
- [x] Set `unitSI` to a non-1 value, because we store in eV.

Fix #6039