### PR TITLE
Add S3DF documentation

### DIFF
--- a/Docs/source/install/hpc.rst
+++ b/Docs/source/install/hpc.rst
@@ -52,6 +52,7 @@ This section documents quick-start guides for a selection of supercomputers that
    hpc/pitzer
    hpc/polaris
    hpc/dane
+   hpc/s3df
    hpc/summit
    hpc/taurus
    hpc/tuolumne

--- a/Docs/source/install/hpc/s3df.rst
+++ b/Docs/source/install/hpc/s3df.rst
@@ -1,0 +1,193 @@
+.. _building-s3df:
+
+S3DF (SLAC)
+=============
+
+The S3DF cluster is located at SLAC.
+
+
+Introduction
+------------
+
+If you are new to this system, **please see the following resources**:
+
+* `S3DF documentation <https://s3df.slac.stanford.edu/#/>`__
+* Batch system: `Slurm <https://github.com/slaclab/sdf-docs/blob/main/batch-compute.md>`__
+* Filesystem locations:
+    * User folder: ``$HOME>`` (25GB on Weka file system)
+    * Scratch folder: ``/sdf/scratch/<username_initial>/<username>`` (100GB on Weka file system)
+    * Group storage: Depends on your group, see e.g. information for the ATLAS group `here <https://usatlas.readthedocs.io/projects/af-docs/en/latest/sshlogin/ssh2SLAC/>`__
+
+Through S3DF we have access to CPU and GPU nodes (the latter equipped with NVIDIA A100).
+
+
+
+Installation
+------------
+
+
+1) Prerequisites
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+- S3DF login to a node with access to A100 GPUs (via SLURM job or interactive session).
+- Conda available in your shell (Miniconda/Anaconda on S3DF user space).
+- GPU: NVIDIA A100 (sm_80).
+
+For other GPUs, adjust ``-DCMAKE_CUDA_ARCHITECTURES``:
+
+- V100: `70`
+- A100: `80`
+- H100: `90`
+
+.. note::
+  
+  SLURM tip (S3DF):
+
+  -  Use srun to have GPU nodes allocated. WarpX requires a "task" per CPU-GPU pair, so if you want to run WarpX e.g. on 4 GPUs, you would do:
+
+  .. code-block:: bash
+  
+    srun --pty --cpus-per-task=8 --ntasks-per-node=4 --gpus=4 --mem=100GB --nodes=1 --time=2:00:00 --partition=ampere --account=atlas bash
+
+
+
+
+2) Create & Populate the Conda Environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+  .. code-block:: bash
+    
+    # A) create env (example set; versions can vary by site repos)
+    
+    conda create -n warpx-gpu-test -y python=3.11
+    conda activate warpx-gpu-test
+
+    #Get the full CUDA toolkit in your conda env.
+    conda install -c nvidia -y "cuda=12.9.*"
+    
+    # Additionally install NVTX dev tools (cuda separates from the runtime version)
+    conda install -c nvidia -y "cuda-nvtx-dev=12.9.*"
+    
+    # B) Install build tools
+    conda install -c conda-forge -y \
+      "cmake>=3.27" ninja make pkg-config git \
+      openmpi ucx mpi4py \
+      gcc_linux-64=13 gxx_linux-64=13
+    
+    # C) Install ADIOS2 with OpenMPI (so we can use openpmd_backend = bp)
+    conda install -c conda-forge "adios2=*=mpi_openmpi*"
+    
+    # D) Verify build tools
+    which cmake && cmake --version     # should show cmake >= 3.24 from your env
+    which nvcc  && nvcc  --version     # should show CUDA 12.9 from the nvidia 'cuda' metapackage
+    which mpicxx && ompi_info | head   # Open MPI from conda-forge
+
+
+
+.. note::
+  - ``cuda-nvtx-dev`` provides the nvtx3 headers used by recent NVTX versions.
+  - ``cuda-nvcc`` brings nvcc under ``$CONDA_PREFIX/bin/nvcc``.
+  - MPI here is via ``mpich`` in the env (``mpicc``, ``mpicxx`` will be at ``$CONDA_PREFIX/bin/...``).
+
+
+3) Download WarpX
+^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+  git clone https://github.com/BLAST-WarpX/warpx.git 
+  cd warpx
+
+
+
+
+4) Environment Fixes (NVTX headers + dlopen/dlsym)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+Recent NVTX installs the header under ``nvtx3/nvToolsExt.h``. Add it to your include path, and ensure ``libdl`` is linked (``CUDA/NVTX`` uses ``dlopen()/dlsym()`` dynamically):
+
+.. code-block:: bash
+
+  # ensure libdl is not dropped by the linker (GCC + gold/ld with --as-needed)
+  export LDFLAGS="${LDFLAGS} -Wl,--no-as-needed -ldl"
+  
+  # verify the header exists (one of these should print a path)
+  ls "$CONDA_PREFIX/targets/x86_64-linux/include/nvtx3/nvToolsExt.h" \
+   || ls "$CONDA_PREFIX/include/nvtx3/nvToolsExt.h"
+  
+  # include & library paths from the conda CUDA toolchain
+  export CUDACXX="$CONDA_PREFIX/bin/nvcc"
+  export CUDA_HOME="$CONDA_PREFIX"
+  
+  export CPATH="$CONDA_PREFIX/targets/x86_64-linux/include/nvtx3:$CONDA_PREFIX/targets/x86_64-linux/include"
+  export LIBRARY_PATH="$CONDA_PREFIX/targets/x86_64-linux/lib"
+  export LD_LIBRARY_PATH="$CONDA_PREFIX/targets/x86_64-linux/lib"
+  
+  # help CMake find ADIOS2/openPMD (if using conda-provided openPMD)
+  export ADIOS2_DIR="$CONDA_PREFIX"
+  export openPMD_DIR="$CONDA_PREFIX"
+
+
+
+
+5) Configure with CMake (CUDA + MPI, 3D)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+.. code-block:: bash
+
+  "$CONDA_PREFIX/bin/cmake" -S . -B build \
+    -DWarpX_APP=ON \
+    -DWarpX_DIMS="3" \
+    -DWarpX_COMPUTE=CUDA \
+    -DCMAKE_CUDA_ARCHITECTURES=80 \
+    -DCMAKE_CUDA_RUNTIME_LIBRARY=Shared \
+    -DCMAKE_CUDA_COMPILER="$CONDA_PREFIX/bin/nvcc" \
+    -DCMAKE_CUDA_HOST_COMPILER="$(which mpicxx)" \
+    -DCMAKE_C_COMPILER="$(which mpicc)" \
+    -DCMAKE_CXX_COMPILER="$(which mpicxx)" \
+    -DWarpX_FFT=ON
+
+
+
+.. note::
+  What these do:
+
+  - ``WarpX_APP=ON``: build the warpx application.
+  - ``WarpX_DIMS="3"``: build the 3D executable.
+  - ``WarpX_COMPUTE=CUDA``: enable GPU backend.
+  - ``CMAKE_CUDA_ARCHITECTURES=80``: targets A100.
+  - ``CMAKE_CUDA_RUNTIME_LIBRARY=Shared``: link CUDA runtime dynamically (matches conda toolchain layout).
+  - Compilers explicitly point to MPI wrappers from the env.
+
+
+
+6) Build
+^^^^^^^^
+
+
+.. code-block:: bash
+
+  "$CONDA_PREFIX/bin/cmake" --build build -j 8
+
+
+
+7) Run (MPI + GPU)
+^^^^^^^^^^^^^^^^^^
+
+From the build dir:
+
+.. code-block:: bash
+
+  mkdir run_test  # create run folder for each new test!
+  cp build/bin/warpx.3d run_test/  # copy warpx executable to each run folder!
+  cp Examples/Physics_applications/beam_beam_collision/inputs_test_3d_beam_beam_collision run_test/ #copy input file!
+  cd run_test/
+  mpirun -np 4 ./warpx.3d inputs_test_3d_beam_beam_collision # run!
+
+
+
+

