### PR TITLE
Skip `SortForDeposition` if `do_not_deposit`

### DIFF
--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -776,6 +776,7 @@ MultiParticleContainer::SortParticlesByBin (
 {
     for (auto& pc : allcontainers) {
         if (sort_particles_for_deposition) {
+            if (pc->do_not_deposit) { continue; }
             pc->SortParticlesForDeposition(sort_idx_type);
         } else {
             pc->SortParticlesByBin(bin_size);


### PR DESCRIPTION
In large 3d cases where we have lots of neutral particles this change sped up the simulation from on average getting 0.91 steps/s to 1.45 steps/s.