### PR TITLE
Fix a bug in the 2d mode of the IGF solver

### DIFF
--- a/Source/ablastr/fields/IntegratedGreenFunctionSolver.H
+++ b/Source/ablastr/fields/IntegratedGreenFunctionSolver.H
@@ -123,14 +123,12 @@ namespace ablastr::fields
      * @param[in] rho the charge density amrex::MultiFab
      * @param[out] phi the electrostatic potential amrex::MultiFab
      * @param[in] cell_size an arreay of 3 reals dx dy dz
-     * @param[in] ba amrex::BoxArray with the grid of a given level
      * @param[in] is_igf_2d_slices boolean to select between fully 3D Poisson solver and quasi-3D, i.e. one 2D Poisson solve on every z slice (default: false)
      */
     void
     computePhiIGF (amrex::MultiFab const & rho,
                    amrex::MultiFab & phi,
                    std::array<amrex::Real, 3> const & cell_size,
-                   amrex::BoxArray const & ba,
                    bool is_igf_2d_slices);
 
 } // namespace ablastr::fields

--- a/Source/ablastr/fields/IntegratedGreenFunctionSolver.cpp
+++ b/Source/ablastr/fields/IntegratedGreenFunctionSolver.cpp
@@ -34,7 +34,6 @@ void
 computePhiIGF ( amrex::MultiFab const & rho,
                 amrex::MultiFab & phi,
                 std::array<amrex::Real, 3> const & cell_size,
-                amrex::BoxArray const & ba,
                 bool const is_igf_2d_slices)
 {
     using namespace amrex::literals;
@@ -42,8 +41,7 @@ computePhiIGF ( amrex::MultiFab const & rho,
     BL_PROFILE("ablastr::fields::computePhiIGF");
 
     // Define box that encompasses the full domain
-    amrex::Box domain = ba.minimalBox();
-    domain.surroundingNodes(); // get nodal points, since `phi` and `rho` are nodal
+    amrex::Box domain = rho.boxArray().minimalBox();
     domain.grow( phi.nGrowVect() ); // include guard cells
 
     int nprocs = amrex::ParallelDescriptor::NProcs();

--- a/Source/ablastr/fields/PoissonSolver.H
+++ b/Source/ablastr/fields/PoissonSolver.H
@@ -279,7 +279,7 @@ computePhi (
             if ( max_norm_b == 0 ) {
                 phi[lev]->setVal(0);
             } else {
-                computePhiIGF( *rho[lev], *phi[lev], dx_scaled, grids[lev], is_igf_2d);
+                computePhiIGF( *rho[lev], *phi[lev], dx_scaled, is_igf_2d);
             }
             continue;
         }


### PR DESCRIPTION
When there is only one node in the z-direction, the previous way of creating the domain for the IGF solver ends up with two nodes. That's not the desired behavior. Using the nodal BoxArray in MultiFab rho solves the issue.
