### PR TITLE
FlushFormat int comp writing

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -237,7 +237,7 @@ FlushFormatCheckpoint::CheckpointParticles (
         write_int_comps.resize(pc->NumIntComps());
         //   note: inames and h_redistribute_int_comp are note the same size
         auto inames = pc->GetIntSoANames();
-        std::size_t const i0_redist = pc->h_redistribute_int_comp.size() - pc->NumIntComps();
+        std::size_t const i0_redist = pc->h_redistribute_int_comp.size() - inames.size();
         for (std::size_t index = 0; index < inames.size(); ++index) {
             int_names[index] = inames[index];
             write_int_comps[index] = pc->h_redistribute_int_comp[i0_redist + index];

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -235,8 +235,7 @@ FlushFormatCheckpoint::CheckpointParticles (
         // and the int comps
         int_names.resize(pc->NumIntComps());
         write_int_comps.resize(pc->NumIntComps());
-
-        // inames and pc->h_redistribute_int_comp are note the same size
+        //   note: inames and h_redistribute_int_comp are note the same size
         auto inames = pc->GetIntSoANames();
         std::size_t const i0_redist = pc->h_redistribute_int_comp.size() - pc->NumIntComps();
         for (std::size_t index = 0; index < inames.size(); ++index) {

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -238,10 +238,10 @@ FlushFormatCheckpoint::CheckpointParticles (
 
         // inames and pc->h_redistribute_int_comp are note the same size
         auto inames = pc->GetIntSoANames();
-        std::size_t const index_start = pc->h_redistribute_int_comp.size() - pc->NumIntComps();
-        for (std::size_t i = 0; i < inames.size(); ++i) {
-            int_names[i] = inames[i];
-            write_int_comps[i] = pc->h_redistribute_int_comp[index_start + i];
+        std::size_t const i0_redist = pc->h_redistribute_int_comp.size() - pc->NumIntComps();
+        for (std::size_t index = 0; index < inames.size(); ++index) {
+            int_names[index] = inames[index];
+            write_int_comps[index] = pc->h_redistribute_int_comp[i0_redist + index];
         }
 
         pc->Checkpoint(dir, part_diag.getSpeciesName(),

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -235,7 +235,7 @@ FlushFormatCheckpoint::CheckpointParticles (
         // and the int comps
         int_names.resize(pc->NumIntComps());
         write_int_comps.resize(pc->NumIntComps());
-        //   note: inames and h_redistribute_int_comp are note the same size
+        //   note: inames and h_redistribute_int_comp are not the same size
         auto inames = pc->GetIntSoANames();
         std::size_t const i0_redist = pc->h_redistribute_int_comp.size() - inames.size();
         for (std::size_t index = 0; index < inames.size(); ++index) {

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -235,10 +235,13 @@ FlushFormatCheckpoint::CheckpointParticles (
         // and the int comps
         int_names.resize(pc->NumIntComps());
         write_int_comps.resize(pc->NumIntComps());
+
+        // inames and pc->h_redistribute_int_comp are note the same size
         auto inames = pc->GetIntSoANames();
-        for (std::size_t index = 0; index < inames.size(); ++index) {
-            int_names[index] = inames[index];
-            write_int_comps[index] = pc->h_redistribute_int_comp[index];
+        std::size_t const index_start = pc->h_redistribute_int_comp.size() - pc->NumIntComps();
+        for (std::size_t i = 0; i < inames.size(); ++i) {
+            int_names[i] = inames[i];
+            write_int_comps[i] = pc->h_redistribute_int_comp[index_start + i];
         }
 
         pc->Checkpoint(dir, part_diag.getSpeciesName(),

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -410,9 +410,10 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
         int_names.resize(tmp.NumIntComps());
         int_flags.resize(tmp.NumIntComps());
         auto inames = tmp.GetIntSoANames();
+        std::size_t const i0_redist = tmp.h_redistribute_int_comp.size() - tmp.NumIntComps();
         for (std::size_t index = 0; index < inames.size(); ++index) {
             int_names[index] = inames[index];
-            int_flags[index] = tmp.h_redistribute_int_comp[index];
+            int_flags[index] = tmp.h_redistribute_int_comp[i0_redist + index];
         }
 
         const auto mass = pc->AmIA<PhysicalSpecies::photon>() ? PhysConst::m_e : pc->getMass();

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -409,6 +409,7 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
         // and the int comps
         int_names.resize(tmp.NumIntComps());
         int_flags.resize(tmp.NumIntComps());
+        //   note: inames and h_redistribute_int_comp are note the same size
         auto inames = tmp.GetIntSoANames();
         std::size_t const i0_redist = tmp.h_redistribute_int_comp.size() - tmp.NumIntComps();
         for (std::size_t index = 0; index < inames.size(); ++index) {

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -411,7 +411,7 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
         int_flags.resize(tmp.NumIntComps());
         //   note: inames and h_redistribute_int_comp are note the same size
         auto inames = tmp.GetIntSoANames();
-        std::size_t const i0_redist = tmp.h_redistribute_int_comp.size() - tmp.NumIntComps();
+        std::size_t const i0_redist = tmp.h_redistribute_int_comp.size() - inames.size();
         for (std::size_t index = 0; index < inames.size(); ++index) {
             int_names[index] = inames[index];
             int_flags[index] = tmp.h_redistribute_int_comp[i0_redist + index];

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -409,7 +409,7 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
         // and the int comps
         int_names.resize(tmp.NumIntComps());
         int_flags.resize(tmp.NumIntComps());
-        //   note: inames and h_redistribute_int_comp are note the same size
+        //   note: inames and h_redistribute_int_comp are not the same size
         auto inames = tmp.GetIntSoANames();
         std::size_t const i0_redist = tmp.h_redistribute_int_comp.size() - inames.size();
         for (std::size_t index = 0; index < inames.size(); ++index) {


### PR DESCRIPTION
This PR fixes an indexing bug related to writing integer components of particles in WarpX. 

This PR fixes a bug in PR #5969, where an integer value is added to the particle container at runtime and an error occurs on restarts.