### PR TITLE
Documentation: update in adastra documentation

### DIFF
--- a/Docs/source/install/hpc/adastra.rst
+++ b/Docs/source/install/hpc/adastra.rst
@@ -214,8 +214,6 @@ Known System Issues
 .. warning::
 
    April 30th, 2025:
-   We observed several unidentified issues that can cause WarpX simulations to hang or crash:
-   - Releases ``25.03`` and above lead to a segmentation fault error
-   - Release ``25.02`` will hang when writing particles diagnostics
-
-   Releases ``25.01`` and below are currently working.
+   We observed several issues that can cause WarpX simulations to hang or crash on releases ``25.02`` and ``25.03``.
+   
+   Releases ``<=25.01`` and ``>=25.04`` are currently working.

--- a/Docs/source/install/hpc/adastra.rst
+++ b/Docs/source/install/hpc/adastra.rst
@@ -221,7 +221,7 @@ Known System Issues
 .. warning::
 
    August 2025:
-   We oberved a heavy node memory increase over time when using module ``cray-mpich`` versions ``8.1.28`` and ``8.1.30``, which
+   We observed a heavy node memory increase over time when using module ``cray-mpich`` versions ``8.1.28`` and ``8.1.30``, which
    causes simulations to slow down and eventually crash.
 
    While no ``cray-mpich`` version ``>8.1.30`` is available on Adastra, stay with version ``8.1.26`` to avoid this issue.

--- a/Docs/source/install/hpc/adastra.rst
+++ b/Docs/source/install/hpc/adastra.rst
@@ -222,6 +222,6 @@ Known System Issues
 
    August 2025:
    We oberved a heavy node memory increase over time when using module ``cray-mpich`` versions ``8.1.28`` and ``8.1.30``, which
-   causes simulations to slow down and eventually crash. 
+   causes simulations to slow down and eventually crash.
 
-   While no ``cray-mpich`` version ``>8.1.30`` is available on Adastra, stay with version ``8.1.26`` to avoid this issue. 
+   While no ``cray-mpich`` version ``>8.1.30`` is available on Adastra, stay with version ``8.1.26`` to avoid this issue.

--- a/Docs/source/install/hpc/adastra.rst
+++ b/Docs/source/install/hpc/adastra.rst
@@ -215,5 +215,13 @@ Known System Issues
 
    April 30th, 2025:
    We observed several issues that can cause WarpX simulations to hang or crash on releases ``25.02`` and ``25.03``.
-   
+
    Releases ``<=25.01`` and ``>=25.04`` are currently working.
+
+.. warning::
+
+   August 2025:
+   We oberved a heavy node memory increase over time when using module ``cray-mpich`` versions ``8.1.28`` and ``8.1.30``, which
+   causes simulations to slow down and eventually crash. 
+
+   While no ``cray-mpich`` version ``>8.1.30`` is available on Adastra, stay with version ``8.1.26`` to avoid this issue. 

--- a/Tools/machines/adastra-cines/submit.sh
+++ b/Tools/machines/adastra-cines/submit.sh
@@ -18,6 +18,14 @@ module load PrgEnv-cray
 # Some architecture related libraries and tools
 module load develop
 module load CCE-GPU-4.0.0
+# AMD related libraries 
+module load rocm/6.1.2
+module load amd-mixed/6.1.2
+# note
+# cray-mpich versions 8.1.28 and 8.1.30 have known issues
+# that cause node memory increase over time which leads 
+# to slowdown and out-of-memory crashes.
+module load cray-mpich/8.1.26
 
 date
 module list

--- a/Tools/machines/adastra-cines/submit.sh
+++ b/Tools/machines/adastra-cines/submit.sh
@@ -18,12 +18,12 @@ module load PrgEnv-cray
 # Some architecture related libraries and tools
 module load develop
 module load CCE-GPU-4.0.0
-# AMD related libraries 
+# AMD related libraries
 module load rocm/6.1.2
 module load amd-mixed/6.1.2
 # note
 # cray-mpich versions 8.1.28 and 8.1.30 have known issues
-# that cause node memory increase over time which leads 
+# that cause node memory increase over time which leads
 # to slowdown and out-of-memory crashes.
 module load cray-mpich/8.1.26
 


### PR DESCRIPTION
This PR updates the documentation for the Adastra HPC :

- updated known issue on warpx crashing to reflect that this issue is solved on the last versions
- added known issue regarding an increase in node memory usage which slows and can crash simulations due to `cray-mpich` versions `8.1.28` and `8.1.30`
- updated the job submit script to avoid those versions