### PR TITLE
Added 1D & 2D CI test with loading density from .h5 file

### DIFF
--- a/Examples/Tests/load_density/CMakeLists.txt
+++ b/Examples/Tests/load_density/CMakeLists.txt
@@ -20,3 +20,23 @@ add_warpx_test(
     "analysis_default_regression.py --path diags/diag/"   # checksum
     test_3d_load_density_prepare  # dependency
 )
+
+add_warpx_test(
+    test_2d_load_density_prepare  # name
+    2  # dims
+    1  # nprocs
+    inputs_test_2d_load_density_prepare.py  # inputs
+    OFF  # analysis
+    OFF  # checksum
+    OFF  # dependency
+)
+
+add_warpx_test(
+    test_2d_load_density  # name
+    2  # dims
+    1  # nprocs
+    inputs_test_2d_load_density  # inputs
+    "analysis_2d.py"  # analysis
+    "analysis_default_regression.py --path diags/diag/"   # checksum
+    test_2d_load_density_prepare  # dependency
+)

--- a/Examples/Tests/load_density/CMakeLists.txt
+++ b/Examples/Tests/load_density/CMakeLists.txt
@@ -2,23 +2,23 @@
 #
 
 add_warpx_test(
-    test_3d_load_density_prepare  # name
-    3  # dims
+    test_1d_load_density_prepare  # name
+    1  # dims
     1  # nprocs
-    inputs_test_3d_load_density_prepare.py  # inputs
+    inputs_test_1d_load_density_prepare.py  # inputs
     OFF  # analysis
     OFF  # checksum
     OFF  # dependency
 )
 
 add_warpx_test(
-    test_3d_load_density  # name
-    3  # dims
+    test_1d_load_density  # name
+    1  # dims
     1  # nprocs
-    inputs_test_3d_load_density  # inputs
-    "analysis_3d.py"  # analysis
+    inputs_test_1d_load_density  # inputs
+    "analysis_1d.py"  # analysis
     "analysis_default_regression.py --path diags/diag/"   # checksum
-    test_3d_load_density_prepare  # dependency
+    test_1d_load_density_prepare  # dependency
 )
 
 add_warpx_test(
@@ -39,4 +39,24 @@ add_warpx_test(
     "analysis_2d.py"  # analysis
     "analysis_default_regression.py --path diags/diag/"   # checksum
     test_2d_load_density_prepare  # dependency
+)
+
+add_warpx_test(
+    test_3d_load_density_prepare  # name
+    3  # dims
+    1  # nprocs
+    inputs_test_3d_load_density_prepare.py  # inputs
+    OFF  # analysis
+    OFF  # checksum
+    OFF  # dependency
+)
+
+add_warpx_test(
+    test_3d_load_density  # name
+    3  # dims
+    1  # nprocs
+    inputs_test_3d_load_density  # inputs
+    "analysis_3d.py"  # analysis
+    "analysis_default_regression.py --path diags/diag/"   # checksum
+    test_3d_load_density_prepare  # dependency
 )

--- a/Examples/Tests/load_density/analysis_1d.py
+++ b/Examples/Tests/load_density/analysis_1d.py
@@ -26,7 +26,6 @@ for iteration in ts.iterations:
 
     # Compute expected density
     on_axis_density = 1e24  # m^-3
-    channel_radius = 40e-6  # m
     ramp_length = 60e-6  # m
     z = info.z
     density_th = on_axis_density * np.where(z < ramp_length, z / ramp_length, 1)

--- a/Examples/Tests/load_density/analysis_1d.py
+++ b/Examples/Tests/load_density/analysis_1d.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 Remi Lehe
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+# This tests the loading of the plasma density from a file.
+# An openPMD file is created, containing a density corresponding to
+# a linear ramp in z followed by a plateau)
+# This file checks that the density of the particles that are injected in the simulation
+# (including continuous injection by a moving window) corresponds to the expected density.
+
+import numpy as np
+from openpmd_viewer import OpenPMDTimeSeries
+from scipy.constants import e
+
+ts = OpenPMDTimeSeries("./diags/diag")
+
+# Loop over all iterations, so that we test loading of the density
+# as the moving window moves.
+for iteration in ts.iterations:
+    rho, info = ts.get_field("rho", iteration=iteration)
+    density_sim = -rho / e
+
+    # Compute expected density
+    on_axis_density = 1e24  # m^-3
+    channel_radius = 40e-6  # m
+    ramp_length = 60e-6  # m
+    z = info.z
+    density_th = on_axis_density * np.where(z < ramp_length, z / ramp_length, 1)
+    density_th[z < 0] = 0
+
+    # Do not check the 3 first cells and 3 last cells,
+    # as this is affected by the edges of the domain
+    assert np.all(
+        abs(density_th[3:-3] - density_sim[3:-3]) / abs(density_th[3:-3]).max() < 0.02
+    )

--- a/Examples/Tests/load_density/analysis_2d.py
+++ b/Examples/Tests/load_density/analysis_2d.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 Remi Lehe
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+# This tests the loading of the plasma density from a file.
+# An openPMD file is created, containing a density corresponding to
+# a plasma channel (parabolic in x and linear ramp in z followed by a plateau)
+# This file checks that the density of the particles that are injected in the simulation
+# (including continuous injection by a moving window) corresponds to the expected density.
+
+import numpy as np
+from openpmd_viewer import OpenPMDTimeSeries
+from scipy.constants import e
+
+ts = OpenPMDTimeSeries("./diags/diag")
+
+# Loop over all iterations, so that we test loading of the density
+# as the moving window moves.
+for iteration in ts.iterations:
+    rho, info = ts.get_field("rho", iteration=iteration)
+    density_sim = -rho / e
+
+    # Compute expected density
+    on_axis_density = 1e24  # m^-3
+    channel_radius = 40e-6  # m
+    ramp_length = 60e-6  # m
+    z, x = np.meshgrid(info.z, info.x, indexing="ij")
+    density_th = (
+        on_axis_density
+        * (1 + x**2 / channel_radius**2)
+        * np.where(z < ramp_length, z / ramp_length, 1)
+    )
+    density_th[z < 0] = 0
+
+    # Do not check the 3 first cells and 3 last cells,
+    # as this is affected by the edges of the domain
+    assert np.all(
+        abs(density_th[3:-3, 3:-3] - density_sim[3:-3, 3:-3])
+        / abs(density_th[3:-3, 3:-3]).max()
+        < 0.02
+    )

--- a/Examples/Tests/load_density/inputs_test_1d_load_density
+++ b/Examples/Tests/load_density/inputs_test_1d_load_density
@@ -1,0 +1,52 @@
+#################################
+####### GENERAL PARAMETERS ######
+#################################
+max_step = 64
+amr.n_cell = 32
+amr.max_grid_size = 16
+amr.blocking_factor = 16
+amr.max_level = 0
+geometry.dims = 1
+geometry.prob_lo = -50.e-6      # physical domain
+geometry.prob_hi =  50.e-6
+
+#################################
+####### Boundary condition ######
+#################################
+boundary.field_lo = pec
+boundary.field_hi = pec
+
+#################################
+############ NUMERICS ###########
+#################################
+warpx.serialize_initial_conditions = 1
+warpx.verbose = 1
+warpx.cfl = 1.0
+
+# Order of particle shape factors
+algo.particle_shape = 1
+
+# Moving window
+warpx.do_moving_window = 1
+warpx.moving_window_dir = z
+warpx.moving_window_v = 1
+
+#################################
+############ PLASMA #############
+#################################
+particles.species_names = electrons
+
+electrons.species_type = electron
+electrons.injection_style = "NUniformPerCell"
+electrons.num_particles_per_cell_each_dim = 2
+electrons.profile = "read_from_file"
+electrons.read_density_from_path = "../test_1d_load_density_prepare/example-density.h5"
+electrons.momentum_distribution_type = "at_rest"
+electrons.do_continuous_injection = 1
+
+# Diagnostics
+diagnostics.diags_names = diag
+diag.intervals = 5
+diag.diag_type = Full
+diag.fields_to_plot = rho
+diag.format = openpmd

--- a/Examples/Tests/load_density/inputs_test_1d_load_density_prepare.py
+++ b/Examples/Tests/load_density/inputs_test_1d_load_density_prepare.py
@@ -41,4 +41,4 @@ density_d.reset_dataset(dataset)
 density_d.store_chunk(density_data)
 series.flush()
 
-del series
+series.close()

--- a/Examples/Tests/load_density/inputs_test_1d_load_density_prepare.py
+++ b/Examples/Tests/load_density/inputs_test_1d_load_density_prepare.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""
+Create an openPMD file containing the density with which
+the WarpX particles should be initialized (on a 2D Cartesian grid)
+"""
+
+import numpy as np
+import openpmd_api as io
+
+# Define density as a function of z using numpy syntax
+# with a ramp and plateau in z
+on_axis_density = 1e24  # m^-3
+channel_radius = 40e-6  # m
+ramp_length = 60e-6  # m
+# - Define the grid
+z = np.linspace(0, 500e-6, 100)
+# - Define density as a function of z
+density_data = np.where(
+    z < ramp_length, z * on_axis_density / ramp_length, on_axis_density
+)
+# create openpmd file
+series = io.Series("example-density.h5", io.Access.create)
+
+# only 1 iteration needed
+it = series.iterations[1]
+# set meta information
+density = it.meshes["density"]
+density.grid_spacing = np.array([z[1] - z[0]])
+density.grid_global_offset = [z.min()]
+density.axis_labels = ["z"]
+density.geometry = io.Geometry.cartesian
+density.unit_dimension = {
+    io.Unit_Dimension.L: -3,
+}
+
+# label
+density_d = density[io.Mesh_Record_Component.SCALAR]
+density_d.position = [0]
+
+dataset = io.Dataset(density_data.dtype, density_data.shape)
+density_d.reset_dataset(dataset)
+density_d.store_chunk(density_data)
+series.flush()
+
+del series

--- a/Examples/Tests/load_density/inputs_test_1d_load_density_prepare.py
+++ b/Examples/Tests/load_density/inputs_test_1d_load_density_prepare.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Create an openPMD file containing the density with which
-the WarpX particles should be initialized (on a 2D Cartesian grid)
+the WarpX particles should be initialized (on a 1D Cartesian grid)
 """
 
 import numpy as np

--- a/Examples/Tests/load_density/inputs_test_1d_load_density_prepare.py
+++ b/Examples/Tests/load_density/inputs_test_1d_load_density_prepare.py
@@ -10,7 +10,6 @@ import openpmd_api as io
 # Define density as a function of z using numpy syntax
 # with a ramp and plateau in z
 on_axis_density = 1e24  # m^-3
-channel_radius = 40e-6  # m
 ramp_length = 60e-6  # m
 # - Define the grid
 z = np.linspace(0, 500e-6, 100)

--- a/Examples/Tests/load_density/inputs_test_2d_load_density
+++ b/Examples/Tests/load_density/inputs_test_2d_load_density
@@ -43,8 +43,6 @@ electrons.profile = "read_from_file"
 electrons.read_density_from_path = "../test_2d_load_density_prepare/example-density.h5"
 electrons.momentum_distribution_type = "at_rest"
 electrons.do_continuous_injection = 1
-#electrons.profile = parse_density_function
-#electrons.density_function(x,y,z) = "if(z<60e-6, 1e24 * (1 + x**2 / (40e-6)**2)*z / 60e-6,1e24 * (1 + x**2 / (40e-6)**2))"
 
 # Diagnostics
 diagnostics.diags_names = diag

--- a/Examples/Tests/load_density/inputs_test_2d_load_density
+++ b/Examples/Tests/load_density/inputs_test_2d_load_density
@@ -1,0 +1,54 @@
+#################################
+####### GENERAL PARAMETERS ######
+#################################
+max_step = 64
+amr.n_cell = 32 32
+amr.max_grid_size = 16
+amr.blocking_factor = 16
+amr.max_level = 0
+geometry.dims = 2
+geometry.prob_lo = -50.e-6 -50.e-6    # physical domain
+geometry.prob_hi =  50.e-6  50.e-6
+
+#################################
+####### Boundary condition ######
+#################################
+boundary.field_lo = pec pec
+boundary.field_hi = pec pec
+
+#################################
+############ NUMERICS ###########
+#################################
+warpx.serialize_initial_conditions = 1
+warpx.verbose = 1
+warpx.cfl = 1.0
+
+# Order of particle shape factors
+algo.particle_shape = 1
+
+# Moving window
+warpx.do_moving_window = 1
+warpx.moving_window_dir = z
+warpx.moving_window_v = 1
+
+#################################
+############ PLASMA #############
+#################################
+particles.species_names = electrons
+
+electrons.species_type = electron
+electrons.injection_style = "NUniformPerCell"
+electrons.num_particles_per_cell_each_dim = 1 2
+electrons.profile = "read_from_file"
+electrons.read_density_from_path = "../test_2d_load_density_prepare/example-density.h5"
+electrons.momentum_distribution_type = "at_rest"
+electrons.do_continuous_injection = 1
+#electrons.profile = parse_density_function
+#electrons.density_function(x,y,z) = "if(z<60e-6, 1e24 * (1 + x**2 / (40e-6)**2)*z / 60e-6,1e24 * (1 + x**2 / (40e-6)**2))"
+
+# Diagnostics
+diagnostics.diags_names = diag
+diag.intervals = 1
+diag.diag_type = Full
+diag.fields_to_plot = rho
+diag.format = openpmd

--- a/Examples/Tests/load_density/inputs_test_2d_load_density_prepare.py
+++ b/Examples/Tests/load_density/inputs_test_2d_load_density_prepare.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""
+Create an openPMD file containing the density with which
+the WarpX particles should be initialized (on a 2D Cartesian grid)
+"""
+
+import numpy as np
+import openpmd_api as io
+
+# Define density as a function of x, z, using numpy syntax
+# parabolic channel in x with a ramp and plateau in z
+on_axis_density = 1e24  # m^-3
+channel_radius = 40e-6  # m
+ramp_length = 60e-6  # m
+# - Define the grid
+x_1d = np.linspace(-50e-6, 50e-6, 200)
+z_1d = np.linspace(0, 500e-6, 200)
+
+x, z = np.meshgrid(x_1d, z_1d, indexing="ij")
+# - Define density as a function of x, z
+density_data = (
+    on_axis_density
+    * (1 + (x**2) / channel_radius**2)
+    * np.where(z < ramp_length, z / ramp_length, 1)
+)
+# create openpmd file
+series = io.Series("example-density.h5", io.Access.create)
+
+# only 1 iteration needed
+it = series.iterations[1]
+# set meta information
+density = it.meshes["density"]
+density.grid_spacing = np.array([x_1d[1] - x_1d[0], z_1d[1] - z_1d[0]])
+density.grid_global_offset = [x_1d.min(), z_1d.min()]
+density.axis_labels = ["x", "z"]
+density.geometry = io.Geometry.cartesian
+density.unit_dimension = {
+    io.Unit_Dimension.L: -3,
+}
+
+# label
+density_d = density[io.Mesh_Record_Component.SCALAR]
+density_d.position = [0, 0]
+
+dataset = io.Dataset(density_data.dtype, density_data.shape)
+density_d.reset_dataset(dataset)
+density_d.store_chunk(density_data)
+series.flush()
+
+del series

--- a/Examples/Tests/load_density/inputs_test_2d_load_density_prepare.py
+++ b/Examples/Tests/load_density/inputs_test_2d_load_density_prepare.py
@@ -47,4 +47,4 @@ density_d.reset_dataset(dataset)
 density_d.store_chunk(density_data)
 series.flush()
 
-del series
+series.close()

--- a/Regression/Checksum/benchmarks_json/test_1d_load_density.json
+++ b/Regression/Checksum/benchmarks_json/test_1d_load_density.json
@@ -1,0 +1,14 @@
+{
+  "lev=0": {
+    "rho": 4826557.10992499
+  },
+  "electrons": {
+    "particle_position_x": 0.0,
+    "particle_position_y": 0.0,
+    "particle_position_z": 0.012109375000000004,
+    "particle_momentum_x": 0.0,
+    "particle_momentum_y": 0.0,
+    "particle_momentum_z": 0.0,
+    "particle_weight": 9.687500000000003e+19
+  }
+}

--- a/Regression/Checksum/benchmarks_json/test_2d_load_density.json
+++ b/Regression/Checksum/benchmarks_json/test_2d_load_density.json
@@ -1,0 +1,14 @@
+{
+  "lev=0": {
+    "rho": 0.0
+  },
+  "electrons": {
+    "particle_position_x": 0.0,
+    "particle_position_y": 0.0,
+    "particle_position_z": 0.0,
+    "particle_momentum_x": 0.0,
+    "particle_momentum_y": 0.0,
+    "particle_momentum_z": 0.0,
+    "particle_weight": 0.0
+  }
+}

--- a/Regression/Checksum/benchmarks_json/test_2d_load_density.json
+++ b/Regression/Checksum/benchmarks_json/test_2d_load_density.json
@@ -1,14 +1,14 @@
 {
-  "lev=0": {
-    "rho": 0.0
-  },
   "electrons": {
-    "particle_position_x": 0.0,
-    "particle_position_y": 0.0,
-    "particle_position_z": 0.0,
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 0.0,
-    "particle_weight": 0.0
+    "particle_position_x": 0.05120000000000001,
+    "particle_position_y": 0.0,
+    "particle_position_z": 0.2879999999999999,
+    "particle_weight": 1.5203510239245906e+16
+  },
+  "lev=0": {
+    "rho": 219886168.58807635
   }
 }

--- a/Source/Initialization/InjectorDensity.H
+++ b/Source/Initialization/InjectorDensity.H
@@ -134,12 +134,12 @@ struct InjectorDensityFromFile
 #if (AMREX_SPACEDIM < 3)
         amrex::ignore_unused(x,y,z);
 #endif
-#if defined(WARPX_DIM_RZ)
-        return m_external_field_view(amrex::RealVect{x,z});
-#elif defined(WARPX_DIM_1D_Z)
+#if (AMREX_SPACEDIM == 1)
         return m_external_field_view(amrex::RealVect{z});
+#elif (AMREX_SPACEDIM == 2)
+        return m_external_field_view(amrex::RealVect{x,z});
 #else
-        return m_external_field_view(amrex::RealVect{AMREX_D_DECL(x,y,z)});
+        return m_external_field_view(amrex::RealVect{x,y,z});
 #endif
     }
 


### PR DESCRIPTION
This PR will add 1D, 2D and RZ CI tests to load density from .h5 file.
To do: 
 
- [x] 1D
- [ ] ~RZ~ (let us do a follow-up PR)
- [x] 2D: includes bug fix


