### PR TITLE
AddParticles.cpp : fix "maybe-uninitialized" issue for variable XDim3 r

### DIFF
--- a/Source/Particles/ParticleCreation/AddParticles.cpp
+++ b/Source/Particles/ParticleCreation/AddParticles.cpp
@@ -1404,7 +1404,7 @@ PhysicalParticleContainer::AddPlasmaFlux (PlasmaInjector const& plasma_injector,
 
                 // Determine the position of the particle within the cell
                 XDim3 pos;
-                XDim3 r;
+                auto r = XDim3{0.0_rt,0.0_rt,0.0_rt};
 #ifdef AMREX_USE_EB
                 if (inject_from_eb) {
                     auto const& pt = eb_data.randomPointOnEB(i,j,k,engine);


### PR DESCRIPTION
This PR fixes the following issue, found by compiling WarpX with `g++` v 14.2 :

```
/home/lfedeli/Projects/warpx/WarpX/Source/Particles/ParticleCreation/AddParticles.cpp:1506:75: warning: ‘r.amrex::XDim3::y’ may be used uninitialized [-Wmaybe-uninitialized]
 1506 |                 const amrex::Real theta = (nmodes == 1 && rz_random_theta)?
      |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
 1507 | #if defined(WARPX_DIM_RZ)
      | ~~~~~~~~~~~~~~~~~~~~~~~~~                                                  
 1508 |                     // This should be updated to be the same as below, since theta
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1509 |                     // should range from -pi to +pi. This should be a separate PR
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1510 |                     // since it will break RZ CI tests.
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                    
 1511 |                     (2._rt*MathConst::pi*amrex::Random(engine)):
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~           
 1512 | #elif defined(WARPX_DIM_RCYLINDER)
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                         
 1513 |                     (MathConst::pi*(2._rt*amrex::Random(engine) - 1._rt)):
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
 1514 | #endif
      | ~~~~~~                                                                     
 1515 |                     (2._prt*MathConst::pi*r.y);
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~                             
/home/lfedeli/Projects/warpx/WarpX/Source/Particles/ParticleCreation/AddParticles.cpp: In function ‘_ZN25PhysicalParticleContainer13AddPlasmaFluxERK14PlasmaInjectord._omp_fn.0’:
/home/lfedeli/Projects/warpx/WarpX/Source/Particles/ParticleCreation/AddParticles.cpp:1407:23: note: ‘r.amrex::XDim3::y’ was declared here
 1407 |                 XDim3 r;
      |                       ^

```