### PR TITLE
CI: edit permissions for autoupdate workflows

### DIFF
--- a/.github/workflows/monthly_release.yml
+++ b/.github/workflows/monthly_release.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 0 1 * *"  # every first day of the month at midnight
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   monthly_release:
     name: Monthly release

--- a/.github/workflows/weekly_update.yml
+++ b/.github/workflows/weekly_update.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 0 * * 1"  # every Monday at midnight
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   weekly_update:
     name: Weekly update


### PR DESCRIPTION
The newly added autoupdate workflow for the weekly update ran when scheduled as expected, but could not complete successfully because of permissions.

Here's the log of the workflow run: https://github.com/BLAST-WarpX/warpx/actions/runs/17195850637/job/48777718771.

Here's a screenshot of the error:
<img width="1967" height="728" alt="Screenshot from 2025-08-25 08-48-52" src="https://github.com/user-attachments/assets/8427b16d-a256-49cb-bdc2-0f6a5aa87f5a" />

I think it might be enough to set the following permissions:
```yaml
permissions:
  contents: write
  pull-requests: write
```

The full list would to choose from would be:
```yaml
permissions:
  actions: read|write|none
  attestations: read|write|none
  checks: read|write|none
  contents: read|write|none
  deployments: read|write|none
  id-token: write|none
  issues: read|write|none
  models: read|none
  discussions: read|write|none
  packages: read|write|none
  pages: read|write|none
  pull-requests: read|write|none
  security-events: read|write|none
  statuses: read|write|none
```

The documentation says that _"if you specify the access for any of these permissions, all of those that are not specified are set to `none`."_, so we will have to see if this fix is enough, or if we need to set all of them to specific values - to avoid `none`s where we don't want them.

Another alternative would be to set 
```yaml
permissions: write-all
```
for these workflows.

References from the documentation:
- https://docs.github.com/en/actions/tutorials/authenticate-with-github_token
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions 