### PR TITLE
Update aurora.rst fixing a mistakenly pasted path from Perlmutter

### DIFF
--- a/Docs/source/install/hpc/aurora.rst
+++ b/Docs/source/install/hpc/aurora.rst
@@ -65,7 +65,7 @@ Finally, since Aurora does not yet provide software modules for some of our depe
 .. code-block:: bash
 
    bash $HOME/src/warpx/Tools/machines/aurora-alcf/install_dependencies.sh
-   source ${CFS}/${proj%_g}/${USER}/sw/aurora/gpu/venvs/warpx/bin/activate
+   source /home/${USER}/sw/aurora/gpu/venvs/warpx-aurora/bin/activate
 
 .. dropdown:: Script Details
    :color: light


### PR DESCRIPTION
Updated source script path on Aurora to be consistent with preceding Aurora instructions.  The errant reference to ${CFS} is clearly a duplication issue stemming from the Perlmutter instructions.