### PR TITLE
Docs: Hide tutorial chapter title from front page

### DIFF
--- a/Docs/source/index.rst
+++ b/Docs/source/index.rst
@@ -38,6 +38,7 @@ We also have a `discussion page <https://github.com/BLAST-WarpX/warpx/discussion
     */
    section#installation,
    section#usage,
+   section#tutorials,
    section#theory,
    section#data-analysis,
    section#development,
@@ -82,7 +83,7 @@ Usage
    usage/faq
 
 Tutorials
-------------
+---------
 .. toctree::
    :caption: TUTORIALS
    :maxdepth: 1


### PR DESCRIPTION
I think this fixes the issue I reported in https://github.com/BLAST-WarpX/warpx/pull/6065#issuecomment-3161530836, provided that we agree on the fact that it is an issue. 

This way we treat the tutorial chapter like all other chapters and hide it from the front page. 

I tested this locally but let's double check that this works by inspecting the docs once the `docs/readthedocs.org:warpx` CI check runs for this PR.