### PR TITLE
WarpX Citation

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -226,5 +226,61 @@
     "access_right": "open",
     "references": [
       "Please see https://warpx.readthedocs.io/en/latest/acknowledge_us.html#acknowledge-warpx-all-refs"
+    ],
+    "related_identifiers": [
+    {
+      "identifier": "https://warpx.readthedocs.io",
+      "relation_type": {
+        "id": "isdocumentedby",
+        "title": {
+          "en": "Is documented by"
+        }
+      },
+      "resource_type": {
+        "id": "publication-softwaredocumentation",
+        "title": {
+          "en": "Software documentation"
+        }
+      },
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://blast-warpx.github.io",
+      "relation_type": {
+        "id": "isdescribedby",
+        "title": {
+          "en": "Is described by"
+        }
+      },
+      "resource_type": {
+        "id": "other",
+        "title": {
+          "en": "Other"
+        }
+      },
+      "scheme": "url"
+    }
+  ],
+  "custom_fields": {
+    "code:developmentStatus": {
+      "id": "active",
+      "title": {
+        "en": "Active"
+      }
+    },
+    "code:programmingLanguage": [
+      {
+        "id": "c++",
+        "title": {
+          "en": "C++"
+        }
+      },
+      {
+        "id": "python",
+        "title": {
+          "en": "Python"
+        }
+      }
     ]
+  }
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -17,11 +17,6 @@
       },
       {
         "affiliation": "Lawrence Berkeley National Laboratory",
-        "name": "Antoun, Thierry",
-        "orcid": "0000-0002-1003-0698"
-      },
-      {
-        "affiliation": "Lawrence Berkeley National Laboratory",
         "name": "Amorim, L\u00edgia Diana",
         "orcid": "0000-0002-1445-0032"
       },
@@ -34,6 +29,11 @@
         "affiliation": "Lawrence Livermore National Laboratory",
         "name": "Angus, Justin Ray",
         "orcid": "0000-0003-1474-0002"
+      },
+      {
+        "affiliation": "Lawrence Berkeley National Laboratory",
+        "name": "Antoun, Thierry",
+        "orcid": "0000-0002-1003-0698"
       },
       {
         "affiliation": "Lawrence Berkeley National Laboratory",
@@ -79,14 +79,14 @@
         "orcid": "0000-0002-1442-0706"
       },
       {
-        "affiliation": "Lawrence Berkeley National Laboratory",
-        "name": "Gott, Kevin",
-        "orcid": "0000-0003-3244-5525"
-      },
-      {
         "affiliation": "CERN",
         "name": "Giacomel, Lorenzo",
         "orcid": "0000-0002-1750-9757"
+      },
+      {
+        "affiliation": "Lawrence Berkeley National Laboratory",
+        "name": "Gott, Kevin",
+        "orcid": "0000-0003-3244-5525"
       },
       {
         "affiliation": "TAE Technologies Inc.",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -6,7 +6,7 @@
         "orcid": "0000-0002-0040-799X"
       },
       {
-        "affiliation": "Marathon Fusion, Inc.",
+        "affiliation": "Helion Energy, Inc.",
         "name": "Acciarri, Marco",
         "orcid": "0000-0003-2768-1259"
       },

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -209,53 +209,6 @@
         "orcid": "0000-0001-5662-4646"
       }
     ],
-    "contributors": [
-      {
-        "type": "Other",
-        "affiliation": "Lawrence Berkeley National Laboratory",
-        "name": "Weber, Gunther H.",
-        "orcid": "0000-0002-1794-1398"
-      },
-      {
-        "type": "Other",
-        "affiliation": "Intel",
-        "name": "Cohn, Robert"
-      },
-      {
-        "type": "Other",
-        "affiliation": "Modern Electron",
-        "name": "Kieburtz, Michael",
-        "orcid": "0000-0001-6161-3669"
-      },
-      {
-        "type": "Other",
-        "affiliation": "Bloomberg LP",
-        "name": "Levine, Michael"
-      },
-      {
-        "type": "Other",
-        "affiliation": "Helmholtz Institute Jena",
-        "name": "Liu, Bin",
-        "orcid": "0000-0002-8066-184X"
-      },
-      {
-        "type": "Other",
-        "affiliation": "SLAC National Accelerator Laboratory",
-        "name": "Ng, Cho-Kuen",
-        "orcid": "0000-0002-1903-904X"
-      },
-      {
-        "type": "Other",
-        "affiliation": "Lawrence Berkeley National Laboratory",
-        "name": "Park, Jaehong"
-      },
-      {
-        "type": "Other",
-        "affiliation": "Modern Electron",
-        "name": "Ruof, Nicholas W.",
-        "orcid": "0000-0001-9665-6722"
-      }
-    ],
     "license": {
       "id": "BSD-3-Clause-LBNL"
     },
