### PR TITLE
WarpX class: remove unused variables plotfile_headerversion and slice_plotfile_headerversion

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -66,7 +66,6 @@
 #include <AMReX_RealBox.H>
 #include <AMReX_RealVect.H>
 #include <AMReX_Vector.H>
-#include <AMReX_VisMF.H>
 
 #include <AMReX_BaseFwd.H>
 #include <AMReX_AmrCoreFwd.H>
@@ -1347,9 +1346,6 @@ private:
 
     /** When `true`, write the diagnostics after restart at the time of the restart. */
     bool write_diagnostics_on_restart = false;
-
-    amrex::VisMF::Header::Version plotfile_headerversion  = amrex::VisMF::Header::Version_v1;
-    amrex::VisMF::Header::Version slice_plotfile_headerversion  = amrex::VisMF::Header::Version_v1;
 
     bool synchronize_velocity_for_diagnostics = true;
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1020,13 +1020,6 @@ WarpX::ReadParameters ()
 
         {
             // Parameters below control all plotfile diagnostics
-            bool plotfile_min_max = true;
-            pp_warpx.query("plotfile_min_max", plotfile_min_max);
-            if (plotfile_min_max) {
-                plotfile_headerversion = amrex::VisMF::Header::Version_v1;
-            } else {
-                plotfile_headerversion = amrex::VisMF::Header::NoFabHeader_v1;
-            }
             pp_warpx.query("usesingleread", use_single_read);
             pp_warpx.query("usesinglewrite", use_single_write);
             ParmParse pp_vismf("vismf");

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -88,6 +88,7 @@
 #include <AMReX_Random.H>
 #include <AMReX_SPACE.H>
 #include <AMReX_TagBox.H>
+#include <AMReX_VisMF.H>
 
 #include <algorithm>
 #include <cmath>


### PR DESCRIPTION
`plotfile_headerversion` and `slice_plotfile_headerversion` seem to be unused. This PR removes them from the WarpX class. This allows us to move `#include <AMReX_VisMF.H>` from `WarpX.H` to `WarpX.cpp` .