### PR TITLE
Use shuffling to avoid N^2 computation in luminosity calculation

### DIFF
--- a/Source/Diagnostics/ReducedDiags/ColliderRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/ColliderRelevant.cpp
@@ -9,7 +9,6 @@
 
 #include "Diagnostics/ReducedDiags/ReducedDiags.H"
 #include "Fields.H"
-#include "Particles/Collision/BinaryCollision/ShuffleFisherYates.H"
 #if (defined WARPX_QED)
 #   include "Particles/ElementaryProcess/QEDInternals/QedChiFunctions.H"
 #endif

--- a/Source/Diagnostics/ReducedDiags/ColliderRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/ColliderRelevant.cpp
@@ -9,6 +9,7 @@
 
 #include "Diagnostics/ReducedDiags/ReducedDiags.H"
 #include "Fields.H"
+#include "Particles/Collision/BinaryCollision/ShuffleFisherYates.H"
 #if (defined WARPX_QED)
 #   include "Particles/ElementaryProcess/QEDInternals/QedChiFunctions.H"
 #endif

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
@@ -8,6 +8,7 @@
 #include "DifferentialLuminosity.H"
 
 #include "Diagnostics/ReducedDiags/ReducedDiags.H"
+#include "Particles/Collision/BinaryCollision/ShuffleFisherYates.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/SpeciesPhysicalProperties.H"
@@ -141,6 +142,7 @@ void DifferentialLuminosity::ComputeDiags (int step)
     const Real dt = warpx.getdt(0);
     // get cell volume
     Geometry const & geom = warpx.Geom(0);
+    // is this valid in non-cartesian?
     const Real dV = AMREX_D_TERM(geom.CellSize(0), *geom.CellSize(1), *geom.CellSize(2));
 
     // declare local variables
@@ -159,16 +161,16 @@ void DifferentialLuminosity::ComputeDiags (int step)
 
     amrex::Real* const AMREX_RESTRICT dptr_data = d_data.dataPtr();
 
+    // is this needed?
     // Enable tiling
     amrex::MFItInfo info;
     if (amrex::Gpu::notInLaunchRegion()) { info.EnableTiling(WarpXParticleContainer::tile_size); }
 
     int const nlevs = std::max(0, species_1.finestLevel()+1); // species_1 ?
