### PR TITLE
CI: debug autoupdate workflows (GitHub Actions)

### DIFF
--- a/.github/workflows/clang_sanitizers.yml
+++ b/.github/workflows/clang_sanitizers.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "development"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-clangsanitizers

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "development"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-clangtidy

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "development" ]
   pull_request:
     branches: [ "development" ]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-codeql

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "development"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-cuda

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "development"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-hip

--- a/.github/workflows/insitu.yml
+++ b/.github/workflows/insitu.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "development"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-insituvis

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "development"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-intel

--- a/.github/workflows/jupyter.yml
+++ b/.github/workflows/jupyter.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "development"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-jupyter

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "development"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-macos

--- a/.github/workflows/monthly_release.yml
+++ b/.github/workflows/monthly_release.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Open pull request
         run: |
           gh pr create \
+            --draft \
             --base development \
             --body "Automated via .github/workflows/monthly_release.yml." \
             --label "component: third party" \

--- a/.github/workflows/monthly_release.yml
+++ b/.github/workflows/monthly_release.yml
@@ -5,7 +5,9 @@ on:
     - cron: "0 0 1 * *"  # every first day of the month at midnight
   workflow_dispatch:
 
-permissions: write-all
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   autoupdate:

--- a/.github/workflows/monthly_release.yml
+++ b/.github/workflows/monthly_release.yml
@@ -1,17 +1,15 @@
-name: Autoupdate
+name: Monthly release
 
 on:
   schedule:
     - cron: "0 0 1 * *"  # every first day of the month at midnight
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: write-all
 
 jobs:
-  monthly_release:
-    name: Monthly release
+  autoupdate:
+    name: Autoupdate
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -37,7 +35,7 @@ jobs:
           git commit -m "Update dependencies.json"
       - name: Push changes
         run: |
-          git push -u origin monthly_release
+          git push -f origin monthly_release
       - name: Open pull request
         run: |
           gh pr create \

--- a/.github/workflows/petsc.yml
+++ b/.github/workflows/petsc.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "development"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-petsc

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - "development"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-source

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "development"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-ubuntu

--- a/.github/workflows/weekly_update.yml
+++ b/.github/workflows/weekly_update.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Open pull request
         run: |
           gh pr create \
+            --draft \
             --base development \
             --body "Automated via .github/workflows/weekly_update.yml." \
             --label "component: third party" \

--- a/.github/workflows/weekly_update.yml
+++ b/.github/workflows/weekly_update.yml
@@ -1,17 +1,15 @@
-name: Autoupdate
+name: Weekly update
 
 on:
   schedule:
     - cron: "0 0 * * 1"  # every Monday at midnight
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: write-all
 
 jobs:
-  weekly_update:
-    name: Weekly update
+  autoupdate:
+    name: Autoupdate
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -34,7 +32,7 @@ jobs:
           git commit -m "Update dependencies.json"
       - name: Push changes
         run: |
-          git push -u origin weekly_update
+          git push -f origin weekly_update
       - name: Open pull request
         run: |
           gh pr create \

--- a/.github/workflows/weekly_update.yml
+++ b/.github/workflows/weekly_update.yml
@@ -5,7 +5,9 @@ on:
     - cron: "0 0 * * 1"  # every Monday at midnight
   workflow_dispatch:
 
-permissions: write-all
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   autoupdate:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "development"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-windows


### PR DESCRIPTION
Debugging the weekly autoupdate workflow, ~trying `permissions: write-all` this time.~ 

Also in this PR:
- Renamed the workflows to avoid duplication of the "Autoupdate" label.
- Replaced `git push -u ...` with `git push -f ...` to force push when necessary.
- Added `--draft` flag to the `gh pr create` command to create a draft pull request and work around the CI issue.
- Added activity types to the `pull_request` trigger event for all regular workflows to include `ready_for_review`.

See https://github.com/BLAST-WarpX/warpx/pull/6115#issuecomment-3225928638 and references therein for more details on the last two points.