### PR TITLE
CMake: WarpX_SIMD in C++20 or Newer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -574,7 +574,13 @@ if(WarpX_COMPUTE STREQUAL CUDA)
     )
 else()
     foreach(warpx_tgt IN LISTS _ALL_TARGETS)
-        target_compile_features(${warpx_tgt} PUBLIC cxx_std_17)
+        if(WarpX_SIMD)
+            # vir::cvt
+            # https://github.com/mattkretz/vir-simd/issues/45
+            target_compile_features(${warpx_tgt} PUBLIC cxx_std_20)
+        else()
+            target_compile_features(${warpx_tgt} PUBLIC cxx_std_17)
+        endif()
     endforeach()
     set_target_properties(${_ALL_TARGETS} PROPERTIES
         CXX_EXTENSIONS OFF


### PR DESCRIPTION
Will make development easier and is fully optional. See: https://github.com/AMReX-Codes/amrex/pull/4607