### PR TITLE
Update to use the correct stencils in FieldPoyntingFlux

### DIFF
--- a/Source/Diagnostics/ReducedDiags/FieldPoyntingFlux.H
+++ b/Source/Diagnostics/ReducedDiags/FieldPoyntingFlux.H
@@ -343,6 +343,10 @@ namespace Poynting {
 
                 constexpr int comp = 0;
 
+                // This is needed by the GPU compilers where captured variables cannot first appear
+                // in a constexpr-if context
+                amrex::ignore_unused(Ez_arr, By_arr, Ex_arr, Bz_arr, Ey_arr, Bx_arr);
+
                 amrex::Real const af = area_factor(i,j,k);
                 if constexpr (normal_dir == 0) {
                     return af*(T_Algo::EyBz(i,j,k,comp,Ey_arr,Bz_arr) - T_Algo::EzBy(i,j,k,comp,Ez_arr,By_arr));

--- a/Source/Diagnostics/ReducedDiags/FieldPoyntingFlux.H
+++ b/Source/Diagnostics/ReducedDiags/FieldPoyntingFlux.H
@@ -10,7 +10,358 @@
 
 #include "ReducedDiags.H"
 
+#include <AMReX_Array4.H>
+#include <AMReX_GpuControl.H>
+#include <AMReX_Box.H>
+#include <AMReX_REAL.H>
+#include <AMReX_Reduce.H>
+
 #include <string>
+
+using namespace amrex::literals;
+
+struct PoyntingStaggered {
+    // This requires the arrays to have Yee centering
+
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    static amrex::Real EyBx(int i, int j, int k, int comp,
+                            amrex::Array4<const amrex::Real> const & Ey_arr,
+                            amrex::Array4<const amrex::Real> const & Bx_arr) {
+#if defined(WARPX_DIM_3D)
+        amrex::Real EyBx_dn = Ey_arr(i,j,k,comp)*0.5_rt*(Bx_arr(i,j,k-1,comp) + Bx_arr(i,j,k,comp));
+        amrex::Real EyBx_up = Ey_arr(i+1,j,k,comp)*0.5_rt*(Bx_arr(i+1,j,k-1,comp) + Bx_arr(i+1,j,k,comp));
+        return 0.5_rt*(EyBx_dn + EyBx_up);
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+        amrex::Real EyBx_dn = Ey_arr(i,j,k,comp)*0.5_rt*(Bx_arr(i,j-1,k,comp) + Bx_arr(i,j,k,comp));
+        amrex::Real EyBx_up = Ey_arr(i+1,j,k,comp)*0.5_rt*(Bx_arr(i+1,j-1,k,comp) + Bx_arr(i+1,j,k,comp));
+        return 0.5_rt*(EyBx_dn + EyBx_up);
+#elif defined(WARPX_DIM_1D_Z)
+        return Ey_arr(i,j,k,comp)*0.5_rt*(Bx_arr(i-1,j,k,comp) + Bx_arr(i,j,k,comp));
+#elif defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+        amrex::ignore_unused(i, j, k, comp, Ey_arr, Bx_arr);
+        return 0._rt;
+#endif
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    static amrex::Real ExBy(int i, int j, int k, int comp,
+                            amrex::Array4<const amrex::Real> const & Ex_arr,
+                            amrex::Array4<const amrex::Real> const & By_arr) {
+#if defined(WARPX_DIM_3D)
+        amrex::Real ExBy_dn = Ex_arr(i,j,k,comp)*0.5_rt*(By_arr(i,j,k-1,comp) + By_arr(i,j,k,comp));
+        amrex::Real ExBy_up = Ex_arr(i,j+1,k,comp)*0.5_rt*(By_arr(i,j+1,k-1,comp) + By_arr(i,j+1,k,comp));
+        return 0.5_rt*(ExBy_dn + ExBy_up);
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ) || defined(WARPX_DIM_1D_Z)
+        return Ex_arr(i,j,k,comp)*0.5_rt*(By_arr(i-1,j,k,comp) + By_arr(i,j,k,comp));
+#elif defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+        amrex::ignore_unused(i, j, k, comp, Ex_arr, By_arr);
+        return 0._rt;
+#endif
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    static amrex::Real EzBx(int i, int j, int k, int comp,
+                            amrex::Array4<const amrex::Real> const & Ez_arr,
+                            amrex::Array4<const amrex::Real> const & Bx_arr) {
+#if defined(WARPX_DIM_3D)
+        amrex::Real EzBx_dn = Ez_arr(i,j,k,comp)*0.5_rt*(Bx_arr(i,j-1,k,comp) + Bx_arr(i,j,k,comp));
+        amrex::Real EzBx_up = Ez_arr(i+1,j,k,comp)*0.5_rt*(Bx_arr(i+1,j-1,k,comp) + Bx_arr(i+1,j,k,comp));
+        return 0.5_rt*(EzBx_dn + EzBx_up);
+#else
+        amrex::ignore_unused(i, j, k, comp, Ez_arr, Bx_arr);
+        return 0._rt;
+#endif
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    static amrex::Real ExBz(int i, int j, int k, int comp,
+                            amrex::Array4<const amrex::Real> const & Ex_arr,
+                            amrex::Array4<const amrex::Real> const & Bz_arr) {
+#if defined(WARPX_DIM_3D)
+        amrex::Real ExBz_dn = Ex_arr(i,j,k,comp)*0.5_rt*(Bz_arr(i,j-1,k,comp) + Bz_arr(i,j,k,comp));
+        amrex::Real ExBz_up = Ex_arr(i,j,k+1,comp)*0.5_rt*(Bz_arr(i,j-1,k+1,comp) + Bz_arr(i,j,k+1,comp));
+        return 0.5_rt*(ExBz_dn + ExBz_up);
+#else
+        amrex::ignore_unused(i, j, k, comp, Ex_arr, Bz_arr);
+        return 0._rt;
+#endif
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    static amrex::Real EyBz(int i, int j, int k, int comp,
+                            amrex::Array4<const amrex::Real> const & Ey_arr,
+                            amrex::Array4<const amrex::Real> const & Bz_arr) {
+#if defined(WARPX_DIM_3D)
+        amrex::Real EyBz_dn = Ey_arr(i,j,k,comp)*0.5_rt*(Bz_arr(i-1,j,k,comp) + Bz_arr(i,j,k,comp));
+        amrex::Real EyBz_up = Ey_arr(i,j,k+1,comp)*0.5_rt*(Bz_arr(i-1,j,k+1,comp) + Bz_arr(i,j,k+1,comp));
+        return 0.5_rt*(EyBz_dn + EyBz_up);
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+        amrex::Real EyBz_dn = Ey_arr(i,j,k,comp)*0.5_rt*(Bz_arr(i-1,j,k,comp) + Bz_arr(i,j,k,comp));
+        amrex::Real EyBz_up = Ey_arr(i,j+1,k,comp)*0.5_rt*(Bz_arr(i-1,j+1,k,comp) + Bz_arr(i,j+1,k,comp));
+        return 0.5_rt*(EyBz_dn + EyBz_up);
+#elif defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+        return Ey_arr(i,j,k,comp)*0.5_rt*(Bz_arr(i-1,j,k,comp) + Bz_arr(i,j,k,comp));
+#elif defined(WARPX_DIM_1D_Z)
+        amrex::ignore_unused(i, j, k, comp, Ey_arr, Bz_arr);
+        return 0._rt;
+#endif
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    static amrex::Real EzBy(int i, int j, int k, int comp,
+                            amrex::Array4<const amrex::Real> const & Ez_arr,
+                            amrex::Array4<const amrex::Real> const & By_arr) {
+#if defined(WARPX_DIM_3D)
+        amrex::Real EzBy_dn = Ez_arr(i,j,k,comp)*0.5_rt*(By_arr(i-1,j,k,comp) + By_arr(i,j,k,comp));
+        amrex::Real EzBy_up = Ez_arr(i,j+1,k,comp)*0.5_rt*(By_arr(i-1,j+1,k,comp) + By_arr(i,j+1,k,comp));
+        return 0.5_rt*(EzBy_dn + EzBy_up);
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+        return Ez_arr(i,j,k,comp)*0.5_rt*(By_arr(i-1,j,k,comp) + By_arr(i,j,k,comp));
+#elif defined(WARPX_DIM_1D_Z)
+        amrex::ignore_unused(i, j, k, comp, Ez_arr, By_arr);
+        return 0._rt;
+#endif
+    }
+
+};
+
+struct PoyntingCell {
+
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    static amrex::Real EyBx(int i, int j, int k, int comp,
+                            amrex::Array4<const amrex::Real> const & Ey_arr,
+                            amrex::Array4<const amrex::Real> const & Bx_arr) {
+#if defined(WARPX_DIM_3D) || defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ) || defined(WARPX_DIM_1D_Z)
+        return 0.5_rt*(Ey_arr(i,j,k-1,comp)*Bx_arr(i,j,k-1,comp)
+                     + Ey_arr(i,j,k,comp)*Bx_arr(i,j,k,comp));
+#elif defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+        amrex::ignore_unused(i, j, k, comp, Ey_arr, Bx_arr);
+        return 0._rt;
+#endif
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    static amrex::Real ExBy(int i, int j, int k, int comp,
+                            amrex::Array4<const amrex::Real> const & Ex_arr,
+                            amrex::Array4<const amrex::Real> const & By_arr) {
+#if defined(WARPX_DIM_3D) || defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ) || defined(WARPX_DIM_1D_Z)
+        return 0.5_rt*(Ex_arr(i,j,k-1,comp)*By_arr(i,j,k-1,comp)
+                     + Ex_arr(i,j,k,comp)*By_arr(i,j,k,comp));
+#elif defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+        amrex::ignore_unused(i, j, k, comp, Ex_arr, By_arr);
+        return 0._rt;
+#endif
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    static amrex::Real EzBx(int i, int j, int k, int comp,
+                            amrex::Array4<const amrex::Real> const & Ez_arr,
+                            amrex::Array4<const amrex::Real> const & Bx_arr) {
+#if defined(WARPX_DIM_3D)
+        return 0.5_rt*(Ez_arr(i,j-1,k,comp)*Bx_arr(i,j-1,k,comp)
+                     + Ez_arr(i,j,k,comp)*Bx_arr(i,j,k,comp));
+#else
+        amrex::ignore_unused(i, j, k, comp, Ez_arr, Bx_arr);
+        return 0._rt;
+#endif
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    static amrex::Real ExBz(int i, int j, int k, int comp,
+                            amrex::Array4<const amrex::Real> const & Ex_arr,
+                            amrex::Array4<const amrex::Real> const & Bz_arr) {
+#if defined(WARPX_DIM_3D)
+        return 0.5_rt*(Ex_arr(i,j-1,k,comp)*Bz_arr(i,j-1,k,comp)
+                     + Ex_arr(i,j,k,comp)*Bz_arr(i,j,k,comp));
+#else
+        amrex::ignore_unused(i, j, k, comp, Ex_arr, Bz_arr);
+        return 0._rt;
+#endif
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    static amrex::Real EyBz(int i, int j, int k, int comp,
+                            amrex::Array4<const amrex::Real> const & Ey_arr,
+                            amrex::Array4<const amrex::Real> const & Bz_arr) {
+#if defined(WARPX_DIM_3D) || defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+        return 0.5_rt*(Ey_arr(i-1,j,k,comp)*Bz_arr(i-1,j,k,comp)
+                     + Ey_arr(i,j,k,comp)*Bz_arr(i,j,k,comp));
+#elif defined(WARPX_DIM_1D_Z)
+        amrex::ignore_unused(i, j, k, comp, Ey_arr, Bz_arr);
+        return 0._rt;
+#endif
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    static amrex::Real EzBy(int i, int j, int k, int comp,
+                            amrex::Array4<const amrex::Real> const & Ez_arr,
+                            amrex::Array4<const amrex::Real> const & By_arr) {
+#if defined(WARPX_DIM_3D) || defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+        return 0.5_rt*(Ez_arr(i-1,j,k,comp)*By_arr(i-1,j,k,comp)
+                     + Ez_arr(i,j,k,comp)*By_arr(i,j,k,comp));
+#elif defined(WARPX_DIM_1D_Z)
+        amrex::ignore_unused(i, j, k, comp, Ez_arr, By_arr);
+        return 0._rt;
+#endif
+    }
+
+};
+
+struct PoyntingNodal {
+
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    static amrex::Real EyBx(int i, int j, int k, int comp,
+                            amrex::Array4<const amrex::Real> const & Ey_arr,
+                            amrex::Array4<const amrex::Real> const & Bx_arr) {
+#if defined(WARPX_DIM_3D)
+        return 0.25_rt*(Ey_arr(i,j,k,comp)*Bx_arr(i,j,k,comp)
+                      + Ey_arr(i+1,j,k,comp)*Bx_arr(i+1,j,k,comp)
+                      + Ey_arr(i,j+1,k,comp)*Bx_arr(i,j+1,k,comp)
+                      + Ey_arr(i+1,j+1,k,comp)*Bx_arr(i+1,j+1,k,comp));
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+        return 0.5_rt*(Ey_arr(i,j,k,comp)*Bx_arr(i,j,k,comp) +
+                       Ey_arr(i+1,j,k,comp)*Bx_arr(i+1,j,k,comp));
+#elif defined(WARPX_DIM_1D_Z)
+        return Ey_arr(i,j,k,comp)*Bx_arr(i,j,k,comp);
+#elif defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+        amrex::ignore_unused(i, j, k, comp, Ey_arr, Bx_arr);
+        return 0._rt;
+#endif
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    static amrex::Real ExBy(int i, int j, int k, int comp,
+                            amrex::Array4<const amrex::Real> const & Ex_arr,
+                            amrex::Array4<const amrex::Real> const & By_arr) {
+#if defined(WARPX_DIM_3D)
+        return 0.25_rt*(Ex_arr(i,j,k,comp)*By_arr(i,j,k,comp)
+                      + Ex_arr(i+1,j,k,comp)*By_arr(i+1,j,k,comp)
+                      + Ex_arr(i,j+1,k,comp)*By_arr(i,j+1,k,comp)
+                      + Ex_arr(i+1,j+1,k,comp)*By_arr(i+1,j+1,k,comp));
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+        return 0.5_rt*(Ex_arr(i,j,k,comp)*By_arr(i,j,k,comp)
+                     + Ex_arr(i+1,j,k,comp)*By_arr(i+1,j,k,comp));
+#elif defined(WARPX_DIM_1D_Z)
+        return Ex_arr(i,j,k,comp)*By_arr(i,j,k,comp);
+#elif defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+        amrex::ignore_unused(i, j, k, comp, Ex_arr, By_arr);
+        return 0._rt;
+#endif
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    static amrex::Real EzBx(int i, int j, int k, int comp,
+                            amrex::Array4<const amrex::Real> const & Ez_arr,
+                            amrex::Array4<const amrex::Real> const & Bx_arr) {
+#if defined(WARPX_DIM_3D)
+        return 0.25_rt*(Ez_arr(i,j,k,comp)*Bx_arr(i,j,k,comp)
+                      + Ez_arr(i+1,j,k,comp)*Bx_arr(i+1,j,k,comp)
+                      + Ez_arr(i,j,k+1,comp)*Bx_arr(i,j,k+1,comp)
+                      + Ez_arr(i+1,j,k+1,comp)*Bx_arr(i+1,j,k+1,comp));
+#else
+        amrex::ignore_unused(i, j, k, comp, Ez_arr, Bx_arr);
+        return 0._rt;
+#endif
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    static amrex::Real ExBz(int i, int j, int k, int comp,
+                            amrex::Array4<const amrex::Real> const & Ex_arr,
+                            amrex::Array4<const amrex::Real> const & Bz_arr) {
+#if defined(WARPX_DIM_3D)
+        return 0.25_rt*(Ex_arr(i,j,k,comp)*Bz_arr(i,j,k,comp)
+                      + Ex_arr(i+1,j,k,comp)*Bz_arr(i+1,j,k,comp)
+                      + Ex_arr(i,j,k+1,comp)*Bz_arr(i,j,k+1,comp)
+                      + Ex_arr(i+1,j,k+1,comp)*Bz_arr(i+1,j,k+1,comp));
+#else
+        amrex::ignore_unused(i, j, k, comp, Ex_arr, Bz_arr);
+        return 0._rt;
+#endif
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    static amrex::Real EyBz(int i, int j, int k, int comp,
+                            amrex::Array4<const amrex::Real> const & Ey_arr,
+                            amrex::Array4<const amrex::Real> const & Bz_arr) {
+#if defined(WARPX_DIM_3D)
+        return 0.25_rt*(Ey_arr(i,j,k,comp)*Bz_arr(i,j,k,comp)
+                      + Ey_arr(i,j+1,k,comp)*Bz_arr(i,j+1,k,comp)
+                      + Ey_arr(i,j,k+1,comp)*Bz_arr(i,j,k+1,comp)
+                      + Ey_arr(i,j+1,k+1,comp)*Bz_arr(i,j+1,k+1,comp));
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+        return 0.5_rt*(Ey_arr(i,j,k,comp)*Bz_arr(i,j,k,comp)
+                     + Ey_arr(i,j+1,k,comp)*Bz_arr(i,j+1,k,comp));
+#elif defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+        return Ey_arr(i,j,k,comp)*Bz_arr(i,j,k,comp);
+#elif defined(WARPX_DIM_1D_Z)
+        amrex::ignore_unused(i, j, k, comp, Ey_arr, Bz_arr);
+        return 0._rt;
+#endif
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    static amrex::Real EzBy(int i, int j, int k, int comp,
+                            amrex::Array4<const amrex::Real> const & Ez_arr,
+                            amrex::Array4<const amrex::Real> const & By_arr) {
+#if defined(WARPX_DIM_3D)
+        return 0.25_rt*(Ez_arr(i,j,k,comp)*By_arr(i,j,k,comp)
+                      + Ez_arr(i,j+1,k,comp)*By_arr(i,j+1,k,comp)
+                      + Ez_arr(i,j,k+1,comp)*By_arr(i,j,k+1,comp)
+                      + Ez_arr(i,j+1,k+1,comp)*By_arr(i,j+1,k+1,comp));
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+        return 0.5_rt*(Ez_arr(i,j,k,comp)*By_arr(i,j,k,comp)
+                     + Ez_arr(i,j+1,k,comp)*By_arr(i,j+1,k,comp));
+#elif defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+        return Ez_arr(i,j,k,comp)*By_arr(i,j,k,comp);
+#elif defined(WARPX_DIM_1D_Z)
+        amrex::ignore_unused(i, j, k, comp, Ez_arr, By_arr);
+        return 0._rt;
+#endif
+    }
+
+};
+
+namespace Poynting {
+
+    template<int normal_dir, typename T_Algo, typename AreaFunc>
+    amrex::Real Kernel (amrex::Box const & box,
+                        amrex::Array4<const amrex::Real> const & Ex_arr,
+                        amrex::Array4<const amrex::Real> const & Ey_arr,
+                        amrex::Array4<const amrex::Real> const & Ez_arr,
+                        amrex::Array4<const amrex::Real> const & Bx_arr,
+                        amrex::Array4<const amrex::Real> const & By_arr,
+                        amrex::Array4<const amrex::Real> const & Bz_arr,
+                        AreaFunc area_factor)
+    {
+
+        amrex::ReduceOps<amrex::ReduceOpSum> reduce_ops;
+        amrex::ReduceData<amrex::Real> reduce_data(reduce_ops);
+
+        reduce_ops.eval(box, reduce_data,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k) -> amrex::GpuTuple<amrex::Real>
+            {
+
+                constexpr int comp = 0;
+
+                amrex::Real const af = area_factor(i,j,k);
+                if constexpr (normal_dir == 0) {
+                    return af*(T_Algo::EyBz(i,j,k,comp,Ey_arr,Bz_arr) - T_Algo::EzBy(i,j,k,comp,Ez_arr,By_arr));
+                }
+
+                else if constexpr (normal_dir == 1) {
+                    return af*(T_Algo::EzBx(i,j,k,comp,Ez_arr,Bx_arr) - T_Algo::ExBz(i,j,k,comp,Ex_arr,Bz_arr));
+                }
+
+                else if constexpr (normal_dir == 2) {
+                    return af*(T_Algo::ExBy(i,j,k,comp,Ex_arr,By_arr) - T_Algo::EyBx(i,j,k,comp,Ey_arr,Bx_arr));
+                }
+
+            });
+
+        auto r = reduce_data.value();
+        return amrex::get<0>(r);
+    }
+}
 
 /**
  * \brief This class mainly contains a function that computes the field Poynting flux,

--- a/Source/Diagnostics/ReducedDiags/FieldPoyntingFlux.H
+++ b/Source/Diagnostics/ReducedDiags/FieldPoyntingFlux.H
@@ -131,7 +131,7 @@ struct PoyntingStaggered {
 
 };
 
-struct PoyntingCell {
+struct PoyntingCellCentered {
 
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
     static amrex::Real EyBx(int i, int j, int k, int comp,

--- a/Source/Diagnostics/ReducedDiags/FieldPoyntingFlux.H
+++ b/Source/Diagnostics/ReducedDiags/FieldPoyntingFlux.H
@@ -22,6 +22,12 @@ using namespace amrex::literals;
 
 struct PoyntingStaggered {
     // This requires the arrays to have Yee centering
+    // The procedure (in 3D) is to interpolate the B (which is centered on faces normal
+    // to the plane of the calculaton) to the edge in the plane of the calculation to match
+    // the location of the E. Then the product E*B is interpolated to the face center in
+    // the plane of the calculation.
+    // The procedure is mapped to lower dimensions, and in some cases the second interpolation
+    // is not needed.
 
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
     static amrex::Real EyBx(int i, int j, int k, int comp,

--- a/Source/Diagnostics/ReducedDiags/FieldPoyntingFlux.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldPoyntingFlux.cpp
@@ -14,6 +14,7 @@
 
 #include <ablastr/fields/MultiFabRegister.H>
 #include <ablastr/coarsen/sample.H>
+#include <ablastr/utils/Enums.H>
 
 #include <AMReX_Array.H>
 #include <AMReX_Array4.H>
@@ -30,7 +31,6 @@
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX_REAL.H>
-#include <AMReX_Reduce.H>
 #include <AMReX_Tuple.H>
 #include <AMReX_Vector.H>
 
@@ -144,12 +144,6 @@ void FieldPoyntingFlux::ComputePoyntingFlux ()
     amrex::MultiFab const & By = *warpx.m_fields.get(FieldType::Bfield_fp, Direction{1}, lev);
     amrex::MultiFab const & Bz = *warpx.m_fields.get(FieldType::Bfield_fp, Direction{2}, lev);
 
-    // Coarsening ratio (no coarsening)
-    amrex::GpuArray<int,3> const cr{1,1,1};
-
-    // Reduction component (fourth component in Array4)
-    constexpr int comp = 0;
-
     // Index type (staggering) of each MultiFab
     // (with third component set to zero in 2D)
     amrex::GpuArray<int,3> Ex_stag{0,0,0};
@@ -189,10 +183,6 @@ void FieldPoyntingFlux::ComputePoyntingFlux ()
         dxtemp[face_dir] = 1._rt;
         amrex::Real const dA = AMREX_D_TERM(dxtemp[0], *dxtemp[1], *dxtemp[2]);
 
-        // Node-centered in the face direction, Cell-centered in other directions
-        amrex::GpuArray<int,3> cc{0,0,0};
-        cc[face_dir] = 1;
-
         // Only calculate the ExB term that is normal to the surface.
         // normal_dir is the normal direction relative to the WarpX coordinates
 #if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
@@ -206,8 +196,7 @@ void FieldPoyntingFlux::ComputePoyntingFlux ()
         int const normal_dir = face_dir;
 #endif
 
-        amrex::ReduceOps<amrex::ReduceOpSum> reduce_ops;
-        amrex::ReduceData<amrex::Real> reduce_data(reduce_ops);
+        amrex::Real flux = 0._rt;
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
@@ -223,6 +212,8 @@ void FieldPoyntingFlux::ComputePoyntingFlux ()
             amrex::Array4<const amrex::Real> const & By_arr = By[mfi].array();
             amrex::Array4<const amrex::Real> const & Bz_arr = Bz[mfi].array();
 
+            // This produces a box that is node center in the face direction
+            // and cell centered in the other directions
             amrex::Box box = enclosedCells(mfi.nodaltilebox());
             box.surroundingNodes(face_dir);
 
@@ -262,38 +253,46 @@ void FieldPoyntingFlux::ComputePoyntingFlux ()
             // Compute E x B
             // On GPU, reduce_ops doesn't work with empty boxes.
             if (box.ok()) {
-                reduce_ops.eval(box, reduce_data,
-                    [=] AMREX_GPU_DEVICE (int i, int j, int k) -> amrex::GpuTuple<amrex::Real>
-                    {
-                        amrex::Real Ex_cc = 0._rt, Ey_cc = 0._rt, Ez_cc = 0._rt;
-                        amrex::Real Bx_cc = 0._rt, By_cc = 0._rt, Bz_cc = 0._rt;
-
-                        if (normal_dir == 1 || normal_dir == 2) {
-                            Ex_cc = ablastr::coarsen::sample::Interp(Ex_arr, Ex_stag, cc, cr, i, j, k, comp);
-                            Bx_cc = ablastr::coarsen::sample::Interp(Bx_arr, Bx_stag, cc, cr, i, j, k, comp);
-                        }
-
-                        if (normal_dir == 0 || normal_dir == 2) {
-                            Ey_cc = ablastr::coarsen::sample::Interp(Ey_arr, Ey_stag, cc, cr, i, j, k, comp);
-                            By_cc = ablastr::coarsen::sample::Interp(By_arr, By_stag, cc, cr, i, j, k, comp);
-                        }
-                        if (normal_dir == 0 || normal_dir == 1) {
-                            Ez_cc = ablastr::coarsen::sample::Interp(Ez_arr, Ez_stag, cc, cr, i, j, k, comp);
-                            Bz_cc = ablastr::coarsen::sample::Interp(Bz_arr, Bz_stag, cc, cr, i, j, k, comp);
-                        }
-
-                        amrex::Real const af = area_factor(i,j,k);
-                        if      (normal_dir == 0) { return af*(Ey_cc * Bz_cc - Ez_cc * By_cc); }
-                        else if (normal_dir == 1) { return af*(Ez_cc * Bx_cc - Ex_cc * Bz_cc); }
-                        else                      { return af*(Ex_cc * By_cc - Ey_cc * Bx_cc); }
-                    });
+                if (warpx.grid_type == ablastr::utils::enums::GridType::Staggered ||
+                    warpx.grid_type == ablastr::utils::enums::GridType::Hybrid) {
+                    if (normal_dir == 0) {
+                        flux += Poynting::Kernel<0, PoyntingStaggered>(box, Ex_arr, Ey_arr, Ez_arr, Bx_arr, By_arr, Bz_arr, area_factor);
+                    }
+                    else if (normal_dir == 1) {
+                        flux += Poynting::Kernel<1, PoyntingStaggered>(box, Ex_arr, Ey_arr, Ez_arr, Bx_arr, By_arr, Bz_arr, area_factor);
+                    }
+                    else if (normal_dir == 2) {
+                        flux += Poynting::Kernel<2, PoyntingStaggered>(box, Ex_arr, Ey_arr, Ez_arr, Bx_arr, By_arr, Bz_arr, area_factor);
+                    }
+                }
+                else if (Ex.is_nodal()) {
+                    if (normal_dir == 0) {
+                        flux += Poynting::Kernel<0, PoyntingNodal>(box, Ex_arr, Ey_arr, Ez_arr, Bx_arr, By_arr, Bz_arr, area_factor);
+                    }
+                    else if (normal_dir == 1) {
+                        flux += Poynting::Kernel<1, PoyntingNodal>(box, Ex_arr, Ey_arr, Ez_arr, Bx_arr, By_arr, Bz_arr, area_factor);
+                    }
+                    else if (normal_dir == 2) {
+                        flux += Poynting::Kernel<2, PoyntingNodal>(box, Ex_arr, Ey_arr, Ez_arr, Bx_arr, By_arr, Bz_arr, area_factor);
+                    }
+                }
+                else if (Ex.is_cell_centered()) {
+                    if (normal_dir == 0) {
+                        flux += Poynting::Kernel<0, PoyntingCell>(box, Ex_arr, Ey_arr, Ez_arr, Bx_arr, By_arr, Bz_arr, area_factor);
+                    }
+                    else if (normal_dir == 1) {
+                        flux += Poynting::Kernel<1, PoyntingCell>(box, Ex_arr, Ey_arr, Ez_arr, Bx_arr, By_arr, Bz_arr, area_factor);
+                    }
+                    else if (normal_dir == 2) {
+                        flux += Poynting::Kernel<2, PoyntingCell>(box, Ex_arr, Ey_arr, Ez_arr, Bx_arr, By_arr, Bz_arr, area_factor);
+                    }
+                }
             }
         }
 
         int const sign = (face().isLow() ? -1 : 1);
-        auto r = reduce_data.value();
         int const ii = int(face());
-        m_data[ii] = sign*amrex::get<0>(r)/PhysConst::mu0*dA;
+        m_data[ii] = sign*flux/PhysConst::mu0*dA;
 
     }
 

--- a/Source/Diagnostics/ReducedDiags/FieldPoyntingFlux.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldPoyntingFlux.cpp
@@ -278,14 +278,17 @@ void FieldPoyntingFlux::ComputePoyntingFlux ()
                 }
                 else if (warpx.grid_type == ablastr::utils::enums::GridType::Collocated && Ex.is_cell_centered()) {
                     if (normal_dir == 0) {
-                        flux += Poynting::Kernel<0, PoyntingCell>(box, Ex_arr, Ey_arr, Ez_arr, Bx_arr, By_arr, Bz_arr, area_factor);
+                        flux += Poynting::Kernel<0, PoyntingCellCentered>(box, Ex_arr, Ey_arr, Ez_arr, Bx_arr, By_arr, Bz_arr, area_factor);
                     }
                     else if (normal_dir == 1) {
-                        flux += Poynting::Kernel<1, PoyntingCell>(box, Ex_arr, Ey_arr, Ez_arr, Bx_arr, By_arr, Bz_arr, area_factor);
+                        flux += Poynting::Kernel<1, PoyntingCellCentered>(box, Ex_arr, Ey_arr, Ez_arr, Bx_arr, By_arr, Bz_arr, area_factor);
                     }
                     else if (normal_dir == 2) {
-                        flux += Poynting::Kernel<2, PoyntingCell>(box, Ex_arr, Ey_arr, Ez_arr, Bx_arr, By_arr, Bz_arr, area_factor);
+                        flux += Poynting::Kernel<2, PoyntingCellCentered>(box, Ex_arr, Ey_arr, Ez_arr, Bx_arr, By_arr, Bz_arr, area_factor);
                     }
+                }
+                else {
+                    WARPX_ABORT_WITH_MESSAGE("FieldPoyntingFlux::ComputePoyntingFlux: unknown grid centering being used");
                 }
             }
         }

--- a/Source/Diagnostics/ReducedDiags/FieldPoyntingFlux.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldPoyntingFlux.cpp
@@ -265,7 +265,7 @@ void FieldPoyntingFlux::ComputePoyntingFlux ()
                         flux += Poynting::Kernel<2, PoyntingStaggered>(box, Ex_arr, Ey_arr, Ez_arr, Bx_arr, By_arr, Bz_arr, area_factor);
                     }
                 }
-                else if (Ex.is_nodal()) {
+                else if (warpx.grid_type == ablastr::utils::enums::GridType::Collocated && Ex.is_nodal()) {
                     if (normal_dir == 0) {
                         flux += Poynting::Kernel<0, PoyntingNodal>(box, Ex_arr, Ey_arr, Ez_arr, Bx_arr, By_arr, Bz_arr, area_factor);
                     }
@@ -276,7 +276,7 @@ void FieldPoyntingFlux::ComputePoyntingFlux ()
                         flux += Poynting::Kernel<2, PoyntingNodal>(box, Ex_arr, Ey_arr, Ez_arr, Bx_arr, By_arr, Bz_arr, area_factor);
                     }
                 }
-                else if (Ex.is_cell_centered()) {
+                else if (warpx.grid_type == ablastr::utils::enums::GridType::Collocated && Ex.is_cell_centered()) {
                     if (normal_dir == 0) {
                         flux += Poynting::Kernel<0, PoyntingCell>(box, Ex_arr, Ey_arr, Ez_arr, Bx_arr, By_arr, Bz_arr, area_factor);
                     }


### PR DESCRIPTION
It was pointed out by @JustinRayAngus that the stencil used to calculate the Poynting flux was not consistent with the finite difference Yee staggering and was not calculating the exact energy flowing out of the grid. This was interfering the energy calculation when exact energy conservation is being checked. This PR fixes this by using the correct stencil. This complicated the code since other stencils are needed depending on the grid centering.

Note that the CI tests in PR #6021 will depend on this PR so a new CI test is not needed here.