--- a/Docs/source/install/hpc/s3df.rst
+++ b/Docs/source/install/hpc/s3df.rst
@@ -1,7 +1,7 @@
 .. _building-s3df:
 
 S3DF (SLAC)
-=============
+===========
 
 The S3DF cluster is located at SLAC.
 
@@ -11,10 +11,10 @@ Introduction
 
 If you are new to this system, **please see the following resources**:
 
-* `S3DF documentation <https://s3df.slac.stanford.edu/#/>`__
+* `S3DF documentation <https://s3df.slac.stanford.edu>`__
 * Batch system: `Slurm <https://github.com/slaclab/sdf-docs/blob/main/batch-compute.md>`__
 * Filesystem locations:
-    * User folder: ``$HOME>`` (25GB on Weka file system)
+    * User folder: ``$HOME`` (25GB on Weka file system)
     * Scratch folder: ``/sdf/scratch/<username_initial>/<username>`` (100GB on Weka file system)
     * Group storage: Depends on your group, see e.g. information for the ATLAS group `here <https://usatlas.readthedocs.io/projects/af-docs/en/latest/sshlogin/ssh2SLAC/>`__
 
@@ -27,7 +27,7 @@ Installation
 
 
 1) Prerequisites
-^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^
 
 
 - S3DF login to a node with access to A100 GPUs (via SLURM job or interactive session).
