### PR TITLE
Fix mislabeled diagnostic output for macroscopic media

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties.cpp
@@ -101,7 +101,7 @@ MacroscopicProperties::ReadParameters ()
     }
     if (!mu_specified) {
         std::stringstream warnMsg;
-        warnMsg << "Material permittivity is not specified. Using default vacuum value of " <<
+        warnMsg << "Material permeability is not specified. Using default vacuum value of " <<
             m_mu << " in the simulation.";
         ablastr::warn_manager::WMRecordWarning("Macroscopic properties",
             warnMsg.str());


### PR DESCRIPTION
When using `macroscopic` media and the permeability is left unspecified, the resulting warning message is mislabeled:
```
* --> [!! ] [Macroscopic properties] [raised once]
*     Material permittivity is not specified. Using default vacuum value of
*     1.25664e-06 in the simulation.
*     @ Raised by: ALL
*
* --> [!! ] [Macroscopic properties] [raised once]
*     Material permittivity is not specified. Using default vacuum value of
*     8.85419e-12 in the simulation.
*     @ Raised by: ALL
```

This PR fixes this copy-and-paste typo.
