### PR TITLE
Several fixes for warnings from doxygen

### DIFF
--- a/Docs/Doxyfile
+++ b/Docs/Doxyfile
@@ -1347,7 +1347,7 @@ HTML_COLORSTYLE_GAMMA  = 80
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_TIMESTAMP         = NO
+TIMESTAMP         = NO
 
 # If the HTML_DYNAMIC_MENUS tag is set to YES then the generated HTML
 # documentation will contain a main index with vertical navigation menus that
@@ -2008,14 +2008,6 @@ LATEX_HIDE_INDICES     = NO
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
 LATEX_BIB_STYLE        = plain
-
-# If the LATEX_TIMESTAMP tag is set to YES then the footer of each generated
-# page will contain the date and time when the page was generated. Setting this
-# to NO can help when comparing the output of multiple runs.
-# The default value is: NO.
-# This tag requires that the tag GENERATE_LATEX is set to YES.
-
-LATEX_TIMESTAMP        = NO
 
 # The LATEX_EMOJI_DIRECTORY tag is used to specify the (relative or absolute)
 # path from which the emoji images will be read. If a relative path is entered,

--- a/Source/FieldSolver/FiniteDifferenceSolver/ComputeCurlA.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/ComputeCurlA.cpp
@@ -66,8 +66,11 @@ void FiniteDifferenceSolver::ComputeCurlA (
 //   * \brief Calculate B from the curl of A
 //   * i.e. B = curl(A) output field on B field mesh staggering
 //   *
-//   * \param[out] curlField  output of curl operation
-//   * \param[in] field   input staggered field, should be on E/J/A mesh staggering
+//   * \param[out] Bfield  output of curl operation
+//   * \param[in] Afield   input staggered field, should be on E/J/A mesh staggering
+//   * \param[in] eb_update_B specifies where the plasma current should be calculated.
+//   * \param[in] lev refinement level
+
 //   */
 #if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
 template<typename T_Algo>

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICSolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICSolveE.cpp
@@ -72,6 +72,8 @@ void FiniteDifferenceSolver::CalculateCurrentAmpere (
 //   *
 //   * \param[out] Jfield  vector of total current MultiFabs at a given level
 //   * \param[in] Bfield   vector of magnetic field MultiFabs at a given level
+//   * \param[in] eb_update_E specifies where the plasma current should be calculated.
+//   * \param[in] lev refinement level
 //   */
 #if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
 template<typename T_Algo>


### PR DESCRIPTION
Somehow several errors slipped past the changes from PR #3560. Also, this updates the Doxyfile to remove warnings for it.

Side comments:
- It might be perhaps useful to set `TIMESTAMP         = YES` so that the timestamp is included on the generated pages.
- Perhaps set `WARN_AS_ERROR = FAIL_ON_WARNINGS` in `Doxyfile` since the requirement is already that there should be no errors, instead of the modification that is done in `.github/workflows/source/doxygen`. `FAIL_ON_WARNINGS` is better that `YES` so than it will show all of the errors and not just the first one.