### PR TITLE
[WIP] Workaround for GCC warray-bounds warnings

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -1342,7 +1342,7 @@ BTDiagnostics::InterleaveBufferAndSnapshotHeader ( const std::string& buffer_Hea
     amrex::IntVect box_lo(0);
     amrex::IntVect box_hi(1);
     // Update prob_lo with min of buffer and snapshot
-    for (int idim = 0; idim < snapshot_HeaderImpl.spaceDim(); ++idim) {
+    for (int idim = 0; idim < std::min(snapshot_HeaderImpl.spaceDim(),AMREX_SPACEDIM); ++idim) {
         const amrex::Real min_prob_lo = amrex::min(buffer_HeaderImpl.problo(idim),
                                              snapshot_HeaderImpl.problo(idim));
         const amrex::Real max_prob_hi = amrex::max(buffer_HeaderImpl.probhi(idim),

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -260,6 +260,11 @@ WarpX::UpdateInjectionPosition (const amrex::Real a_dt)
 {
     const int dir = moving_window_dir;
 
+    if (dir < 0 || dir >= AMREX_SPACEDIM) {
+        WARPX_ABORT_WITH_MESSAGE("Invalid moving window direction: "+std::to_string(dir));
+        return;
+    }
+
     // Loop over species (particles and lasers)
     const int n_containers = mypc->nContainers();
     for (int i=0; i<n_containers; i++)
@@ -365,6 +370,11 @@ WarpX::MoveWindow (const int step, bool move_j)
     // and of the plasma injection
     moving_window_x += (moving_window_v - WarpX::beta_boost * PhysConst::c)/(1 - moving_window_v * WarpX::beta_boost / PhysConst::c) * dt[0];
     const int dir = moving_window_dir;
+
+    if (dir < 0 || dir >= AMREX_SPACEDIM) {
+        WARPX_ABORT_WITH_MESSAGE("Invalid moving window direction: "+std::to_string(dir));
+        return 0;
+    }
 
     // Update current injection position for all containers
     UpdateInjectionPosition(dt[0]);


### PR DESCRIPTION
These warnings are false positives. This PR provides a workaround.