### PR TITLE
Add CI load density RZ

### DIFF
--- a/Examples/Tests/load_density/CMakeLists.txt
+++ b/Examples/Tests/load_density/CMakeLists.txt
@@ -60,3 +60,23 @@ add_warpx_test(
     "analysis_default_regression.py --path diags/diag/"   # checksum
     test_3d_load_density_prepare  # dependency
 )
+
+add_warpx_test(
+    test_rz_load_density_prepare  # name
+    RZ  # dims
+    1  # nprocs
+    inputs_test_rz_load_density_prepare.py  # inputs
+    OFF  # analysis
+    OFF  # checksum
+    OFF  # dependency
+)
+
+add_warpx_test(
+    test_rz_load_density  # name
+    RZ  # dims
+    1  # nprocs
+    inputs_test_rz_load_density  # inputs
+    "analysis_rz.py"  # analysis
+    "analysis_default_regression.py --path diags/diag/"   # checksum
+    test_rz_load_density_prepare  # dependency
+)

--- a/Examples/Tests/load_density/analysis_rz.py
+++ b/Examples/Tests/load_density/analysis_rz.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 Remi Lehe
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+# This tests the loading of the plasma density from a file.
+# An openPMD file is created, containing a density corresponding to
+# a plasma channel (parabolic in r and linear ramp in z followed by a plateau)
+# This file checks that the density of the particles that are injected in the simulation
+# (including continuous injection by a moving window) corresponds to the expected density.
+
+import numpy as np
+from openpmd_viewer import OpenPMDTimeSeries
+from scipy.constants import e
+
+ts = OpenPMDTimeSeries("./diags/diag")
+
+# Loop over all iterations, so that we test loading of the density
+# as the moving window moves.
+for iteration in ts.iterations:
+    rho, info = ts.get_field("rho", iteration=iteration)
+    density_sim = -rho / e
+
+    # Compute expected density
+    on_axis_density = 1e24  # m^-3
+    channel_radius = 40e-6  # m
+    ramp_length = 60e-6  # m
+    z, r = np.meshgrid(info.z, info.r, indexing="ij")
+    density_th = (
+        on_axis_density
+        * (1 + r**2 / channel_radius**2)
+        * np.where(z < ramp_length, z / ramp_length, 1)
+    )
+    density_th[z < 0] = 0
+
+    # Do not check the 3 first cells and 3 last cells,
+    # as this is affected by the edges of the domain
+    assert np.all(
+        abs(density_th[3:-3, 3:-3] - density_sim[3:-3, 3:-3])
+        / abs(density_th[3:-3, 3:-3]).max()
+        < 0.03
+    )

--- a/Examples/Tests/load_density/inputs_test_rz_load_density
+++ b/Examples/Tests/load_density/inputs_test_rz_load_density
@@ -1,0 +1,52 @@
+#################################
+####### GENERAL PARAMETERS ######
+#################################
+max_step = 64
+amr.n_cell = 32 64
+amr.max_grid_size = 16
+amr.blocking_factor = 16
+amr.max_level = 0
+geometry.dims = RZ
+warpx.n_rz_azimuthal_modes = 1
+geometry.prob_lo =  0.e-6   -50.e-6    # physical domain
+geometry.prob_hi =  50.e-6    50.e-6
+
+#################################
+####### Boundary condition ######
+#################################
+boundary.field_lo = none pec
+boundary.field_hi = pec pec
+
+#################################
+############ NUMERICS ###########
+#################################
+warpx.serialize_initial_conditions = 1
+warpx.verbose = 1
+warpx.cfl = 1.0
+
+# Order of particle shape factors
+algo.particle_shape = 1
+
+# Moving window
+warpx.do_moving_window = 1
+warpx.moving_window_dir = z
+warpx.moving_window_v = 1
+
+#################################
+############ PLASMA #############
+#################################
+particles.species_names = electrons
+
+electrons.species_type = electron
+electrons.injection_style = "NUniformPerCell"
+electrons.num_particles_per_cell_each_dim = 2 2 2
+electrons.profile = "read_from_file"
+electrons.read_density_from_path = "../test_rz_load_density_prepare/example-density.h5"
+electrons.momentum_distribution_type = "at_rest"
+electrons.do_continuous_injection = 1
+# Diagnostics
+diagnostics.diags_names = diag
+diag.intervals = 5
+diag.diag_type = Full
+diag.fields_to_plot = rho
+diag.format = openpmd

