### PR TITLE
Fix input file of photon pusher test

### DIFF
--- a/Examples/Tests/photon_pusher/inputs_test_3d_photon_pusher
+++ b/Examples/Tests/photon_pusher/inputs_test_3d_photon_pusher
@@ -1,7 +1,3 @@
-#Automatically generated inputfile
-#Run check.py without arguments to regenerate
-#
-
 max_step = 50
 amr.n_cell = 64 64 64
 amr.max_level = 0
@@ -21,116 +17,100 @@ boundary.field_hi = periodic periodic periodic
 # Order of particle shape factors
 algo.particle_shape = 1
 
-particles.species_names = p_xp_1 p_xn_1 p_yp_1 p_yn_1 p_zp_1 p_zn_1 p_dp_1 p_dn_1 p_xp_10 p_xn_10 p_yp_10 p_yn_10 p_zp_10 p_zn_10 p_dp_10 p_dn_10
+particles.species_names  = p_xp_1 p_xn_1 p_yp_1 p_yn_1 p_zp_1 p_zn_1 p_dp_1 p_dn_1 p_xp_10 p_xn_10 p_yp_10 p_yn_10 p_zp_10 p_zn_10 p_dp_10 p_dn_10
 particles.photon_species = p_xp_1 p_xn_1 p_yp_1 p_yn_1 p_zp_1 p_zn_1 p_dp_1 p_dn_1 p_xp_10 p_xn_10 p_yp_10 p_yn_10 p_zp_10 p_zn_10 p_dp_10 p_dn_10
 
-p_xp_1.charge = -q_e
-p_xp_1.mass = m_e
+p_xp_1.species_type = photon
 p_xp_1.injection_style = "SingleParticle"
 p_xp_1.single_particle_pos = 0.0 0.0 0.0
 p_xp_1.single_particle_u = 1.0 0.0 0.0
 p_xp_1.single_particle_weight = 1.0
 
-p_xn_1.charge = -q_e
-p_xn_1.mass = m_e
+p_xn_1.species_type = photon
 p_xn_1.injection_style = "SingleParticle"
 p_xn_1.single_particle_pos = 0.0 0.0 0.0
 p_xn_1.single_particle_u = -1.0 0.0 0.0
 p_xn_1.single_particle_weight = 1.0
 
-p_yp_1.charge = -q_e
-p_yp_1.mass = m_e
+p_yp_1.species_type = photon
 p_yp_1.injection_style = "SingleParticle"
 p_yp_1.single_particle_pos = 0.0 0.0 0.0
 p_yp_1.single_particle_u = 0.0 1.0 0.0
 p_yp_1.single_particle_weight = 1.0
 
-p_yn_1.charge = -q_e
-p_yn_1.mass = m_e
+p_yn_1.species_type = photon
 p_yn_1.injection_style = "SingleParticle"
 p_yn_1.single_particle_pos = 0.0 0.0 0.0
 p_yn_1.single_particle_u = 0.0 -1.0 0.0
 p_yn_1.single_particle_weight = 1.0
 
-p_zp_1.charge = -q_e
-p_zp_1.mass = m_e
+p_zp_1.species_type = photon
 p_zp_1.injection_style = "SingleParticle"
 p_zp_1.single_particle_pos = 0.0 0.0 0.0
 p_zp_1.single_particle_u = 0.0 0.0 1.0
 p_zp_1.single_particle_weight = 1.0
 
-p_zn_1.charge = -q_e
-p_zn_1.mass = m_e
+p_zn_1.species_type = photon
 p_zn_1.injection_style = "SingleParticle"
 p_zn_1.single_particle_pos = 0.0 0.0 0.0
 p_zn_1.single_particle_u = 0.0 0.0 -1.0
 p_zn_1.single_particle_weight = 1.0
 
-p_dp_1.charge = -q_e
-p_dp_1.mass = m_e
+p_dp_1.species_type = photon
 p_dp_1.injection_style = "SingleParticle"
 p_dp_1.single_particle_pos = 0.0 0.0 0.0
 p_dp_1.single_particle_u = 1.0 1.0 1.0
 p_dp_1.single_particle_weight = 1.0
 
-p_dn_1.charge = -q_e
-p_dn_1.mass = m_e
+p_dn_1.species_type = photon
 p_dn_1.injection_style = "SingleParticle"
 p_dn_1.single_particle_pos = 0.0 0.0 0.0
 p_dn_1.single_particle_u = -1.0 -1.0 -1.0
 p_dn_1.single_particle_weight = 1.0
 
-p_xp_10.charge = -q_e
-p_xp_10.mass = m_e
+p_xp_10.species_type = photon
 p_xp_10.injection_style = "SingleParticle"
 p_xp_10.single_particle_pos = 0.0 0.0 0.0
 p_xp_10.single_particle_u = 10.0 0.0 0.0
 p_xp_10.single_particle_weight = 1.0
 
-p_xn_10.charge = -q_e
-p_xn_10.mass = m_e
+p_xn_10.species_type = photon
 p_xn_10.injection_style = "SingleParticle"
 p_xn_10.single_particle_pos = 0.0 0.0 0.0
 p_xn_10.single_particle_u = -10.0 0.0 0.0
 p_xn_10.single_particle_weight = 1.0
 
-p_yp_10.charge = -q_e
-p_yp_10.mass = m_e
+p_yp_10.species_type = photon
 p_yp_10.injection_style = "SingleParticle"
 p_yp_10.single_particle_pos = 0.0 0.0 0.0
 p_yp_10.single_particle_u = 0.0 10.0 0.0
 p_yp_10.single_particle_weight = 1.0
 
-p_yn_10.charge = -q_e
-p_yn_10.mass = m_e
+p_yn_10.species_type = photon
 p_yn_10.injection_style = "SingleParticle"
 p_yn_10.single_particle_pos = 0.0 0.0 0.0
 p_yn_10.single_particle_u = 0.0 -10.0 0.0
 p_yn_10.single_particle_weight = 1.0
 
-p_zp_10.charge = -q_e
-p_zp_10.mass = m_e
+p_zp_10.species_type = photon
 p_zp_10.injection_style = "SingleParticle"
 p_zp_10.single_particle_pos = 0.0 0.0 0.0
 p_zp_10.single_particle_u = 0.0 0.0 10.0
 p_zp_10.single_particle_weight = 1.0
 
-p_zn_10.charge = -q_e
-p_zn_10.mass = m_e
+p_zn_10.species_type = photon
 p_zn_10.injection_style = "SingleParticle"
 p_zn_10.single_particle_pos = 0.0 0.0 0.0
 p_zn_10.single_particle_u = 0.0 0.0 -10.0
 p_zn_10.single_particle_weight = 1.0
 
-p_dp_10.charge = -q_e
-p_dp_10.mass = m_e
+p_dp_10.species_type = photon
 p_dp_10.injection_style = "SingleParticle"
 p_dp_10.single_particle_pos = 0.0 0.0 0.0
 p_dp_10.single_particle_u = 10.0 10.0 10.0
 p_dp_10.single_particle_weight = 1.0
 
-p_dn_10.charge = -q_e
-p_dn_10.mass = m_e
+p_dn_10.species_type = photon
 p_dn_10.injection_style = "SingleParticle"
 p_dn_10.single_particle_pos = 0.0 0.0 0.0
 p_dn_10.single_particle_u = -10.0 -10.0 -10.0


### PR DESCRIPTION
I noticed in #6231 that the input file of the test `test_3d_photon_pusher` was setting up photons with electron charge and electron mass :eyes:. This PR fixes the input file replacing the charge and mass inputs with the species type.