### PR TITLE
Fix --skip-fields behavior when running default regression test

### DIFF
--- a/Regression/Checksum/checksum.py
+++ b/Regression/Checksum/checksum.py
@@ -140,13 +140,13 @@ class Checksum:
             # Load time series
             ts = OpenPMDTimeSeries(self.output_file)
             data = {}
-            # Compute number of MR levels
-            # TODO This calculation of nlevels assumes that the last element
-            #      of level_fields is by default on the highest MR level.
-            level_fields = [field for field in ts.avail_fields if "lvl" in field]
-            nlevels = 0 if level_fields == [] else int(level_fields[-1][-1])
             # Compute checksum for field quantities
             if do_fields:
+                # Compute number of MR levels
+                # TODO This calculation of nlevels assumes that the last element
+                #      of level_fields is by default on the highest MR level.
+                level_fields = [field for field in ts.avail_fields if "lvl" in field]
+                nlevels = 0 if level_fields == [] else int(level_fields[-1][-1])
                 for lev in range(nlevels + 1):
                     # Create list of fields specific to level lev
                     grid_fields = []


### PR DESCRIPTION
Fixes this type of tests 
`analysis_default_regression.py --path  <path> --skip-fields`
by grabbing the number of levels in the fields only if `do_fields=True`, 
otherwise it fails. 