### PR TITLE
LinearBreitWheelerCollisionFunc.H and LinearComptonCollisionFunc.H  : remove unnecessary #include of the WarpX header

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/LinearBreitWheeler/LinearBreitWheelerCollisionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/LinearBreitWheeler/LinearBreitWheelerCollisionFunc.H
@@ -16,7 +16,6 @@
 #include "Particles/WarpXParticleContainer.H"
 #include "Utils/Parser/ParserUtils.H"
 #include "Utils/TextMsg.H"
-#include "WarpX.H"
 
 #include <AMReX_Algorithm.H>
 #include <AMReX_DenseBins.H>

--- a/Source/Particles/Collision/BinaryCollision/LinearCompton/LinearComptonCollisionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/LinearCompton/LinearComptonCollisionFunc.H
@@ -16,7 +16,6 @@
 #include "Particles/WarpXParticleContainer.H"
 #include "Utils/Parser/ParserUtils.H"
 #include "Utils/TextMsg.H"
-#include "WarpX.H"
 
 #include <AMReX_Algorithm.H>
 #include <AMReX_DenseBins.H>


### PR DESCRIPTION
This PR removes a couple of unnecessary `#include` directives