### PR TITLE
Python: `MultiFabRegister::list`

### DIFF
--- a/Source/Python/MultiFabRegister.cpp
+++ b/Source/Python/MultiFabRegister.cpp
@@ -142,10 +142,10 @@ void init_MultiFabRegister (py::module & m)
              py::arg("level")
         )
 
-        //.def("list",
-        //     &MultiFabRegister::list
-        //     // "..."
-        //)
+        .def("list",
+             &MultiFabRegister::list,
+             "List the internal names of all registered fields"
+        )
 
         .def("erase",
              py::overload_cast<


### PR DESCRIPTION
Add the list Python binding to show all currently registered `MultiFab`s.