### PR TITLE
Some cleaning of the #include directives

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatInSitu.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatInSitu.cpp
@@ -1,6 +1,5 @@
 #include "FlushFormatInSitu.H"
 
-#include "WarpX.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXProfilerWrapper.H"
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatSensei.cpp
@@ -1,8 +1,6 @@
 #include "Utils/WarpXProfilerWrapper.H"
 #include "FlushFormatSensei.H"
 
-#include "WarpX.H"
-
 #ifdef AMREX_USE_SENSEI_INSITU
 # include <AMReX_AmrMeshParticleInSituBridge.H>
 #endif

--- a/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
+++ b/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
@@ -4,7 +4,6 @@
 #include "Particles/WarpXParticleContainer.H"
 #include "Utils/Parser/ParserUtils.H"
 #include "Utils/TextMsg.H"
-#include "WarpX.H"
 
 #include <ablastr/warn_manager/WarnManager.H>
 

--- a/Source/Diagnostics/ReducedDiags/FieldProbeParticleContainer.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbeParticleContainer.cpp
@@ -7,54 +7,21 @@
 
 #include "FieldProbeParticleContainer.H"
 
-#include "Particles/Deposition/ChargeDeposition.H"
-#include "Particles/Deposition/CurrentDeposition.H"
-#include "Particles/Pusher/GetAndSetPosition.H"
-#include "Particles/Pusher/UpdatePosition.H"
-#include "Particles/ParticleBoundaries_K.H"
 #include "Utils/TextMsg.H"
-#include "Utils/WarpXAlgorithmSelection.H"
-#include "Utils/WarpXConst.H"
-#include "Utils/WarpXProfilerWrapper.H"
-#include "WarpX.H"
 
-#include <AMReX.H>
 #include <AMReX_AmrCore.H>
 #include <AMReX_AmrParGDB.H>
 #include <AMReX_BLassert.H>
-#include <AMReX_Box.H>
-#include <AMReX_BoxArray.H>
-#include <AMReX_Config.H>
-#include <AMReX_Dim3.H>
-#include <AMReX_Extension.H>
-#include <AMReX_FabArray.H>
-#include <AMReX_Geometry.H>
 #include <AMReX_GpuAllocators.H>
-#include <AMReX_GpuAtomic.H>
-#include <AMReX_GpuControl.H>
-#include <AMReX_GpuDevice.H>
-#include <AMReX_GpuLaunch.H>
-#include <AMReX_GpuQualifiers.H>
-#include <AMReX_IndexType.H>
-#include <AMReX_IntVect.H>
-#include <AMReX_LayoutData.H>
-#include <AMReX_MFIter.H>
-#include <AMReX_MultiFab.H>
-#include <AMReX_PODVector.H>
-#include <AMReX_ParGDB.H>
 #include <AMReX_ParallelDescriptor.H>
-#include <AMReX_ParallelReduce.H>
-#include <AMReX_ParmParse.H>
 #include <AMReX_Particle.H>
-#include <AMReX_ParticleContainerBase.H>
+#include <AMReX_ParticleContainer.H>
 #include <AMReX_ParticleTile.H>
 #include <AMReX_ParticleTransformation.H>
-#include <AMReX_ParticleUtil.H>
-#include <AMReX_Utility.H>
+#include <AMReX_StructOfArrays.H>
 
+#include <string>
 
-#include <algorithm>
-#include <cmath>
 
 using namespace amrex;
 

--- a/Source/Particles/Collision/BinaryCollision/Bremsstrahlung/BremsstrahlungFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/Bremsstrahlung/BremsstrahlungFunc.H
@@ -15,7 +15,6 @@
 #include "Utils/Parser/ParserUtils.H"
 #include "Utils/ParticleUtils.H"
 #include "Utils/TextMsg.H"
-#include "WarpX.H"
 
 #include <AMReX_Algorithm.H>
 #include <AMReX_DenseBins.H>

--- a/Source/Particles/Collision/ScatteringProcess.H
+++ b/Source/Particles/Collision/ScatteringProcess.H
@@ -9,10 +9,13 @@
 #ifndef WARPX_PARTICLES_COLLISION_SCATTERING_PROCESS_H_
 #define WARPX_PARTICLES_COLLISION_SCATTERING_PROCESS_H_
 
-#include <AMReX_Math.H>
-#include <AMReX_Vector.H>
-#include <AMReX_RandomEngine.H>
 #include <AMReX_GpuContainers.H>
+#include <AMReX_Math.H>
+#include <AMReX_REAL.H>
+#include <AMReX_RandomEngine.H>
+#include <AMReX_Vector.H>
+
+#include <string>
 
 enum class ScatteringProcessType {
     INVALID,

--- a/Source/Particles/Collision/ScatteringProcess.cpp
+++ b/Source/Particles/Collision/ScatteringProcess.cpp
@@ -9,7 +9,6 @@
 #include "ScatteringProcess.H"
 
 #include "Utils/TextMsg.H"
-#include "WarpX.H"
 
 ScatteringProcess::ScatteringProcess (
                         const std::string& scattering_process,


### PR DESCRIPTION
This PR fixes some `#include` issues found with the `iwyu` tool (mostly unnecessary inclusions).
There are several other issues like these ones, but I prefer to address them in separate PRs in order to keep them small.