### PR TITLE
Update picmi.py

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -1855,7 +1855,7 @@ class HybridPICSolver(picmistandard.base._ClassWithInit):
     n0: float
         Reference plasma density in m^-3.
 
-    gamma: float, default=3/2
+    gamma: float, default=5/3
         Exponent in calculation of electron pressure.
 
     n_floor: float, optional


### PR DESCRIPTION
The default value for gamma should be changed from 3/2 to 5/3 for the adiabatic index of an ideal gas.