### PR TITLE
CMake: Fix Fast-Math with Pre-built AMReX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,6 +293,21 @@ foreach(D IN LISTS WarpX_DIMS)
     list(APPEND _ALL_TARGETS ablastr_${SD})
     add_library(WarpX::ablastr_${SD} ALIAS ablastr_${SD})
 
+    # Fast-Math
+    if(ABLASTR_FASTMATH)
+        target_link_libraries(ablastr_${SD} PUBLIC AMReX::Flags_FASTMATH)
+    endif()
+
+    # GCC < 9 need to manually link std::filesystem
+    if(NOT CXX_HAS_STD_FS)
+        if(CXX_HAS_STD_FS_WITH_LINK)
+            target_link_libraries(ablastr_${SD} PUBLIC stdc++fs)
+        else()
+            message(FATAL_ERROR "Your compiler does not support C++17 "
+                    "<filesystem> Please use a newer C++ compiler.")
+        endif()
+    endif()
+
     # link into a library (default: static)
     if(WarpX_LIB)
         add_library(lib_${SD})
@@ -317,14 +332,9 @@ foreach(D IN LISTS WarpX_DIMS)
             )
         endif()
 
-        # GCC < 9 need to manually link std::filesystem
-        if(NOT CXX_HAS_STD_FS)
-            if(CXX_HAS_STD_FS_WITH_LINK)
-                target_link_libraries(ablastr_${SD} PUBLIC stdc++fs)
-            else()
-                message(FATAL_ERROR "Your compiler does not support C++17 "
-                        "<filesystem> Please use a newer C++ compiler.")
-            endif()
+        # Fast-Math
+        if(WarpX_FASTMATH)
+            target_link_libraries(lib_${SD} PUBLIC AMReX::Flags_FASTMATH)
         endif()
     endif()
 


### PR DESCRIPTION
The fast-math flags were not added if AMReX was pre-built without fast-math. This fixes it.