@@ -61,8 +61,8 @@ For other GPUs, adjust ``-DCMAKE_CUDA_ARCHITECTURES``:
 
     # A) create env (example set; versions can vary by site repos)
 
-    conda create -n warpx-gpu-test -y python=3.11
-    conda activate warpx-gpu-test
+    conda create -n warpx-gpu -y python=3.11
+    conda activate warpx-gpu
 
     #Get the full CUDA toolkit in your conda env.
     conda install -c nvidia -y "cuda=12.9.*"
@@ -73,11 +73,11 @@ For other GPUs, adjust ``-DCMAKE_CUDA_ARCHITECTURES``:
     # B) Install build tools
     conda install -c conda-forge -y \
       "cmake>=3.27" ninja make pkg-config git \
-      openmpi ucx mpi4py \
+      openmpi ucx mpi4py=*=mpi_openmpi* \
       gcc_linux-64=13 gxx_linux-64=13
 
-    # C) Install ADIOS2 with OpenMPI (so we can use openpmd_backend = bp)
-    conda install -c conda-forge "adios2=*=mpi_openmpi*"
+    # C) Install ADIOS2 and HDF5 with OpenMPI (so we can use openpmd_backend = bp or = h5)
+    conda install -c conda-forge "adios2=*=mpi_openmpi* hdf5=*=mpi_openmpi*"
 
     # D) Verify build tools
     which cmake && cmake --version     # should show cmake >= 3.24 from your env
@@ -96,7 +96,7 @@ For other GPUs, adjust ``-DCMAKE_CUDA_ARCHITECTURES``:
 ^^^^^^^^^^^^^^^^^
 
 .. code-block:: bash
-
+  cd $HOME
   git clone https://github.com/BLAST-WarpX/warpx.git
   cd warpx
 
@@ -134,12 +134,12 @@ Recent NVTX installs the header under ``nvtx3/nvToolsExt.h``. Add it to your inc
 
 
 5) Configure with CMake (CUDA + MPI, 3D)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 .. code-block:: bash
 
-  "$CONDA_PREFIX/bin/cmake" -S . -B build \
+  cmake -S . -B build \
     -DWarpX_APP=ON \
     -DWarpX_DIMS="3" \
     -DWarpX_COMPUTE=CUDA \
@@ -171,19 +171,37 @@ Recent NVTX installs the header under ``nvtx3/nvToolsExt.h``. Add it to your inc
 
 .. code-block:: bash
 
-  "$CONDA_PREFIX/bin/cmake" --build build -j 8
+  cmake --build build -j 8
 
 
 
 7) Run (MPI + GPU)
 ^^^^^^^^^^^^^^^^^^
 
