### PR TITLE
SpectralFieldData, SpectralFieldDataRZ, SpectralSolver : move implementation of some methods from the header to the cpp file

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.H
@@ -77,39 +77,14 @@ class SpectralFieldDataRZ
          * \param[in] src_comp  component of the source FabArray from which the data are copied
          * \param[in] dest_comp component of the destination FabArray where the data are copied
          */
-        void CopySpectralDataComp (int src_comp, int dest_comp)
-        {
-            // In spectral space fields of each mode are grouped together, so that the index
-            // of a field for a specific mode is given by field_index + mode*n_fields.
-            // That’s why, looping over all azimuthal modes, we need to take into account corresponding
-            // shift, given by imode * m_n_fields.
-            for (int imode=0 ; imode < n_rz_azimuthal_modes ; imode++)
-            {
-                const int shift_comp = imode * m_n_fields;
-                // The last two arguments represent the number of components and
-                // the number of ghost cells to perform this operation
-                Copy(fields, fields, src_comp + shift_comp, dest_comp + shift_comp, 1, 0);
-            }
-        }
+        void CopySpectralDataComp (int src_comp, int dest_comp);
 
         /**
          * \brief Set to zero the data on component \c icomp of \c fields
          *
          * \param[in] icomp component of the FabArray where the data are set to zero
          */
-        void ZeroOutDataComp(int icomp)
-        {
-            // In spectral space fields of each mode are grouped together, so that the index
-            // of a field for a specific mode is given by field_index + mode*n_fields.
-            // That’s why, looping over all azimuthal modes, we need to take into account corresponding
-            // shift, given by imode * m_n_fields.
-            for (int imode=0 ; imode < n_rz_azimuthal_modes ; imode++)
-            {
-                const int shift_comp = imode * m_n_fields;
-                // The last argument represents the number of components to perform this operation
-                fields.setVal(0., icomp + shift_comp, 1);
-            }
-        }
+        void ZeroOutDataComp(int icomp);
 
         /**
          * \brief Scale the data on component \c icomp of \c fields by a given scale factor
@@ -117,19 +92,7 @@ class SpectralFieldDataRZ
          * \param[in] icomp component of the FabArray where the data are scaled
          * \param[in] scale_factor scale factor to use for scaling
          */
-        void ScaleDataComp(int icomp, amrex::Real scale_factor)
-        {
-            // In spectral space fields of each mode are grouped together, so that the index
-            // of a field for a specific mode is given by field_index + mode*n_fields.
-            // That’s why, looping over all azimuthal modes, we need to take into account corresponding
-            // shift, given by imode * m_n_fields.
-            for (int imode=0 ; imode < n_rz_azimuthal_modes ; imode++)
-            {
-                const int shift_comp = imode * m_n_fields;
-                // The last argument represents the number of components to perform this operation
-                fields.mult(scale_factor, icomp + shift_comp, 1);
-            }
-        }
+        void ScaleDataComp(int icomp, amrex::Real scale_factor);
 
         void InitFilter (amrex::IntVect const & filter_npass_each_dir, bool compensation,
                          SpectralKSpaceRZ const & k_space);

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.cpp
@@ -751,6 +751,50 @@ SpectralFieldDataRZ::BackwardTransform (const int lev,
 
 }
 
+
+void SpectralFieldDataRZ::CopySpectralDataComp (const int src_comp, const int dest_comp)
+{
+    // In spectral space fields of each mode are grouped together, so that the index
+    // of a field for a specific mode is given by field_index + mode*n_fields.
+    // That’s why, looping over all azimuthal modes, we need to take into account corresponding
+    // shift, given by imode * m_n_fields.
+    for (int imode=0 ; imode < n_rz_azimuthal_modes ; imode++)
+    {
+        const int shift_comp = imode * m_n_fields;
+        // The last two arguments represent the number of components and
+        // the number of ghost cells to perform this operation
+        Copy(fields, fields, src_comp + shift_comp, dest_comp + shift_comp, 1, 0);
+    }
+}
+
+void SpectralFieldDataRZ::ZeroOutDataComp(const int icomp)
+{
+    // In spectral space fields of each mode are grouped together, so that the index
+    // of a field for a specific mode is given by field_index + mode*n_fields.
+    // That’s why, looping over all azimuthal modes, we need to take into account corresponding
+    // shift, given by imode * m_n_fields.
+    for (int imode=0 ; imode < n_rz_azimuthal_modes ; imode++)
+    {
+        const int shift_comp = imode * m_n_fields;
+        // The last argument represents the number of components to perform this operation
+        fields.setVal(0., icomp + shift_comp, 1);
+    }
+}
+
+void SpectralFieldDataRZ::ScaleDataComp(const int icomp, const amrex::Real scale_factor)
+{
+    // In spectral space fields of each mode are grouped together, so that the index
+    // of a field for a specific mode is given by field_index + mode*n_fields.
+    // That’s why, looping over all azimuthal modes, we need to take into account corresponding
+    // shift, given by imode * m_n_fields.
+    for (int imode=0 ; imode < n_rz_azimuthal_modes ; imode++)
+    {
+        const int shift_comp = imode * m_n_fields;
+        // The last argument represents the number of components to perform this operation
+        fields.mult(scale_factor, icomp + shift_comp, 1);
+    }
+}
+
 /* \brief Initialize arrays used for filtering */
 void
 SpectralFieldDataRZ::InitFilter (amrex::IntVect const & filter_npass_each_dir, bool const compensation,

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver.H
@@ -130,11 +130,7 @@ class SpectralSolver
         void ComputeSpectralDivE (
             int lev,
             ablastr::fields::VectorField const & Efield,
-            amrex::MultiFab& divE
-        )
-        {
-            algorithm->ComputeSpectralDivE( lev, field_data, Efield, divE );
-        }
+            amrex::MultiFab& divE);
 
         /**
          * \brief Public interface to call the virtual function \c CurrentCorrection,
@@ -142,10 +138,7 @@ class SpectralSolver
          * by its derived classes (e.g. PsatdAlgorithm, PsatdAlgorithmComoving, etc.), from
          * objects of class SpectralSolver through the private unique pointer \c algorithm
          */
