### PR TITLE
Doxygen: remove obsolete macros from Doxyfile

### DIFF
--- a/Docs/Doxyfile
+++ b/Docs/Doxyfile
@@ -2285,17 +2285,14 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = AMREX_Linux=1 \
-                         AMREX_PARTICLES=1 \
+PREDEFINED             = AMREX_PARTICLES=1 \
                          AMREX_USE_MPI=1 \
                          AMREX_USE_OMP=1 \
                          AMREX_SPACEDIM=3 \
                          AMREX_TINY_PROFILING=1 \
-                         BL_Linux=1 \
                          BL_USE_MPI=1 \
                          BL_USE_OMP=1 \
                          AMREX_USE_SENSEI_INSITU=1 \
-                         WARPX=1 \
                          WARPX_DIM_RZ=1 \
                          WARPX_DIM_XZ=1 \
                          WARPX_USE_GPU=1 \


### PR DESCRIPTION
Removing the macros `AMREX_Linux`, `BL_Linux`, and `WARPX`, which I think do not match any macro in WarpX nor AMReX. Noticed while working on #6077 and other PRs related to Doxygen.