@@ -272,12 +225,6 @@
     ],
     "access_right": "open",
     "references": [
-      "Myers A, Almgren A, Amorim LD, Bell J, Fedeli L, Ge L, Gott K, Grote DP, Hogan M, Huebl A, Jambunathan R, Lehe R, Ng C, Rowan M, Shapoval O, Thevenet M, Vay JL, Vincenti H, Yang E, Zaim N, Zhang W, Zhao Y, Zoni E. Porting WarpX to GPU-accelerated platforms. Parallel Computing. 2021 Sep, 108:102833. https://doi.org/10.1016/j.parco.2021.102833",
-      "Fedeli L, Zaim N, Sainte-Marie A, Thevenet M, Huebl A, Myers A, Vay J-L, Vincenti H. PICSAR-QED: a Monte Carlo module to simulate Strong-Field Quantum Electrodynamics in Particle-In-Cell codes for exascale architectures. New Journal of Physics. in-press, 2022. https://arxiv.org/abs/2110.00256",
-      "Zoni E, Lehe R, Shapoval O, Belkin D, Zaim N, Fedeli L, Vincenti H, Vay J-L. A Hybrid Nodal-Staggered Pseudo-Spectral Electromagnetic Particle-In-Cell Method with Finite-Order Centering. under review, 2022. https://arxiv.org/abs/2106.12919",
-      "Shapoval O, Lehe R, Thevenet M, Zoni E, Zhao Y, Vay J-L. Overcoming timestep limitations in boosted-frame Particle-In-Cell simulations of plasma-based acceleration. Phys. Rev. E. Nov 2021, 104:055311. https://doi.org/10.1103/PhysRevE.104.055311",
-      "Vay JL, Huebl A, Almgren A, Amorim LD, Bell J, Fedeli L, Ge L, Gott K, Grote DP, Hogan M, Jambunathan R, Lehe R, Myers A, Ng C, Rowan M, Shapoval O, Thevenet M, Vincenti H, Yang E, Zaim N, Zhang W, Zhao Y, Zoni E. Modeling of a chain of three plasma accelerator stages with the WarpX electromagnetic PIC code on GPUs. Physics of Plasmas. 2021 Feb 9, 28(2):023105. https://doi.org/10.1063/5.0028512",
-      "Rowan ME, Gott KN, Deslippe J, Huebl A, Thevenet M, Lehe R, Vay JL. In-situ assessment of device-side compute work for dynamic load balancing in a GPU-accelerated PIC code. PASC '21: Proceedings of the Platform for Advanced Scientific Computing Conference. 2021 July, 10, pages 1-11. https://doi.org/10.1145/3468267.3470614",
-      "Vay JL, Almgren A, Bell J, Ge L, Grote DPHogan M, Kononenko O, Lehe R, Myers A, Ng C, Park J, Ryne R, Shapovala O, Thevene M, Zhang W. Warp-X: A new exascale computing platform for beam–plasma simulations. Nuclear Instruments and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors and Associated Equipment. 2018 Nov, 909(12) Pages 476-479. https://doi.org/10.1016/j.nima.2018.01.035"
+      "Please see https://warpx.readthedocs.io/en/latest/acknowledge_us.html#acknowledge-warpx-all-refs"
     ]
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -55,7 +55,8 @@
       },
       {
         "affiliation": "Lawrence Berkeley National Laboratory, now DESY",
-        "name": "Dammak, Eya"
+        "name": "Dammak, Eya",
+        "orcid": "0009-0003-7821-3508"
       },
       {
         "affiliation": "LIDYL, CEA-Universit\u00e9 Paris-Saclay, CEA Saclay",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -6,7 +6,7 @@
         "orcid": "0000-0002-0040-799X"
       },
       {
-        "affiliation": "Helion Energy, Inc.",
+        "affiliation": "Marathon Fusion, Inc.",
         "name": "Acciarri, Marco",
         "orcid": "0000-0003-2768-1259"
       },

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -54,7 +54,7 @@
         "orcid": "0000-0002-0117-776X"
       },
       {
-        "affiliation": "Lawrence Berkeley National Laboratory, now DESY",
+        "affiliation": "Lawrence Berkeley National Laboratory",
         "name": "Dammak, Eya",
         "orcid": "0009-0003-7821-3508"
       },

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -6,9 +6,19 @@
         "orcid": "0000-0002-0040-799X"
       },
       {
+        "affiliation": "Helion Energy, Inc.",
+        "name": "Acciarri, Marco",
+        "orcid": "0000-0003-2768-1259"
+      },
+      {
         "affiliation": "Lawrence Berkeley National Laboratory",
         "name": "Almgren, Ann",
         "orcid": "0000-0003-2103-312X"
+      },
+      {
+        "affiliation": "Lawrence Berkeley National Laboratory",
+        "name": "Antoun, Thierry",
+        "orcid": "0000-0002-1003-0698"
       },
       {
         "affiliation": "Lawrence Berkeley National Laboratory",
@@ -44,6 +54,10 @@
         "orcid": "0000-0002-0117-776X"
       },
       {
+        "affiliation": "Lawrence Berkeley National Laboratory, now DESY",
+        "name": "Dammak, Eya"
+      },
+      {
         "affiliation": "LIDYL, CEA-Universit\u00e9 Paris-Saclay, CEA Saclay",
         "name": "Fedeli, Luca",
         "orcid": "0000-0002-7215-4178"
@@ -69,16 +83,6 @@
         "orcid": "0000-0003-3244-5525"
       },
       {
-        "affiliation": "Lawrence Livermore National Laboratory",
-        "name": "Harrison, Cyrus",
-        "orcid": "0000-0001-8985-0906"
-      },
-      {
-        "affiliation": "Lawrence Berkeley National Laboratory",
-        "name": "Huebl, Axel",
-        "orcid": "0000-0003-1943-7141"
-      },
-      {
         "affiliation": "CERN",
         "name": "Giacomel, Lorenzo",
         "orcid": "0000-0002-1750-9757"
@@ -99,14 +103,29 @@
         "orcid": "0000-0002-1521-8534"
       },
       {
+        "affiliation": "Lawrence Livermore National Laboratory",
+        "name": "Harrison, Cyrus",
+        "orcid": "0000-0001-8985-0906"
+      },
+      {
         "affiliation": "Lawrence Berkeley National Laboratory",
         "name": "Haseeb, Muhammad",
         "orcid": "0000-0002-0697-6894"
       },
       {
         "affiliation": "Lawrence Berkeley National Laboratory",
+        "name": "Huebl, Axel",
+        "orcid": "0000-0003-1943-7141"
+      },
+      {
+        "affiliation": "Lawrence Berkeley National Laboratory",
         "name": "Jambunathan, Revathi",
         "orcid": "0000-0001-9432-2091"
+      },
+      {
+        "affiliation": "Lawrence Berkeley National Laboratory",
+        "name": "Kara-Mostefa, Ilian",
+        "orcid": "0009-0002-2736-5942"
       },
       {
         "affiliation": "Lawrence Berkeley National Laboratory",
@@ -119,21 +138,6 @@
         "orcid": "0000-0002-8454-7497"
       },
       {
-        "affiliation": "Lawrence Berkeley National Laboratory, now DESY",
-        "name": "Th\u00e9venet, Maxence",
-        "orcid": "0000-0001-7216-2277"
-      },
-      {
-        "affiliation": "Lawrence Berkeley National Laboratory",
-        "name": "Richardson, Glenn",
-        "orcid": "0000-0003-0313-4496"
-      },
-      {
-        "affiliation": "Lawrence Berkeley National Laboratory",
-        "name": "Shapoval, Olga",
-        "orcid": "0000-0003-4003-4507"
-      },
-      {
         "affiliation": "Lawrence Berkeley National Laboratory",
         "name": "Lehe, Remi",
         "orcid": "0000-0002-3656-9659"
@@ -142,6 +146,11 @@
         "affiliation": "Lawrence Berkeley National Laboratory",
         "name": "Loring, Burlen",
         "orcid": "0000-0002-4678-8142"
+      },
+      {
+        "affiliation": "University of Michigan",
+        "name": "Marks, Thomas",
+        "orcid": "0000-0003-3614-6127"
       },
       {
         "affiliation": "Intense Computing",
@@ -155,8 +164,18 @@
       },
       {
         "affiliation": "Lawrence Berkeley National Laboratory",
+        "name": "Pech, Juliette",
+        "orcid": "0009-0008-6165-0708"
+      },
+      {
+        "affiliation": "Lawrence Berkeley National Laboratory",
         "name": "Rheaume, Elisa",
         "orcid": "0000-0002-6710-0650"
+      },
+      {
+        "affiliation": "Lawrence Berkeley National Laboratory",
+        "name": "Richardson, Glenn",
+        "orcid": "0000-0003-0313-4496"
       },
       {
         "affiliation": "Lawrence Berkeley National Laboratory",
@@ -172,6 +191,26 @@
         "affiliation": "Modern Electron",
         "name": "Scherpelz, Peter",
         "orcid": "0000-0001-8185-3387"
+      },
+      {
+        "affiliation": "Deutsches Elektronen-Synchrotron DESY",
+        "name": "Sinn, Alexander",
+        "orcid": "0000-0002-4485-971X"
+      },
+      {
+        "affiliation": "Lawrence Berkeley National Laboratory",
+        "name": "Shapoval, Olga",
+        "orcid": "0000-0003-4003-4507"
+      },
+      {
+        "affiliation": "Lawrence Berkeley National Laboratory",
+        "name": "Terzani, Davide",
+        "orcid": "0000-0002-0105-5420"
+      },
+      {
+        "affiliation": "Lawrence Berkeley National Laboratory, now DESY",
+        "name": "Th\u00e9venet, Maxence",
+        "orcid": "0000-0001-7216-2277"
       },
       {
         "affiliation": "Laboratory for Laser Energetics, University of Rochester",

--- a/Docs/source/acknowledge_us.rst
+++ b/Docs/source/acknowledge_us.rst
@@ -5,193 +5,200 @@ Acknowledge WarpX
 
 Please acknowledge the role that WarpX played in your research.
 
+.. _acknowledge_warpx_presentation:
+
 In presentations
 ****************
 
 For your presentations, you can find a WarpX acknowledgment slide `here <https://docs.google.com/presentation/d/1irVUyGKc-1vaQbJN7HgdBpPGQICfD5ci_maOu6noypk/edit?usp=sharing>`__.
 Feel free to use it to acknowledge WarpX in your presentation.
 
-In publications
-***************
+.. _acknowledge_warpx_generic:
 
-Please add the following sentence to your publications, it helps contributors keep in touch with the community and promote the project.
+Acknowledgement Sentence
+************************
+
+Please add the following acknowledgement sentence to your publications, it helps contributors keep in touch with the community and promote the project.
 
 .. tab-set::
 
    .. tab-item:: Plain text
 
-      This research used the open-source particle-in-cell code WarpX https://github.com/BLAST-WarpX/warpx. Primary WarpX contributors are with LBNL, LLNL, CEA-LIDYL, SLAC, DESY, CERN, Helion Energy, and TAE Technologies. We acknowledge all WarpX contributors.
+      This research used the open-source `particle-in-cell code WarpX <https://blast-warpx.github.io>`__. Primary WarpX contributors are with LBNL, LLNL, CEA-LIDYL, SLAC, DESY, CERN, Helion Energy, and TAE Technologies. We acknowledge all WarpX contributors.
 
    .. tab-item:: LaTeX
 
       .. code-block:: latex
 
         \usepackage{hyperref}
-        This research used the open-source particle-in-cell code WarpX \url{https://github.com/BLAST-WarpX/warpx}.
+        This research used the open-source \href{https://blast-warpx.github.io}{particle-in-cell code WarpX}.
         Primary WarpX contributors are with LBNL, LLNL, CEA-LIDYL, SLAC, DESY, CERN, Helion Energy, and TAE Technologies.
         We acknowledge all WarpX contributors.
 
 .. _acknowledge_warpx_ref:
 
-Latest WarpX reference
-**********************
+Citation
+********
 
-If your project leads to a scientific publication, please consider citing all co-authors via our persistent Zenodo DOI:
+If your project leads to a scientific publication, please consider citing all WarpX authors via our *persistent Zenodo DOI*:
 
 .. tab-set::
 
    .. tab-item:: Plain Text
 
-      J.-L. Vay et al., **WarpX: an advanced Particle-In-Cell code**,
-      DOI:10.5281/zenodo.4571577, https://blast-warpx.github.io (2018)
+      J.-L. Vay et al., **WarpX: An advanced Particle-In-Cell code**.
+      `DOI:10.5281/zenodo.4571577 <https://doi.org/10.5281/zenodo.4571577>`__,
+      `https://blast-warpx.github.io <https://blast-warpx.github.io>`__ (2018)
 
    .. tab-item:: LateX: Bibtex
 
       .. code-block:: bibtex
 
-      @misc{WarpX,
-        author = {Vay, Jean-Luc and
-                  Acciarri, Marco and
-                  Almgren, Ann and
-                  Amorim, Lígia Diana and
-                  Andriyash, Igor and
-                  Angus, Justin Ray and
-                  Antoun, Thierry and
-                  Belkin, Daniel and
-                  Bizzozero, David and
-                  Blelly, Aurore and
-                  Clark, Stephen Eric and
-                  Dammak, Eya and
-                  Fedeli, Luca and
-                  Formenti, Arianna and
-                  Garten, Marco and
-                  Ge, Lixin and
-                  Giacomel, Lorenzo and
-                  Gott, Kevin and
-                  Giacomel, Lorenzo and
-                  Groenewald, Roelof E. and
-                  Grote, David and
-                  Gu, Junmin and
-                  Harrison, Cyrus and
-                  Haseeb, Muhammad and
-                  Huebl, Axel and
-                  Jambunathan, Revathi and
-                  Kara-Mostefa, Ilian and
-                  Klion, Hannah and
-                  Kumar, Prabhat and
-                  Lehe, Remi and
-                  Loring, Burlen and
-                  Marks, Thomas and
-                  Miller, Phil and
-                  Myers, Andrew and
-                  Pech, Juliette and
-                  Rheaume, Elisa and
-                  Richardson, Glenn and
-                  Rheaume, Elisa and
-                  Rowan, Michael E. and
-                  Sandberg, Ryan Thor and
-                  Scherpelz, Peter and
-                  Sinn, Alexander and
-                  Shapoval, Olga and
-                  Terzani, Davide and
-                  Th{\'e}venet, Maxence and
-                  Weichman, Kale and
-                  Yang, Eloise and
-                  Zaim, Ne{\"i}l and
-                  Zhang, Weiqun and
-                  Zhao, Yinjian and
-                  Zhu, Kevin Z. and
-                  Zoni, Edoardo},
-          title     = {{WarpX: an advanced Particle-In-Cell code}},
-          year      = 2018,
-          publisher = {Zenodo},
-          version   = {25.09},
-          doi       = {10.5281/zenodo.4571577},
-          url       = {https://doi.org/10.5281/zenodo.4571577},
-          howpublished = {https://blast-warpx.github.io}
-       }
+          @misc{WarpX,
+            author = {Vay, Jean-Luc and
+                      Acciarri, Marco and
+                      Almgren, Ann and
+                      Amorim, Lígia Diana and
+                      Andriyash, Igor and
+                      Angus, Justin Ray and
+                      Antoun, Thierry and
+                      Belkin, Daniel and
+                      Bizzozero, David and
+                      Blelly, Aurore and
+                      Clark, Stephen Eric and
+                      Dammak, Eya and
+                      Fedeli, Luca and
+                      Formenti, Arianna and
+                      Garten, Marco and
+                      Ge, Lixin and
+                      Giacomel, Lorenzo and
+                      Gott, Kevin and
+                      Giacomel, Lorenzo and
+                      Groenewald, Roelof E. and
+                      Grote, David and
+                      Gu, Junmin and
+                      Harrison, Cyrus and
+                      Haseeb, Muhammad and
+                      Huebl, Axel and
+                      Jambunathan, Revathi and
+                      Kara-Mostefa, Ilian and
+                      Klion, Hannah and
+                      Kumar, Prabhat and
+                      Lehe, Remi and
+                      Loring, Burlen and
+                      Marks, Thomas and
+                      Miller, Phil and
+                      Myers, Andrew and
+                      Pech, Juliette and
+                      Rheaume, Elisa and
+                      Richardson, Glenn and
+                      Rheaume, Elisa and
+                      Rowan, Michael E. and
+                      Sandberg, Ryan Thor and
+                      Scherpelz, Peter and
+                      Sinn, Alexander and
+                      Shapoval, Olga and
+                      Terzani, Davide and
+                      Th{\'e}venet, Maxence and
+                      Weichman, Kale and
+                      Yang, Eloise and
+                      Zaim, Ne{\"i}l and
+                      Zhang, Weiqun and
+                      Zhao, Yinjian and
+                      Zhu, Kevin Z. and
+                      Zoni, Edoardo},
+              title     = {{WarpX: An advanced Particle-In-Cell code}},
+              year      = 2018,
+              publisher = {Zenodo},
+              doi       = {10.5281/zenodo.4571577},
+              url       = {https://doi.org/10.5281/zenodo.4571577},
+              note      = {\url{https://doi.org/10.5281/zenodo.4571577}},
+              howpublished = {https://blast-warpx.github.io}
+           }
 
-Since the WarpX is an actively evolving project, a specific version might be used in your work to ensure reproducibility. You can select a version-specific DOI from the `release page <https://github.com/BLAST-WarpX/warpx/releases>`__ and add the version number to the cited title, e.g.:
+Since the WarpX is an actively evolving project, a specific version might be used in your work to ensure reproducibility. You can select a *version-specific DOI* from the `release page <https://github.com/BLAST-WarpX/warpx/releases>`__ and add the version number to the cited title, e.g. for version ``25.10``:
 
 .. tab-set::
 
    .. tab-item:: Plain Text
 
-      J.-L. Vay et al., **WarpX: an advanced Particle-In-Cell code**,
+      J.-L. Vay et al., **WarpX: An advanced Particle-In-Cell code**.
       version 25.10,
-      DOI:10.5281/zenodo.17261711, https://blast-warpx.github.io (2025)
+      `DOI:10.5281/zenodo.17261711 <https://doi.org/10.5281/zenodo.17261711>`__
+      `https://blast-warpx.github.io <https://blast-warpx.github.io>`__ (2025)
 
    .. tab-item:: LateX: Bibtex
 
       .. code-block:: bibtex
 
-      @misc{WarpXv25.10,
-        author = {Vay, Jean-Luc and
-                  Acciarri, Marco and
-                  Almgren, Ann and
-                  Amorim, Lígia Diana and
-                  Andriyash, Igor and
-                  Angus, Justin Ray and
-                  Antoun, Thierry and
-                  Belkin, Daniel and
-                  Bizzozero, David and
-                  Blelly, Aurore and
-                  Clark, Stephen Eric and
-                  Dammak, Eya and
-                  Fedeli, Luca and
-                  Formenti, Arianna and
-                  Garten, Marco and
-                  Ge, Lixin and
-                  Giacomel, Lorenzo and
-                  Gott, Kevin and
-                  Giacomel, Lorenzo and
-                  Groenewald, Roelof E. and
-                  Grote, David and
-                  Gu, Junmin and
-                  Harrison, Cyrus and
-                  Haseeb, Muhammad and
-                  Huebl, Axel and
-                  Jambunathan, Revathi and
-                  Kara-Mostefa, Ilian and
-                  Klion, Hannah and
-                  Kumar, Prabhat and
-                  Lehe, Remi and
-                  Loring, Burlen and
-                  Marks, Thomas and
-                  Miller, Phil and
-                  Myers, Andrew and
-                  Pech, Juliette and
-                  Rheaume, Elisa and
-                  Richardson, Glenn and
-                  Rheaume, Elisa and
-                  Rowan, Michael E. and
-                  Sandberg, Ryan Thor and
-                  Scherpelz, Peter and
-                  Sinn, Alexander and
-                  Shapoval, Olga and
-                  Terzani, Davide and
-                  Th{\'e}venet, Maxence and
-                  Weichman, Kale and
-                  Yang, Eloise and
-                  Zaim, Ne{\"i}l and
-                  Zhang, Weiqun and
-                  Zhao, Yinjian and
-                  Zhu, Kevin Z. and
-                  Zoni, Edoardo},
-          title     = {{WarpX: an advanced Particle-In-Cell code}},
-          year      = 2025,
-          publisher = {Zenodo},
-          version   = {25.10},
-          doi       = {10.5281/zenodo.17261711},
-          url       = {https://doi.org/10.5281/zenodo.17261711},
-          howpublished = {https://blast-warpx.github.io}
-       }
+          @misc{WarpXv25.10,
+            author = {Vay, Jean-Luc and
+                      Acciarri, Marco and
+                      Almgren, Ann and
+                      Amorim, Lígia Diana and
+                      Andriyash, Igor and
+                      Angus, Justin Ray and
+                      Antoun, Thierry and
+                      Belkin, Daniel and
+                      Bizzozero, David and
+                      Blelly, Aurore and
+                      Clark, Stephen Eric and
+                      Dammak, Eya and
+                      Fedeli, Luca and
+                      Formenti, Arianna and
+                      Garten, Marco and
+                      Ge, Lixin and
+                      Giacomel, Lorenzo and
+                      Gott, Kevin and
+                      Giacomel, Lorenzo and
+                      Groenewald, Roelof E. and
+                      Grote, David and
+                      Gu, Junmin and
+                      Harrison, Cyrus and
+                      Haseeb, Muhammad and
+                      Huebl, Axel and
+                      Jambunathan, Revathi and
+                      Kara-Mostefa, Ilian and
+                      Klion, Hannah and
+                      Kumar, Prabhat and
+                      Lehe, Remi and
+                      Loring, Burlen and
+                      Marks, Thomas and
+                      Miller, Phil and
+                      Myers, Andrew and
+                      Pech, Juliette and
+                      Rheaume, Elisa and
+                      Richardson, Glenn and
+                      Rheaume, Elisa and
+                      Rowan, Michael E. and
+                      Sandberg, Ryan Thor and
+                      Scherpelz, Peter and
+                      Sinn, Alexander and
+                      Shapoval, Olga and
+                      Terzani, Davide and
+                      Th{\'e}venet, Maxence and
+                      Weichman, Kale and
+                      Yang, Eloise and
+                      Zaim, Ne{\"i}l and
+                      Zhang, Weiqun and
+                      Zhao, Yinjian and
+                      Zhu, Kevin Z. and
+                      Zoni, Edoardo},
+              title     = {{WarpX: An advanced Particle-In-Cell code}},
+              year      = 2025,
+              publisher = {Zenodo},
+              version   = {25.10},
+              doi       = {10.5281/zenodo.17261711},
+              url       = {https://doi.org/10.5281/zenodo.17261711},
+              note      = {\url{https://doi.org/10.5281/zenodo.17261711}},
+              howpublished = {https://blast-warpx.github.io}
+           }
 
 
 .. _acknowledge_warpx_all_refs:
 
-Prior WarpX references
-----------------------
+Detailed WarpX references
+-------------------------
 
 If your project uses a specific algorithm or component, please consider citing the respective publications in addition.
 

--- a/Docs/source/acknowledge_us.rst
+++ b/Docs/source/acknowledge_us.rst
@@ -16,90 +16,176 @@ In publications
 
 Please add the following sentence to your publications, it helps contributors keep in touch with the community and promote the project.
 
-**Plain text:**
+.. tab-set::
 
-  This research used the open-source particle-in-cell code WarpX https://github.com/BLAST-WarpX/warpx. Primary WarpX contributors are with LBNL, LLNL, CEA-LIDYL, SLAC, DESY, CERN, Helion Energy, and TAE Technologies. We acknowledge all WarpX contributors.
+   .. tab-item:: Plain text
 
-**LaTeX:**
+      This research used the open-source particle-in-cell code WarpX https://github.com/BLAST-WarpX/warpx. Primary WarpX contributors are with LBNL, LLNL, CEA-LIDYL, SLAC, DESY, CERN, Helion Energy, and TAE Technologies. We acknowledge all WarpX contributors.
 
-.. code-block:: latex
+   .. tab-item:: LaTeX
 
-  \usepackage{hyperref}
-  This research used the open-source particle-in-cell code WarpX \url{https://github.com/BLAST-WarpX/warpx}.
-  Primary WarpX contributors are with LBNL, LLNL, CEA-LIDYL, SLAC, DESY, CERN, Helion Energy, and TAE Technologies.
-  We acknowledge all WarpX contributors.
+      .. code-block:: latex
+
+        \usepackage{hyperref}
+        This research used the open-source particle-in-cell code WarpX \url{https://github.com/BLAST-WarpX/warpx}.
+        Primary WarpX contributors are with LBNL, LLNL, CEA-LIDYL, SLAC, DESY, CERN, Helion Energy, and TAE Technologies.
+        We acknowledge all WarpX contributors.
 
 .. _acknowledge_warpx_ref:
 
 Latest WarpX reference
 **********************
 
-If your project leads to a scientific publication, please consider citing all co-authors via our persisten Zenodo DOI:
+If your project leads to a scientific publication, please consider citing all co-authors via our persistent Zenodo DOI:
 
 .. tab-set::
+
+   .. tab-item:: Plain Text
+
+      J.-L. Vay et al., **WarpX: an advanced Particle-In-Cell code**,
+      DOI:10.5281/zenodo.4571577, https://blast-warpx.github.io (2018)
 
    .. tab-item:: LateX: Bibtex
 
       .. code-block:: bibtex
 
       @misc{WarpX,
-  author       = {Vay, Jean-Luc and
+        author = {Vay, Jean-Luc and
+                  Acciarri, Marco and
                   Almgren, Ann and
                   Amorim, Lígia Diana and
                   Andriyash, Igor and
                   Angus, Justin Ray and
+                  Antoun, Thierry and
                   Belkin, Daniel and
                   Bizzozero, David and
                   Blelly, Aurore and
                   Clark, Stephen Eric and
+                  Dammak, Eya and
                   Fedeli, Luca and
                   Formenti, Arianna and
                   Garten, Marco and
                   Ge, Lixin and
+                  Giacomel, Lorenzo and
                   Gott, Kevin and
-                  Harrison, Cyrus and
-                  Huebl, Axel and
                   Giacomel, Lorenzo and
                   Groenewald, Roelof E. and
                   Grote, David and
                   Gu, Junmin and
+                  Harrison, Cyrus and
                   Haseeb, Muhammad and
+                  Huebl, Axel and
                   Jambunathan, Revathi and
+                  Kara-Mostefa, Ilian and
                   Klion, Hannah and
                   Kumar, Prabhat and
-                  Thévenet, Maxence and
-                  Richardson, Glenn and
-                  Shapoval, Olga and
                   Lehe, Remi and
                   Loring, Burlen and
+                  Marks, Thomas and
                   Miller, Phil and
                   Myers, Andrew and
+                  Pech, Juliette and
+                  Rheaume, Elisa and
+                  Richardson, Glenn and
                   Rheaume, Elisa and
                   Rowan, Michael E. and
                   Sandberg, Ryan Thor and
                   Scherpelz, Peter and
+                  Sinn, Alexander and
+                  Shapoval, Olga and
+                  Terzani, Davide and
+                  Th{\'e}venet, Maxence and
                   Weichman, Kale and
                   Yang, Eloise and
-                  Zaim, Neïl and
+                  Zaim, Ne{\"i}l and
                   Zhang, Weiqun and
                   Zhao, Yinjian and
                   Zhu, Kevin Z. and
                   Zoni, Edoardo},
-          title          = {WarpX: an advanced Particle-In-Cell code},
-          year         = 2025,
+          title     = {{WarpX: an advanced Particle-In-Cell code}},
+          year      = 2018,
           publisher = {Zenodo},
-          version    = {25.09},
-          doi           = {10.5281/zenodo.17080408},
-          url            = {https://doi.org/10.5281/zenodo.17080408},
-          howpublished = {https://github.com/BLAST-WarpX}
-}
+          version   = {25.09},
+          doi       = {10.5281/zenodo.4571577},
+          url       = {https://doi.org/10.5281/zenodo.4571577},
+          howpublished = {https://blast-warpx.github.io}
        }
+
+Since the WarpX is an actively evolving project, a specific version might be used in your work to ensure reproducibility. You can select a version-specific DOI from the `release page <https://github.com/BLAST-WarpX/warpx/releases>`__ and add the version number to the cited title, e.g.:
+
+.. tab-set::
 
    .. tab-item:: Plain Text
 
-      ...
+      J.-L. Vay et al., **WarpX: an advanced Particle-In-Cell code**,
+      version 25.10,
+      DOI:10.5281/zenodo.17261711, https://blast-warpx.github.io (2025)
 
-Add version if needed...
+   .. tab-item:: LateX: Bibtex
+
+      .. code-block:: bibtex
+
+      @misc{WarpXv25.10,
+        author = {Vay, Jean-Luc and
+                  Acciarri, Marco and
+                  Almgren, Ann and
+                  Amorim, Lígia Diana and
+                  Andriyash, Igor and
+                  Angus, Justin Ray and
+                  Antoun, Thierry and
+                  Belkin, Daniel and
+                  Bizzozero, David and
+                  Blelly, Aurore and
+                  Clark, Stephen Eric and
+                  Dammak, Eya and
+                  Fedeli, Luca and
+                  Formenti, Arianna and
+                  Garten, Marco and
+                  Ge, Lixin and
+                  Giacomel, Lorenzo and
+                  Gott, Kevin and
+                  Giacomel, Lorenzo and
+                  Groenewald, Roelof E. and
+                  Grote, David and
+                  Gu, Junmin and
+                  Harrison, Cyrus and
+                  Haseeb, Muhammad and
+                  Huebl, Axel and
+                  Jambunathan, Revathi and
+                  Kara-Mostefa, Ilian and
+                  Klion, Hannah and
+                  Kumar, Prabhat and
+                  Lehe, Remi and
+                  Loring, Burlen and
+                  Marks, Thomas and
+                  Miller, Phil and
+                  Myers, Andrew and
+                  Pech, Juliette and
+                  Rheaume, Elisa and
+                  Richardson, Glenn and
+                  Rheaume, Elisa and
+                  Rowan, Michael E. and
+                  Sandberg, Ryan Thor and
+                  Scherpelz, Peter and
+                  Sinn, Alexander and
+                  Shapoval, Olga and
+                  Terzani, Davide and
+                  Th{\'e}venet, Maxence and
+                  Weichman, Kale and
+                  Yang, Eloise and
+                  Zaim, Ne{\"i}l and
+                  Zhang, Weiqun and
+                  Zhao, Yinjian and
+                  Zhu, Kevin Z. and
+                  Zoni, Edoardo},
+          title     = {{WarpX: an advanced Particle-In-Cell code}},
+          year      = 2025,
+          publisher = {Zenodo},
+          version   = {25.10},
+          doi       = {10.5281/zenodo.17261711},
+          url       = {https://doi.org/10.5281/zenodo.17261711},
+          howpublished = {https://blast-warpx.github.io}
+       }
 
 
 .. _acknowledge_warpx_all_refs:

--- a/Docs/source/acknowledge_us.rst
+++ b/Docs/source/acknowledge_us.rst
@@ -95,7 +95,7 @@ If your project leads to a scientific publication, please consider citing all co
 }
        }
 
-   .. tab-item:: Word
+   .. tab-item:: Plain Text
 
       ...
 

--- a/Docs/source/acknowledge_us.rst
+++ b/Docs/source/acknowledge_us.rst
@@ -85,25 +85,14 @@ If your project leads to a scientific publication, please consider citing all co
                   Zhao, Yinjian and
                   Zhu, Kevin Z. and
                   Zoni, Edoardo},
-          title        = {WarpX: an advanced electromagnetic & electrostatic Particle-In-Cell code},
-          year         = 2018,
-          publisher    = {Zenodo},
-          version      = {25.08},
-          doi          = {10.5281/zenodo.16750069},
-          url          = {https://doi.org/10.5281/zenodo.16750069},
-          swhid        = {swh:1:dir:12d584a99e9625391d4bc82fbbca1a089652f3f8
-                           ;origin=https://doi.org/10.5281/zenodo.4571577;vis
-                           it=swh:1:snp:42a98189c61704a75545d176f00552bd43071
-                           d45;anchor=swh:1:rel:5843c56c1006a8673ba5ea31e0fc8
-                           0fd36afcf45;path=BLAST-WarpX-warpx-6680268
-                          },
+          title          = {WarpX: an advanced Particle-In-Cell code},
+          year         = 2025,
+          publisher = {Zenodo},
+          version    = {25.09},
+          doi           = {10.5281/zenodo.17080408},
+          url            = {https://doi.org/10.5281/zenodo.17080408},
+          howpublished = {https://github.com/BLAST-WarpX}
 }
-         title        = {{openPMD: A meta data standard for particle and mesh based data}},
-         year         = 2015,
-         publisher    = {Zenodo},
-         doi          = {10.5281/zenodo.591699},
-         url          = {https://www.openPMD.org},
-         howpublished = {https://github.com/openPMD}
        }
 
    .. tab-item:: Word

--- a/Docs/source/acknowledge_us.rst
+++ b/Docs/source/acknowledge_us.rst
@@ -34,12 +34,84 @@ Please add the following sentence to your publications, it helps contributors ke
 Latest WarpX reference
 **********************
 
-If your project leads to a scientific publication, please consider citing the paper below.
+If your project leads to a scientific publication, please consider citing all co-authors via our persisten Zenodo DOI:
 
-- Fedeli L, Huebl A, Boillod-Cerneux F, Clark T, Gott K, Hillairet C, Jaure S, Leblanc A, Lehe R, Myers A, Piechurski C, Sato M, Zaim N, Zhang W, Vay J-L, Vincenti H.
-  **Pushing the Frontier in the Design of Laser-Based Electron Accelerators with Groundbreaking Mesh-Refined Particle-In-Cell Simulations on Exascale-Class Supercomputers**.
-  *SC22: International Conference for High Performance Computing, Networking, Storage and Analysis (SC)*. ISSN:2167-4337, pp. 25-36, Dallas, TX, US, 2022.
-  `DOI:10.1109/SC41404.2022.00008 <https://doi.org/10.1109/SC41404.2022.00008>`__ (`preprint here <https://www.computer.org/csdl/proceedings-article/sc/2022/544400a025/1I0bSKaoECc>`__)
+.. tab-set::
+
+   .. tab-item:: LateX: Bibtex
+
+      .. code-block:: bibtex
+
+      @misc{WarpX,
+  author       = {Vay, Jean-Luc and
+                  Almgren, Ann and
+                  Amorim, Lígia Diana and
+                  Andriyash, Igor and
+                  Angus, Justin Ray and
+                  Belkin, Daniel and
+                  Bizzozero, David and
+                  Blelly, Aurore and
+                  Clark, Stephen Eric and
+                  Fedeli, Luca and
+                  Formenti, Arianna and
+                  Garten, Marco and
+                  Ge, Lixin and
+                  Gott, Kevin and
+                  Harrison, Cyrus and
+                  Huebl, Axel and
+                  Giacomel, Lorenzo and
+                  Groenewald, Roelof E. and
+                  Grote, David and
+                  Gu, Junmin and
+                  Haseeb, Muhammad and
+                  Jambunathan, Revathi and
+                  Klion, Hannah and
+                  Kumar, Prabhat and
+                  Thévenet, Maxence and
+                  Richardson, Glenn and
+                  Shapoval, Olga and
+                  Lehe, Remi and
+                  Loring, Burlen and
+                  Miller, Phil and
+                  Myers, Andrew and
+                  Rheaume, Elisa and
+                  Rowan, Michael E. and
+                  Sandberg, Ryan Thor and
+                  Scherpelz, Peter and
+                  Weichman, Kale and
+                  Yang, Eloise and
+                  Zaim, Neïl and
+                  Zhang, Weiqun and
+                  Zhao, Yinjian and
+                  Zhu, Kevin Z. and
+                  Zoni, Edoardo},
+          title        = {WarpX: an advanced electromagnetic & electrostatic Particle-In-Cell code},
+          year         = 2018,
+          publisher    = {Zenodo},
+          version      = {25.08},
+          doi          = {10.5281/zenodo.16750069},
+          url          = {https://doi.org/10.5281/zenodo.16750069},
+          swhid        = {swh:1:dir:12d584a99e9625391d4bc82fbbca1a089652f3f8
+                           ;origin=https://doi.org/10.5281/zenodo.4571577;vis
+                           it=swh:1:snp:42a98189c61704a75545d176f00552bd43071
+                           d45;anchor=swh:1:rel:5843c56c1006a8673ba5ea31e0fc8
+                           0fd36afcf45;path=BLAST-WarpX-warpx-6680268
+                          },
+}
+         title        = {{openPMD: A meta data standard for particle and mesh based data}},
+         year         = 2015,
+         publisher    = {Zenodo},
+         doi          = {10.5281/zenodo.591699},
+         url          = {https://www.openPMD.org},
+         howpublished = {https://github.com/openPMD}
+       }
+
+   .. tab-item:: Word
+
+      ...
+
+Add version if needed...
+
 
 .. _acknowledge_warpx_all_refs:
 
@@ -72,6 +144,12 @@ If your project uses a specific algorithm or component, please consider citing t
   **Hybrid Beamline Element ML-Training for Surrogates in the ImpactX Beam-Dynamics Code**.
   14th International Particle Accelerator Conference (IPAC'23), WEPA101, 2023.
   `DOI:10.18429/JACoW-IPAC2023-WEPA101 <https://doi.org/10.18429/JACoW-IPAC2023-WEPA101>`__
+
+- Fedeli L, Huebl A, Boillod-Cerneux F, Clark T, Gott K, Hillairet C, Jaure S, Leblanc A, Lehe R, Myers A, Piechurski C, Sato M, Zaim N, Zhang W, Vay J-L, Vincenti H.
+  **Pushing the Frontier in the Design of Laser-Based Electron Accelerators with Groundbreaking Mesh-Refined Particle-In-Cell Simulations on Exascale-Class Supercomputers**.
+  *SC22: International Conference for High Performance Computing, Networking, Storage and Analysis (SC)*. ISSN:2167-4337, pp. 25-36, Dallas, TX, US, 2022.
+  **2022 ACM Gordon Bell Prize Winner**,
+  `DOI:10.1109/SC41404.2022.00008 <https://doi.org/10.1109/SC41404.2022.00008>`__ (`preprint here <https://www.computer.org/csdl/proceedings-article/sc/2022/544400a025/1I0bSKaoECc>`__)
 
 - Huebl A, Lehe R, Zoni E, Shapoval O, Sandberg R T, Garten M, Formenti A, Jambunathan R, Kumar P, Gott K, Myers A, Zhang W, Almgren A, Mitchell C E, Qiang J, Sinn A, Diederichs S, Thevenet M, Grote D, Fedeli L, Clark T, Zaim N, Vincenti H, Vay JL.
   **From Compact Plasma Particle Sources to Advanced Accelerators with Modeling at Exascale**.


### PR DESCRIPTION
Rework the WarpX recommended citation as discussed in the Tue, Aug 19 developer meeting.

[Preview here.](https://warpx--6102.org.readthedocs.build/en/6102/acknowledge_us.html)

- [x] Zenodo: add new co-authors to 
- [x] Zenodo: remove "contributors" (not co-authors) that had minimal contributions
- [x] finalize more in the style of https://openpmd-api.readthedocs.io/en/0.16.1/citation.html#openpmd-api w/ link to homepage. two sections, each with a tab "copy bibtex" and a tab "copy plain text":
    - [x] One that is "how to credit generally WarpX (2018)" via the general Zenodo link
    - [x] One that is "how to reproducibly cite a specific version of WarpX (2025) via the version-specific Zenodo link
