### PR TITLE
Speedup MultiFab registry

### DIFF
--- a/Source/ablastr/fields/MultiFabRegister.H
+++ b/Source/ablastr/fields/MultiFabRegister.H
@@ -35,6 +35,8 @@ namespace
     template <typename T>
     struct is_castable_to_string<T, std::void_t<decltype(static_cast<std::string>(std::declval<T>()))>> : std::true_type {};
 
+    std::map<int, std::string> name_map;
+
     /** helper to either cast a string/char array to string to query an AMREX_ENUM */
     template<typename T>
     std::string getExtractedName (T name)
@@ -45,8 +47,19 @@ namespace
             return std::string(name);
         } else
         {
-            // user-defined AMREX_ENUM or compile error
-            return amrex::getEnumNameString(name);
+            // Check if the string name had already been generated.
+            // If so, return that, otherwise generate it.
+            // The generated names are cached in the map since the
+            // generation of the string name (getEnumNameString) can be relatively slow.
+            int k = static_cast<int>(name);
+            if (name_map.count(k) > 0) {
+                return name_map.at(k);
+            } else {
+                // user-defined AMREX_ENUM or compile error
+                std::string v = amrex::getEnumNameString(name);
+                name_map.emplace(k, v);
+                return v;
+            }
         }
     }
 }

--- a/Source/ablastr/fields/MultiFabRegister.H
+++ b/Source/ablastr/fields/MultiFabRegister.H
@@ -35,7 +35,7 @@ namespace
     template <typename T>
     struct is_castable_to_string<T, std::void_t<decltype(static_cast<std::string>(std::declval<T>()))>> : std::true_type {};
 
-    std::map<int, std::string> name_map;
+    std::map<int, std::string> name_cache;
 
     /** helper to either cast a string/char array to string to query an AMREX_ENUM */
     template<typename T>
@@ -52,12 +52,12 @@ namespace
             // The generated names are cached in the map since the
             // generation of the string name (getEnumNameString) can be relatively slow.
             int k = static_cast<int>(name);
-            if (name_map.count(k) > 0) {
-                return name_map.at(k);
+            if (name_cache.count(k) > 0) {
+                return name_cache.at(k);
             } else {
                 // user-defined AMREX_ENUM or compile error
                 std::string v = amrex::getEnumNameString(name);
-                name_map.emplace(k, v);
+                name_cache.emplace(k, v);
                 return v;
             }
         }


### PR DESCRIPTION
This PR is a possible solution to speed up the MultiFab registry, when getting MultiFabs.

Most MultiFabs in WarpX are specified by the enum FieldType, and when the MultiFab is fetched (using `get`), the enum is converted to a string since the MultiFab map keys are strings. This conversion is done using the `amrex::getEnumNameString` routine. That routine then internally calls `amrex::getEnumNameValuePairs` which generates a vector of the name, value pairs for whole enum type. Then `getEnumNameString` returns the one name requested. This means that every time a `get` is done, the whole name, value vector for the enum is generated.

The `FieldType` enum has 67 values, so creating that vector is somewhat expensive. For 2D and 3D, this time is not significant, but for 1D it can be. In a test case, this was taking up about half of the run time (since it was done almost 30 million times).

There are two relatively simple solutions. The first is to not use the `FieldType` enum, but always use strings for the MultiFabs. A second solution is to cache the names. This PR shows what that might look like.

This cache is not perfect. This assumes that the int values of each of the enums is unique. This is true in WarpX, but some other code could break this (by using more than one enum type for the MultiFabs for example).