### PR TITLE
AMReX/pyAMReX/PICSAR: Weekly Update

### DIFF
--- a/cmake/dependencies/pybind11.cmake
+++ b/cmake/dependencies/pybind11.cmake
@@ -37,7 +37,7 @@ function(find_pybind11)
             mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDpybind11)
         endif()
     else()
-        find_package(pybind11 3.0.0 CONFIG REQUIRED)
+        find_package(pybind11 3.0.1 CONFIG REQUIRED)
         message(STATUS "pybind11: Found version '${pybind11_VERSION}'")
     endif()
 endfunction()
@@ -52,7 +52,7 @@ option(WarpX_pybind11_internal "Download & build pybind11" ON)
 set(WarpX_pybind11_repo "https://github.com/pybind/pybind11.git"
     CACHE STRING
     "Repository URI to pull and build pybind11 from if(WarpX_pybind11_internal)")
-set(WarpX_pybind11_branch "v3.0.0"
+set(WarpX_pybind11_branch "v3.0.1"
     CACHE STRING
     "Repository branch for WarpX_pybind11_repo if(WarpX_pybind11_internal)")
 

--- a/dependencies.json
+++ b/dependencies.json
@@ -4,6 +4,6 @@
     "version_pyamrex": "25.09",
     "version_picsar": "25.06",
     "commit_amrex": "38547bb7f27764a6a711e48ff076bed62392797d",
-    "commit_pyamrex": "7a07587b36678c098d4da6f51d07b6da1ecbcb16",
+    "commit_pyamrex": "5e0cefeb427cadf4b016b05ec3a5c0cbf521972d",
     "commit_picsar": "0c329e66010267662a82219f7de7abbd231463f4"
 }

--- a/dependencies.json
+++ b/dependencies.json
@@ -3,7 +3,7 @@
     "version_amrex": "25.09",
     "version_pyamrex": "25.09",
     "version_picsar": "25.06",
-    "commit_amrex": "a67a8c6ee6e7cc22e1c2e1bae0e0d385e6c0233b",
+    "commit_amrex": "38547bb7f27764a6a711e48ff076bed62392797d",
     "commit_pyamrex": "7a07587b36678c098d4da6f51d07b6da1ecbcb16",
     "commit_picsar": "0c329e66010267662a82219f7de7abbd231463f4"
 }


### PR DESCRIPTION
Mainly to pull in https://github.com/AMReX-Codes/amrex/pull/4671

Also updates pybind11 to [v3.0.1](https://github.com/pybind/pybind11/releases/tag/v3.0.1), to stay in sync with [pyAMReX](https://github.com/AMReX-Codes/pyamrex/pull/481).

<hr>

Weekly update to latest AMReX.
Weekly update to latest pyAMReX.
Weekly update to latest PICSAR (no changes).

```console
./Tools/Release/update_dependencies.py --amrex
./Tools/Release/update_dependencies.py --pyamrex
./Tools/Release/update_dependencies.py --picsar
```

This pull request was created with the script `./Tools/Release/weeklyUpdate.py`,
following the instructions described in https://warpx.readthedocs.io/en/latest/maintenance/release.html#update-warpx-core-dependencies.
