### PR TITLE
Automated workflows for weekly update and monthly release

### DIFF
--- a/.github/workflows/monthly_release.yml
+++ b/.github/workflows/monthly_release.yml
@@ -25,11 +25,11 @@ jobs:
           python Tools/Release/update_dependencies.py --release
       - name: Commit changes
         run: |
-          git add .
+          git add -u
           git commit -m "Update dependencies and release"
       - name: Push changes
         run: |
-          git push --set-upstream origin monthly_release
+          git push -u origin monthly_release
       - name: Open pull request
         run: |
           gh pr create \

--- a/.github/workflows/monthly_release.yml
+++ b/.github/workflows/monthly_release.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-      - name: Create new branch
+      - name: Checkout branch
         run: |
           git checkout monthly_release || git checkout -b monthly_release
       - name: Update dependencies

--- a/.github/workflows/monthly_release.yml
+++ b/.github/workflows/monthly_release.yml
@@ -3,6 +3,7 @@ name: Autoupdate
 on:
   schedule:
     - cron: "0 0 1 * *"  # every first day of the month at midnight
+  workflow_dispatch:
 
 jobs:
   monthly_release:

--- a/.github/workflows/monthly_release.yml
+++ b/.github/workflows/monthly_release.yml
@@ -1,0 +1,39 @@
+name: Autoupdate
+
+on:
+  schedule:
+    - cron: "0 0 1 * *"  # every first day of the month at midnight
+
+jobs:
+  monthly_release:
+    name: Monthly release
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Create new branch
+        run: |
+          git checkout -b monthly_release
+      - name: Update dependencies
+        run: |
+          python Tools/Release/update_dependencies.py --release
+      - name: Commit changes
+        run: |
+          git add .
+          git commit -m "Update dependencies and release"
+      - name: Push changes
+        run: |
+          git push --set-upstream origin monthly_release
+      - name: Open pull request
+        run: |
+          gh pr create \
+            --base development \
+            --body "Automated via .github/workflows/monthly_release.yml." \
+            --label "component: third party" \
+            --title "Update dependencies and release"

--- a/.github/workflows/monthly_release.yml
+++ b/.github/workflows/monthly_release.yml
@@ -19,7 +19,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Create new branch
         run: |
-          git checkout -b monthly_release
+          git checkout monthly_release || git checkout -b monthly_release
       - name: Update dependencies
         run: |
           python Tools/Release/update_dependencies.py --release

--- a/.github/workflows/monthly_release.yml
+++ b/.github/workflows/monthly_release.yml
@@ -11,6 +11,9 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - name: Set current date
+        run: |
+          echo "DATE=$(date +'%y.%m')" >> $GITHUB_ENV
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Configure Git
@@ -26,7 +29,7 @@ jobs:
       - name: Commit changes
         run: |
           git add -u
-          git commit -m "Update dependencies and release"
+          git commit -m "Update dependencies.json"
       - name: Push changes
         run: |
           git push -u origin monthly_release
@@ -36,4 +39,4 @@ jobs:
             --base development \
             --body "Automated via .github/workflows/monthly_release.yml." \
             --label "component: third party" \
-            --title "Update dependencies and release"
+            --title "Release: WarpX ${{ env.DATE }}"

--- a/.github/workflows/weekly_update.yml
+++ b/.github/workflows/weekly_update.yml
@@ -25,11 +25,11 @@ jobs:
           python Tools/Release/update_dependencies.py
       - name: Commit changes
         run: |
-          git add .
+          git add -u
           git commit -m "Update dependencies"
       - name: Push changes
         run: |
-          git push --set-upstream origin weekly_update
+          git push -u origin weekly_update
       - name: Open pull request
         run: |
           gh pr create \

--- a/.github/workflows/weekly_update.yml
+++ b/.github/workflows/weekly_update.yml
@@ -19,7 +19,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Create new branch
         run: |
-          git checkout -b weekly_update
+          git checkout weekly_update || git checkout -b weekly_update
       - name: Update dependencies
         run: |
           python Tools/Release/update_dependencies.py

--- a/.github/workflows/weekly_update.yml
+++ b/.github/workflows/weekly_update.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Commit changes
         run: |
           git add -u
-          git commit -m "Update dependencies"
+          git commit -m "Update dependencies.json"
       - name: Push changes
         run: |
           git push -u origin weekly_update
@@ -36,4 +36,4 @@ jobs:
             --base development \
             --body "Automated via .github/workflows/weekly_update.yml." \
             --label "component: third party" \
-            --title "Update dependencies"
+            --title "Dependencies: weekly update"

--- a/.github/workflows/weekly_update.yml
+++ b/.github/workflows/weekly_update.yml
@@ -3,6 +3,7 @@ name: Autoupdate
 on:
   schedule:
     - cron: "0 0 * * 1"  # every Monday at midnight
+  workflow_dispatch:
 
 jobs:
   weekly_update:

--- a/.github/workflows/weekly_update.yml
+++ b/.github/workflows/weekly_update.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-      - name: Create new branch
+      - name: Checkout branch
         run: |
           git checkout weekly_update || git checkout -b weekly_update
       - name: Update dependencies

--- a/.github/workflows/weekly_update.yml
+++ b/.github/workflows/weekly_update.yml
@@ -1,0 +1,39 @@
+name: Autoupdate
+
+on:
+  schedule:
+    - cron: "0 0 * * 1"  # every Monday at midnight
+
+jobs:
+  weekly_update:
+    name: Weekly update
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Create new branch
+        run: |
+          git checkout -b weekly_update
+      - name: Update dependencies
+        run: |
+          python Tools/Release/update_dependencies.py
+      - name: Commit changes
+        run: |
+          git add .
+          git commit -m "Update dependencies"
+      - name: Push changes
+        run: |
+          git push --set-upstream origin weekly_update
+      - name: Open pull request
+        run: |
+          gh pr create \
+            --base development \
+            --body "Automated via .github/workflows/weekly_update.yml." \
+            --label "component: third party" \
+            --title "Update dependencies"


### PR DESCRIPTION
Follow up on #5965, #6033, and #6038.

Add GitHub Actions workflows to:
- update the dependencies weekly (on Mondays, at midnight) and create a pull request from the branch `weekly_update`;
- update the dependencies and release montly (on the first day, at midnight) and create a pull request from the branch `monthly_release`.

Useful documentation:
- https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-github-cli
- https://docs.github.com/en/actions/tutorials/authenticate-with-github_token
- https://docs.github.com/en/actions/concepts/security/github_token
- https://cli.github.com/manual/gh_pr_create