### PR TITLE
Add error message for non-supported scattering processes in DSMC

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
@@ -53,6 +53,10 @@ DSMCFunc::DSMCFunc (
 
         ScatteringProcess process(scattering_process, cross_section_file, energy);
 
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(process.type() != ScatteringProcessType::EXCITATION,
+                                        "Excitation collisions are not yet supported in DSMC");
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(process.type() != ScatteringProcessType::FORWARD,
+                                        "Forward scattering collisions are not yet supported in DSMC");
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(process.type() != ScatteringProcessType::INVALID,
                                         "Cannot add an unknown scattering process type");
 


### PR DESCRIPTION
Excitation and forward scattering is not yet supported in DSMC but currently these processes do not result in sensible error messages.

Addresses https://github.com/BLAST-WarpX/warpx/discussions/6229.