### PR TITLE
Add tutorials section in documentation 

### DIFF
--- a/Docs/source/index.rst
+++ b/Docs/source/index.rst
@@ -81,6 +81,15 @@ Usage
    usage/workflows
    usage/faq
 
+Tutorials
+------------
+.. toctree::
+   :caption: TUTORIALS
+   :maxdepth: 1
+   :hidden:
+
+   tutorials
+
 Data Analysis
 -------------
 .. toctree::

--- a/Docs/source/tutorials.rst
+++ b/Docs/source/tutorials.rst
@@ -1,0 +1,18 @@
+.. _tutorials:
+
+Step-by-step examples
+=====================
+
+We provide a set of tutorials to help you get started with WarpX.
+These are examples that we present at conferences and workshops, so we will add to them over time.
+You can find them on `the dedicated website <https://blast-warpx.github.io/warpx-tutorials/>`__.
+
+So far we have two tutorials on two different topics:
+
+  🪞 `Magnetic mirror <https://blast-warpx.github.io/warpx-tutorials/a-magnetic-mirror.html>`__
+
+  💥 `Beam-beam collision <https://blast-warpx.github.io/warpx-tutorials/a-beam-beam-collision.html>`__
+
+Check them out and let us know if you have any suggestions for new tutorials or improvements to existing ones.
+You can find the source code for the tutorials in the `warpx-tutorials repository <https://github.com/BLAST-WarpX/warpx-tutorials>`__.
+Feel free to open an issue or a pull request if you would like to contribute!


### PR DESCRIPTION
Adds:
* link to the [WarpX's tutorials repository](https://github.com/BLAST-WarpX/warpx-tutorials) 
* link to the [web page](https://blast-warpx.github.io/warpx-tutorials/)
* list of examples 