### PR TITLE
Change y to z in WarpX 2D examples

### DIFF
--- a/Examples/Tests/collision/inputs_test_2d_collision_xz_picmi.py
+++ b/Examples/Tests/collision/inputs_test_2d_collision_xz_picmi.py
@@ -17,12 +17,12 @@ max_steps = 150
 max_grid_size = 8
 max_level = 0
 nx = max_grid_size
-ny = max_grid_size
+nz = max_grid_size
 
 xmin = 0
 xmax = 4.154046151855669e2
-ymin = xmin
-ymax = xmax
+zmin = xmin
+zmax = xmax
 
 plasma_density = 1e21
 elec_rms_velocity = 0.044237441120300 * constants.c
@@ -88,11 +88,11 @@ collision3 = picmi.CoulombCollisions(
 #################################
 
 grid = picmi.Cartesian2DGrid(
-    number_of_cells=[nx, ny],
+    number_of_cells=[nx, nz],
     warpx_max_grid_size=max_grid_size,
     warpx_blocking_factor=max_grid_size,
-    lower_bound=[xmin, ymin],
-    upper_bound=[xmax, ymax],
+    lower_bound=[xmin, zmin],
+    upper_bound=[xmax, zmax],
     lower_boundary_conditions=["periodic", "periodic"],
     upper_boundary_conditions=["periodic", "periodic"],
 )

--- a/Examples/Tests/electrostatic_dirichlet_bc/inputs_test_2d_dirichlet_bc_picmi.py
+++ b/Examples/Tests/electrostatic_dirichlet_bc/inputs_test_2d_dirichlet_bc_picmi.py
@@ -23,12 +23,12 @@ max_steps = 100
 # --- grid
 
 nx = 64
-ny = 8
+nz = 8
 
 xmin = 0
 xmax = 0.032
-ymin = 0
-ymax = 0.004
+zmin = 0
+zmax = 0.004
 
 
 ##########################
@@ -36,9 +36,9 @@ ymax = 0.004
 ##########################
 
 grid = picmi.Cartesian2DGrid(
-    number_of_cells=[nx, ny],
-    lower_bound=[xmin, ymin],
-    upper_bound=[xmax, ymax],
+    number_of_cells=[nx, nz],
+    lower_bound=[xmin, zmin],
+    upper_bound=[xmax, zmax],
     lower_boundary_conditions=["dirichlet", "periodic"],
     upper_boundary_conditions=["dirichlet", "periodic"],
     lower_boundary_conditions_particles=["absorbing", "periodic"],

--- a/Examples/Tests/langmuir/inputs_test_2d_langmuir_multi_picmi.py
+++ b/Examples/Tests/langmuir/inputs_test_2d_langmuir_multi_picmi.py
@@ -25,12 +25,12 @@ diagnostic_intervals = "::10"
 
 # --- Grid
 nx = 64
-ny = 64
+nz = 64
 
 xmin = -20.0e-6
-ymin = -20.0e-6
+zmin = -20.0e-6
 xmax = +20.0e-6
-ymax = +20.0e-6
+zmax = +20.0e-6
 
 number_per_cell_each_dim = [2, 2]
 
@@ -53,9 +53,9 @@ electrons = picmi.Species(
 ##########################
 
 grid = picmi.Cartesian2DGrid(
-    number_of_cells=[nx, ny],
-    lower_bound=[xmin, ymin],
-    upper_bound=[xmax, ymax],
+    number_of_cells=[nx, nz],
+    lower_bound=[xmin, zmin],
+    upper_bound=[xmax, zmax],
     lower_boundary_conditions=["periodic", "periodic"],
     upper_boundary_conditions=["periodic", "periodic"],
     moving_window_velocity=[0.0, 0.0, 0.0],

--- a/Examples/Tests/pass_mpi_communicator/inputs_test_2d_pass_mpi_comm_picmi.py
+++ b/Examples/Tests/pass_mpi_communicator/inputs_test_2d_pass_mpi_comm_picmi.py
@@ -138,7 +138,7 @@ sim.add_diagnostic(part_diag)
 # NOTE: Some tests are done in this input PICMI file. These tests
 # check that amrex initialized the correct amount of procs and
 # that the procs ranks in amrex are correct.
-# If anz of these tests fail, the terminal will print that the
+# If any of these tests fail, the terminal will print that the
 # program crashed.
 
 # TODO: Enable in pyAMReX, then enable lines in inputs_test_2d_pass_mpi_comm_picmi.py again

--- a/Examples/Tests/pass_mpi_communicator/inputs_test_2d_pass_mpi_comm_picmi.py
+++ b/Examples/Tests/pass_mpi_communicator/inputs_test_2d_pass_mpi_comm_picmi.py
@@ -43,12 +43,12 @@ diagnostic_intervals = "::10"
 
 # --- Grid
 nx = 64
-ny = 64
+nz = 64
 
 xmin = -20.0e-6
-ymin = -20.0e-6
+zmin = -20.0e-6
 xmax = +20.0e-6
-ymax = +20.0e-6
+zmax = +20.0e-6
 
 number_per_cell_each_dim = [2, 2]
 
@@ -71,9 +71,9 @@ electrons = picmi.Species(
 ##########################
 
 grid = picmi.Cartesian2DGrid(
-    number_of_cells=[nx, ny],
-    lower_bound=[xmin, ymin],
-    upper_bound=[xmax, ymax],
+    number_of_cells=[nx, nz],
+    lower_bound=[xmin, zmin],
+    upper_bound=[xmax, zmax],
     lower_boundary_conditions=["periodic", "periodic"],
     upper_boundary_conditions=["periodic", "periodic"],
     moving_window_velocity=[0.0, 0.0, 0.0],
@@ -138,7 +138,7 @@ sim.add_diagnostic(part_diag)
 # NOTE: Some tests are done in this input PICMI file. These tests
 # check that amrex initialized the correct amount of procs and
 # that the procs ranks in amrex are correct.
-# If any of these tests fail, the terminal will print that the
+# If anz of these tests fail, the terminal will print that the
 # program crashed.
 
 # TODO: Enable in pyAMReX, then enable lines in inputs_test_2d_pass_mpi_comm_picmi.py again

--- a/Examples/Tests/restart/inputs_test_2d_id_cpu_read_picmi.py
+++ b/Examples/Tests/restart/inputs_test_2d_id_cpu_read_picmi.py
@@ -22,21 +22,21 @@ dt = 7.5e-10
 max_steps = 10
 
 nx = 64
-ny = 64
+nz = 64
 
 xmin = 0
 xmax = 0.03
-ymin = 0
-ymax = 0.03
+zmin = 0
+zmax = 0.03
 
 ##########################
 # numerics components
 ##########################
 
 grid = picmi.Cartesian2DGrid(
-    number_of_cells=[nx, ny],
-    lower_bound=[xmin, ymin],
-    upper_bound=[xmax, ymax],
+    number_of_cells=[nx, nz],
+    lower_bound=[xmin, zmin],
+    upper_bound=[xmax, zmax],
     lower_boundary_conditions=["dirichlet", "periodic"],
     upper_boundary_conditions=["dirichlet", "periodic"],
     lower_boundary_conditions_particles=["absorbing", "periodic"],

--- a/Examples/Tests/restart/inputs_test_2d_runtime_components_picmi.py
+++ b/Examples/Tests/restart/inputs_test_2d_runtime_components_picmi.py
@@ -23,21 +23,21 @@ dt = 7.5e-10
 max_steps = 10
 
 nx = 64
-ny = 64
+nz = 64
 
 xmin = 0
 xmax = 0.03
-ymin = 0
-ymax = 0.03
+zmin = 0
+zmax = 0.03
 
 ##########################
 # numerics components
 ##########################
 
 grid = picmi.Cartesian2DGrid(
-    number_of_cells=[nx, ny],
-    lower_bound=[xmin, ymin],
-    upper_bound=[xmax, ymax],
+    number_of_cells=[nx, nz],
+    lower_bound=[xmin, zmin],
+    upper_bound=[xmax, zmax],
     lower_boundary_conditions=["dirichlet", "periodic"],
     upper_boundary_conditions=["dirichlet", "periodic"],
     lower_boundary_conditions_particles=["absorbing", "periodic"],


### PR DESCRIPTION
In 2D, in WarpX, the variables are `x` and `z`. It is good to reflect this in the name of the Python variables used in the scripts.

Many thanks to [yanghf263](https://github.com/yanghf263) for pointing out this issue.