### PR TITLE
Print maximum relative error when checksums fail

### DIFF
--- a/Regression/Checksum/checksum.py
+++ b/Regression/Checksum/checksum.py
@@ -265,6 +265,7 @@ class Checksum:
 
         # Dictionaries have same values?
         checksums_differ = False
+        max_rel_err = 0.0
         for key1 in ref_benchmark.data.keys():
             for key2 in ref_benchmark.data[key1].keys():
                 passed = np.isclose(
@@ -294,6 +295,8 @@ class Checksum:
                     if np.abs(x) != 0.0:
                         rel_err = abs_err / np.abs(x)
                         print("Relative error: {:.2e}".format(rel_err))
+                        max_rel_err = max(max_rel_err, rel_err)
+        print("\nMaximum relative error: {:.2e}".format(max_rel_err))
         if checksums_differ:
             print(f"\nNew checksums file {self.test_name}.json:")
             print(json.dumps(self.data, indent=2))


### PR DESCRIPTION
This PR adds a print of the maximum relative error when checksums fail, which I think is quite useful when they fail for many "keys" and/or many tests (e.g., #5955, #6248) - the maximum relative error gives a glimpse of how good or bad things are.

This is an example of the new output, with the extra line printing the maximum relative error:
```
...

ERROR: Benchmark and output file checksum have different value for key [lev=0,Ex]
Benchmark: [lev=0,Ex] 9.408402900367834e+05
Test file: [lev=0,Ex] 9.409402900367834e+05
Absolute error: 1.00e+02
Relative error: 1.06e-04
ERROR: Benchmark and output file checksum have different value for key [lev=0,Ez]
Benchmark: [lev=0,Ez] 6.654423300420902e+05
Test file: [lev=0,Ez] 6.754423300420902e+05
Absolute error: 1.00e+04
Relative error: 1.50e-02
ERROR: Benchmark and output file checksum have different value for key [lev=0,jx]
Benchmark: [lev=0,jx] 9.956269465957083e+03
Test file: [lev=0,jx] 9.956269365957083e+03
Absolute error: 1.00e-04
Relative error: 1.00e-08

Maximum relative error: 1.50e-02

New checksums file test_2d_larmor.json:

...
```

Feel free to close the PR without merging if you think this is not useful.