### PR TITLE
Fix loading photons from openPMD file

### DIFF
--- a/Source/Particles/ParticleCreation/AddParticles.cpp
+++ b/Source/Particles/ParticleCreation/AddParticles.cpp
@@ -642,7 +642,7 @@ PhysicalParticleContainer::AddPlasmaFromFile(PlasmaInjector & plasma_injector,
 
             if (plasma_injector.insideBounds(x, y, z)) {
 
-                amrex::Particle real const mass_eff = (mass > 0.0_prt) ? mass : PhysConst::m_e;
+                amrex::ParticleReal const mass_eff = (mass > 0.0_prt) ? mass : PhysConst::m_e;
                 amrex::ParticleReal const ux = ptr_ux.get()[i]*momentum_unit_x/mass_eff;
                 amrex::ParticleReal const uz = ptr_uz.get()[i]*momentum_unit_z/mass_eff;
                 amrex::ParticleReal uy = 0.0_prt;

--- a/Source/Particles/ParticleCreation/AddParticles.cpp
+++ b/Source/Particles/ParticleCreation/AddParticles.cpp
@@ -641,11 +641,13 @@ PhysicalParticleContainer::AddPlasmaFromFile(PlasmaInjector & plasma_injector,
 #endif
 
             if (plasma_injector.insideBounds(x, y, z)) {
-                amrex::ParticleReal const ux = ptr_ux.get()[i]*momentum_unit_x/mass;
-                amrex::ParticleReal const uz = ptr_uz.get()[i]*momentum_unit_z/mass;
+
+                amrex::Particle real const mass_eff = (mass > 0.0_prt) ? mass : PhysConst::m_e;
+                amrex::ParticleReal const ux = ptr_ux.get()[i]*momentum_unit_x/mass_eff;
+                amrex::ParticleReal const uz = ptr_uz.get()[i]*momentum_unit_z/mass_eff;
                 amrex::ParticleReal uy = 0.0_prt;
                 if (ps["momentum"].contains("y")) {
-                    uy = ptr_uy.get()[i]*momentum_unit_y/mass;
+                    uy = ptr_uy.get()[i]*momentum_unit_y/mass_eff;
                 }
                 CheckAndAddParticle(x, y, z, ux, uy, uz, weight,
                                     particle_x,  particle_y,  particle_z,

--- a/Source/Particles/ParticleCreation/AddParticles.cpp
+++ b/Source/Particles/ParticleCreation/AddParticles.cpp
@@ -642,6 +642,8 @@ PhysicalParticleContainer::AddPlasmaFromFile(PlasmaInjector & plasma_injector,
 
             if (plasma_injector.insideBounds(x, y, z)) {
 
+                // The normalized momentum is u = p / m = gamma beta c
+                // with m = m_e for photons, m the particle mass otherwise.
                 amrex::ParticleReal const mass_eff = (mass > 0.0_prt) ? mass : PhysConst::m_e;
                 amrex::ParticleReal const ux = ptr_ux.get()[i]*momentum_unit_x/mass_eff;
                 amrex::ParticleReal const uz = ptr_uz.get()[i]*momentum_unit_z/mass_eff;


### PR DESCRIPTION
When injecting particles from an openPMD file using  `<species>.injection_style = external_file`, the momentum is normalized using the mass of the particles. This fails with photons. This PR changes the mass used to normalize the momentum of massless particles to `m_e` when injecting from an external file.