### PR TITLE
Tuo (LLNL): HDF5 Module Gone

### DIFF
--- a/Tools/machines/tuolumne-llnl/tuolumne_mi300a_warpx.profile.example
+++ b/Tools/machines/tuolumne-llnl/tuolumne_mi300a_warpx.profile.example
@@ -19,7 +19,7 @@ module load ninja/1.10.2
 
 # optional: for openPMD and PSATD+RZ support
 SW_DIR="/p/lustre5/${USER}/tuolumne/warpx/mi300a"
-module load cray-hdf5-parallel/1.14.3.7
+# module load cray-hdf5-parallel/1.14.3.5  # missing module for cce/20.0.0
 export CMAKE_PREFIX_PATH=${SW_DIR}/c-blosc-2.15.1:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=${SW_DIR}/adios2-2.10.2:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=${SW_DIR}/blaspp-2024.05.31:$CMAKE_PREFIX_PATH


### PR DESCRIPTION
After the latest update, a parallel HDF5 module is not available for the `rocm` modules anymore. An issue has been opened with support.