-From the build dir:
+Interactive
+"""""""""""
+Request resources, for example:
 
 .. code-block:: bash
 
-  mkdir run_test  # create run folder for each new test!
-  cp build/bin/warpx.3d run_test/  # copy warpx executable to each run folder!
-  cp Examples/Physics_applications/beam_beam_collision/inputs_test_3d_beam_beam_collision run_test/ #copy input file!
-  cd run_test/
-  mpirun -np 4 ./warpx.3d inputs_test_3d_beam_beam_collision # run!
+    srun --pty --nodes=1 --ntasks-per-node=4 --cpus-per-task=8 --gpus=4 --mem=100GB  --time=2:00:00 --partition=ampere --account=<account> bash
+
+Move to scratch:
+
+.. code-block:: bash
+
+  cd /sdf/scratch/<first_letter_of_username>/<username>
+
+Create and move into run folder for each new test:
+
+.. code-block:: bash
+
+  mkdir run_test  
+  cd run_test 
+
+Copy input file and run:
+
+.. code-block:: bash
+
+  cp $HOME/warpx/Examples/Physics_applications/beam_beam_collision/inputs_test_3d_beam_beam_collision . 
+  mpirun -np 4 $HOME/warpx/build/bin/warpx.3d inputs_test_3d_beam_beam_collision 

--- a/Docs/source/install/hpc/s3df.rst
+++ b/Docs/source/install/hpc/s3df.rst
@@ -41,13 +41,13 @@ For other GPUs, adjust ``-DCMAKE_CUDA_ARCHITECTURES``:
 - H100: `90`
 
 .. note::
-  
+
   SLURM tip (S3DF):
 
   -  Use srun to have GPU nodes allocated. WarpX requires a "task" per CPU-GPU pair, so if you want to run WarpX e.g. on 4 GPUs, you would do:
 
   .. code-block:: bash
-  
+
     srun --pty --cpus-per-task=8 --ntasks-per-node=4 --gpus=4 --mem=100GB --nodes=1 --time=2:00:00 --partition=ampere --account=atlas bash
 
 
@@ -58,27 +58,27 @@ For other GPUs, adjust ``-DCMAKE_CUDA_ARCHITECTURES``:
 
 
   .. code-block:: bash
-    
+
     # A) create env (example set; versions can vary by site repos)
-    
+
     conda create -n warpx-gpu-test -y python=3.11
     conda activate warpx-gpu-test
 
     #Get the full CUDA toolkit in your conda env.
     conda install -c nvidia -y "cuda=12.9.*"
-    
+
     # Additionally install NVTX dev tools (cuda separates from the runtime version)
     conda install -c nvidia -y "cuda-nvtx-dev=12.9.*"
-    
+
     # B) Install build tools
     conda install -c conda-forge -y \
       "cmake>=3.27" ninja make pkg-config git \
       openmpi ucx mpi4py \
       gcc_linux-64=13 gxx_linux-64=13
-    
+
     # C) Install ADIOS2 with OpenMPI (so we can use openpmd_backend = bp)
     conda install -c conda-forge "adios2=*=mpi_openmpi*"
-    
+
     # D) Verify build tools
     which cmake && cmake --version     # should show cmake >= 3.24 from your env
     which nvcc  && nvcc  --version     # should show CUDA 12.9 from the nvidia 'cuda' metapackage
@@ -97,7 +97,7 @@ For other GPUs, adjust ``-DCMAKE_CUDA_ARCHITECTURES``:
 
 .. code-block:: bash
 
-  git clone https://github.com/BLAST-WarpX/warpx.git 
+  git clone https://github.com/BLAST-WarpX/warpx.git
   cd warpx
 
 
@@ -113,19 +113,19 @@ Recent NVTX installs the header under ``nvtx3/nvToolsExt.h``. Add it to your inc
 
   # ensure libdl is not dropped by the linker (GCC + gold/ld with --as-needed)
   export LDFLAGS="${LDFLAGS} -Wl,--no-as-needed -ldl"
-  
+
   # verify the header exists (one of these should print a path)
   ls "$CONDA_PREFIX/targets/x86_64-linux/include/nvtx3/nvToolsExt.h" \
    || ls "$CONDA_PREFIX/include/nvtx3/nvToolsExt.h"
-  
+
   # include & library paths from the conda CUDA toolchain
   export CUDACXX="$CONDA_PREFIX/bin/nvcc"
   export CUDA_HOME="$CONDA_PREFIX"
-  
+
   export CPATH="$CONDA_PREFIX/targets/x86_64-linux/include/nvtx3:$CONDA_PREFIX/targets/x86_64-linux/include"
   export LIBRARY_PATH="$CONDA_PREFIX/targets/x86_64-linux/lib"
   export LD_LIBRARY_PATH="$CONDA_PREFIX/targets/x86_64-linux/lib"
-  
+
   # help CMake find ADIOS2/openPMD (if using conda-provided openPMD)
   export ADIOS2_DIR="$CONDA_PREFIX"
   export openPMD_DIR="$CONDA_PREFIX"
@@ -187,7 +187,3 @@ From the build dir:
   cp Examples/Physics_applications/beam_beam_collision/inputs_test_3d_beam_beam_collision run_test/ #copy input file!
   cd run_test/
   mpirun -np 4 ./warpx.3d inputs_test_3d_beam_beam_collision # run!
-
-
-
-

--- a/Docs/source/install/hpc/s3df.rst
+++ b/Docs/source/install/hpc/s3df.rst
@@ -196,12 +196,12 @@ Create and move into run folder for each new test:
 
 .. code-block:: bash
 
-  mkdir run_test  
-  cd run_test 
+  mkdir run_test
+  cd run_test
 
 Copy input file and run:
 
 .. code-block:: bash
 
-  cp $HOME/warpx/Examples/Physics_applications/beam_beam_collision/inputs_test_3d_beam_beam_collision . 
-  mpirun -np 4 $HOME/warpx/build/bin/warpx.3d inputs_test_3d_beam_beam_collision 
+  cp $HOME/warpx/Examples/Physics_applications/beam_beam_collision/inputs_test_3d_beam_beam_collision .
+  mpirun -np 4 $HOME/warpx/build/bin/warpx.3d inputs_test_3d_beam_beam_collision


### PR DESCRIPTION
Hi! 

Opening this PR to include instructions on how to set up warpx on the SLAC Shared Science Data Facility (S3DF) since more and more people at SLAC are starting to use warpx and I couldn't find any documentation on how to do it.

Tagging @aeriforme as an interested party.

Let me know if you have any suggestions on how to improve it. Also, it would be great if more people with access to S3DF can try out the instructions to foolproof them. 