### PR TITLE
VarianceAccumationBuffer.cpp: remove unnecessary include

### DIFF
--- a/Source/Particles/Deposition/VarianceAccumulationBuffer.cpp
+++ b/Source/Particles/Deposition/VarianceAccumulationBuffer.cpp
@@ -9,7 +9,6 @@
 
 #include "Particles/Deposition/VarianceAccumulationBuffer.H"
 #include "Particles/Deposition/TemperatureDeposition.H"
-#include "Parallelization/WarpXSumGuardCells.H"
 #include "Fields.H"
 
 #include <ablastr/utils/Communication.H>


### PR DESCRIPTION
Including `Parallelization/WarpXSumGuardCells.H` is not necessary in this cpp file.