### PR TITLE
Docs: fix link to input files 

### DIFF
--- a/Examples/Physics_applications/laser_acceleration/README.rst
+++ b/Examples/Physics_applications/laser_acceleration/README.rst
@@ -37,9 +37,9 @@ For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with `
 
          .. tab-item:: Executable: Input File
 
-             .. literalinclude:: inputs_test_3d_laser_acceleration
+             .. literalinclude:: inputs_base_3d
                 :language: ini
-                :caption: You can copy this file from ``Examples/Physics_applications/laser_acceleration/inputs_test_3d_laser_acceleration``.
+                :caption: You can copy this file from ``Examples/Physics_applications/laser_acceleration/inputs_base_3d``.
 
    .. tab-item:: RZ
 
@@ -58,9 +58,9 @@ For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with `
 
          .. tab-item:: Executable: Input File
 
-             .. literalinclude:: inputs_test_rz_laser_acceleration
+             .. literalinclude:: inputs_base_rz
                 :language: ini
-                :caption: You can copy this file from ``Examples/Physics_applications/laser_acceleration/inputs_test_rz_laser_acceleration``.
+                :caption: You can copy this file from ``Examples/Physics_applications/laser_acceleration/inputs_base_rz``.
 
 Analyze
 -------

--- a/Examples/Physics_applications/plasma_acceleration/README.rst
+++ b/Examples/Physics_applications/plasma_acceleration/README.rst
@@ -43,9 +43,9 @@ For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with `
 
    .. tab-item:: Executable: Input File
 
-      .. literalinclude:: inputs_test_3d_plasma_acceleration_boosted
+      .. literalinclude:: inputs_base_3d
          :language: ini
-         :caption: You can copy this file from ``Examples/Physics_applications/plasma_acceleration/inputs_test_3d_plasma_acceleration_boosted``.
+         :caption: You can copy this file from ``Examples/Physics_applications/plasma_acceleration/inputs_base_3d``.
 
 Analyze
 -------

--- a/Examples/Physics_applications/uniform_plasma/README.rst
+++ b/Examples/Physics_applications/uniform_plasma/README.rst
@@ -25,11 +25,11 @@ For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with `
 
          .. tab-item:: Executable: Input File
 
-            This example can be run **either** as WarpX **executable** using an input file: ``warpx.3d inputs_test_3d_uniform_plasma``
+            This example can be run **either** as WarpX **executable** using an input file: ``warpx.3d inputs_base_3d``
 
-             .. literalinclude:: inputs_test_3d_uniform_plasma
+             .. literalinclude:: inputs_base_3d
                 :language: ini
-                :caption: You can copy this file from ``usage/examples/lwfa/inputs_test_3d_uniform_plasma``.
+                :caption: You can copy this file from ``usage/examples/lwfa/inputs_base_3d``.
 
    .. tab-item:: 2D
 

--- a/Examples/Tests/langmuir/README.rst
+++ b/Examples/Tests/langmuir/README.rst
@@ -31,11 +31,12 @@ For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with `
 
          .. tab-item:: Executable: Input File
 
-            This example can be run as WarpX **executable** using an input file: ``warpx.3d inputs_test_3d_langmuir_multi``
+            This example can be run as WarpX **executable** using an input file: ``warpx.3d inputs_base_3d``.
+            Check out ``Examples/Tests/langmuir/inputs_test_3d_langmuir_multi`` for additional input parameters.
 
-            .. literalinclude:: inputs_test_3d_langmuir_multi
+            .. literalinclude:: inputs_base_3d
                :language: ini
-               :caption: You can copy this file from ``Examples/Tests/langmuir/inputs_test_3d_langmuir_multi``.
+               :caption: You can copy this file from ``Examples/Tests/langmuir/inputs_base_3d``.
 
    .. tab-item:: 2D
 
@@ -51,11 +52,12 @@ For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with `
 
          .. tab-item:: Executable: Input File
 
-            This example can be run as WarpX **executable** using an input file: ``warpx.2d inputs_test_2d_langmuir_multi``
+            This example can be run as WarpX **executable** using an input file: ``warpx.2d inputs_base_2d``
+            Check out ``Examples/Tests/langmuir/inputs_test_2d_langmuir_multi`` for additional input parameters.
 
-            .. literalinclude:: inputs_test_2d_langmuir_multi
+            .. literalinclude:: inputs_base_2d
                :language: ini
-               :caption: You can copy this file from ``Examples/Tests/langmuir/inputs_test_2d_langmuir_multi``.
+               :caption: You can copy this file from ``Examples/Tests/langmuir/inputs_base_2d``.
 
 
    .. tab-item:: RZ
@@ -72,11 +74,12 @@ For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with `
 
          .. tab-item:: Executable: Input File
 
-            This example can be run as WarpX **executable** using an input file: ``warpx.rz inputs_test_rz_langmuir_multi``
+            This example can be run as WarpX **executable** using an input file: ``warpx.rz inputs_base_rz``
+            Check out ``Examples/Tests/langmuir/inputs_test_rz_langmuir_multi`` for additional input parameters.
 
-            .. literalinclude:: inputs_test_rz_langmuir_multi
+            .. literalinclude:: inputs_base_rz
                :language: ini
-               :caption: You can copy this file from ``Examples/Tests/langmuir/inputs_test_rz_langmuir_multi``.
+               :caption: You can copy this file from ``Examples/Tests/langmuir/inputs_base_rz``.
 
 
    .. tab-item:: 1D


### PR DESCRIPTION
Changes the links of some input files in the documentation. 
The examples in the documentation are linked to specific CI tests. 
The inputs of some of these CI tests are scattered in two separate files: a base file, and an auxiliary one with additional options. See for example 
`../Examples/Physics_applications/laser_acceleration/`.
In the docs we now link the base files. 