### PR TITLE
[WIP] Adding support to collect memory usage from boxes to load balancing

### DIFF
--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.H
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.H
@@ -40,9 +40,9 @@ public:
      *  (cost, processor, level, i_low, j_low, k_low, gpu_ID [if GPU run], num_cells, num_macro_particles
      * note: the hostname per box is stored separately (in m_data_string) */
 #ifdef AMREX_USE_GPU
-    static const int m_nDataFields = 9;
+    static const int m_nDataFields = 10;
 #else
-    static const int m_nDataFields = 8;
+    static const int m_nDataFields = 9;
 #endif
 
     /** used to keep track of max number of boxes over all timesteps; this allows

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
@@ -80,6 +80,9 @@ void LoadBalanceCosts::ComputeDiags (int step)
     // get a reference to WarpX instance
     auto& warpx = WarpX::GetInstance();
 
+    // get MultiParticleContainer class object
+    const auto & mypc = warpx.GetPartContainer();
+
     // judge if the diags should be done
     // costs is initialized only if we're doing load balance
     if (!m_intervals.contains(step+1) ||
@@ -109,11 +112,15 @@ void LoadBalanceCosts::ComputeDiags (int step)
 
     // read in WarpX costs to local copy; compute if using `Heuristic` update
     amrex::Vector<std::unique_ptr<amrex::LayoutData<amrex::Real> > > costs;
+    amrex::Vector<std::unique_ptr<amrex::LayoutData<std::size_t> > > mem_used;
 
     costs.resize(nLevels);
+    mem_used.resize(nLevels);
     for (int lev = 0; lev < nLevels; ++lev)
     {
         costs[lev] = std::make_unique<LayoutData<Real>>(*WarpX::getCosts(lev));
+        mem_used[lev] = std::make_unique<LayoutData<std::size_t>>(warpx.boxArray(lev), warpx.DistributionMap(lev));
+        mypc.CapacityOfParticlesInGrid(*mem_used[lev], lev);
     }
 
     if (WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Heuristic)
@@ -151,8 +158,9 @@ void LoadBalanceCosts::ComputeDiags (int step)
 #endif
             m_data[shift_m_data + mfi.index()*m_nDataFields + 6] = static_cast<amrex::Real>(tbx.d_numPts()); // note: difference to volume
             m_data[shift_m_data + mfi.index()*m_nDataFields + 7] = countBoxMacroParticles(mfi, lev);
+            m_data[shift_m_data + mfi.index()*m_nDataFields + 8] = (*mem_used[lev])[mfi.index()];
 #ifdef AMREX_USE_GPU
-            m_data[shift_m_data + mfi.index()*m_nDataFields + 8] = amrex::Gpu::Device::deviceId();
+            m_data[shift_m_data + mfi.index()*m_nDataFields + 9] = amrex::Gpu::Device::deviceId();
 #endif
             // ...
         }
@@ -326,6 +334,8 @@ void LoadBalanceCosts::WriteToFile (int step) const
             ofstmp << "[" << c++ << "]num_cells_" + std::to_string(boxNumber) + "()";
             ofstmp << m_sep;
             ofstmp << "[" << c++ << "]num_macro_particles_" + std::to_string(boxNumber) + "()";
+            ofstmp << m_sep;
+            ofstmp << "[" << c++ << "]particles_mem_" + std::to_string(boxNumber) + "()";
 #ifdef AMREX_USE_GPU
             ofstmp << m_sep;
             ofstmp << "[" << c++ << "]gpu_ID_box_" + std::to_string(boxNumber) + "()";

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
@@ -83,6 +83,8 @@ void LoadBalanceCosts::ComputeDiags (int step)
     // get MultiParticleContainer class object
     const auto & mypc = warpx.GetPartContainer();
 
+    const auto & mymfr = warpx.GetMultiFabRegister();
+
     // judge if the diags should be done
     // costs is initialized only if we're doing load balance
     if (!m_intervals.contains(step+1) ||
@@ -116,11 +118,13 @@ void LoadBalanceCosts::ComputeDiags (int step)
 
     costs.resize(nLevels);
     mem_used.resize(nLevels);
+
     for (int lev = 0; lev < nLevels; ++lev)
     {
         costs[lev] = std::make_unique<LayoutData<Real>>(*WarpX::getCosts(lev));
         mem_used[lev] = std::make_unique<LayoutData<std::size_t>>(warpx.boxArray(lev), warpx.DistributionMap(lev));
         mypc.CapacityOfParticlesInGrid(*mem_used[lev], lev);
+        mymfr.CapacityOfFabs(*mem_used[lev], warpx.boxArray(lev), warpx.DistributionMap(lev));
     }
 
     if (WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Heuristic)

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -258,7 +258,7 @@ public:
 
     [[nodiscard]] amrex::Vector<amrex::Long> NumberOfParticlesInGrid(int lev) const;
 
-    [[nodiscard]] amrex::LayoutData<std::size_t> CapacityOfParticlesInGrid(int lev) const;
+    void CapacityOfParticlesInGrid(amrex::LayoutData<std::size_t>& mem, int lev) const;
 
     void Increment (amrex::MultiFab& mf, int lev);
 

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -258,6 +258,8 @@ public:
 
     [[nodiscard]] amrex::Vector<amrex::Long> NumberOfParticlesInGrid(int lev) const;
 
+    [[nodiscard]] amrex::LayoutData<std::size_t> CapacityOfParticlesInGrid(int lev) const;
+
     void Increment (amrex::MultiFab& mf, int lev);
 
     void SetParticleBoxArray (int lev, amrex::BoxArray& new_ba);

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -810,14 +810,18 @@ MultiParticleContainer::NumberOfParticlesInGrid (int lev) const
     }
 }
 
-amrex::LayoutData<std::size_t>
-MultiParticleContainer::CapacityOfParticlesInGrid (int lev) const
+void
+MultiParticleContainer::CapacityOfParticlesInGrid (amrex::LayoutData<std::size_t>& mem, int lev) const
 {
-    amrex::LayoutData<std::size_t> mem(pc->boxArray(lev), pc->DistributionMap(lev));
+    WarpX & warpx = WarpX::GetInstance();
+
     for (auto& pc : allcontainers) {
-        pc->CapacityOfParticlesInGrid(mem, lev);
+        amrex::LayoutData<std::size_t> tmpmem(warpx.boxArray(lev), warpx.DistributionMap(lev));
+        pc->CapacityOfParticlesInGrid(tmpmem, lev);
+        for (amrex::MFIter mfi(tmpmem); mfi.isValid(); ++mfi) {
+            mem[mfi.index()] += tmpmem[mfi];
+        }
     }
-    return mem;
 }
 
 void

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -810,6 +810,16 @@ MultiParticleContainer::NumberOfParticlesInGrid (int lev) const
     }
 }
 
+amrex::LayoutData<std::size_t>
+MultiParticleContainer::CapacityOfParticlesInGrid (int lev) const
+{
+    amrex::LayoutData<std::size_t> mem(pc->boxArray(lev), pc->DistributionMap(lev));
+    for (auto& pc : allcontainers) {
+        pc->CapacityOfParticlesInGrid(mem, lev);
+    }
+    return mem;
+}
+
 void
 MultiParticleContainer::Increment (MultiFab& mf, int lev)
 {

--- a/Source/ablastr/fields/MultiFabRegister.H
+++ b/Source/ablastr/fields/MultiFabRegister.H
@@ -681,6 +681,12 @@ namespace ablastr::fields
             std::string const & internal_name
         );
 
+        void CapacityOfFabs (
+            amrex::LayoutData<std::size_t>& mem,
+            amrex::BoxArray const & ba,
+            amrex::DistributionMapping const & dm
+        ) const;
+
     private:
 
         [[nodiscard]] amrex::MultiFab const *

--- a/Source/ablastr/fields/MultiFabRegister.cpp
+++ b/Source/ablastr/fields/MultiFabRegister.cpp
@@ -366,6 +366,9 @@ namespace ablastr::fields
     {
         for (auto & element : m_mf_register ) {
             const MultiFabOwner & mf_owner = element.second;
+            if (mf_owner.is_alias()) {
+                continue;
+            }
             amrex::LayoutData<std::size_t> tmpmem(ba, dm);
             mf_owner.m_mf.capacityOfFabs(tmpmem);
             for (amrex::MFIter mfi(tmpmem); mfi.isValid(); ++mfi) {

--- a/Source/ablastr/fields/MultiFabRegister.cpp
+++ b/Source/ablastr/fields/MultiFabRegister.cpp
@@ -357,6 +357,23 @@ namespace ablastr::fields
         return &mf;
     }
 
+    void
+    MultiFabRegister::CapacityOfFabs (
+        amrex::LayoutData<std::size_t>& mem,
+        amrex::BoxArray const & ba,
+        amrex::DistributionMapping const & dm
+    ) const
+    {
+        for (auto & element : m_mf_register ) {
+            const MultiFabOwner & mf_owner = element.second;
+            amrex::LayoutData<std::size_t> tmpmem(ba, dm);
+            mf_owner.m_mf.capacityOfFabs(tmpmem);
+            for (amrex::MFIter mfi(tmpmem); mfi.isValid(); ++mfi) {
+                mem[mfi.index()] += tmpmem[mfi];
+            }
+        }
+    }
+
     amrex::MultiFab const *
     MultiFabRegister::internal_get (
         std::string const & internal_name


### PR DESCRIPTION
This PR aims to add support for collecting memory usage of each box (considering `MultiFabs` and `Particles`) in the simulation. The goal is to use this information for the load balancing algorithms.