### PR TITLE
Docs: Fix HTTP Error 403

### DIFF
--- a/Docs/source/conf.py
+++ b/Docs/source/conf.py
@@ -39,6 +39,19 @@ module_path = os.path.dirname(os.path.abspath(__file__))
 checksum_path = os.path.join(module_path, "../../Regression/Checksum")
 sys.path.insert(0, checksum_path)
 
+
+def download_with_headers(url, filename):
+    """Download a file with proper User-Agent header to avoid 403 errors."""
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "WarpX-docs-builder"})
+        with urllib.request.urlopen(req) as response:
+            with open(filename, "wb") as f:
+                f.write(response.read())
+    except Exception as e:
+        print(f"Could not download {filename} from {url}: {e}")
+        print("Continuing build without cross-reference file...")
+
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -243,11 +256,14 @@ primary_domain = "cpp"
 highlight_language = "cpp"
 
 # Download AMReX & openPMD-api Doxygen Tagfile to interlink Doxygen docs
-url = "https://amrex-codes.github.io/amrex/docs_xml/doxygen/amrex-doxygen-web.tag.xml"
-urllib.request.urlretrieve(url, "../amrex-doxygen-web.tag.xml")
-
-url = "https://openpmd-api.readthedocs.io/en/latest/_static/doxyhtml/openpmd-api-doxygen-web.tag.xml"
-urllib.request.urlretrieve(url, "../openpmd-api-doxygen-web.tag.xml")
+download_with_headers(
+    url="https://amrex-codes.github.io/amrex/docs_xml/doxygen/amrex-doxygen-web.tag.xml",
+    filename="../amrex-doxygen-web.tag.xml",
+)
+download_with_headers(
+    url="https://openpmd-api.readthedocs.io/en/latest/_static/doxyhtml/openpmd-api-doxygen-web.tag.xml",
+    filename="../openpmd-api-doxygen-web.tag.xml",
+)
 
 # Build Doxygen
 subprocess.call(


### PR DESCRIPTION
Fix Read the Docs build error:
```
python -m sphinx -T -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html  
Running Sphinx v7.1.2
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/site-packages/sphinx/config.py", line 356, in eval_config_file
    exec(code, namespace)  # NoQA: S102
    ~~~~^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/checkouts/latest/Docs/source/conf.py", line 250, in <module>
    urllib.request.urlretrieve(url, "../openpmd-api-doxygen-web.tag.xml")
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/urllib/request.py", line 214, in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
                            ~~~~~~~^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/urllib/request.py", line 189, in urlopen
    return opener.open(url, data, timeout)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/urllib/request.py", line 495, in open
    response = meth(req, response)
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/urllib/request.py", line 604, in http_response
    response = self.parent.error(
        'http', request, response, code, msg, hdrs)
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/urllib/request.py", line 533, in error
    return self._call_chain(*args)
           ~~~~~~~~~~~~~~~~^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/urllib/request.py", line 466, in _call_chain
    result = func(*args)
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/urllib/request.py", line 613, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 403: Forbidden
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/site-packages/sphinx/cmd/build.py", line 285, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
                 args.doctreedir, args.builder, args.confoverrides, args.status,
                 args.warning, args.freshenv, args.warningiserror,
                 args.tags, args.verbosity, args.jobs, args.keep_going,
                 args.pdb)
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/site-packages/sphinx/application.py", line 207, in __init__
    self.config = Config.read(self.confdir, confoverrides or {}, self.tags)
                  ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/site-packages/sphinx/config.py", line 179, in read
    namespace = eval_config_file(filename, tags)
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/site-packages/sphinx/config.py", line 369, in eval_config_file
    raise ConfigError(msg % traceback.format_exc()) from exc
sphinx.errors.ConfigError: There is a programmable error in your configuration file:
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/site-packages/sphinx/config.py", line 356, in eval_config_file
    exec(code, namespace)  # NoQA: S102
    ~~~~^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/checkouts/latest/Docs/source/conf.py", line 250, in <module>
    urllib.request.urlretrieve(url, "../openpmd-api-doxygen-web.tag.xml")
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/urllib/request.py", line 214, in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
                            ~~~~~~~^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/urllib/request.py", line 189, in urlopen
    return opener.open(url, data, timeout)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/urllib/request.py", line 495, in open
    response = meth(req, response)
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/urllib/request.py", line 604, in http_response
    response = self.parent.error(
        'http', request, response, code, msg, hdrs)
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/urllib/request.py", line 533, in error
    return self._call_chain(*args)
           ~~~~~~~~~~~~~~~~^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/urllib/request.py", line 466, in _call_chain
    result = func(*args)
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/urllib/request.py", line 613, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 403: Forbidden
Configuration error:
There is a programmable error in your configuration file:
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/site-packages/sphinx/config.py", line 356, in eval_config_file
    exec(code, namespace)  # NoQA: S102
    ~~~~^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/checkouts/latest/Docs/source/conf.py", line 250, in <module>
    urllib.request.urlretrieve(url, "../openpmd-api-doxygen-web.tag.xml")
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/urllib/request.py", line 214, in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
                            ~~~~~~~^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/urllib/request.py", line 189, in urlopen
    return opener.open(url, data, timeout)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/urllib/request.py", line 495, in open
    response = meth(req, response)
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/urllib/request.py", line 604, in http_response
    response = self.parent.error(
        'http', request, response, code, msg, hdrs)
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/urllib/request.py", line 533, in error
    return self._call_chain(*args)
           ~~~~~~~~~~~~~~~~^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/urllib/request.py", line 466, in _call_chain
    result = func(*args)
  File "/home/docs/checkouts/readthedocs.org/user_builds/warpx/conda/latest/lib/python3.13/urllib/request.py", line 613, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 403: Forbidden
```

It may be that Read the Docs is now blocking requests with no User-Agent header (which is urllib's default).