### PR TITLE
Fix potential recursive calls of WarpX constructor.

### DIFF
--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -319,6 +319,8 @@ WarpX::Finalize()
 
 WarpX::WarpX ()
 {
+    m_instance = this;
+
     warpx::initialization::initialize_warning_manager();
 
     ReadParameters();

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -319,7 +319,8 @@ WarpX::Finalize()
 
 WarpX::WarpX ()
 {
-    m_instance = this;
+    m_instance = this; // This guarantees that GetInstance() can be
+                       // indirectly used in WarpX constructor.
 
     warpx::initialization::initialize_warning_manager();
 


### PR DESCRIPTION
WarpX's constructor may build objects that call WarpX::getInstance, which in turn build WarpX again if `m_instance` is nullptr. So we should assign `this` to `m_instance` at the beginning of the constructor to avoid the recursion.