-        void CurrentCorrection ()
-        {
-            algorithm->CurrentCorrection(field_data);
-        }
+        void CurrentCorrection ();
 
         /**
          * \brief Public interface to call the virtual function \c VayDeposition,
@@ -153,10 +146,7 @@ class SpectralSolver
          * derived classes, from objects of class SpectralSolver through the private
          * unique pointer \c algorithm.
          */
-        void VayDeposition ()
-        {
-            algorithm->VayDeposition(field_data);
-        }
+        void VayDeposition ();
 
         /**
          * \brief Copy spectral data from component \c src_comp to component \c dest_comp
@@ -165,23 +155,14 @@ class SpectralSolver
          * \param[in] src_comp  component of the source FabArray from which the data are copied
          * \param[in] dest_comp component of the destination FabArray where the data are copied
          */
-        void CopySpectralDataComp (const int src_comp, const int dest_comp)
-        {
-            // The last two arguments represent the number of components and
-            // the number of ghost cells to perform this operation
-            Copy(field_data.fields, field_data.fields, src_comp, dest_comp, 1, 0);
-        }
+        void CopySpectralDataComp (int src_comp, int dest_comp);
 
         /**
          * \brief Set to zero the data on component \c icomp of \c field_data.fields
          *
          * \param[in] icomp component of the FabArray where the data are set to zero
          */
-        void ZeroOutDataComp (const int icomp)
-        {
-            // The last argument represents the number of components to perform this operation
-            field_data.fields.setVal(0., icomp, 1);
-        }
+        void ZeroOutDataComp (int icomp);
 
         /**
          * \brief Scale the data on component \c icomp of \c field_data.fields
@@ -190,11 +171,7 @@ class SpectralSolver
          * \param[in] icomp component of the FabArray where the data are scaled
          * \param[in] scale_factor scale factor to use for scaling
          */
-        void ScaleDataComp (const int icomp, const amrex::Real scale_factor)
-        {
-            // The last argument represents the number of components to perform this operation
-            field_data.fields.mult(scale_factor, icomp, 1);
-        }
+        void ScaleDataComp (int icomp, amrex::Real scale_factor);
 
         SpectralFieldIndex m_spectral_index;
 

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver.cpp
@@ -144,4 +144,41 @@ SpectralSolver::pushSpectralFields(){
     algorithm->pushSpectralFields( field_data );
 }
 
+void SpectralSolver::ComputeSpectralDivE (
+        const int lev,
+        ablastr::fields::VectorField const & Efield,
+        amrex::MultiFab& divE)
+{
+    algorithm->ComputeSpectralDivE(lev, field_data, Efield, divE );
+}
+
+void SpectralSolver::CurrentCorrection ()
+{
+    algorithm->CurrentCorrection(field_data);
+}
+
+void SpectralSolver::VayDeposition ()
+{
+    algorithm->VayDeposition(field_data);
+}
+
+void SpectralSolver::CopySpectralDataComp (const int src_comp, const int dest_comp)
+{
+    // The last two arguments represent the number of components and
+    // the number of ghost cells to perform this operation
+    Copy(field_data.fields, field_data.fields, src_comp, dest_comp, 1, 0);
+}
+
+void SpectralSolver::ZeroOutDataComp (const int icomp)
+{
+    // The last argument represents the number of components to perform this operation
+    field_data.fields.setVal(0., icomp, 1);
+}
+
+void SpectralSolver::ScaleDataComp (const int icomp, const amrex::Real scale_factor)
+{
+    // The last argument represents the number of components to perform this operation
+    field_data.fields.mult(scale_factor, icomp, 1);
+}
+
 #endif // WARPX_USE_FFT