--- a/Examples/Tests/load_density/inputs_test_rz_load_density_prepare.py
+++ b/Examples/Tests/load_density/inputs_test_rz_load_density_prepare.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+Create an openPMD file containing the density with which
+the WarpX particles should be initialized (on a 2D axisymmetric (RZ) grid)
+"""
+
+import numpy as np
+import openpmd_api as io
+
+# Define density as a function of r, z, using numpy syntax
+# parabolic channel in r, with a ramp and plateau in z
+on_axis_density = 1e24  # m^-3
+channel_radius = 40e-6  # m
+ramp_length = 60e-6  # m
+# - Define the grid
+num_nodes = 1
+nr = 200
+nz = 200
+r_1d = np.linspace(0, 50e-6, nr)
+z_1d = np.linspace(0, 500e-6, nz)
+r, z = np.meshgrid(r_1d, z_1d, indexing="ij")
+# - Define density as a function of r, z
+density_data = (
+    on_axis_density
+    * (1 + r**2 / channel_radius**2)
+    * np.where(z < ramp_length, z / ramp_length, 1)
+).reshape(num_nodes, nr, nz)
+
+# create openpmd file
+series = io.Series("example-density.h5", io.Access.create)
+# only 1 iteration needed
+it = series.iterations[1]
+# set meta information
+density = it.meshes["density"]
+density.grid_spacing = np.array([r_1d[1] - r_1d[0], z_1d[1] - z_1d[0]])
+density.grid_global_offset = [r_1d.min(), z_1d.min()]
+density.axis_labels = ["r", "z"]
+density.geometry = io.Geometry.thetaMode
+density.unit_dimension = {
+    io.Unit_Dimension.L: -3,
+}
+
+# label
+density_d = density[io.Mesh_Record_Component.SCALAR]
+density_d.position = [0, 0, 0]
+
+dataset = io.Dataset(density_data.dtype, density_data.shape)
+density_d.reset_dataset(dataset)
+density_d.store_chunk(density_data)
+series.flush()
+
+del series

--- a/Regression/Checksum/benchmarks_json/test_rz_load_density.json
+++ b/Regression/Checksum/benchmarks_json/test_rz_load_density.json
@@ -1,0 +1,14 @@
+{
+  "electrons": {
+    "particle_momentum_x": 0.0,
+    "particle_momentum_y": 0.0,
+    "particle_momentum_z": 0.0,
+    "particle_position_x": 0.26048217220846437,
+    "particle_position_y": 0.2611845809741635,
+    "particle_position_z": 1.1008000000000004,
+    "particle_weight": 1185170529304.9824
+  },
+  "lev=0": {
+    "rho": 830836991.2464554
+  }
+}

--- a/Regression/Checksum/benchmarks_json/test_rz_load_density.json
+++ b/Regression/Checksum/benchmarks_json/test_rz_load_density.json
@@ -1,14 +1,14 @@
 {
+  "lev=0": {
+    "rho": 830836991.2464554
+  },
   "electrons": {
+    "particle_position_x": 0.2607198189947113,
+    "particle_position_y": 0.26085137477508324,
+    "particle_position_z": 1.1008000000000004,
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 0.0,
-    "particle_position_x": 0.26048217220846437,
-    "particle_position_y": 0.2611845809741635,
-    "particle_position_z": 1.1008000000000004,
     "particle_weight": 1185170529304.9824
-  },
-  "lev=0": {
-    "rho": 830836991.2464554
   }
 }

--- a/Source/Initialization/InjectorDensity.H
+++ b/Source/Initialization/InjectorDensity.H
@@ -134,7 +134,7 @@ struct InjectorDensityFromFile
 #if (AMREX_SPACEDIM < 3)
         amrex::ignore_unused(x,y,z);
 #endif
-#if defined(WARPX_DIM_1D_Z)
+#if (AMREX_SPACEDIM == 1)
         return m_external_field_view(amrex::RealVect{z});
 #elif defined(WARPX_DIM_RZ)
         return m_external_field_view(amrex::RealVect{std::sqrt(x*x+y*y),z});

--- a/Source/Initialization/InjectorDensity.H
+++ b/Source/Initialization/InjectorDensity.H
@@ -136,6 +136,8 @@ struct InjectorDensityFromFile
 #endif
 #if (AMREX_SPACEDIM == 1)
         return m_external_field_view(amrex::RealVect{z});
+#elif defined(WARPX_DIM_RZ)
+        return m_external_field_view(amrex::RealVect{std::sqrt(x*x+y*y),z});
 #elif (AMREX_SPACEDIM == 2)
         return m_external_field_view(amrex::RealVect{x,z});
 #else

--- a/Source/Initialization/InjectorDensity.H
+++ b/Source/Initialization/InjectorDensity.H
@@ -134,11 +134,11 @@ struct InjectorDensityFromFile
 #if (AMREX_SPACEDIM < 3)
         amrex::ignore_unused(x,y,z);
 #endif
-#if (AMREX_SPACEDIM == 1)
+#if defined(WARPX_DIM_1D_Z)
         return m_external_field_view(amrex::RealVect{z});
 #elif defined(WARPX_DIM_RZ)
         return m_external_field_view(amrex::RealVect{std::sqrt(x*x+y*y),z});
-#elif (AMREX_SPACEDIM == 2)
+#elif defined(WARPX_DIM_XZ)
         return m_external_field_view(amrex::RealVect{x,z});
 #else
         return m_external_field_view(amrex::RealVect{x,y,z});


### PR DESCRIPTION
As a continuation of [6106](https://github.com/BLAST-WarpX/warpx/pull/6106), this PR adds RZ CI test to load density from a .h5 file with @RemiLehe .
To do:
- [x] RZ