### PR TITLE
CI: workaround for macOS issue

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -47,6 +47,7 @@ jobs:
         brew install pkg-config
         set -e
         brew tap openpmd/openpmd
+        brew uninstall cmake  # https://github.com/actions/runner-images/issues/12912
         brew install openpmd-api
     - name: install pip dependencies
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -70,7 +70,7 @@ jobs:
         export CCACHE_SLOPPINESS=time_macros
         ccache -z
 
-        export CXXFLAGS="-Werror -Wno-error=pass-failed"
+        export CXXFLAGS="-Werror -Wno-error=pass-failed -Wno-error=c++23-attribute-extensions"
 
         cmake -S . -B build_dp         \
           -DCMAKE_VERBOSE_MAKEFILE=ON  \


### PR DESCRIPTION
Workaround for https://github.com/actions/runner-images/issues/12912 to avoid the following error:
```
Error: cmake is already installed from local/pinned!
Please `brew uninstall cmake` first."
```