--- a/Source/FieldSolver/SpectralSolver/SpectralSolverRZ.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolverRZ.H
@@ -74,23 +74,14 @@ class SpectralSolverRZ
 
         /* \brief Initialize K space filtering arrays */
         void InitFilter (amrex::IntVect const & filter_npass_each_dir,
-                         bool const compensation)
-        {
-            field_data.InitFilter(filter_npass_each_dir, compensation, k_space);
-        }
+                         bool compensation);
 
         /* \brief Apply K space filtering for a scalar */
-        void ApplyFilter (const int lev, int const field_index)
-        {
-            field_data.ApplyFilter(lev, field_index);
-        }
+        void ApplyFilter (int lev, int field_index);
 
         /* \brief Apply K space filtering for a vector */
-        void ApplyFilter (const int lev, int const field_index1,
-                          int const field_index2, int const field_index3)
-        {
-            field_data.ApplyFilter(lev, field_index1, field_index2, field_index3);
-        }
+        void ApplyFilter (int lev, int field_index1,
+                          int field_index2, int field_index3);
 
         /**
           * \brief Public interface to call the member function ComputeSpectralDivE
@@ -123,20 +114,14 @@ class SpectralSolverRZ
          * \param[in] src_comp  component of the source FabArray from which the data are copied
          * \param[in] dest_comp component of the destination FabArray where the data are copied
          */
-        void CopySpectralDataComp (const int src_comp, const int dest_comp)
-        {
-            field_data.CopySpectralDataComp(src_comp, dest_comp);
-        }
+        void CopySpectralDataComp (int src_comp, int dest_comp);
 
         /**
          * \brief Set to zero the data on component \c icomp of \c field_data.fields
          *
          * \param[in] icomp component of the FabArray where the data are set to zero
          */
-        void ZeroOutDataComp (const int icomp)
-        {
-            field_data.ZeroOutDataComp(icomp);
-        }
+        void ZeroOutDataComp (int icomp);
 
         /**
          * \brief Scale the data on component \c icomp of \c field_data.fields
@@ -145,10 +130,7 @@ class SpectralSolverRZ
          * \param[in] icomp component of the FabArray where the data are scaled
          * \param[in] scale_factor scale factor to use for scaling
          */
-        void ScaleDataComp (const int icomp, const amrex::Real scale_factor)
-        {
-            field_data.ScaleDataComp(icomp, scale_factor);
-        }
+        void ScaleDataComp (int icomp, amrex::Real scale_factor);
 
         SpectralFieldIndex m_spectral_index;
 

--- a/Source/FieldSolver/SpectralSolver/SpectralSolverRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolverRZ.cpp
@@ -136,6 +136,25 @@ SpectralSolverRZ::pushSpectralFields (const bool doing_pml) {
     }
 }
 
+void SpectralSolverRZ::InitFilter (
+    amrex::IntVect const & filter_npass_each_dir,
+    bool const compensation)
+{
+    field_data.InitFilter(filter_npass_each_dir, compensation, k_space);
+}
+
+void SpectralSolverRZ::ApplyFilter (const int lev, int const field_index)
+{
+    field_data.ApplyFilter(lev, field_index);
+}
+
+void SpectralSolverRZ::ApplyFilter (
+    const int lev, int const field_index1,
+    int const field_index2, int const field_index3)
+{
+    field_data.ApplyFilter(lev, field_index1, field_index2, field_index3);
+}
+
 /**
   * \brief Public interface to call the member function ComputeSpectralDivE
   * of the base class SpectralBaseAlgorithmRZ from objects of class SpectralSolverRZ
@@ -165,4 +184,23 @@ void
 SpectralSolverRZ::VayDeposition ()
 {
     algorithm->VayDeposition(field_data);
+}
+
+
+void
+SpectralSolverRZ::CopySpectralDataComp (const int src_comp, const int dest_comp)
+{
+    field_data.CopySpectralDataComp(src_comp, dest_comp);
+}
+
+void
+SpectralSolverRZ::ZeroOutDataComp (const int icomp)
+{
+    field_data.ZeroOutDataComp(icomp);
+}
+
+void
+SpectralSolverRZ::ScaleDataComp (const int icomp, const amrex::Real scale_factor)
+{
+    field_data.ScaleDataComp(icomp, scale_factor);
 }


### PR DESCRIPTION
This PR moves the implementation of some methods of `SpectralFieldData`, `SpectralFieldDataRZ`, and `SpectralSolver` from the header file to the cpp file. This makes the header files smaller and more readable.