### PR TITLE
Dependencies: weekly update

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,9 +1,9 @@
 {
-    "version_warpx": "25.08",
+    "version_warpx": "25.09",
     "version_amrex": "25.08",
     "version_pyamrex": "25.08",
     "version_picsar": "25.06",
-    "commit_amrex": "d44e9269444cc15978b14e7e0165a5b855338393",
-    "commit_pyamrex": "4544ca06a294b3d0484dd6a110bd8ed596dca382",
+    "commit_amrex": "5d1b6c2bdec3498971fa4a00788e4bab3aeaaac2",
+    "commit_pyamrex": "d5bdd1b464559cc1c172d98c96d72fbb4b3be62c",
     "commit_picsar": "0c329e66010267662a82219f7de7abbd231463f4"
 }


### PR DESCRIPTION
Manual update automated via [Tools/Release/update_dependencies.py](https://github.com/BLAST-WarpX/warpx/blob/development/Tools/Release/update_dependencies.py), until we wait for #6122 to fix the autoupdate workflows.