### PR TITLE
Make sure we geometrically grow the capacity of the particle buffers

### DIFF
--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -459,6 +459,11 @@ void ParticleBoundaryBuffer::gatherParticlesFromDomainBoundaries (MultiParticleC
                         auto dst_index = ptile_buffer.numParticles();
                         {
                           WARPX_PROFILE("ParticleBoundaryBuffer::gatherParticles::resize");
+                          auto np_to_add = amrex::get<0>(reduce_data.value());
+                          amrex::Long np_cap = ptile_buffer.capacity() / species_buffer.superParticleSize();
+                          if (dst_index + np_to_add > np_cap) {
+                              ptile_buffer.resize(2*(dst_index + np_to_add));
+                          }
                           ptile_buffer.resize(dst_index + amrex::get<0>(reduce_data.value()));
                         }
                         {
@@ -563,6 +568,11 @@ void ParticleBoundaryBuffer::gatherParticlesFromEmbeddedBoundaries (
                     auto dst_index = ptile_buffer.numParticles();
                     {
                         WARPX_PROFILE("ParticleBoundaryBuffer::gatherParticles::resize_eb");
+                        auto np_to_add = amrex::get<0>(reduce_data.value());
+                        amrex::Long np_cap = ptile_buffer.capacity() / species_buffer.superParticleSize();
+                        if (dst_index + np_to_add > np_cap) {
+                            ptile_buffer.resize(2*(dst_index + np_to_add));
+                        }
                         ptile_buffer.resize(dst_index + amrex::get<0>(reduce_data.value()));
                     }
                     auto &warpx = WarpX::GetInstance();

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -462,6 +462,8 @@ void ParticleBoundaryBuffer::gatherParticlesFromDomainBoundaries (MultiParticleC
                           auto np_to_add = amrex::get<0>(reduce_data.value());
                           auto new_np = dst_index + np_to_add;
                           amrex::Long capacity = ptile_buffer.capacity() / species_buffer.superParticleSize();
+                          // reserve space to avoid many small resize operations for performance reasons
+                          // the resize below will not shrink the capacity
                           if (new_np > capacity) { ptile_buffer.reserve(2*new_np); }
                           ptile_buffer.resize(new_np);
                         }
@@ -570,6 +572,8 @@ void ParticleBoundaryBuffer::gatherParticlesFromEmbeddedBoundaries (
                         auto np_to_add = amrex::get<0>(reduce_data.value());
                         auto new_np = dst_index + np_to_add;
                         amrex::Long capacity = ptile_buffer.capacity() / species_buffer.superParticleSize();
+                        // reserve space to avoid many small resize operations for performance reasons
+                          // the resize below will not shrink the capacity
                         if (new_np > capacity) { ptile_buffer.reserve(2*new_np); }
                         ptile_buffer.resize(new_np);
                     }

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -460,11 +460,10 @@ void ParticleBoundaryBuffer::gatherParticlesFromDomainBoundaries (MultiParticleC
                         {
                           WARPX_PROFILE("ParticleBoundaryBuffer::gatherParticles::resize");
                           auto np_to_add = amrex::get<0>(reduce_data.value());
-                          amrex::Long np_cap = ptile_buffer.capacity() / species_buffer.superParticleSize();
-                          if (dst_index + np_to_add > np_cap) {
-                              ptile_buffer.resize(2*(dst_index + np_to_add));
-                          }
-                          ptile_buffer.resize(dst_index + amrex::get<0>(reduce_data.value()));
+                          auto new_np = dst_index + np_to_add;
+                          amrex::Long capacity = ptile_buffer.capacity() / species_buffer.superParticleSize();
+                          if (new_np > capacity) { ptile_buffer.reserve(2*new_np); }
+                          ptile_buffer.resize(new_np);
                         }
                         {
                           WARPX_PROFILE("ParticleBoundaryBuffer::gatherParticles::filterAndTransform");
@@ -569,11 +568,10 @@ void ParticleBoundaryBuffer::gatherParticlesFromEmbeddedBoundaries (
                     {
                         WARPX_PROFILE("ParticleBoundaryBuffer::gatherParticles::resize_eb");
                         auto np_to_add = amrex::get<0>(reduce_data.value());
-                        amrex::Long np_cap = ptile_buffer.capacity() / species_buffer.superParticleSize();
-                        if (dst_index + np_to_add > np_cap) {
-                            ptile_buffer.resize(2*(dst_index + np_to_add));
-                        }
-                        ptile_buffer.resize(dst_index + amrex::get<0>(reduce_data.value()));
+                        auto new_np = dst_index + np_to_add;
+                        amrex::Long capacity = ptile_buffer.capacity() / species_buffer.superParticleSize();
+                        if (new_np > capacity) { ptile_buffer.reserve(2*new_np); }
+                        ptile_buffer.resize(new_np);
                     }
                     auto &warpx = WarpX::GetInstance();
                     const auto dt = warpx.getdt(pti.GetLevel());

--- a/dependencies.json
+++ b/dependencies.json
@@ -3,7 +3,7 @@
     "version_amrex": "25.10",
     "version_pyamrex": "25.10",
     "version_picsar": "25.06",
-    "commit_amrex": "26054b26bb653e594835a5a686893f6c20e7c5cd",
+    "commit_amrex": "06ba8bd2e226823cbe11bc80a976c5df9e97d7bb",
     "commit_pyamrex": "6f1b2dd4cd9374e196b0d47b1abf0051b51ce023",
     "commit_picsar": "0c329e66010267662a82219f7de7abbd231463f4"
 }


### PR DESCRIPTION
This makes a significant performance difference on a problem setup @aeriforme gave me. In this simulation, many particles leave the domain and we need to store them all for analysis.

On development:

```
TinyProfiler total time across processes [min...avg...max]: 4246 ... 4246 ... 4246

-------------------------------------------------------------------------------------------------------------
Name                                                          NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
-------------------------------------------------------------------------------------------------------------
ParticleBoundaryBuffer::gatherParticles::resize                 8772       3843       3843       3843  90.49%
WarpXOpenPMDPlot::SeriesFlush()()                                 96      89.46      89.46      89.46   2.11%
ParticleBoundaryBuffer::gatherParticles                          256      58.11      58.11      58.11   1.37%
ParticleContainer::addParticles                                   48      53.54      53.54      53.54   1.26%
ParticleBoundaryBuffer::gatherParticles::filterAndTransform     8772      27.26      27.26      27.26   0.64%
```

This PR:
```
TinyProfiler total time across processes [min...avg...max]: 494.6 ... 494.6 ... 494.6

-------------------------------------------------------------------------------------------------------------
Name                                                          NCalls  Excl. Min  Excl. Avg  Excl. Max   Max %
-------------------------------------------------------------------------------------------------------------
ParticleBoundaryBuffer::gatherParticles::resize                 8754      126.3      126.3      126.3  25.53%
WarpXOpenPMDPlot::SeriesFlush()()                                 96       90.3       90.3       90.3  18.26%
ParticleContainer::addParticles                                   48      59.01      59.01      59.01  11.93%
FFT::R2C::forward(in)                                           1934      27.05      27.05      27.05   5.47%
ParticleBoundaryBuffer::gatherParticles::filterAndTransform     8754       26.8       26.8       26.8   5.42%
```