-    for (int lev = 0; lev < nlevs; ++lev) {
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-
+    for (int lev = 0; lev < nlevs; ++lev) {
         for (amrex::MFIter mfi = species_1.MakeMFIter(lev, info); mfi.isValid(); ++mfi){
 
             ParticleTileType& ptile_1 = species_1.ParticlesAt(lev, mfi);
@@ -177,7 +179,7 @@ void DifferentialLuminosity::ComputeDiags (int step)
             ParticleBins bins_1 = ParticleUtils::findParticlesInEachCell( warpx.Geom(lev), mfi, ptile_1 );
             ParticleBins bins_2 = ParticleUtils::findParticlesInEachCell( warpx.Geom(lev), mfi, ptile_2 );
 
-            // Species
+            // Species 1
             const auto soa_1 = ptile_1.getParticleTileData();
             index_type* AMREX_RESTRICT indices_1 = bins_1.permutationPtr();
             index_type const* AMREX_RESTRICT cell_offsets_1 = bins_1.offsetsPtr();
@@ -189,6 +191,7 @@ void DifferentialLuminosity::ComputeDiags (int step)
             amrex::ParticleReal * const AMREX_RESTRICT u1z = soa_1.m_rdata[PIdx::uz];
             bool const species1_is_photon = species_1.AmIA<PhysicalSpecies::photon>();
 
+	    // Species 2
             const auto soa_2 = ptile_2.getParticleTileData();
             index_type* AMREX_RESTRICT indices_2 = bins_2.permutationPtr();
             index_type const* AMREX_RESTRICT cell_offsets_2 = bins_2.offsetsPtr();
@@ -202,83 +205,160 @@ void DifferentialLuminosity::ComputeDiags (int step)
             // Extract low-level data
             auto const n_cells = static_cast<int>(bins_1.numBins());
 
-            // Loop over cells
-            amrex::ParallelFor( n_cells,
+	    // Compute the number of independent pairs in each cell. This is equal to
+	    // the number of particles in whichever species has fewer
+            amrex::Gpu::DeviceVector<index_type> n_ind_pairs_in_each_cell(n_cells+1);
+            index_type* AMREX_RESTRICT p_n_ind_pairs_in_each_cell = n_ind_pairs_in_each_cell.dataPtr();
+
+            amrex::ParallelFor( n_cells+1,
                 [=] AMREX_GPU_DEVICE (int i_cell) noexcept
-            {
-                // The particles from species1 that are in the cell `i_cell` are
-                // given by the `indices_1[cell_start_1:cell_stop_1]`
-                index_type const cell_start_1 = cell_offsets_1[i_cell];
-                index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
-                // Same for species 2
-                index_type const cell_start_2 = cell_offsets_2[i_cell];
-                index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
+                {
+                    if (i_cell < n_cells)
+                    {
+                        const auto n_part_in_cell_1 = cell_offsets_1[i_cell+1] - cell_offsets_1[i_cell];
+                        const auto n_part_in_cell_2 = cell_offsets_2[i_cell+1] - cell_offsets_2[i_cell];
+                        p_n_ind_pairs_in_each_cell[i_cell] = amrex::min(n_part_in_cell_1, n_part_in_cell_2);
+                    }
+                    else
+                    {
+                        p_n_ind_pairs_in_each_cell[i_cell] = 0;
+                    }
+                }
+            );
 
-                for(index_type i_1=cell_start_1; i_1<cell_stop_1; ++i_1){
-                    for(index_type i_2=cell_start_2; i_2<cell_stop_2; ++i_2){
+            // start indices of independent collisions.
+            amrex::Gpu::DeviceVector<index_type> coll_offsets(n_cells+1);
+            // number of total independent collision pairs
+            const auto n_independent_pairs = (int) amrex::Scan::ExclusiveSum(n_cells+1,
+	        p_n_ind_pairs_in_each_cell, coll_offsets.data(), amrex::Scan::RetSum{true});
+            index_type* AMREX_RESTRICT p_coll_offsets = coll_offsets.dataPtr();
 
-                        index_type const j_1 = indices_1[i_1];
-                        index_type const j_2 = indices_2[i_2];
+            // shuffle each species.
+	    // we launch 2*n_cells threads to process both species simultaneously
+            amrex::ParallelForRNG( 2*n_cells,
+	        [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
+	    {
+		int i_cell = i < n_cells ? i : i - n_cells;
 
-                        Real p1t=0, p1x=0, p1y=0, p1z=0; // components of 4-momentum of particle 1
-                        Real const u1_sq =  u1x[j_1]*u1x[j_1] + u1y[j_1]*u1y[j_1] + u1z[j_1]*u1z[j_1];
-                        if (species1_is_photon) {
-                            // photon case (momentum is normalized by m_e in WarpX)
-                            p1t = PhysConst::m_e*std::sqrt( u1_sq );
-                            p1x = PhysConst::m_e*u1x[j_1];
-                            p1y = PhysConst::m_e*u1y[j_1];
-                            p1z = PhysConst::m_e*u1z[j_1];
-                        } else {
-                            p1t = m1*std::sqrt( c_sq + u1_sq );
-                            p1x = m1*u1x[j_1];
-                            p1y = m1*u1y[j_1];
-                            p1z = m1*u1z[j_1];
-                        }
+		// The particles from species1 that are in the cell `i_cell` are
+		// given by the `indices_1[cell_start_1:cell_stop_1]`
+		index_type const cell_start_1 = cell_offsets_1[i_cell];
+		index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
 
-                        Real p2t=0, p2x=0, p2y=0, p2z=0; // components of 4-momentum of particle 2
-                        Real const u2_sq =  u2x[j_2]*u2x[j_2] + u2y[j_2]*u2y[j_2] + u2z[j_2]*u2z[j_2];
-                        if (species2_is_photon) {
-                            // photon case (momentum is normalized by m_e in WarpX)
-                            p2t = PhysConst::m_e*std::sqrt(u2_sq);
-                            p2x = PhysConst::m_e*u2x[j_2];
-                            p2y = PhysConst::m_e*u2y[j_2];
-                            p2z = PhysConst::m_e*u2z[j_2];
-                        } else {
-                            p2t = m2*std::sqrt( c_sq + u2_sq );
-                            p2x = m2*u2x[j_2];
-                            p2y = m2*u2y[j_2];
-                            p2z = m2*u2z[j_2];
-                        }
+		// Same for species 2
+		index_type const cell_start_2 = cell_offsets_2[i_cell];
+		index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
 
-                        // center of mass energy in eV
-                        Real const E_com = c_over_qe * std::sqrt(m1*m1*c_sq + m2*m2*c_sq + 2*(p1t*p2t - p1x*p2x - p1y*p2y - p1z*p2z));
+		// Do not collide if one species is missing in the cell
+		if ( cell_stop_1 - cell_start_1 < 1 ||
+		     cell_stop_2 - cell_start_2 < 1 ) { return; }
 
-                        // determine particle bin
-                        int const bin = int(Math::floor((E_com-bin_min)/bin_size));
+		if (i < n_cells) {
+		    ShuffleFisherYates(indices_1, cell_start_1, cell_stop_1, engine);
+		} else {
+		    ShuffleFisherYates(indices_2, cell_start_2, cell_stop_2, engine);
+		}
+	    });
 
-                        if ( bin<0 || bin>=num_bins ) { continue; } // discard if out-of-range
+            // Loop over independent pairs
+	    amrex::ParallelFor( n_independent_pairs, [=] AMREX_GPU_DEVICE (int i_coll) noexcept
+	    {
+		// to avoid type mismatch errors
+		auto ui_coll = (index_type)i_coll;
 
-                        Real const inv_p1t = 1.0_rt/p1t;
-                        Real const inv_p2t = 1.0_rt/p2t;
+		// Use a bisection algorithm to find the index of the cell in which this pair is located
+		const int i_cell = amrex::bisect( p_coll_offsets, 0, n_cells, ui_coll );
 
-                        Real const beta1_sq = (p1x*p1x + p1y*p1y + p1z*p1z) * inv_p1t*inv_p1t;
-                        Real const beta2_sq = (p2x*p2x + p2y*p2y + p2z*p2z) * inv_p2t*inv_p2t;
-                        Real const beta1_dot_beta2 = (p1x*p2x + p1y*p2y + p1z*p2z) * inv_p1t*inv_p2t;
+		// The particles from species1 that are in the cell `i_cell` are
+		// given by the `indices_1[cell_start_1:cell_stop_1]`
+		index_type const cell_start_1 = cell_offsets_1[i_cell];
+		index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
 
-                        // Here we use the fact that:
-                        // (v1 - v2)^2 = v1^2 + v2^2 - 2 v1.v2
-                        // and (v1 x v2)^2 = v1^2 v2^2 - (v1.v2)^2
-                        // we also use beta=v/c instead of v
+		// Same for species 2
+		index_type const cell_start_2 = cell_offsets_2[i_cell];
+		index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
 
-                        Real const radicand = beta1_sq + beta2_sq - 2*beta1_dot_beta2 - beta1_sq*beta2_sq + beta1_dot_beta2*beta1_dot_beta2;
+		const index_type NI1 = cell_stop_1 - cell_start_1;
+		const index_type NI2 = cell_stop_2 - cell_start_2;
+		const index_type max_N = amrex::max(NI1,NI2);
+		const index_type min_N = amrex::min(NI1,NI2);
 
-                        Real const dL_dEcom = PhysConst::c * std::sqrt( radicand ) * w1[j_1] * w2[j_2] / dV / bin_size * dt; // m^-2 eV^-1
+		// collision number of the cell
+		const index_type coll_idx = ui_coll - p_coll_offsets[i_cell];
+		index_type i_1 = cell_start_1 + coll_idx;
+		index_type i_2 = cell_start_2 + coll_idx;
 
-                        amrex::HostDevice::Atomic::Add(&dptr_data[bin], dL_dEcom);
+		// we will start from collision number = coll_idx and then add
+		// stride (smaller set size) until we do all collisions (larger set size)
+		for (index_type k = coll_idx; k < max_N; k += min_N)
+		{
+		    index_type const j_1 = indices_1[i_1];
+		    index_type const j_2 = indices_2[i_2];
 
-                    } // particles species 2
-                } // particles species 1
-            }); // cells
+		    Real p1t=0, p1x=0, p1y=0, p1z=0; // components of 4-momentum of particle 1
+		    Real const u1_sq =  u1x[j_1]*u1x[j_1] + u1y[j_1]*u1y[j_1] + u1z[j_1]*u1z[j_1];
+		    if (species1_is_photon) {
+			// photon case (momentum is normalized by m_e in WarpX)
+			p1t = PhysConst::m_e*std::sqrt( u1_sq );
+			p1x = PhysConst::m_e*u1x[j_1];
+			p1y = PhysConst::m_e*u1y[j_1];
+			p1z = PhysConst::m_e*u1z[j_1];
+		    } else {
+			p1t = m1*std::sqrt( c_sq + u1_sq );
+			p1x = m1*u1x[j_1];
+			p1y = m1*u1y[j_1];
+			p1z = m1*u1z[j_1];
+		    }
+
+		    Real p2t=0, p2x=0, p2y=0, p2z=0; // components of 4-momentum of particle 2
+		    Real const u2_sq =  u2x[j_2]*u2x[j_2] + u2y[j_2]*u2y[j_2] + u2z[j_2]*u2z[j_2];
+		    if (species2_is_photon) {
+			// photon case (momentum is normalized by m_e in WarpX)
+			p2t = PhysConst::m_e*std::sqrt(u2_sq);
+			p2x = PhysConst::m_e*u2x[j_2];
+			p2y = PhysConst::m_e*u2y[j_2];
+			p2z = PhysConst::m_e*u2z[j_2];
+		    } else {
+			p2t = m2*std::sqrt( c_sq + u2_sq );
+			p2x = m2*u2x[j_2];
+			p2y = m2*u2y[j_2];
+			p2z = m2*u2z[j_2];
+		    }
+
+		    // center of mass energy in eV
+		    Real const E_com = c_over_qe * std::sqrt(m1*m1*c_sq + m2*m2*c_sq + 2*(p1t*p2t - p1x*p2x - p1y*p2y - p1z*p2z));
+
+		    // determine particle bin
+		    int const bin = int(Math::floor((E_com-bin_min)/bin_size));
+
+		    if ( bin<0 || bin>=num_bins ) { continue; } // discard if out-of-range
+
+		    Real const inv_p1t = 1.0_rt/p1t;
+		    Real const inv_p2t = 1.0_rt/p2t;
+
+		    Real const beta1_sq = (p1x*p1x + p1y*p1y + p1z*p1z) * inv_p1t*inv_p1t;
+		    Real const beta2_sq = (p2x*p2x + p2y*p2y + p2z*p2z) * inv_p2t*inv_p2t;
+		    Real const beta1_dot_beta2 = (p1x*p2x + p1y*p2y + p1z*p2z) * inv_p1t*inv_p2t;
+
+		    // Here we use the fact that:
+		    // (v1 - v2)^2 = v1^2 + v2^2 - 2 v1.v2
+		    // and (v1 x v2)^2 = v1^2 v2^2 - (v1.v2)^2
+		    // we also use beta=v/c instead of v
+
+		    Real const radicand = beta1_sq + beta2_sq - 2*beta1_dot_beta2 - beta1_sq*beta2_sq + beta1_dot_beta2*beta1_dot_beta2;
+
+		    Real const dL_dEcom = PhysConst::c * std::sqrt( radicand ) * min_N * w1[j_1] * w2[j_2] / dV / bin_size * dt; // m^-2 eV^-1
+
+		    amrex::HostDevice::Atomic::Add(&dptr_data[bin], dL_dEcom);
+
+		    if (max_N == NI1) {
+			i_1 += min_N;
+		    }
+		    if (max_N == NI2) {
+			i_2 += min_N;
+		    }
+		} // k
+            }); // independent pairs
         } // boxes
     } // levels
 

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
@@ -347,7 +347,7 @@ void DifferentialLuminosity::ComputeDiags (int step)
 
             Real const radicand = beta1_sq + beta2_sq - 2*beta1_dot_beta2 - beta1_sq*beta2_sq + beta1_dot_beta2*beta1_dot_beta2;
 
-            Real const dL_dEcom = PhysConst::c * std::sqrt( radicand ) * w1[j_1] * w2[j_2] / dV / bin_size * dt; // m^-2 eV^-1
+            Real const dL_dEcom = PhysConst::c * std::sqrt( radicand ) * min_N * w1[j_1] * w2[j_2] / dV / bin_size * dt; // m^-2 eV^-1
 
             amrex::HostDevice::Atomic::Add(&dptr_data[bin], dL_dEcom);
 

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
@@ -191,7 +191,7 @@ void DifferentialLuminosity::ComputeDiags (int step)
             amrex::ParticleReal * const AMREX_RESTRICT u1z = soa_1.m_rdata[PIdx::uz];
             bool const species1_is_photon = species_1.AmIA<PhysicalSpecies::photon>();
 
-	    // Species 2
+        // Species 2
             const auto soa_2 = ptile_2.getParticleTileData();
             index_type* AMREX_RESTRICT indices_2 = bins_2.permutationPtr();
             index_type const* AMREX_RESTRICT cell_offsets_2 = bins_2.offsetsPtr();
@@ -205,8 +205,8 @@ void DifferentialLuminosity::ComputeDiags (int step)
             // Extract low-level data
             auto const n_cells = static_cast<int>(bins_1.numBins());
 
-	    // Compute the number of independent pairs in each cell. This is equal to
-	    // the number of particles in whichever species has fewer
+        // Compute the number of independent pairs in each cell. This is equal to
+        // the number of particles in whichever species has fewer
             amrex::Gpu::DeviceVector<index_type> n_ind_pairs_in_each_cell(n_cells+1);
             index_type* AMREX_RESTRICT p_n_ind_pairs_in_each_cell = n_ind_pairs_in_each_cell.dataPtr();
 
@@ -230,134 +230,134 @@ void DifferentialLuminosity::ComputeDiags (int step)
             amrex::Gpu::DeviceVector<index_type> coll_offsets(n_cells+1);
             // number of total independent collision pairs
             const auto n_independent_pairs = (int) amrex::Scan::ExclusiveSum(n_cells+1,
-	        p_n_ind_pairs_in_each_cell, coll_offsets.data(), amrex::Scan::RetSum{true});
+            p_n_ind_pairs_in_each_cell, coll_offsets.data(), amrex::Scan::RetSum{true});
             index_type* AMREX_RESTRICT p_coll_offsets = coll_offsets.dataPtr();
 
             // shuffle each species.
-	    // we launch 2*n_cells threads to process both species simultaneously
+        // we launch 2*n_cells threads to process both species simultaneously
             amrex::ParallelForRNG( 2*n_cells,
-	        [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
-	    {
-		int i_cell = i < n_cells ? i : i - n_cells;
+            [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
+        {
+        int i_cell = i < n_cells ? i : i - n_cells;
 
-		// The particles from species1 that are in the cell `i_cell` are
-		// given by the `indices_1[cell_start_1:cell_stop_1]`
-		index_type const cell_start_1 = cell_offsets_1[i_cell];
-		index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
+        // The particles from species1 that are in the cell `i_cell` are
+        // given by the `indices_1[cell_start_1:cell_stop_1]`
+        index_type const cell_start_1 = cell_offsets_1[i_cell];
+        index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
 
-		// Same for species 2
-		index_type const cell_start_2 = cell_offsets_2[i_cell];
-		index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
+        // Same for species 2
+        index_type const cell_start_2 = cell_offsets_2[i_cell];
+        index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
 
-		// Do not collide if one species is missing in the cell
-		if ( cell_stop_1 - cell_start_1 < 1 ||
-		     cell_stop_2 - cell_start_2 < 1 ) { return; }
+        // Do not collide if one species is missing in the cell
+        if ( cell_stop_1 - cell_start_1 < 1 ||
+             cell_stop_2 - cell_start_2 < 1 ) { return; }
 
-		if (i < n_cells) {
-		    ShuffleFisherYates(indices_1, cell_start_1, cell_stop_1, engine);
-		} else {
-		    ShuffleFisherYates(indices_2, cell_start_2, cell_stop_2, engine);
-		}
-	    });
+        if (i < n_cells) {
+            ShuffleFisherYates(indices_1, cell_start_1, cell_stop_1, engine);
+        } else {
+            ShuffleFisherYates(indices_2, cell_start_2, cell_stop_2, engine);
+        }
+        });
 
             // Loop over independent pairs
-	    amrex::ParallelFor( n_independent_pairs, [=] AMREX_GPU_DEVICE (int i_coll) noexcept
-	    {
-		// to avoid type mismatch errors
-		auto ui_coll = (index_type)i_coll;
+        amrex::ParallelFor( n_independent_pairs, [=] AMREX_GPU_DEVICE (int i_coll) noexcept
+        {
+        // to avoid type mismatch errors
+        auto ui_coll = (index_type)i_coll;
 
-		// Use a bisection algorithm to find the index of the cell in which this pair is located
-		const int i_cell = amrex::bisect( p_coll_offsets, 0, n_cells, ui_coll );
+        // Use a bisection algorithm to find the index of the cell in which this pair is located
+        const int i_cell = amrex::bisect( p_coll_offsets, 0, n_cells, ui_coll );
 
-		// The particles from species1 that are in the cell `i_cell` are
-		// given by the `indices_1[cell_start_1:cell_stop_1]`
-		index_type const cell_start_1 = cell_offsets_1[i_cell];
-		index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
+        // The particles from species1 that are in the cell `i_cell` are
+        // given by the `indices_1[cell_start_1:cell_stop_1]`
+        index_type const cell_start_1 = cell_offsets_1[i_cell];
+        index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
 
-		// Same for species 2
-		index_type const cell_start_2 = cell_offsets_2[i_cell];
-		index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
+        // Same for species 2
+        index_type const cell_start_2 = cell_offsets_2[i_cell];
+        index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
 
-		const index_type NI1 = cell_stop_1 - cell_start_1;
-		const index_type NI2 = cell_stop_2 - cell_start_2;
-		const index_type max_N = amrex::max(NI1,NI2);
-		const index_type min_N = amrex::min(NI1,NI2);
+        const index_type NI1 = cell_stop_1 - cell_start_1;
+        const index_type NI2 = cell_stop_2 - cell_start_2;
+        const index_type max_N = amrex::max(NI1,NI2);
+        const index_type min_N = amrex::min(NI1,NI2);
 
-		// collision number of the cell
-		const index_type coll_idx = ui_coll - p_coll_offsets[i_cell];
-		index_type i_1 = cell_start_1 + coll_idx;
-		index_type i_2 = cell_start_2 + coll_idx;
+        // collision number of the cell
+        const index_type coll_idx = ui_coll - p_coll_offsets[i_cell];
+        index_type i_1 = cell_start_1 + coll_idx;
+        index_type i_2 = cell_start_2 + coll_idx;
 
-		// we will start from collision number = coll_idx and then add
-		// stride (smaller set size) until we do all collisions (larger set size)
-		for (index_type k = coll_idx; k < max_N; k += min_N)
-		{
-		    index_type const j_1 = indices_1[i_1];
-		    index_type const j_2 = indices_2[i_2];
+        // we will start from collision number = coll_idx and then add
+        // stride (smaller set size) until we do all collisions (larger set size)
+        for (index_type k = coll_idx; k < max_N; k += min_N)
+        {
+            index_type const j_1 = indices_1[i_1];
+            index_type const j_2 = indices_2[i_2];
 
-		    Real p1t=0, p1x=0, p1y=0, p1z=0; // components of 4-momentum of particle 1
-		    Real const u1_sq =  u1x[j_1]*u1x[j_1] + u1y[j_1]*u1y[j_1] + u1z[j_1]*u1z[j_1];
-		    if (species1_is_photon) {
-			// photon case (momentum is normalized by m_e in WarpX)
-			p1t = PhysConst::m_e*std::sqrt( u1_sq );
-			p1x = PhysConst::m_e*u1x[j_1];
-			p1y = PhysConst::m_e*u1y[j_1];
-			p1z = PhysConst::m_e*u1z[j_1];
-		    } else {
-			p1t = m1*std::sqrt( c_sq + u1_sq );
-			p1x = m1*u1x[j_1];
-			p1y = m1*u1y[j_1];
-			p1z = m1*u1z[j_1];
-		    }
+            Real p1t=0, p1x=0, p1y=0, p1z=0; // components of 4-momentum of particle 1
+            Real const u1_sq =  u1x[j_1]*u1x[j_1] + u1y[j_1]*u1y[j_1] + u1z[j_1]*u1z[j_1];
+            if (species1_is_photon) {
+            // photon case (momentum is normalized by m_e in WarpX)
+            p1t = PhysConst::m_e*std::sqrt( u1_sq );
+            p1x = PhysConst::m_e*u1x[j_1];
+            p1y = PhysConst::m_e*u1y[j_1];
+            p1z = PhysConst::m_e*u1z[j_1];
+            } else {
+            p1t = m1*std::sqrt( c_sq + u1_sq );
+            p1x = m1*u1x[j_1];
+            p1y = m1*u1y[j_1];
+            p1z = m1*u1z[j_1];
+            }
 
-		    Real p2t=0, p2x=0, p2y=0, p2z=0; // components of 4-momentum of particle 2
-		    Real const u2_sq =  u2x[j_2]*u2x[j_2] + u2y[j_2]*u2y[j_2] + u2z[j_2]*u2z[j_2];
-		    if (species2_is_photon) {
-			// photon case (momentum is normalized by m_e in WarpX)
-			p2t = PhysConst::m_e*std::sqrt(u2_sq);
-			p2x = PhysConst::m_e*u2x[j_2];
-			p2y = PhysConst::m_e*u2y[j_2];
-			p2z = PhysConst::m_e*u2z[j_2];
-		    } else {
-			p2t = m2*std::sqrt( c_sq + u2_sq );
-			p2x = m2*u2x[j_2];
-			p2y = m2*u2y[j_2];
-			p2z = m2*u2z[j_2];
-		    }
+            Real p2t=0, p2x=0, p2y=0, p2z=0; // components of 4-momentum of particle 2
+            Real const u2_sq =  u2x[j_2]*u2x[j_2] + u2y[j_2]*u2y[j_2] + u2z[j_2]*u2z[j_2];
+            if (species2_is_photon) {
+            // photon case (momentum is normalized by m_e in WarpX)
+            p2t = PhysConst::m_e*std::sqrt(u2_sq);
+            p2x = PhysConst::m_e*u2x[j_2];
+            p2y = PhysConst::m_e*u2y[j_2];
+            p2z = PhysConst::m_e*u2z[j_2];
+            } else {
+            p2t = m2*std::sqrt( c_sq + u2_sq );
+            p2x = m2*u2x[j_2];
+            p2y = m2*u2y[j_2];
+            p2z = m2*u2z[j_2];
+            }
 
-		    // center of mass energy in eV
-		    Real const E_com = c_over_qe * std::sqrt(m1*m1*c_sq + m2*m2*c_sq + 2*(p1t*p2t - p1x*p2x - p1y*p2y - p1z*p2z));
+            // center of mass energy in eV
+            Real const E_com = c_over_qe * std::sqrt(m1*m1*c_sq + m2*m2*c_sq + 2*(p1t*p2t - p1x*p2x - p1y*p2y - p1z*p2z));
 
-		    // determine particle bin
-		    int const bin = int(Math::floor((E_com-bin_min)/bin_size));
+            // determine particle bin
+            int const bin = int(Math::floor((E_com-bin_min)/bin_size));
 
-		    if ( bin<0 || bin>=num_bins ) { continue; } // discard if out-of-range
+            if ( bin<0 || bin>=num_bins ) { continue; } // discard if out-of-range
 
-		    Real const inv_p1t = 1.0_rt/p1t;
-		    Real const inv_p2t = 1.0_rt/p2t;
+            Real const inv_p1t = 1.0_rt/p1t;
+            Real const inv_p2t = 1.0_rt/p2t;
 
-		    Real const beta1_sq = (p1x*p1x + p1y*p1y + p1z*p1z) * inv_p1t*inv_p1t;
-		    Real const beta2_sq = (p2x*p2x + p2y*p2y + p2z*p2z) * inv_p2t*inv_p2t;
-		    Real const beta1_dot_beta2 = (p1x*p2x + p1y*p2y + p1z*p2z) * inv_p1t*inv_p2t;
+            Real const beta1_sq = (p1x*p1x + p1y*p1y + p1z*p1z) * inv_p1t*inv_p1t;
+            Real const beta2_sq = (p2x*p2x + p2y*p2y + p2z*p2z) * inv_p2t*inv_p2t;
+            Real const beta1_dot_beta2 = (p1x*p2x + p1y*p2y + p1z*p2z) * inv_p1t*inv_p2t;
 
-		    // Here we use the fact that:
-		    // (v1 - v2)^2 = v1^2 + v2^2 - 2 v1.v2
-		    // and (v1 x v2)^2 = v1^2 v2^2 - (v1.v2)^2
-		    // we also use beta=v/c instead of v
+            // Here we use the fact that:
+            // (v1 - v2)^2 = v1^2 + v2^2 - 2 v1.v2
+            // and (v1 x v2)^2 = v1^2 v2^2 - (v1.v2)^2
+            // we also use beta=v/c instead of v
 
-		    Real const radicand = beta1_sq + beta2_sq - 2*beta1_dot_beta2 - beta1_sq*beta2_sq + beta1_dot_beta2*beta1_dot_beta2;
+            Real const radicand = beta1_sq + beta2_sq - 2*beta1_dot_beta2 - beta1_sq*beta2_sq + beta1_dot_beta2*beta1_dot_beta2;
 
-		    Real const dL_dEcom = PhysConst::c * std::sqrt( radicand ) * min_N * w1[j_1] * w2[j_2] / dV / bin_size * dt; // m^-2 eV^-1
+            Real const dL_dEcom = PhysConst::c * std::sqrt( radicand ) * min_N * w1[j_1] * w2[j_2] / dV / bin_size * dt; // m^-2 eV^-1
 
-		    amrex::HostDevice::Atomic::Add(&dptr_data[bin], dL_dEcom);
+            amrex::HostDevice::Atomic::Add(&dptr_data[bin], dL_dEcom);
 
-		    if (max_N == NI1) {
-			i_1 += min_N;
-		    }
-		    if (max_N == NI2) {
-			i_2 += min_N;
-		    }
-		} // k
+            if (max_N == NI1) {
+            i_1 += min_N;
+            }
+            if (max_N == NI2) {
+            i_2 += min_N;
+            }
+        } // k
             }); // independent pairs
         } // boxes
     } // levels

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
@@ -185,7 +185,7 @@ void DifferentialLuminosity::ComputeDiags (int step)
             amrex::ParticleReal * const AMREX_RESTRICT u1z = soa_1.m_rdata[PIdx::uz];
             bool const species1_is_photon = species_1.AmIA<PhysicalSpecies::photon>();
 
-	    // Species 2
+        // Species 2
             const auto soa_2 = ptile_2.getParticleTileData();
             index_type* AMREX_RESTRICT indices_2 = bins_2.permutationPtr();
             index_type const* AMREX_RESTRICT cell_offsets_2 = bins_2.offsetsPtr();
@@ -199,110 +199,110 @@ void DifferentialLuminosity::ComputeDiags (int step)
             // Extract low-level data
             auto const n_cells = static_cast<int>(bins_1.numBins());
 
-	    IndependentPairHelper<index_type> indep_pairs(n_cells, cell_offsets_1, cell_offsets_2);
-	    indep_pairs.shuffle(indices_1, indices_2);
+        IndependentPairHelper<index_type> indep_pairs(n_cells, cell_offsets_1, cell_offsets_2);
+        indep_pairs.shuffle(indices_1, indices_2);
 
-	    int n_independent_pairs = indep_pairs.numIndependentPairs();
-	    const index_type*  AMREX_RESTRICT p_coll_offsets = indep_pairs.collisionOffsetsPtr();
+        int n_independent_pairs = indep_pairs.numIndependentPairs();
+        const index_type*  AMREX_RESTRICT p_coll_offsets = indep_pairs.collisionOffsetsPtr();
 
             // Loop over independent pairs
-	    amrex::ParallelFor( n_independent_pairs, [=] AMREX_GPU_DEVICE (int i_coll) noexcept
-	    {
-		// to avoid type mismatch errors
-		auto ui_coll = (index_type)i_coll;
+        amrex::ParallelFor( n_independent_pairs, [=] AMREX_GPU_DEVICE (int i_coll) noexcept
+        {
+        // to avoid type mismatch errors
+        auto ui_coll = (index_type)i_coll;
 
-		// Use a bisection algorithm to find the index of the cell in which this pair is located
-		const int i_cell = amrex::bisect( p_coll_offsets, 0, n_cells, ui_coll );
+        // Use a bisection algorithm to find the index of the cell in which this pair is located
+        const int i_cell = amrex::bisect( p_coll_offsets, 0, n_cells, ui_coll );
 
-		// The particles from species1 that are in the cell `i_cell` are
-		// given by the `indices_1[cell_start_1:cell_stop_1]`
-		index_type const cell_start_1 = cell_offsets_1[i_cell];
-		index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
+        // The particles from species1 that are in the cell `i_cell` are
+        // given by the `indices_1[cell_start_1:cell_stop_1]`
+        index_type const cell_start_1 = cell_offsets_1[i_cell];
+        index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
 
-		// Same for species 2
-		index_type const cell_start_2 = cell_offsets_2[i_cell];
-		index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
+        // Same for species 2
+        index_type const cell_start_2 = cell_offsets_2[i_cell];
+        index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
 
-		const index_type NI1 = cell_stop_1 - cell_start_1;
-		const index_type NI2 = cell_stop_2 - cell_start_2;
-		const index_type max_N = amrex::max(NI1,NI2);
-		const index_type min_N = amrex::min(NI1,NI2);
+        const index_type NI1 = cell_stop_1 - cell_start_1;
+        const index_type NI2 = cell_stop_2 - cell_start_2;
+        const index_type max_N = amrex::max(NI1,NI2);
+        const index_type min_N = amrex::min(NI1,NI2);
 
-		// collision number of the cell
-		const index_type coll_idx = ui_coll - p_coll_offsets[i_cell];
-		index_type i_1 = cell_start_1 + coll_idx;
-		index_type i_2 = cell_start_2 + coll_idx;
+        // collision number of the cell
+        const index_type coll_idx = ui_coll - p_coll_offsets[i_cell];
+        index_type i_1 = cell_start_1 + coll_idx;
+        index_type i_2 = cell_start_2 + coll_idx;
 
-		// we will start from collision number = coll_idx and then add
-		// stride (smaller set size) until we do all collisions (larger set size)
-		for (index_type k = coll_idx; k < max_N; k += min_N)
-		{
-		    index_type const j_1 = indices_1[i_1];
-		    index_type const j_2 = indices_2[i_2];
+        // we will start from collision number = coll_idx and then add
+        // stride (smaller set size) until we do all collisions (larger set size)
+        for (index_type k = coll_idx; k < max_N; k += min_N)
+        {
+            index_type const j_1 = indices_1[i_1];
+            index_type const j_2 = indices_2[i_2];
 
-		    Real p1t=0, p1x=0, p1y=0, p1z=0; // components of 4-momentum of particle 1
-		    Real const u1_sq =  u1x[j_1]*u1x[j_1] + u1y[j_1]*u1y[j_1] + u1z[j_1]*u1z[j_1];
-		    if (species1_is_photon) {
-			// photon case (momentum is normalized by m_e in WarpX)
-			p1t = PhysConst::m_e*std::sqrt( u1_sq );
-			p1x = PhysConst::m_e*u1x[j_1];
-			p1y = PhysConst::m_e*u1y[j_1];
-			p1z = PhysConst::m_e*u1z[j_1];
-		    } else {
-			p1t = m1*std::sqrt( c_sq + u1_sq );
-			p1x = m1*u1x[j_1];
-			p1y = m1*u1y[j_1];
-			p1z = m1*u1z[j_1];
-		    }
+            Real p1t=0, p1x=0, p1y=0, p1z=0; // components of 4-momentum of particle 1
+            Real const u1_sq =  u1x[j_1]*u1x[j_1] + u1y[j_1]*u1y[j_1] + u1z[j_1]*u1z[j_1];
+            if (species1_is_photon) {
+            // photon case (momentum is normalized by m_e in WarpX)
+            p1t = PhysConst::m_e*std::sqrt( u1_sq );
+            p1x = PhysConst::m_e*u1x[j_1];
+            p1y = PhysConst::m_e*u1y[j_1];
+            p1z = PhysConst::m_e*u1z[j_1];
+            } else {
+            p1t = m1*std::sqrt( c_sq + u1_sq );
+            p1x = m1*u1x[j_1];
+            p1y = m1*u1y[j_1];
+            p1z = m1*u1z[j_1];
+            }
 
-		    Real p2t=0, p2x=0, p2y=0, p2z=0; // components of 4-momentum of particle 2
-		    Real const u2_sq =  u2x[j_2]*u2x[j_2] + u2y[j_2]*u2y[j_2] + u2z[j_2]*u2z[j_2];
-		    if (species2_is_photon) {
-			// photon case (momentum is normalized by m_e in WarpX)
-			p2t = PhysConst::m_e*std::sqrt(u2_sq);
-			p2x = PhysConst::m_e*u2x[j_2];
-			p2y = PhysConst::m_e*u2y[j_2];
-			p2z = PhysConst::m_e*u2z[j_2];
-		    } else {
-			p2t = m2*std::sqrt( c_sq + u2_sq );
-			p2x = m2*u2x[j_2];
-			p2y = m2*u2y[j_2];
-			p2z = m2*u2z[j_2];
-		    }
+            Real p2t=0, p2x=0, p2y=0, p2z=0; // components of 4-momentum of particle 2
+            Real const u2_sq =  u2x[j_2]*u2x[j_2] + u2y[j_2]*u2y[j_2] + u2z[j_2]*u2z[j_2];
+            if (species2_is_photon) {
+            // photon case (momentum is normalized by m_e in WarpX)
+            p2t = PhysConst::m_e*std::sqrt(u2_sq);
+            p2x = PhysConst::m_e*u2x[j_2];
+            p2y = PhysConst::m_e*u2y[j_2];
+            p2z = PhysConst::m_e*u2z[j_2];
+            } else {
+            p2t = m2*std::sqrt( c_sq + u2_sq );
+            p2x = m2*u2x[j_2];
+            p2y = m2*u2y[j_2];
+            p2z = m2*u2z[j_2];
+            }
 
-		    // center of mass energy in eV
-		    Real const E_com = c_over_qe * std::sqrt(m1*m1*c_sq + m2*m2*c_sq + 2*(p1t*p2t - p1x*p2x - p1y*p2y - p1z*p2z));
+            // center of mass energy in eV
+            Real const E_com = c_over_qe * std::sqrt(m1*m1*c_sq + m2*m2*c_sq + 2*(p1t*p2t - p1x*p2x - p1y*p2y - p1z*p2z));
 
-		    // determine particle bin
-		    int const bin = int(Math::floor((E_com-bin_min)/bin_size));
+            // determine particle bin
+            int const bin = int(Math::floor((E_com-bin_min)/bin_size));
 
-		    if ( bin<0 || bin>=num_bins ) { continue; } // discard if out-of-range
+            if ( bin<0 || bin>=num_bins ) { continue; } // discard if out-of-range
 
-		    Real const inv_p1t = 1.0_rt/p1t;
-		    Real const inv_p2t = 1.0_rt/p2t;
+            Real const inv_p1t = 1.0_rt/p1t;
+            Real const inv_p2t = 1.0_rt/p2t;
 
-		    Real const beta1_sq = (p1x*p1x + p1y*p1y + p1z*p1z) * inv_p1t*inv_p1t;
-		    Real const beta2_sq = (p2x*p2x + p2y*p2y + p2z*p2z) * inv_p2t*inv_p2t;
-		    Real const beta1_dot_beta2 = (p1x*p2x + p1y*p2y + p1z*p2z) * inv_p1t*inv_p2t;
+            Real const beta1_sq = (p1x*p1x + p1y*p1y + p1z*p1z) * inv_p1t*inv_p1t;
+            Real const beta2_sq = (p2x*p2x + p2y*p2y + p2z*p2z) * inv_p2t*inv_p2t;
+            Real const beta1_dot_beta2 = (p1x*p2x + p1y*p2y + p1z*p2z) * inv_p1t*inv_p2t;
 
-		    // Here we use the fact that:
-		    // (v1 - v2)^2 = v1^2 + v2^2 - 2 v1.v2
-		    // and (v1 x v2)^2 = v1^2 v2^2 - (v1.v2)^2
-		    // we also use beta=v/c instead of v
+            // Here we use the fact that:
+            // (v1 - v2)^2 = v1^2 + v2^2 - 2 v1.v2
+            // and (v1 x v2)^2 = v1^2 v2^2 - (v1.v2)^2
+            // we also use beta=v/c instead of v
 
-		    Real const radicand = beta1_sq + beta2_sq - 2*beta1_dot_beta2 - beta1_sq*beta2_sq + beta1_dot_beta2*beta1_dot_beta2;
+            Real const radicand = beta1_sq + beta2_sq - 2*beta1_dot_beta2 - beta1_sq*beta2_sq + beta1_dot_beta2*beta1_dot_beta2;
 
-		    Real const dL_dEcom = PhysConst::c * std::sqrt( radicand ) * min_N * w1[j_1] * w2[j_2] / dV / bin_size * dt; // m^-2 eV^-1
+            Real const dL_dEcom = PhysConst::c * std::sqrt( radicand ) * min_N * w1[j_1] * w2[j_2] / dV / bin_size * dt; // m^-2 eV^-1
 
-		    amrex::HostDevice::Atomic::Add(&dptr_data[bin], dL_dEcom);
+            amrex::HostDevice::Atomic::Add(&dptr_data[bin], dL_dEcom);
 
-		    if (max_N == NI1) {
-			i_1 += min_N;
-		    }
-		    if (max_N == NI2) {
-			i_2 += min_N;
-		    }
-		} // k
+            if (max_N == NI1) {
+            i_1 += min_N;
+            }
+            if (max_N == NI2) {
+            i_2 += min_N;
+            }
+        } // k
             }); // independent pairs
         } // boxes
     } // levels

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
@@ -206,6 +206,13 @@ void DifferentialLuminosity::ComputeDiags (int step)
             const index_type*  AMREX_RESTRICT p_coll_offsets = indep_pairs.collisionOffsetsPtr();
 
             // Loop over independent pairs
+            // This uses the Takizuka and Abe pairing algorithm 
+            // (https://doi.org/10.1016/0021-9991(77)90099-7)
+            // to estimate the number of collisions in each cell.
+            // Instead of evaluating the number of collisions for every `NI1*NI2`
+            // pair of macroparticles, it samples max(NI1,NI2) pairs
+            // and scales the resulting number by multiplying by min(NI1,NI2).
+            // The parallelization strategy follows: https://dl.acm.org/doi/10.1145/3732775.3733578
             amrex::ParallelFor( n_independent_pairs, [=] AMREX_GPU_DEVICE (int i_coll) noexcept
             {
                 // to avoid type mismatch errors
@@ -292,6 +299,8 @@ void DifferentialLuminosity::ComputeDiags (int step)
 
                     Real const radicand = beta1_sq + beta2_sq - 2*beta1_dot_beta2 - beta1_sq*beta2_sq + beta1_dot_beta2*beta1_dot_beta2;
 
+                    // Scale the number of collisions by multiplying by `min_N`
+                    // to reflect the fact that we only sampled `max_N` pairs instead of `NI1*NI2`
                     Real const dL_dEcom = PhysConst::c * std::sqrt( radicand ) * min_N * w1[j_1] * w2[j_2] / dV / bin_size * dt; // m^-2 eV^-1
 
                     amrex::HostDevice::Atomic::Add(&dptr_data[bin], dL_dEcom);

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
@@ -142,7 +142,6 @@ void DifferentialLuminosity::ComputeDiags (int step)
     const Real dt = warpx.getdt(0);
     // get cell volume
     Geometry const & geom = warpx.Geom(0);
-    // is this valid in non-cartesian?
     const Real dV = AMREX_D_TERM(geom.CellSize(0), *geom.CellSize(1), *geom.CellSize(2));
 
     // declare local variables

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
@@ -185,7 +185,7 @@ void DifferentialLuminosity::ComputeDiags (int step)
             amrex::ParticleReal * const AMREX_RESTRICT u1z = soa_1.m_rdata[PIdx::uz];
             bool const species1_is_photon = species_1.AmIA<PhysicalSpecies::photon>();
 
-        // Species 2
+            // Species 2
             const auto soa_2 = ptile_2.getParticleTileData();
             index_type* AMREX_RESTRICT indices_2 = bins_2.permutationPtr();
             index_type const* AMREX_RESTRICT cell_offsets_2 = bins_2.offsetsPtr();
@@ -199,110 +199,110 @@ void DifferentialLuminosity::ComputeDiags (int step)
             // Extract low-level data
             auto const n_cells = static_cast<int>(bins_1.numBins());
 
-        IndependentPairHelper<index_type> indep_pairs(n_cells, cell_offsets_1, cell_offsets_2);
-        indep_pairs.shuffle(indices_1, indices_2);
+            IndependentPairHelper<index_type> indep_pairs(n_cells, cell_offsets_1, cell_offsets_2);
+            indep_pairs.shuffle(indices_1, indices_2);
 
-        int n_independent_pairs = indep_pairs.numIndependentPairs();
-        const index_type*  AMREX_RESTRICT p_coll_offsets = indep_pairs.collisionOffsetsPtr();
+            int n_independent_pairs = indep_pairs.numIndependentPairs();
+            const index_type*  AMREX_RESTRICT p_coll_offsets = indep_pairs.collisionOffsetsPtr();
 
             // Loop over independent pairs
-        amrex::ParallelFor( n_independent_pairs, [=] AMREX_GPU_DEVICE (int i_coll) noexcept
-        {
-        // to avoid type mismatch errors
-        auto ui_coll = (index_type)i_coll;
+            amrex::ParallelFor( n_independent_pairs, [=] AMREX_GPU_DEVICE (int i_coll) noexcept
+            {
+                // to avoid type mismatch errors
+                auto ui_coll = (index_type)i_coll;
 
-        // Use a bisection algorithm to find the index of the cell in which this pair is located
-        const int i_cell = amrex::bisect( p_coll_offsets, 0, n_cells, ui_coll );
+                // Use a bisection algorithm to find the index of the cell in which this pair is located
+                const int i_cell = amrex::bisect( p_coll_offsets, 0, n_cells, ui_coll );
 
-        // The particles from species1 that are in the cell `i_cell` are
-        // given by the `indices_1[cell_start_1:cell_stop_1]`
-        index_type const cell_start_1 = cell_offsets_1[i_cell];
-        index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
+                // The particles from species1 that are in the cell `i_cell` are
+                // given by the `indices_1[cell_start_1:cell_stop_1]`
+                index_type const cell_start_1 = cell_offsets_1[i_cell];
+                index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
 
-        // Same for species 2
-        index_type const cell_start_2 = cell_offsets_2[i_cell];
-        index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
+                // Same for species 2
+                index_type const cell_start_2 = cell_offsets_2[i_cell];
+                index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
 
-        const index_type NI1 = cell_stop_1 - cell_start_1;
-        const index_type NI2 = cell_stop_2 - cell_start_2;
-        const index_type max_N = amrex::max(NI1,NI2);
-        const index_type min_N = amrex::min(NI1,NI2);
+                const index_type NI1 = cell_stop_1 - cell_start_1;
+                const index_type NI2 = cell_stop_2 - cell_start_2;
+                const index_type max_N = amrex::max(NI1,NI2);
+                const index_type min_N = amrex::min(NI1,NI2);
 
-        // collision number of the cell
-        const index_type coll_idx = ui_coll - p_coll_offsets[i_cell];
-        index_type i_1 = cell_start_1 + coll_idx;
-        index_type i_2 = cell_start_2 + coll_idx;
+                // collision number of the cell
+                const index_type coll_idx = ui_coll - p_coll_offsets[i_cell];
+                index_type i_1 = cell_start_1 + coll_idx;
+                index_type i_2 = cell_start_2 + coll_idx;
 
-        // we will start from collision number = coll_idx and then add
-        // stride (smaller set size) until we do all collisions (larger set size)
-        for (index_type k = coll_idx; k < max_N; k += min_N)
-        {
-            index_type const j_1 = indices_1[i_1];
-            index_type const j_2 = indices_2[i_2];
+                // we will start from collision number = coll_idx and then add
+                // stride (smaller set size) until we do all collisions (larger set size)
+                for (index_type k = coll_idx; k < max_N; k += min_N)
+                {
+                    index_type const j_1 = indices_1[i_1];
+                    index_type const j_2 = indices_2[i_2];
 
-            Real p1t=0, p1x=0, p1y=0, p1z=0; // components of 4-momentum of particle 1
-            Real const u1_sq =  u1x[j_1]*u1x[j_1] + u1y[j_1]*u1y[j_1] + u1z[j_1]*u1z[j_1];
-            if (species1_is_photon) {
-            // photon case (momentum is normalized by m_e in WarpX)
-            p1t = PhysConst::m_e*std::sqrt( u1_sq );
-            p1x = PhysConst::m_e*u1x[j_1];
-            p1y = PhysConst::m_e*u1y[j_1];
-            p1z = PhysConst::m_e*u1z[j_1];
-            } else {
-            p1t = m1*std::sqrt( c_sq + u1_sq );
-            p1x = m1*u1x[j_1];
-            p1y = m1*u1y[j_1];
-            p1z = m1*u1z[j_1];
-            }
+                    Real p1t=0, p1x=0, p1y=0, p1z=0; // components of 4-momentum of particle 1
+                    Real const u1_sq =  u1x[j_1]*u1x[j_1] + u1y[j_1]*u1y[j_1] + u1z[j_1]*u1z[j_1];
+                    if (species1_is_photon) {
+                        // photon case (momentum is normalized by m_e in WarpX)
+                        p1t = PhysConst::m_e*std::sqrt( u1_sq );
+                        p1x = PhysConst::m_e*u1x[j_1];
+                        p1y = PhysConst::m_e*u1y[j_1];
+                        p1z = PhysConst::m_e*u1z[j_1];
+                    } else {
+                        p1t = m1*std::sqrt( c_sq + u1_sq );
+                        p1x = m1*u1x[j_1];
+                        p1y = m1*u1y[j_1];
+                        p1z = m1*u1z[j_1];
+                    }
 
-            Real p2t=0, p2x=0, p2y=0, p2z=0; // components of 4-momentum of particle 2
-            Real const u2_sq =  u2x[j_2]*u2x[j_2] + u2y[j_2]*u2y[j_2] + u2z[j_2]*u2z[j_2];
-            if (species2_is_photon) {
-            // photon case (momentum is normalized by m_e in WarpX)
-            p2t = PhysConst::m_e*std::sqrt(u2_sq);
-            p2x = PhysConst::m_e*u2x[j_2];
-            p2y = PhysConst::m_e*u2y[j_2];
-            p2z = PhysConst::m_e*u2z[j_2];
-            } else {
-            p2t = m2*std::sqrt( c_sq + u2_sq );
-            p2x = m2*u2x[j_2];
-            p2y = m2*u2y[j_2];
-            p2z = m2*u2z[j_2];
-            }
+                    Real p2t=0, p2x=0, p2y=0, p2z=0; // components of 4-momentum of particle 2
+                    Real const u2_sq =  u2x[j_2]*u2x[j_2] + u2y[j_2]*u2y[j_2] + u2z[j_2]*u2z[j_2];
+                    if (species2_is_photon) {
+                        // photon case (momentum is normalized by m_e in WarpX)
+                        p2t = PhysConst::m_e*std::sqrt(u2_sq);
+                        p2x = PhysConst::m_e*u2x[j_2];
+                        p2y = PhysConst::m_e*u2y[j_2];
+                        p2z = PhysConst::m_e*u2z[j_2];
+                    } else {
+                        p2t = m2*std::sqrt( c_sq + u2_sq );
+                        p2x = m2*u2x[j_2];
+                        p2y = m2*u2y[j_2];
+                        p2z = m2*u2z[j_2];
+                    }
 
-            // center of mass energy in eV
-            Real const E_com = c_over_qe * std::sqrt(m1*m1*c_sq + m2*m2*c_sq + 2*(p1t*p2t - p1x*p2x - p1y*p2y - p1z*p2z));
+                    // center of mass energy in eV
+                    Real const E_com = c_over_qe * std::sqrt(m1*m1*c_sq + m2*m2*c_sq + 2*(p1t*p2t - p1x*p2x - p1y*p2y - p1z*p2z));
 
-            // determine particle bin
-            int const bin = int(Math::floor((E_com-bin_min)/bin_size));
+                    // determine particle bin
+                    int const bin = int(Math::floor((E_com-bin_min)/bin_size));
 
-            if ( bin<0 || bin>=num_bins ) { continue; } // discard if out-of-range
+                    if ( bin<0 || bin>=num_bins ) { continue; } // discard if out-of-range
 
-            Real const inv_p1t = 1.0_rt/p1t;
-            Real const inv_p2t = 1.0_rt/p2t;
+                    Real const inv_p1t = 1.0_rt/p1t;
+                    Real const inv_p2t = 1.0_rt/p2t;
 
-            Real const beta1_sq = (p1x*p1x + p1y*p1y + p1z*p1z) * inv_p1t*inv_p1t;
-            Real const beta2_sq = (p2x*p2x + p2y*p2y + p2z*p2z) * inv_p2t*inv_p2t;
-            Real const beta1_dot_beta2 = (p1x*p2x + p1y*p2y + p1z*p2z) * inv_p1t*inv_p2t;
+                    Real const beta1_sq = (p1x*p1x + p1y*p1y + p1z*p1z) * inv_p1t*inv_p1t;
+                    Real const beta2_sq = (p2x*p2x + p2y*p2y + p2z*p2z) * inv_p2t*inv_p2t;
+                    Real const beta1_dot_beta2 = (p1x*p2x + p1y*p2y + p1z*p2z) * inv_p1t*inv_p2t;
 
-            // Here we use the fact that:
-            // (v1 - v2)^2 = v1^2 + v2^2 - 2 v1.v2
-            // and (v1 x v2)^2 = v1^2 v2^2 - (v1.v2)^2
-            // we also use beta=v/c instead of v
+                    // Here we use the fact that:
+                    // (v1 - v2)^2 = v1^2 + v2^2 - 2 v1.v2
+                    // and (v1 x v2)^2 = v1^2 v2^2 - (v1.v2)^2
+                    // we also use beta=v/c instead of v
 
-            Real const radicand = beta1_sq + beta2_sq - 2*beta1_dot_beta2 - beta1_sq*beta2_sq + beta1_dot_beta2*beta1_dot_beta2;
+                    Real const radicand = beta1_sq + beta2_sq - 2*beta1_dot_beta2 - beta1_sq*beta2_sq + beta1_dot_beta2*beta1_dot_beta2;
 
-            Real const dL_dEcom = PhysConst::c * std::sqrt( radicand ) * min_N * w1[j_1] * w2[j_2] / dV / bin_size * dt; // m^-2 eV^-1
+                    Real const dL_dEcom = PhysConst::c * std::sqrt( radicand ) * min_N * w1[j_1] * w2[j_2] / dV / bin_size * dt; // m^-2 eV^-1
 
-            amrex::HostDevice::Atomic::Add(&dptr_data[bin], dL_dEcom);
+                    amrex::HostDevice::Atomic::Add(&dptr_data[bin], dL_dEcom);
 
-            if (max_N == NI1) {
-            i_1 += min_N;
-            }
-            if (max_N == NI2) {
-            i_2 += min_N;
-            }
-        } // k
+                    if (max_N == NI1) {
+                        i_1 += min_N;
+                    }
+                    if (max_N == NI2) {
+                        i_2 += min_N;
+                    }
+                } // k
             }); // independent pairs
         } // boxes
     } // levels

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
@@ -161,17 +161,12 @@ void DifferentialLuminosity::ComputeDiags (int step)
 
     amrex::Real* const AMREX_RESTRICT dptr_data = d_data.dataPtr();
 
-    // is this needed?
-    // Enable tiling
-    amrex::MFItInfo info;
-    if (amrex::Gpu::notInLaunchRegion()) { info.EnableTiling(WarpXParticleContainer::tile_size); }
-
     int const nlevs = std::max(0, species_1.finestLevel()+1); // species_1 ?
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (int lev = 0; lev < nlevs; ++lev) {
-        for (amrex::MFIter mfi = species_1.MakeMFIter(lev, info); mfi.isValid(); ++mfi){
+        for (amrex::MFIter mfi = species_1.MakeMFIter(lev); mfi.isValid(); ++mfi){
 
             ParticleTileType& ptile_1 = species_1.ParticlesAt(lev, mfi);
             ParticleTileType& ptile_2 = species_2.ParticlesAt(lev, mfi);

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
@@ -347,7 +347,7 @@ void DifferentialLuminosity::ComputeDiags (int step)
 
             Real const radicand = beta1_sq + beta2_sq - 2*beta1_dot_beta2 - beta1_sq*beta2_sq + beta1_dot_beta2*beta1_dot_beta2;
 
-            Real const dL_dEcom = PhysConst::c * std::sqrt( radicand ) * min_N * w1[j_1] * w2[j_2] / dV / bin_size * dt; // m^-2 eV^-1
+            Real const dL_dEcom = PhysConst::c * std::sqrt( radicand ) * w1[j_1] * w2[j_2] / dV / bin_size * dt; // m^-2 eV^-1
 
             amrex::HostDevice::Atomic::Add(&dptr_data[bin], dL_dEcom);
 

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
@@ -185,7 +185,7 @@ void DifferentialLuminosity::ComputeDiags (int step)
             amrex::ParticleReal * const AMREX_RESTRICT u1z = soa_1.m_rdata[PIdx::uz];
             bool const species1_is_photon = species_1.AmIA<PhysicalSpecies::photon>();
 
-        // Species 2
+	    // Species 2
             const auto soa_2 = ptile_2.getParticleTileData();
             index_type* AMREX_RESTRICT indices_2 = bins_2.permutationPtr();
             index_type const* AMREX_RESTRICT cell_offsets_2 = bins_2.offsetsPtr();
@@ -199,159 +199,110 @@ void DifferentialLuminosity::ComputeDiags (int step)
             // Extract low-level data
             auto const n_cells = static_cast<int>(bins_1.numBins());
 
-        // Compute the number of independent pairs in each cell. This is equal to
-        // the number of particles in whichever species has fewer
-            amrex::Gpu::DeviceVector<index_type> n_ind_pairs_in_each_cell(n_cells+1);
-            index_type* AMREX_RESTRICT p_n_ind_pairs_in_each_cell = n_ind_pairs_in_each_cell.dataPtr();
+	    IndependentPairHelper<index_type> indep_pairs(n_cells, cell_offsets_1, cell_offsets_2);
+	    indep_pairs.shuffle(indices_1, indices_2);
 
-            amrex::ParallelFor( n_cells+1,
-                [=] AMREX_GPU_DEVICE (int i_cell) noexcept
-                {
-                    if (i_cell < n_cells)
-                    {
-                        const auto n_part_in_cell_1 = cell_offsets_1[i_cell+1] - cell_offsets_1[i_cell];
-                        const auto n_part_in_cell_2 = cell_offsets_2[i_cell+1] - cell_offsets_2[i_cell];
-                        p_n_ind_pairs_in_each_cell[i_cell] = amrex::min(n_part_in_cell_1, n_part_in_cell_2);
-                    }
-                    else
-                    {
-                        p_n_ind_pairs_in_each_cell[i_cell] = 0;
-                    }
-                }
-            );
-
-            // start indices of independent collisions.
-            amrex::Gpu::DeviceVector<index_type> coll_offsets(n_cells+1);
-            // number of total independent collision pairs
-            const auto n_independent_pairs = (int) amrex::Scan::ExclusiveSum(n_cells+1,
-            p_n_ind_pairs_in_each_cell, coll_offsets.data(), amrex::Scan::RetSum{true});
-            index_type* AMREX_RESTRICT p_coll_offsets = coll_offsets.dataPtr();
-
-            // shuffle each species.
-        // we launch 2*n_cells threads to process both species simultaneously
-            amrex::ParallelForRNG( 2*n_cells,
-            [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
-        {
-        int i_cell = i < n_cells ? i : i - n_cells;
-
-        // The particles from species1 that are in the cell `i_cell` are
-        // given by the `indices_1[cell_start_1:cell_stop_1]`
-        index_type const cell_start_1 = cell_offsets_1[i_cell];
-        index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
-
-        // Same for species 2
-        index_type const cell_start_2 = cell_offsets_2[i_cell];
-        index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
-
-        // Do not collide if one species is missing in the cell
-        if ( cell_stop_1 - cell_start_1 < 1 ||
-             cell_stop_2 - cell_start_2 < 1 ) { return; }
-
-        if (i < n_cells) {
-            ShuffleFisherYates(indices_1, cell_start_1, cell_stop_1, engine);
-        } else {
-            ShuffleFisherYates(indices_2, cell_start_2, cell_stop_2, engine);
-        }
-        });
+	    int n_independent_pairs = indep_pairs.numIndependentPairs();
+	    const index_type*  AMREX_RESTRICT p_coll_offsets = indep_pairs.collisionOffsetsPtr();
 
             // Loop over independent pairs
-        amrex::ParallelFor( n_independent_pairs, [=] AMREX_GPU_DEVICE (int i_coll) noexcept
-        {
-        // to avoid type mismatch errors
-        auto ui_coll = (index_type)i_coll;
+	    amrex::ParallelFor( n_independent_pairs, [=] AMREX_GPU_DEVICE (int i_coll) noexcept
+	    {
+		// to avoid type mismatch errors
+		auto ui_coll = (index_type)i_coll;
 
-        // Use a bisection algorithm to find the index of the cell in which this pair is located
-        const int i_cell = amrex::bisect( p_coll_offsets, 0, n_cells, ui_coll );
+		// Use a bisection algorithm to find the index of the cell in which this pair is located
+		const int i_cell = amrex::bisect( p_coll_offsets, 0, n_cells, ui_coll );
 
-        // The particles from species1 that are in the cell `i_cell` are
-        // given by the `indices_1[cell_start_1:cell_stop_1]`
-        index_type const cell_start_1 = cell_offsets_1[i_cell];
-        index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
+		// The particles from species1 that are in the cell `i_cell` are
+		// given by the `indices_1[cell_start_1:cell_stop_1]`
+		index_type const cell_start_1 = cell_offsets_1[i_cell];
+		index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
 
-        // Same for species 2
-        index_type const cell_start_2 = cell_offsets_2[i_cell];
-        index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
+		// Same for species 2
+		index_type const cell_start_2 = cell_offsets_2[i_cell];
+		index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
 
-        const index_type NI1 = cell_stop_1 - cell_start_1;
-        const index_type NI2 = cell_stop_2 - cell_start_2;
-        const index_type max_N = amrex::max(NI1,NI2);
-        const index_type min_N = amrex::min(NI1,NI2);
+		const index_type NI1 = cell_stop_1 - cell_start_1;
+		const index_type NI2 = cell_stop_2 - cell_start_2;
+		const index_type max_N = amrex::max(NI1,NI2);
+		const index_type min_N = amrex::min(NI1,NI2);
 
-        // collision number of the cell
-        const index_type coll_idx = ui_coll - p_coll_offsets[i_cell];
-        index_type i_1 = cell_start_1 + coll_idx;
-        index_type i_2 = cell_start_2 + coll_idx;
+		// collision number of the cell
+		const index_type coll_idx = ui_coll - p_coll_offsets[i_cell];
+		index_type i_1 = cell_start_1 + coll_idx;
+		index_type i_2 = cell_start_2 + coll_idx;
 
-        // we will start from collision number = coll_idx and then add
-        // stride (smaller set size) until we do all collisions (larger set size)
-        for (index_type k = coll_idx; k < max_N; k += min_N)
-        {
-            index_type const j_1 = indices_1[i_1];
-            index_type const j_2 = indices_2[i_2];
+		// we will start from collision number = coll_idx and then add
+		// stride (smaller set size) until we do all collisions (larger set size)
+		for (index_type k = coll_idx; k < max_N; k += min_N)
+		{
+		    index_type const j_1 = indices_1[i_1];
+		    index_type const j_2 = indices_2[i_2];
 
-            Real p1t=0, p1x=0, p1y=0, p1z=0; // components of 4-momentum of particle 1
-            Real const u1_sq =  u1x[j_1]*u1x[j_1] + u1y[j_1]*u1y[j_1] + u1z[j_1]*u1z[j_1];
-            if (species1_is_photon) {
-            // photon case (momentum is normalized by m_e in WarpX)
-            p1t = PhysConst::m_e*std::sqrt( u1_sq );
-            p1x = PhysConst::m_e*u1x[j_1];
-            p1y = PhysConst::m_e*u1y[j_1];
-            p1z = PhysConst::m_e*u1z[j_1];
-            } else {
-            p1t = m1*std::sqrt( c_sq + u1_sq );
-            p1x = m1*u1x[j_1];
-            p1y = m1*u1y[j_1];
-            p1z = m1*u1z[j_1];
-            }
+		    Real p1t=0, p1x=0, p1y=0, p1z=0; // components of 4-momentum of particle 1
+		    Real const u1_sq =  u1x[j_1]*u1x[j_1] + u1y[j_1]*u1y[j_1] + u1z[j_1]*u1z[j_1];
+		    if (species1_is_photon) {
+			// photon case (momentum is normalized by m_e in WarpX)
+			p1t = PhysConst::m_e*std::sqrt( u1_sq );
+			p1x = PhysConst::m_e*u1x[j_1];
+			p1y = PhysConst::m_e*u1y[j_1];
+			p1z = PhysConst::m_e*u1z[j_1];
+		    } else {
+			p1t = m1*std::sqrt( c_sq + u1_sq );
+			p1x = m1*u1x[j_1];
+			p1y = m1*u1y[j_1];
+			p1z = m1*u1z[j_1];
+		    }
 
-            Real p2t=0, p2x=0, p2y=0, p2z=0; // components of 4-momentum of particle 2
-            Real const u2_sq =  u2x[j_2]*u2x[j_2] + u2y[j_2]*u2y[j_2] + u2z[j_2]*u2z[j_2];
-            if (species2_is_photon) {
-            // photon case (momentum is normalized by m_e in WarpX)
-            p2t = PhysConst::m_e*std::sqrt(u2_sq);
-            p2x = PhysConst::m_e*u2x[j_2];
-            p2y = PhysConst::m_e*u2y[j_2];
-            p2z = PhysConst::m_e*u2z[j_2];
-            } else {
-            p2t = m2*std::sqrt( c_sq + u2_sq );
-            p2x = m2*u2x[j_2];
-            p2y = m2*u2y[j_2];
-            p2z = m2*u2z[j_2];
-            }
+		    Real p2t=0, p2x=0, p2y=0, p2z=0; // components of 4-momentum of particle 2
+		    Real const u2_sq =  u2x[j_2]*u2x[j_2] + u2y[j_2]*u2y[j_2] + u2z[j_2]*u2z[j_2];
+		    if (species2_is_photon) {
+			// photon case (momentum is normalized by m_e in WarpX)
+			p2t = PhysConst::m_e*std::sqrt(u2_sq);
+			p2x = PhysConst::m_e*u2x[j_2];
+			p2y = PhysConst::m_e*u2y[j_2];
+			p2z = PhysConst::m_e*u2z[j_2];
+		    } else {
+			p2t = m2*std::sqrt( c_sq + u2_sq );
+			p2x = m2*u2x[j_2];
+			p2y = m2*u2y[j_2];
+			p2z = m2*u2z[j_2];
+		    }
 
-            // center of mass energy in eV
-            Real const E_com = c_over_qe * std::sqrt(m1*m1*c_sq + m2*m2*c_sq + 2*(p1t*p2t - p1x*p2x - p1y*p2y - p1z*p2z));
+		    // center of mass energy in eV
+		    Real const E_com = c_over_qe * std::sqrt(m1*m1*c_sq + m2*m2*c_sq + 2*(p1t*p2t - p1x*p2x - p1y*p2y - p1z*p2z));
 
-            // determine particle bin
-            int const bin = int(Math::floor((E_com-bin_min)/bin_size));
+		    // determine particle bin
+		    int const bin = int(Math::floor((E_com-bin_min)/bin_size));
 
-            if ( bin<0 || bin>=num_bins ) { continue; } // discard if out-of-range
+		    if ( bin<0 || bin>=num_bins ) { continue; } // discard if out-of-range
 
-            Real const inv_p1t = 1.0_rt/p1t;
-            Real const inv_p2t = 1.0_rt/p2t;
+		    Real const inv_p1t = 1.0_rt/p1t;
+		    Real const inv_p2t = 1.0_rt/p2t;
 
-            Real const beta1_sq = (p1x*p1x + p1y*p1y + p1z*p1z) * inv_p1t*inv_p1t;
-            Real const beta2_sq = (p2x*p2x + p2y*p2y + p2z*p2z) * inv_p2t*inv_p2t;
-            Real const beta1_dot_beta2 = (p1x*p2x + p1y*p2y + p1z*p2z) * inv_p1t*inv_p2t;
+		    Real const beta1_sq = (p1x*p1x + p1y*p1y + p1z*p1z) * inv_p1t*inv_p1t;
+		    Real const beta2_sq = (p2x*p2x + p2y*p2y + p2z*p2z) * inv_p2t*inv_p2t;
+		    Real const beta1_dot_beta2 = (p1x*p2x + p1y*p2y + p1z*p2z) * inv_p1t*inv_p2t;
 
-            // Here we use the fact that:
-            // (v1 - v2)^2 = v1^2 + v2^2 - 2 v1.v2
-            // and (v1 x v2)^2 = v1^2 v2^2 - (v1.v2)^2
-            // we also use beta=v/c instead of v
+		    // Here we use the fact that:
+		    // (v1 - v2)^2 = v1^2 + v2^2 - 2 v1.v2
+		    // and (v1 x v2)^2 = v1^2 v2^2 - (v1.v2)^2
+		    // we also use beta=v/c instead of v
 
-            Real const radicand = beta1_sq + beta2_sq - 2*beta1_dot_beta2 - beta1_sq*beta2_sq + beta1_dot_beta2*beta1_dot_beta2;
+		    Real const radicand = beta1_sq + beta2_sq - 2*beta1_dot_beta2 - beta1_sq*beta2_sq + beta1_dot_beta2*beta1_dot_beta2;
 
-            Real const dL_dEcom = PhysConst::c * std::sqrt( radicand ) * min_N * w1[j_1] * w2[j_2] / dV / bin_size * dt; // m^-2 eV^-1
+		    Real const dL_dEcom = PhysConst::c * std::sqrt( radicand ) * min_N * w1[j_1] * w2[j_2] / dV / bin_size * dt; // m^-2 eV^-1
 
-            amrex::HostDevice::Atomic::Add(&dptr_data[bin], dL_dEcom);
+		    amrex::HostDevice::Atomic::Add(&dptr_data[bin], dL_dEcom);
 
-            if (max_N == NI1) {
-            i_1 += min_N;
-            }
-            if (max_N == NI2) {
-            i_2 += min_N;
-            }
-        } // k
+		    if (max_N == NI1) {
+			i_1 += min_N;
+		    }
+		    if (max_N == NI2) {
+			i_2 += min_N;
+		    }
+		} // k
             }); // independent pairs
         } // boxes
     } // levels

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
@@ -206,7 +206,7 @@ void DifferentialLuminosity::ComputeDiags (int step)
             const index_type*  AMREX_RESTRICT p_coll_offsets = indep_pairs.collisionOffsetsPtr();
 
             // Loop over independent pairs
-            // This uses the Takizuka and Abe pairing algorithm 
+            // This uses the Takizuka and Abe pairing algorithm
             // (https://doi.org/10.1016/0021-9991(77)90099-7)
             // to estimate the number of collisions in each cell.
             // Instead of evaluating the number of collisions for every `NI1*NI2`

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity2D.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity2D.cpp
@@ -226,6 +226,13 @@ void DifferentialLuminosity2D::ComputeDiags (int step)
             const index_type*  AMREX_RESTRICT p_coll_offsets = indep_pairs.collisionOffsetsPtr();
 
             // Loop over independent pairs
+            // This uses the Takizuka and Abe pairing algorithm 
+            // (https://doi.org/10.1016/0021-9991(77)90099-7)
+            // to estimate the number of collisions in each cell.
+            // Instead of evaluating the number of collisions for every `NI1*NI2`
+            // pair of macroparticles, it samples max(NI1,NI2) pairs
+            // and scales the resulting number by multiplying by min(NI1,NI2).
+            // The parallelization strategy follows: https://dl.acm.org/doi/10.1145/3732775.3733578
             amrex::ParallelFor( n_independent_pairs, [=] AMREX_GPU_DEVICE (int i_coll) noexcept
             {
                 // to avoid type mismatch errors
@@ -314,6 +321,8 @@ void DifferentialLuminosity2D::ComputeDiags (int step)
                     // we also use beta=v/c instead of v
                     Real const radicand = beta1_sq + beta2_sq - 2*beta1_dot_beta2 - beta1_sq*beta2_sq + beta1_dot_beta2*beta1_dot_beta2;
 
+                    // Scale the number of collisions by multiplying by `min_N`
+                    // to reflect the fact that we only sampled `max_N` pairs instead of `NI1*NI2`
                     Real const d2L_dE1_dE2 = PhysConst::c * std::sqrt( radicand ) * min_N * w1[j_1] * w2[j_2] / (dV * bin_size_1 * bin_size_2) * dt; // m^-2 eV^-2
 
                     amrex::Real &data = d_table(bin_1, bin_2);

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity2D.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity2D.cpp
@@ -9,6 +9,7 @@
 
 #include "Diagnostics/ReducedDiags/ReducedDiags.H"
 #include "Diagnostics/OpenPMDHelpFunction.H"
+#include "Particles/Collision/BinaryCollision/ShuffleFisherYates.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/SpeciesPhysicalProperties.H"
@@ -180,11 +181,10 @@ void DifferentialLuminosity2D::ComputeDiags (int step)
     const ParticleReal m2 = species_2.getMass();
 
     int const nlevs = std::max(0, species_1.finestLevel()+1); // species_1 ?
-    for (int lev = 0; lev < nlevs; ++lev) {
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-
+    for (int lev = 0; lev < nlevs; ++lev) {
         for (amrex::MFIter mfi = species_1.MakeMFIter(lev); mfi.isValid(); ++mfi){
 
             ParticleTileType& ptile_1 = species_1.ParticlesAt(lev, mfi);
@@ -219,86 +219,162 @@ void DifferentialLuminosity2D::ComputeDiags (int step)
             // Extract low-level (cell-level) data
             auto const n_cells = static_cast<int>(bins_1.numBins());
 
-            // Loop over cells
-            amrex::ParallelFor( n_cells,
+	    // Compute the number of independent pairs in each cell. This is equal to
+	    // the number of particles in whichever species has fewer
+            amrex::Gpu::DeviceVector<index_type> n_ind_pairs_in_each_cell(n_cells+1);
+            index_type* AMREX_RESTRICT p_n_ind_pairs_in_each_cell = n_ind_pairs_in_each_cell.dataPtr();
+
+            amrex::ParallelFor( n_cells+1,
                 [=] AMREX_GPU_DEVICE (int i_cell) noexcept
+                {
+                    if (i_cell < n_cells)
+                    {
+                        const auto n_part_in_cell_1 = cell_offsets_1[i_cell+1] - cell_offsets_1[i_cell];
+                        const auto n_part_in_cell_2 = cell_offsets_2[i_cell+1] - cell_offsets_2[i_cell];
+                        p_n_ind_pairs_in_each_cell[i_cell] = amrex::min(n_part_in_cell_1, n_part_in_cell_2);
+                    }
+                    else
+                    {
+                        p_n_ind_pairs_in_each_cell[i_cell] = 0;
+                    }
+                }
+            );
+
+            // start indices of independent collisions.
+            amrex::Gpu::DeviceVector<index_type> coll_offsets(n_cells+1);
+            // number of total independent collision pairs
+            const auto n_independent_pairs = (int) amrex::Scan::ExclusiveSum(n_cells+1,
+	        p_n_ind_pairs_in_each_cell, coll_offsets.data(), amrex::Scan::RetSum{true});
+            index_type* AMREX_RESTRICT p_coll_offsets = coll_offsets.dataPtr();
+
+            // shuffle each species.
+	    // we launch 2*n_cells threads to process both species simultaneously
+            amrex::ParallelForRNG( 2*n_cells,
+	        [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
+	    {
+		int i_cell = i < n_cells ? i : i - n_cells;
+
+		// The particles from species1 that are in the cell `i_cell` are
+		// given by the `indices_1[cell_start_1:cell_stop_1]`
+		index_type const cell_start_1 = cell_offsets_1[i_cell];
+		index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
+
+		// Same for species 2
+		index_type const cell_start_2 = cell_offsets_2[i_cell];
+		index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
+
+		// Do not collide if one species is missing in the cell
+		if ( cell_stop_1 - cell_start_1 < 1 ||
+		     cell_stop_2 - cell_start_2 < 1 ) { return; }
+
+		if (i < n_cells) {
+		    ShuffleFisherYates(indices_1, cell_start_1, cell_stop_1, engine);
+		} else {
+		    ShuffleFisherYates(indices_2, cell_start_2, cell_stop_2, engine);
+		}
+	    });
+
+            // Loop over independent pairs
+            amrex::ParallelFor( n_independent_pairs, [=] AMREX_GPU_DEVICE (int i_coll) noexcept
             {
+		// to avoid type mismatch errors
+		auto ui_coll = (index_type)i_coll;
+
+		// Use a bisection algorithm to find the index of the cell in which this pair is located
+		const int i_cell = amrex::bisect( p_coll_offsets, 0, n_cells, ui_coll );
 
                 // The particles from species1 that are in the cell `i_cell` are
                 // given by the `indices_1[cell_start_1:cell_stop_1]`
                 index_type const cell_start_1 = cell_offsets_1[i_cell];
                 index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
+
                 // Same for species 2
                 index_type const cell_start_2 = cell_offsets_2[i_cell];
                 index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
 
-                for(index_type i_1=cell_start_1; i_1<cell_stop_1; ++i_1){
-                    for(index_type i_2=cell_start_2; i_2<cell_stop_2; ++i_2){
+		const index_type NI1 = cell_stop_1 - cell_start_1;
+		const index_type NI2 = cell_stop_2 - cell_start_2;
+		const index_type max_N = amrex::max(NI1,NI2);
+		const index_type min_N = amrex::min(NI1,NI2);
 
-                        index_type const j_1 = indices_1[i_1];
-                        index_type const j_2 = indices_2[i_2];
+		// collision number of the cell
+		const index_type coll_idx = ui_coll - p_coll_offsets[i_cell];
+		index_type i_1 = cell_start_1 + coll_idx;
+		index_type i_2 = cell_start_2 + coll_idx;
 
-                        Real p1t=0, p1x=0, p1y=0, p1z=0; // components of 4-momentum of particle 1
-                        Real const u1_sq =  u1x[j_1]*u1x[j_1] + u1y[j_1]*u1y[j_1] + u1z[j_1]*u1z[j_1];
-                        if (species1_is_photon) {
-                            // photon case (momentum is normalized by m_e in WarpX)
-                            p1t = PhysConst::m_e*std::sqrt( u1_sq );
-                            p1x = PhysConst::m_e*u1x[j_1];
-                            p1y = PhysConst::m_e*u1y[j_1];
-                            p1z = PhysConst::m_e*u1z[j_1];
-                        } else {
-                            p1t = m1*std::sqrt( c_sq + u1_sq );
-                            p1x = m1*u1x[j_1];
-                            p1y = m1*u1y[j_1];
-                            p1z = m1*u1z[j_1];
-                        }
+		// we will start from collision number = coll_idx and then add
+		// stride (smaller set size) until we do all collisions (larger set size)
+		for (index_type k = coll_idx; k < max_N; k += min_N)
+		{
+                    index_type const j_1 = indices_1[i_1];
+                    index_type const j_2 = indices_2[i_2];
 
-                        Real p2t=0, p2x=0, p2y=0, p2z=0; // components of 4-momentum of particle 2
-                        Real const u2_sq =  u2x[j_2]*u2x[j_2] + u2y[j_2]*u2y[j_2] + u2z[j_2]*u2z[j_2];
-                        if (species2_is_photon) {
-                            // photon case (momentum is normalized by m_e in WarpX)
-                            p2t = PhysConst::m_e*std::sqrt( u2_sq );
-                            p2x = PhysConst::m_e*u2x[j_2];
-                            p2y = PhysConst::m_e*u2y[j_2];
-                            p2z = PhysConst::m_e*u2z[j_2];
-                        } else {
-                            p2t = m2*std::sqrt( c_sq + u2_sq );
-                            p2x = m2*u2x[j_2];
-                            p2y = m2*u2y[j_2];
-                            p2z = m2*u2z[j_2];
-                        }
+                    Real p1t=0, p1x=0, p1y=0, p1z=0; // components of 4-momentum of particle 1
+                    Real const u1_sq =  u1x[j_1]*u1x[j_1] + u1y[j_1]*u1y[j_1] + u1z[j_1]*u1z[j_1];
+                    if (species1_is_photon) {
+                        // photon case (momentum is normalized by m_e in WarpX)
+                        p1t = PhysConst::m_e*std::sqrt( u1_sq );
+                        p1x = PhysConst::m_e*u1x[j_1];
+                        p1y = PhysConst::m_e*u1y[j_1];
+                        p1z = PhysConst::m_e*u1z[j_1];
+                    } else {
+                        p1t = m1*std::sqrt( c_sq + u1_sq );
+                        p1x = m1*u1x[j_1];
+                        p1y = m1*u1y[j_1];
+                        p1z = m1*u1z[j_1];
+                    }
 
-                        Real const E_1 = p1t * c_over_qe; // eV
-                        Real const E_2 = p2t * c_over_qe; // eV
+                    Real p2t=0, p2x=0, p2y=0, p2z=0; // components of 4-momentum of particle 2
+                    Real const u2_sq =  u2x[j_2]*u2x[j_2] + u2y[j_2]*u2y[j_2] + u2z[j_2]*u2z[j_2];
+                    if (species2_is_photon) {
+                        // photon case (momentum is normalized by m_e in WarpX)
+                        p2t = PhysConst::m_e*std::sqrt( u2_sq );
+                        p2x = PhysConst::m_e*u2x[j_2];
+                        p2y = PhysConst::m_e*u2y[j_2];
+                        p2z = PhysConst::m_e*u2z[j_2];
+                    } else {
+                        p2t = m2*std::sqrt( c_sq + u2_sq );
+                        p2x = m2*u2x[j_2];
+                        p2y = m2*u2y[j_2];
+                        p2z = m2*u2z[j_2];
+                    }
 
-                        // determine energy bin of particle 1
-                        int const bin_1 = int(Math::floor((E_1-bin_min_1)/bin_size_1));
-                        if ( bin_1<0 || bin_1>=num_bins_1 ) { continue; } // discard if out-of-range
+                    Real const E_1 = p1t * c_over_qe; // eV
+                    Real const E_2 = p2t * c_over_qe; // eV
 
-                        // determine energy bin of particle 2
-                        int const bin_2 = int(Math::floor((E_2-bin_min_2)/bin_size_2));
-                        if ( bin_2<0 || bin_2>=num_bins_2 ) { continue; } // discard if out-of-range
+                    // determine energy bin of particle 1
+                    int const bin_1 = int(Math::floor((E_1-bin_min_1)/bin_size_1));
+                    if ( bin_1<0 || bin_1>=num_bins_1 ) { continue; } // discard if out-of-range
 
-                        Real const inv_p1t = 1.0_rt/p1t;
-                        Real const inv_p2t = 1.0_rt/p2t;
+                    // determine energy bin of particle 2
+                    int const bin_2 = int(Math::floor((E_2-bin_min_2)/bin_size_2));
+                    if ( bin_2<0 || bin_2>=num_bins_2 ) { continue; } // discard if out-of-range
 
-                        Real const beta1_sq = (p1x*p1x + p1y*p1y + p1z*p1z) * inv_p1t*inv_p1t;
-                        Real const beta2_sq = (p2x*p2x + p2y*p2y + p2z*p2z) * inv_p2t*inv_p2t;
-                        Real const beta1_dot_beta2 = (p1x*p2x + p1y*p2y + p1z*p2z) * inv_p1t*inv_p2t;
+                    Real const inv_p1t = 1.0_rt/p1t;
+                    Real const inv_p2t = 1.0_rt/p2t;
 
-                        // Here we use the fact that:
-                        // (v1 - v2)^2 = v1^2 + v2^2 - 2 v1.v2
-                        // and (v1 x v2)^2 = v1^2 v2^2 - (v1.v2)^2
-                        // we also use beta=v/c instead of v
-                        Real const radicand = beta1_sq + beta2_sq - 2*beta1_dot_beta2 - beta1_sq*beta2_sq + beta1_dot_beta2*beta1_dot_beta2;
+                    Real const beta1_sq = (p1x*p1x + p1y*p1y + p1z*p1z) * inv_p1t*inv_p1t;
+                    Real const beta2_sq = (p2x*p2x + p2y*p2y + p2z*p2z) * inv_p2t*inv_p2t;
+                    Real const beta1_dot_beta2 = (p1x*p2x + p1y*p2y + p1z*p2z) * inv_p1t*inv_p2t;
 
-                        Real const d2L_dE1_dE2 = PhysConst::c * std::sqrt( radicand ) * w1[j_1] * w2[j_2] / (dV * bin_size_1 * bin_size_2) * dt; // m^-2 eV^-2
+                    // Here we use the fact that:
+                    // (v1 - v2)^2 = v1^2 + v2^2 - 2 v1.v2
+                    // and (v1 x v2)^2 = v1^2 v2^2 - (v1.v2)^2
+                    // we also use beta=v/c instead of v
+                    Real const radicand = beta1_sq + beta2_sq - 2*beta1_dot_beta2 - beta1_sq*beta2_sq + beta1_dot_beta2*beta1_dot_beta2;
 
-                        amrex::Real &data = d_table(bin_1, bin_2);
-                        amrex::HostDevice::Atomic::Add(&data, d2L_dE1_dE2);
+                    Real const d2L_dE1_dE2 = PhysConst::c * std::sqrt( radicand ) * min_N * w1[j_1] * w2[j_2] / (dV * bin_size_1 * bin_size_2) * dt; // m^-2 eV^-2
 
-                    } // particles species 2
-                } // particles species 1
+                    amrex::Real &data = d_table(bin_1, bin_2);
+                    amrex::HostDevice::Atomic::Add(&data, d2L_dE1_dE2);
+
+                    if (max_N == NI1) {
+			i_1 += min_N;
+		    }
+		    if (max_N == NI2) {
+			i_2 += min_N;
+		    }
+                } // k
             }); // cells
         } // boxes
     } // levels

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity2D.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity2D.cpp
@@ -219,69 +219,20 @@ void DifferentialLuminosity2D::ComputeDiags (int step)
             // Extract low-level (cell-level) data
             auto const n_cells = static_cast<int>(bins_1.numBins());
 
-        // Compute the number of independent pairs in each cell. This is equal to
-        // the number of particles in whichever species has fewer
-            amrex::Gpu::DeviceVector<index_type> n_ind_pairs_in_each_cell(n_cells+1);
-            index_type* AMREX_RESTRICT p_n_ind_pairs_in_each_cell = n_ind_pairs_in_each_cell.dataPtr();
+	    IndependentPairHelper<index_type> indep_pairs(n_cells, cell_offsets_1, cell_offsets_2);
+	    indep_pairs.shuffle(indices_1, indices_2);
 
-            amrex::ParallelFor( n_cells+1,
-                [=] AMREX_GPU_DEVICE (int i_cell) noexcept
-                {
-                    if (i_cell < n_cells)
-                    {
-                        const auto n_part_in_cell_1 = cell_offsets_1[i_cell+1] - cell_offsets_1[i_cell];
-                        const auto n_part_in_cell_2 = cell_offsets_2[i_cell+1] - cell_offsets_2[i_cell];
-                        p_n_ind_pairs_in_each_cell[i_cell] = amrex::min(n_part_in_cell_1, n_part_in_cell_2);
-                    }
-                    else
-                    {
-                        p_n_ind_pairs_in_each_cell[i_cell] = 0;
-                    }
-                }
-            );
-
-            // start indices of independent collisions.
-            amrex::Gpu::DeviceVector<index_type> coll_offsets(n_cells+1);
-            // number of total independent collision pairs
-            const auto n_independent_pairs = (int) amrex::Scan::ExclusiveSum(n_cells+1,
-            p_n_ind_pairs_in_each_cell, coll_offsets.data(), amrex::Scan::RetSum{true});
-            index_type* AMREX_RESTRICT p_coll_offsets = coll_offsets.dataPtr();
-
-            // shuffle each species.
-        // we launch 2*n_cells threads to process both species simultaneously
-            amrex::ParallelForRNG( 2*n_cells,
-            [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
-        {
-        int i_cell = i < n_cells ? i : i - n_cells;
-
-        // The particles from species1 that are in the cell `i_cell` are
-        // given by the `indices_1[cell_start_1:cell_stop_1]`
-        index_type const cell_start_1 = cell_offsets_1[i_cell];
-        index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
-
-        // Same for species 2
-        index_type const cell_start_2 = cell_offsets_2[i_cell];
-        index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
-
-        // Do not collide if one species is missing in the cell
-        if ( cell_stop_1 - cell_start_1 < 1 ||
-             cell_stop_2 - cell_start_2 < 1 ) { return; }
-
-        if (i < n_cells) {
-            ShuffleFisherYates(indices_1, cell_start_1, cell_stop_1, engine);
-        } else {
-            ShuffleFisherYates(indices_2, cell_start_2, cell_stop_2, engine);
-        }
-        });
+	    int n_independent_pairs = indep_pairs.numIndependentPairs();
+	    const index_type*  AMREX_RESTRICT p_coll_offsets = indep_pairs.collisionOffsetsPtr();
 
             // Loop over independent pairs
             amrex::ParallelFor( n_independent_pairs, [=] AMREX_GPU_DEVICE (int i_coll) noexcept
             {
-        // to avoid type mismatch errors
-        auto ui_coll = (index_type)i_coll;
+                // to avoid type mismatch errors
+                auto ui_coll = (index_type)i_coll;
 
-        // Use a bisection algorithm to find the index of the cell in which this pair is located
-        const int i_cell = amrex::bisect( p_coll_offsets, 0, n_cells, ui_coll );
+                // Use a bisection algorithm to find the index of the cell in which this pair is located
+                const int i_cell = amrex::bisect( p_coll_offsets, 0, n_cells, ui_coll );
 
                 // The particles from species1 that are in the cell `i_cell` are
                 // given by the `indices_1[cell_start_1:cell_stop_1]`
@@ -292,20 +243,20 @@ void DifferentialLuminosity2D::ComputeDiags (int step)
                 index_type const cell_start_2 = cell_offsets_2[i_cell];
                 index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
 
-        const index_type NI1 = cell_stop_1 - cell_start_1;
-        const index_type NI2 = cell_stop_2 - cell_start_2;
-        const index_type max_N = amrex::max(NI1,NI2);
-        const index_type min_N = amrex::min(NI1,NI2);
+                const index_type NI1 = cell_stop_1 - cell_start_1;
+                const index_type NI2 = cell_stop_2 - cell_start_2;
+                const index_type max_N = amrex::max(NI1,NI2);
+                const index_type min_N = amrex::min(NI1,NI2);
 
-        // collision number of the cell
-        const index_type coll_idx = ui_coll - p_coll_offsets[i_cell];
-        index_type i_1 = cell_start_1 + coll_idx;
-        index_type i_2 = cell_start_2 + coll_idx;
+                // collision number of the cell
+                const index_type coll_idx = ui_coll - p_coll_offsets[i_cell];
+                index_type i_1 = cell_start_1 + coll_idx;
+                index_type i_2 = cell_start_2 + coll_idx;
 
-        // we will start from collision number = coll_idx and then add
-        // stride (smaller set size) until we do all collisions (larger set size)
-        for (index_type k = coll_idx; k < max_N; k += min_N)
-        {
+                // we will start from collision number = coll_idx and then add
+                // stride (smaller set size) until we do all collisions (larger set size)
+                for (index_type k = coll_idx; k < max_N; k += min_N)
+                {
                     index_type const j_1 = indices_1[i_1];
                     index_type const j_2 = indices_2[i_2];
 
@@ -369,11 +320,11 @@ void DifferentialLuminosity2D::ComputeDiags (int step)
                     amrex::HostDevice::Atomic::Add(&data, d2L_dE1_dE2);
 
                     if (max_N == NI1) {
-            i_1 += min_N;
-            }
-            if (max_N == NI2) {
-            i_2 += min_N;
-            }
+                        i_1 += min_N;
+                    }
+                    if (max_N == NI2) {
+                        i_2 += min_N;
+                    }
                 } // k
             }); // cells
         } // boxes

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity2D.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity2D.cpp
@@ -226,7 +226,7 @@ void DifferentialLuminosity2D::ComputeDiags (int step)
             const index_type*  AMREX_RESTRICT p_coll_offsets = indep_pairs.collisionOffsetsPtr();
 
             // Loop over independent pairs
-            // This uses the Takizuka and Abe pairing algorithm 
+            // This uses the Takizuka and Abe pairing algorithm
             // (https://doi.org/10.1016/0021-9991(77)90099-7)
             // to estimate the number of collisions in each cell.
             // Instead of evaluating the number of collisions for every `NI1*NI2`

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity2D.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity2D.cpp
@@ -219,11 +219,11 @@ void DifferentialLuminosity2D::ComputeDiags (int step)
             // Extract low-level (cell-level) data
             auto const n_cells = static_cast<int>(bins_1.numBins());
 
-	    IndependentPairHelper<index_type> indep_pairs(n_cells, cell_offsets_1, cell_offsets_2);
-	    indep_pairs.shuffle(indices_1, indices_2);
+        IndependentPairHelper<index_type> indep_pairs(n_cells, cell_offsets_1, cell_offsets_2);
+        indep_pairs.shuffle(indices_1, indices_2);
 
-	    int n_independent_pairs = indep_pairs.numIndependentPairs();
-	    const index_type*  AMREX_RESTRICT p_coll_offsets = indep_pairs.collisionOffsetsPtr();
+        int n_independent_pairs = indep_pairs.numIndependentPairs();
+        const index_type*  AMREX_RESTRICT p_coll_offsets = indep_pairs.collisionOffsetsPtr();
 
             // Loop over independent pairs
             amrex::ParallelFor( n_independent_pairs, [=] AMREX_GPU_DEVICE (int i_coll) noexcept

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity2D.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity2D.cpp
@@ -179,17 +179,13 @@ void DifferentialLuminosity2D::ComputeDiags (int step)
     const ParticleReal m1 = species_1.getMass();
     const ParticleReal m2 = species_2.getMass();
 
-    // Enable tiling
-    amrex::MFItInfo info;
-    if (amrex::Gpu::notInLaunchRegion()) { info.EnableTiling(WarpXParticleContainer::tile_size); }
-
     int const nlevs = std::max(0, species_1.finestLevel()+1); // species_1 ?
     for (int lev = 0; lev < nlevs; ++lev) {
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
 
-        for (amrex::MFIter mfi = species_1.MakeMFIter(lev, info); mfi.isValid(); ++mfi){
+        for (amrex::MFIter mfi = species_1.MakeMFIter(lev); mfi.isValid(); ++mfi){
 
             ParticleTileType& ptile_1 = species_1.ParticlesAt(lev, mfi);
             ParticleTileType& ptile_2 = species_2.ParticlesAt(lev, mfi);

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity2D.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity2D.cpp
@@ -219,11 +219,11 @@ void DifferentialLuminosity2D::ComputeDiags (int step)
             // Extract low-level (cell-level) data
             auto const n_cells = static_cast<int>(bins_1.numBins());
 
-        IndependentPairHelper<index_type> indep_pairs(n_cells, cell_offsets_1, cell_offsets_2);
-        indep_pairs.shuffle(indices_1, indices_2);
+            IndependentPairHelper<index_type> indep_pairs(n_cells, cell_offsets_1, cell_offsets_2);
+            indep_pairs.shuffle(indices_1, indices_2);
 
-        int n_independent_pairs = indep_pairs.numIndependentPairs();
-        const index_type*  AMREX_RESTRICT p_coll_offsets = indep_pairs.collisionOffsetsPtr();
+            int n_independent_pairs = indep_pairs.numIndependentPairs();
+            const index_type*  AMREX_RESTRICT p_coll_offsets = indep_pairs.collisionOffsetsPtr();
 
             // Loop over independent pairs
             amrex::ParallelFor( n_independent_pairs, [=] AMREX_GPU_DEVICE (int i_coll) noexcept

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity2D.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity2D.cpp
@@ -219,8 +219,8 @@ void DifferentialLuminosity2D::ComputeDiags (int step)
             // Extract low-level (cell-level) data
             auto const n_cells = static_cast<int>(bins_1.numBins());
 
-	    // Compute the number of independent pairs in each cell. This is equal to
-	    // the number of particles in whichever species has fewer
+        // Compute the number of independent pairs in each cell. This is equal to
+        // the number of particles in whichever species has fewer
             amrex::Gpu::DeviceVector<index_type> n_ind_pairs_in_each_cell(n_cells+1);
             index_type* AMREX_RESTRICT p_n_ind_pairs_in_each_cell = n_ind_pairs_in_each_cell.dataPtr();
 
@@ -244,44 +244,44 @@ void DifferentialLuminosity2D::ComputeDiags (int step)
             amrex::Gpu::DeviceVector<index_type> coll_offsets(n_cells+1);
             // number of total independent collision pairs
             const auto n_independent_pairs = (int) amrex::Scan::ExclusiveSum(n_cells+1,
-	        p_n_ind_pairs_in_each_cell, coll_offsets.data(), amrex::Scan::RetSum{true});
+            p_n_ind_pairs_in_each_cell, coll_offsets.data(), amrex::Scan::RetSum{true});
             index_type* AMREX_RESTRICT p_coll_offsets = coll_offsets.dataPtr();
 
             // shuffle each species.
-	    // we launch 2*n_cells threads to process both species simultaneously
+        // we launch 2*n_cells threads to process both species simultaneously
             amrex::ParallelForRNG( 2*n_cells,
-	        [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
-	    {
-		int i_cell = i < n_cells ? i : i - n_cells;
+            [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
+        {
+        int i_cell = i < n_cells ? i : i - n_cells;
 
-		// The particles from species1 that are in the cell `i_cell` are
-		// given by the `indices_1[cell_start_1:cell_stop_1]`
-		index_type const cell_start_1 = cell_offsets_1[i_cell];
-		index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
+        // The particles from species1 that are in the cell `i_cell` are
+        // given by the `indices_1[cell_start_1:cell_stop_1]`
+        index_type const cell_start_1 = cell_offsets_1[i_cell];
+        index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
 
-		// Same for species 2
-		index_type const cell_start_2 = cell_offsets_2[i_cell];
-		index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
+        // Same for species 2
+        index_type const cell_start_2 = cell_offsets_2[i_cell];
+        index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
 
-		// Do not collide if one species is missing in the cell
-		if ( cell_stop_1 - cell_start_1 < 1 ||
-		     cell_stop_2 - cell_start_2 < 1 ) { return; }
+        // Do not collide if one species is missing in the cell
+        if ( cell_stop_1 - cell_start_1 < 1 ||
+             cell_stop_2 - cell_start_2 < 1 ) { return; }
 
-		if (i < n_cells) {
-		    ShuffleFisherYates(indices_1, cell_start_1, cell_stop_1, engine);
-		} else {
-		    ShuffleFisherYates(indices_2, cell_start_2, cell_stop_2, engine);
-		}
-	    });
+        if (i < n_cells) {
+            ShuffleFisherYates(indices_1, cell_start_1, cell_stop_1, engine);
+        } else {
+            ShuffleFisherYates(indices_2, cell_start_2, cell_stop_2, engine);
+        }
+        });
 
             // Loop over independent pairs
             amrex::ParallelFor( n_independent_pairs, [=] AMREX_GPU_DEVICE (int i_coll) noexcept
             {
-		// to avoid type mismatch errors
-		auto ui_coll = (index_type)i_coll;
+        // to avoid type mismatch errors
+        auto ui_coll = (index_type)i_coll;
 
-		// Use a bisection algorithm to find the index of the cell in which this pair is located
-		const int i_cell = amrex::bisect( p_coll_offsets, 0, n_cells, ui_coll );
+        // Use a bisection algorithm to find the index of the cell in which this pair is located
+        const int i_cell = amrex::bisect( p_coll_offsets, 0, n_cells, ui_coll );
 
                 // The particles from species1 that are in the cell `i_cell` are
                 // given by the `indices_1[cell_start_1:cell_stop_1]`
@@ -292,20 +292,20 @@ void DifferentialLuminosity2D::ComputeDiags (int step)
                 index_type const cell_start_2 = cell_offsets_2[i_cell];
                 index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
 
-		const index_type NI1 = cell_stop_1 - cell_start_1;
-		const index_type NI2 = cell_stop_2 - cell_start_2;
-		const index_type max_N = amrex::max(NI1,NI2);
-		const index_type min_N = amrex::min(NI1,NI2);
+        const index_type NI1 = cell_stop_1 - cell_start_1;
+        const index_type NI2 = cell_stop_2 - cell_start_2;
+        const index_type max_N = amrex::max(NI1,NI2);
+        const index_type min_N = amrex::min(NI1,NI2);
 
-		// collision number of the cell
-		const index_type coll_idx = ui_coll - p_coll_offsets[i_cell];
-		index_type i_1 = cell_start_1 + coll_idx;
-		index_type i_2 = cell_start_2 + coll_idx;
+        // collision number of the cell
+        const index_type coll_idx = ui_coll - p_coll_offsets[i_cell];
+        index_type i_1 = cell_start_1 + coll_idx;
+        index_type i_2 = cell_start_2 + coll_idx;
 
-		// we will start from collision number = coll_idx and then add
-		// stride (smaller set size) until we do all collisions (larger set size)
-		for (index_type k = coll_idx; k < max_N; k += min_N)
-		{
+        // we will start from collision number = coll_idx and then add
+        // stride (smaller set size) until we do all collisions (larger set size)
+        for (index_type k = coll_idx; k < max_N; k += min_N)
+        {
                     index_type const j_1 = indices_1[i_1];
                     index_type const j_2 = indices_2[i_2];
 
@@ -369,11 +369,11 @@ void DifferentialLuminosity2D::ComputeDiags (int step)
                     amrex::HostDevice::Atomic::Add(&data, d2L_dE1_dE2);
 
                     if (max_N == NI1) {
-			i_1 += min_N;
-		    }
-		    if (max_N == NI2) {
-			i_2 += min_N;
-		    }
+            i_1 += min_N;
+            }
+            if (max_N == NI2) {
+            i_2 += min_N;
+            }
                 } // k
             }); // cells
         } // boxes

--- a/Source/Particles/Collision/BinaryCollision/ShuffleFisherYates.H
+++ b/Source/Particles/Collision/BinaryCollision/ShuffleFisherYates.H
@@ -67,6 +67,9 @@ struct IndependentPairHelper
         Initialize();
     }
 
+    /* \brief Compute the number of independent pairs in each cell. This is equal to
+     * the number of particles in whichever species has fewer
+    */
     void Initialize () {
         // Compute the number of independent pairs in each cell. This is equal to
         // the number of particles in whichever species has fewer
@@ -87,11 +90,10 @@ struct IndependentPairHelper
                     p_n_ind_pairs_in_each_cell[i_cell] = 0;
                 }
         });
-    }
 
-    // number of total independent collision pairs
-    m_n_independent_pairs = (int) amrex::Scan::ExclusiveSum(m_n_cells+1,
-        p_n_ind_pairs_in_each_cell, m_coll_offsets.data(), amrex::Scan::RetSum{true});
+        // number of total independent collision pairs
+        m_n_independent_pairs = (int) amrex::Scan::ExclusiveSum(m_n_cells+1,
+            p_n_ind_pairs_in_each_cell, m_coll_offsets.data(), amrex::Scan::RetSum{true});
     }
 
     /**

--- a/Source/Particles/Collision/BinaryCollision/ShuffleFisherYates.H
+++ b/Source/Particles/Collision/BinaryCollision/ShuffleFisherYates.H
@@ -62,28 +62,32 @@ struct IndependentPairHelper
                index_type const* AMREX_RESTRICT a_cell_offsets_2)
     : m_n_cells(a_n_cells), m_cell_offsets_1(a_cell_offsets_1), m_cell_offsets_2(a_cell_offsets_2)
     {
-    m_n_ind_pairs_in_each_cell.resize(m_n_cells+1);
-    m_coll_offsets.resize(m_n_cells+1);
+        m_n_ind_pairs_in_each_cell.resize(m_n_cells+1);
+        m_coll_offsets.resize(m_n_cells+1);
+        Initialize();
+    }
 
-    // Compute the number of independent pairs in each cell. This is equal to
-    // the number of particles in whichever species has fewer
-    index_type* AMREX_RESTRICT p_n_ind_pairs_in_each_cell = m_n_ind_pairs_in_each_cell.dataPtr();
-    int n_cells = m_n_cells;
-    index_type const* AMREX_RESTRICT cell_offsets_1 = m_cell_offsets_1;
-    index_type const* AMREX_RESTRICT cell_offsets_2 = m_cell_offsets_2;
-    amrex::ParallelFor( n_cells+1, [=] AMREX_GPU_DEVICE (int i_cell) noexcept
-    {
-        if (i_cell < n_cells)
+    void Initialize () {
+        // Compute the number of independent pairs in each cell. This is equal to
+        // the number of particles in whichever species has fewer
+        index_type* AMREX_RESTRICT p_n_ind_pairs_in_each_cell = m_n_ind_pairs_in_each_cell.dataPtr();
+        int n_cells = m_n_cells;
+        index_type const* AMREX_RESTRICT cell_offsets_1 = m_cell_offsets_1;
+        index_type const* AMREX_RESTRICT cell_offsets_2 = m_cell_offsets_2;
+        amrex::ParallelFor( n_cells+1, [=] AMREX_GPU_DEVICE (int i_cell) noexcept
         {
-        const auto n_part_in_cell_1 = cell_offsets_1[i_cell+1] - cell_offsets_1[i_cell];
-        const auto n_part_in_cell_2 = cell_offsets_2[i_cell+1] - cell_offsets_2[i_cell];
-        p_n_ind_pairs_in_each_cell[i_cell] = amrex::min(n_part_in_cell_1, n_part_in_cell_2);
-        }
-        else
-        {
-        p_n_ind_pairs_in_each_cell[i_cell] = 0;
-        }
-    });
+            if (i_cell < n_cells)
+            {
+                const auto n_part_in_cell_1 = cell_offsets_1[i_cell+1] - cell_offsets_1[i_cell];
+                const auto n_part_in_cell_2 = cell_offsets_2[i_cell+1] - cell_offsets_2[i_cell];
+                p_n_ind_pairs_in_each_cell[i_cell] = amrex::min(n_part_in_cell_1, n_part_in_cell_2);
+            }
+            else
+                {
+                    p_n_ind_pairs_in_each_cell[i_cell] = 0;
+                }
+        });
+    }
 
     // number of total independent collision pairs
     m_n_independent_pairs = (int) amrex::Scan::ExclusiveSum(m_n_cells+1,

--- a/Source/Particles/Collision/BinaryCollision/ShuffleFisherYates.H
+++ b/Source/Particles/Collision/BinaryCollision/ShuffleFisherYates.H
@@ -68,12 +68,15 @@ struct IndependentPairHelper
     // Compute the number of independent pairs in each cell. This is equal to
     // the number of particles in whichever species has fewer
     index_type* AMREX_RESTRICT p_n_ind_pairs_in_each_cell = m_n_ind_pairs_in_each_cell.dataPtr();
-    amrex::ParallelFor( m_n_cells+1, [=] AMREX_GPU_DEVICE (int i_cell)
+    int n_cell = m_n_cells;
+    index_type const* AMREX_RESTRICT cell_offsets_1 = m_cell_offsets_1;
+    index_type const* AMREX_RESTRICT cell_offsets_2 = m_cell_offsets_2;
+    amrex::ParallelFor( n_cells+1, [=] AMREX_GPU_DEVICE (int i_cell) noexcept
     {
-        if (i_cell < a_n_cells)
+        if (i_cell < n_cells)
         {
-        const auto n_part_in_cell_1 = a_cell_offsets_1[i_cell+1] - a_cell_offsets_1[i_cell];
-        const auto n_part_in_cell_2 = a_cell_offsets_2[i_cell+1] - a_cell_offsets_2[i_cell];
+        const auto n_part_in_cell_1 = cell_offsets_1[i_cell+1] - cell_offsets_1[i_cell];
+        const auto n_part_in_cell_2 = cell_offsets_2[i_cell+1] - cell_offsets_2[i_cell];
         p_n_ind_pairs_in_each_cell[i_cell] = amrex::min(n_part_in_cell_1, n_part_in_cell_2);
         }
         else

--- a/Source/Particles/Collision/BinaryCollision/ShuffleFisherYates.H
+++ b/Source/Particles/Collision/BinaryCollision/ShuffleFisherYates.H
@@ -57,6 +57,7 @@ struct IndependentPairHelper
      * @param[in] a_cell_offsets_2 the offset array storing the number of particles per cell for species 2
      *
      */
+    AMREX_NO_INLINE
     IndependentPairHelper (int a_n_cells,
                index_type const* AMREX_RESTRICT a_cell_offsets_1,
                index_type const* AMREX_RESTRICT a_cell_offsets_2)
@@ -68,9 +69,8 @@ struct IndependentPairHelper
     // Compute the number of independent pairs in each cell. This is equal to
     // the number of particles in whichever species has fewer
     index_type* AMREX_RESTRICT p_n_ind_pairs_in_each_cell = m_n_ind_pairs_in_each_cell.dataPtr();
-    amrex::ParallelFor( m_n_cells+1,
-        [=] AMREX_GPU_DEVICE (int i_cell) noexcept
-        {
+    amrex::ParallelFor( m_n_cells+1, [=] AMREX_GPU_DEVICE (int i_cell) noexcept
+    {
         if (i_cell < a_n_cells)
         {
         const auto n_part_in_cell_1 = a_cell_offsets_1[i_cell+1] - a_cell_offsets_1[i_cell];

--- a/Source/Particles/Collision/BinaryCollision/ShuffleFisherYates.H
+++ b/Source/Particles/Collision/BinaryCollision/ShuffleFisherYates.H
@@ -52,7 +52,7 @@ struct IndependentPairHelper
     /**
      * \brief Constructor
      *
-     * @param[in] n_cells the number of cells in this tile
+     * @param[in] a_n_cells the number of cells in this tile
      * @param[in] a_cell_offsets_1 the offset array storing the number of particles per cell for species 1
      * @param[in] a_cell_offsets_2 the offset array storing the number of particles per cell for species 2
      *

--- a/Source/Particles/Collision/BinaryCollision/ShuffleFisherYates.H
+++ b/Source/Particles/Collision/BinaryCollision/ShuffleFisherYates.H
@@ -68,7 +68,7 @@ struct IndependentPairHelper
     // Compute the number of independent pairs in each cell. This is equal to
     // the number of particles in whichever species has fewer
     index_type* AMREX_RESTRICT p_n_ind_pairs_in_each_cell = m_n_ind_pairs_in_each_cell.dataPtr();
-    int n_cell = m_n_cells;
+    int n_cells = m_n_cells;
     index_type const* AMREX_RESTRICT cell_offsets_1 = m_cell_offsets_1;
     index_type const* AMREX_RESTRICT cell_offsets_2 = m_cell_offsets_2;
     amrex::ParallelFor( n_cells+1, [=] AMREX_GPU_DEVICE (int i_cell) noexcept

--- a/Source/Particles/Collision/BinaryCollision/ShuffleFisherYates.H
+++ b/Source/Particles/Collision/BinaryCollision/ShuffleFisherYates.H
@@ -34,10 +34,10 @@ void ShuffleFisherYates (T_index *array, T_index const is, T_index const ie,
 
 /* \brief A helper class for computing and looping over the independent pairs of
           macroparticles in each cell, for the purpose of processing collisions.
-	  It also has the ability to shuffle the particles in each cell for both
-	  species according to the Fisher-Yates algorithm.
-	  The number of independent pairs is equivalent to the number of particles per cell in
-	  whichever species has the fewer number of macroparticles.
+      It also has the ability to shuffle the particles in each cell for both
+      species according to the Fisher-Yates algorithm.
+      The number of independent pairs is equivalent to the number of particles per cell in
+      whichever species has the fewer number of macroparticles.
 */
 template <typename index_type>
 struct IndependentPairHelper
@@ -58,34 +58,34 @@ struct IndependentPairHelper
      *
      */
     IndependentPairHelper (int a_n_cells,
-			   index_type const* AMREX_RESTRICT a_cell_offsets_1,
-			   index_type const* AMREX_RESTRICT a_cell_offsets_2)
-	: m_n_cells(a_n_cells), m_cell_offsets_1(a_cell_offsets_1), m_cell_offsets_2(a_cell_offsets_2)
+               index_type const* AMREX_RESTRICT a_cell_offsets_1,
+               index_type const* AMREX_RESTRICT a_cell_offsets_2)
+    : m_n_cells(a_n_cells), m_cell_offsets_1(a_cell_offsets_1), m_cell_offsets_2(a_cell_offsets_2)
     {
-	m_n_ind_pairs_in_each_cell.resize(m_n_cells+1);
-	m_coll_offsets.resize(m_n_cells+1);
+    m_n_ind_pairs_in_each_cell.resize(m_n_cells+1);
+    m_coll_offsets.resize(m_n_cells+1);
 
-	// Compute the number of independent pairs in each cell. This is equal to
-	// the number of particles in whichever species has fewer
-	index_type* AMREX_RESTRICT p_n_ind_pairs_in_each_cell = m_n_ind_pairs_in_each_cell.dataPtr();
-	amrex::ParallelFor( m_n_cells+1,
-	    [=] AMREX_GPU_DEVICE (int i_cell) noexcept
+    // Compute the number of independent pairs in each cell. This is equal to
+    // the number of particles in whichever species has fewer
+    index_type* AMREX_RESTRICT p_n_ind_pairs_in_each_cell = m_n_ind_pairs_in_each_cell.dataPtr();
+    amrex::ParallelFor( m_n_cells+1,
+        [=] AMREX_GPU_DEVICE (int i_cell) noexcept
         {
-	    if (i_cell < a_n_cells)
-	    {
-		const auto n_part_in_cell_1 = a_cell_offsets_1[i_cell+1] - a_cell_offsets_1[i_cell];
-		const auto n_part_in_cell_2 = a_cell_offsets_2[i_cell+1] - a_cell_offsets_2[i_cell];
-		p_n_ind_pairs_in_each_cell[i_cell] = amrex::min(n_part_in_cell_1, n_part_in_cell_2);
-	    }
-	    else
-	    {
-		p_n_ind_pairs_in_each_cell[i_cell] = 0;
-	    }
-	});
+        if (i_cell < a_n_cells)
+        {
+        const auto n_part_in_cell_1 = a_cell_offsets_1[i_cell+1] - a_cell_offsets_1[i_cell];
+        const auto n_part_in_cell_2 = a_cell_offsets_2[i_cell+1] - a_cell_offsets_2[i_cell];
+        p_n_ind_pairs_in_each_cell[i_cell] = amrex::min(n_part_in_cell_1, n_part_in_cell_2);
+        }
+        else
+        {
+        p_n_ind_pairs_in_each_cell[i_cell] = 0;
+        }
+    });
 
-	// number of total independent collision pairs
-	m_n_independent_pairs = (int) amrex::Scan::ExclusiveSum(m_n_cells+1,
-	    p_n_ind_pairs_in_each_cell, m_coll_offsets.data(), amrex::Scan::RetSum{true});
+    // number of total independent collision pairs
+    m_n_independent_pairs = (int) amrex::Scan::ExclusiveSum(m_n_cells+1,
+        p_n_ind_pairs_in_each_cell, m_coll_offsets.data(), amrex::Scan::RetSum{true});
     }
 
     /**
@@ -96,37 +96,37 @@ struct IndependentPairHelper
      *
      */
     void shuffle (index_type* AMREX_RESTRICT a_indices_1,
-		  index_type* AMREX_RESTRICT a_indices_2)
+          index_type* AMREX_RESTRICT a_indices_2)
     {
-	// shuffle each species.
-	// we launch 2*n_cells threads to process both species simultaneously
-	int n_cells = m_n_cells;
-	index_type const* AMREX_RESTRICT cell_offsets_1 = m_cell_offsets_1;
-	index_type const* AMREX_RESTRICT cell_offsets_2 = m_cell_offsets_2;
-	amrex::ParallelForRNG( 2*m_n_cells,
+    // shuffle each species.
+    // we launch 2*n_cells threads to process both species simultaneously
+    int n_cells = m_n_cells;
+    index_type const* AMREX_RESTRICT cell_offsets_1 = m_cell_offsets_1;
+    index_type const* AMREX_RESTRICT cell_offsets_2 = m_cell_offsets_2;
+    amrex::ParallelForRNG( 2*m_n_cells,
         [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
-	{
-	    int i_cell = i < n_cells ? i : i - n_cells;
+    {
+        int i_cell = i < n_cells ? i : i - n_cells;
 
-	    // The particles from species1 that are in the cell `i_cell` are
-	    // given by the `indices_1[cell_start_1:cell_stop_1]`
-	    index_type const cell_start_1 = cell_offsets_1[i_cell];
-	    index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
+        // The particles from species1 that are in the cell `i_cell` are
+        // given by the `indices_1[cell_start_1:cell_stop_1]`
+        index_type const cell_start_1 = cell_offsets_1[i_cell];
+        index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
 
-	    // Same for species 2
-	    index_type const cell_start_2 = cell_offsets_2[i_cell];
-	    index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
+        // Same for species 2
+        index_type const cell_start_2 = cell_offsets_2[i_cell];
+        index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
 
-	    // Do not collide if one species is missing in the cell
-	    if ( cell_stop_1 - cell_start_1 < 1 ||
-		 cell_stop_2 - cell_start_2 < 1 ) { return; }
+        // Do not collide if one species is missing in the cell
+        if ( cell_stop_1 - cell_start_1 < 1 ||
+         cell_stop_2 - cell_start_2 < 1 ) { return; }
 
-	    if (i < n_cells) {
-		ShuffleFisherYates(a_indices_1, cell_start_1, cell_stop_1, engine);
-	    } else {
-		ShuffleFisherYates(a_indices_2, cell_start_2, cell_stop_2, engine);
-	    }
-	});
+        if (i < n_cells) {
+        ShuffleFisherYates(a_indices_1, cell_start_1, cell_stop_1, engine);
+        } else {
+        ShuffleFisherYates(a_indices_2, cell_start_2, cell_stop_2, engine);
+        }
+    });
     }
 
     int numIndependentPairs () const {return m_n_independent_pairs;}

--- a/Source/Particles/Collision/BinaryCollision/ShuffleFisherYates.H
+++ b/Source/Particles/Collision/BinaryCollision/ShuffleFisherYates.H
@@ -57,7 +57,6 @@ struct IndependentPairHelper
      * @param[in] a_cell_offsets_2 the offset array storing the number of particles per cell for species 2
      *
      */
-    AMREX_NO_INLINE
     IndependentPairHelper (int a_n_cells,
                index_type const* AMREX_RESTRICT a_cell_offsets_1,
                index_type const* AMREX_RESTRICT a_cell_offsets_2)
@@ -69,7 +68,7 @@ struct IndependentPairHelper
     // Compute the number of independent pairs in each cell. This is equal to
     // the number of particles in whichever species has fewer
     index_type* AMREX_RESTRICT p_n_ind_pairs_in_each_cell = m_n_ind_pairs_in_each_cell.dataPtr();
-    amrex::ParallelFor( m_n_cells+1, [=] AMREX_GPU_DEVICE (int i_cell) noexcept
+    amrex::ParallelFor( m_n_cells+1, [=] AMREX_GPU_DEVICE (int i_cell)
     {
         if (i_cell < a_n_cells)
         {

--- a/Source/Particles/Collision/BinaryCollision/ShuffleFisherYates.H
+++ b/Source/Particles/Collision/BinaryCollision/ShuffleFisherYates.H
@@ -8,13 +8,13 @@
 #define WARPX_PARTICLES_COLLISION_SHUFFLE_FISHER_YATES_H_
 
 #include <AMReX_Random.H>
+#include <AMReX_Scan.H>
 
 /* \brief Shuffle array according to Fisher-Yates algorithm.
  *        Only shuffle the part between is <= i < ie, n = ie-is.
  *        T_index shall be
  *        amrex::DenseBins<WarpXParticleContainer::ParticleTileType::ParticleTileDataType>::index_type
 */
-
 template <typename T_index>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void ShuffleFisherYates (T_index *array, T_index const is, T_index const ie,
@@ -31,5 +31,106 @@ void ShuffleFisherYates (T_index *array, T_index const is, T_index const ie,
         array[j] = buf;
     }
 }
+
+/* \brief A helper class for computing and looping over the independent pairs of
+          macroparticles in each cell, for the purpose of processing collisions.
+	  It also has the ability to shuffle the particles in each cell for both
+	  species according to the Fisher-Yates algorithm.
+	  The number of independent pairs is equivalent to the number of particles per cell in
+	  whichever species has the fewer number of macroparticles.
+*/
+template <typename index_type>
+struct IndependentPairHelper
+{
+    int m_n_cells;
+    index_type const* AMREX_RESTRICT m_cell_offsets_1;
+    index_type const* AMREX_RESTRICT m_cell_offsets_2;
+    amrex::Gpu::DeviceVector<index_type> m_n_ind_pairs_in_each_cell;
+    amrex::Gpu::DeviceVector<index_type> m_coll_offsets;
+    int m_n_independent_pairs;
+
+    /**
+     * \brief Constructor
+     *
+     * @param[in] n_cells the number of cells in this tile
+     * @param[in] a_cell_offsets_1 the offset array storing the number of particles per cell for species 1
+     * @param[in] a_cell_offsets_2 the offset array storing the number of particles per cell for species 2
+     *
+     */
+    IndependentPairHelper (int a_n_cells,
+			   index_type const* AMREX_RESTRICT a_cell_offsets_1,
+			   index_type const* AMREX_RESTRICT a_cell_offsets_2)
+	: m_n_cells(a_n_cells), m_cell_offsets_1(a_cell_offsets_1), m_cell_offsets_2(a_cell_offsets_2)
+    {
+	m_n_ind_pairs_in_each_cell.resize(m_n_cells+1);
+	m_coll_offsets.resize(m_n_cells+1);
+
+	// Compute the number of independent pairs in each cell. This is equal to
+	// the number of particles in whichever species has fewer
+	index_type* AMREX_RESTRICT p_n_ind_pairs_in_each_cell = m_n_ind_pairs_in_each_cell.dataPtr();
+	amrex::ParallelFor( m_n_cells+1,
+	    [=] AMREX_GPU_DEVICE (int i_cell) noexcept
+        {
+	    if (i_cell < a_n_cells)
+	    {
+		const auto n_part_in_cell_1 = a_cell_offsets_1[i_cell+1] - a_cell_offsets_1[i_cell];
+		const auto n_part_in_cell_2 = a_cell_offsets_2[i_cell+1] - a_cell_offsets_2[i_cell];
+		p_n_ind_pairs_in_each_cell[i_cell] = amrex::min(n_part_in_cell_1, n_part_in_cell_2);
+	    }
+	    else
+	    {
+		p_n_ind_pairs_in_each_cell[i_cell] = 0;
+	    }
+	});
+
+	// number of total independent collision pairs
+	m_n_independent_pairs = (int) amrex::Scan::ExclusiveSum(m_n_cells+1,
+	    p_n_ind_pairs_in_each_cell, m_coll_offsets.data(), amrex::Scan::RetSum{true});
+    }
+
+    /**
+     * \brief Shuffle the particles in each cell using the Fisher-Yates algorithm, for both species.
+     *
+     * @param[inout] a_indices_1 the indices of the particles sorted by cell for species 1
+     * @param[inout] a_indices_2 the indices of the particles sorted by cell for species 2
+     *
+     */
+    void shuffle (index_type* AMREX_RESTRICT a_indices_1,
+		  index_type* AMREX_RESTRICT a_indices_2)
+    {
+	// shuffle each species.
+	// we launch 2*n_cells threads to process both species simultaneously
+	int n_cells = m_n_cells;
+	index_type const* AMREX_RESTRICT cell_offsets_1 = m_cell_offsets_1;
+	index_type const* AMREX_RESTRICT cell_offsets_2 = m_cell_offsets_2;
+	amrex::ParallelForRNG( 2*m_n_cells,
+        [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
+	{
+	    int i_cell = i < n_cells ? i : i - n_cells;
+
+	    // The particles from species1 that are in the cell `i_cell` are
+	    // given by the `indices_1[cell_start_1:cell_stop_1]`
+	    index_type const cell_start_1 = cell_offsets_1[i_cell];
+	    index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
+
+	    // Same for species 2
+	    index_type const cell_start_2 = cell_offsets_2[i_cell];
+	    index_type const cell_stop_2  = cell_offsets_2[i_cell+1];
+
+	    // Do not collide if one species is missing in the cell
+	    if ( cell_stop_1 - cell_start_1 < 1 ||
+		 cell_stop_2 - cell_start_2 < 1 ) { return; }
+
+	    if (i < n_cells) {
+		ShuffleFisherYates(a_indices_1, cell_start_1, cell_stop_1, engine);
+	    } else {
+		ShuffleFisherYates(a_indices_2, cell_start_2, cell_stop_2, engine);
+	    }
+	});
+    }
+
+    int numIndependentPairs () const {return m_n_independent_pairs;}
+    const index_type* collisionOffsetsPtr () const {return m_coll_offsets.dataPtr();}
+};
 
 #endif // WARPX_PARTICLES_COLLISION_SHUFFLE_FISHER_YATES_H_


### PR DESCRIPTION
This replaces the O(N^2) differential luminosity calculation with an O(N) Monte-Carlo algorithm like the one used in the Binary Collision module. It performs pair-wise collisions between interacting particles using a random permutation of the particles in each species. 

Todo:

- [x] Performance test. @aeriforme will send: the input script and the submission script.
- [x] Refactor to reduce duplication

These are the performance results I got on Perlmutter using the input script @aeriforme gave me. On development:

```
TinyProfiler total time across processes [min...avg...max]: 4386 ... 4386 ... 4386

-----------------------------------------------------------------------------------------------------------
Name                                                       NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
-----------------------------------------------------------------------------------------------------------
DifferentialLuminosity::ComputeDiags                        4617      2.729      197.5      552.5  12.60%
DifferentialLuminosity2D::ComputeDiags                      4617      2.552      190.6      535.8  12.21%
```

On this branch:

```
TinyProfiler total time across processes [min...avg...max]: 3319 ... 3319 ... 3319

-------------------------------------------------------------------------------------------------------------
Name                                                          NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
-------------------------------------------------------------------------------------------------------------
DifferentialLuminosity::ComputeDiags                            4617      3.389      6.694      11.06   0.33%
DifferentialLuminosity2D::ComputeDiags                          4617      3.288      5.895      9.201   0.28%

```

Results on lepton version of the differential luminosity diagnostic test:

<img width="640" height="480" alt="theory_compare_1d" src="https://github.com/user-attachments/assets/16f46c24-5113-4c0e-a015-c087d70a08c9" />

and for the 2D diagnostic:

<img width="640" height="480" alt="2d_sim" src="https://github.com/user-attachments/assets/d23f81bb-2f50-4191-ae3b-7ead34d8f0ab" />

