### PR TITLE
WarpX class: remove unnecessary getPMLRZ() method from WarpX class

### DIFF
--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -472,7 +472,7 @@ WarpX::MoveWindow (const int step, bool move_j)
                 ::shiftMF(*pml_E, geom[lev], num_shift, dir, m_safe_guard_cells, do_single_precision_comms, no_cost);
             }
 #if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
-            const bool PMLRZ_flag = getPMLRZ();
+            const bool PMLRZ_flag = pml_rz[0].get();
             if (pml_rz[lev] && dim < 2) {
                 amrex::MultiFab* pml_rz_B = m_fields.get(FieldType::pml_B_fp, Direction{dim}, lev);
                 amrex::MultiFab* pml_rz_E = m_fields.get(FieldType::pml_E_fp, Direction{dim}, lev);

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -388,10 +388,6 @@ public:
     [[nodiscard]] bool DoPML () const {return do_pml;}
     [[nodiscard]] bool DoFluidSpecies () const {return do_fluid_species;}
 
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
-    const PML_RZ* getPMLRZ() {return pml_rz[0].get();}
-#endif
-
     /** get low-high-low-high-... vector for each direction indicating if mother grid PMLs are enabled */
     [[nodiscard]] std::vector<bool> getPMLdirections() const;
 


### PR DESCRIPTION
The `bool WarpX::getPMLRZ()` method is not really necessary, since it is a simple single-line function used only once from within the WarpX class (in `WarpXMovingWindow.cpp` ) . I think that we can remove it to simplify the WarpX class. 