### PR TITLE
[WIP] Communications: remove static variables do_single_precision_comms, do_dynamic_scheduling, and sync_nodal_points from WarpX class

### DIFF
--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -17,6 +17,7 @@
 #ifdef WARPX_USE_FFT
 #   include "FieldSolver/SpectralSolver/SpectralFieldData.H"
 #endif
+#include "Parallelization/Parallelization.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
@@ -60,6 +61,7 @@
 #endif
 
 using namespace amrex;
+using namespace warpx;
 using warpx::fields::FieldType;
 
 namespace
@@ -1140,12 +1142,14 @@ PML::Exchange (MultiFab& pml, MultiFab& reg, const Geometry& geom,
         MultiFab::Add(totpmlmf,pml,2,0,1,0); // Sum the third split component
     }
 
+    const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
+
     // Copy from the sum of PML split field to valid cells of regular grid
     if (do_pml_in_domain){
         // Valid cells of the PML and of the regular grid overlap
         // Copy from valid cells of the PML to valid cells of the regular grid
         ablastr::utils::communication::ParallelCopy(reg, totpmlmf, 0, 0, 1, IntVect(0), IntVect(0),
-                                                    WarpX::do_single_precision_comms,
+                                                    do_single_precision_comms,
                                                     period);
     } else {
         // Valid cells of the PML only overlap with guard cells of regular grid
@@ -1155,7 +1159,7 @@ PML::Exchange (MultiFab& pml, MultiFab& reg, const Geometry& geom,
         if (ngr.max() > 0) {
             MultiFab::Copy(tmpregmf, reg, 0, 0, 1, ngr);
             ablastr::utils::communication::ParallelCopy(tmpregmf, totpmlmf, 0, 0, 1, IntVect(0), ngr,
-                                   WarpX::do_single_precision_comms,
+                                   do_single_precision_comms,
                                                         period);
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
@@ -1190,11 +1194,11 @@ PML::Exchange (MultiFab& pml, MultiFab& reg, const Geometry& geom,
         // copy the PML (this is order to avoid overwriting PML valid cells,
         // in the next `ParallelCopy`)
         ablastr::utils::communication::ParallelCopy(tmpregmf, pml, 0, 0, ncp, IntVect(0), IntVect(0),
-                                                    WarpX::do_single_precision_comms,
+                                                    do_single_precision_comms,
                                                     period);
     }
     ablastr::utils::communication::ParallelCopy(pml, tmpregmf, 0, 0, ncp, IntVect(0), ngp,
-                                                WarpX::do_single_precision_comms, period);
+                                                do_single_precision_comms, period);
 }
 
 
@@ -1204,8 +1208,9 @@ PML::CopyToPML (MultiFab& pml, MultiFab& reg, const Geometry& geom)
   const IntVect& ngp = pml.nGrowVect();
   const auto& period = geom.periodicity();
 
+    const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
     ablastr::utils::communication::ParallelCopy(pml, reg, 0, 0, 1, IntVect(0), ngp,
-                                                WarpX::do_single_precision_comms, period);
+                                                do_single_precision_comms, period);
 }
 
 void
@@ -1217,7 +1222,8 @@ PML::FillBoundary (ablastr::fields::VectorField mf_pml, PatchType patch_type, st
         m_cgeom->periodicity();
 
     const Vector<MultiFab*> mf{mf_pml[0], mf_pml[1], mf_pml[2]};
-    ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, period, nodal_sync);
+    const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
+    ablastr::utils::communication::FillBoundary(mf, do_single_precision_comms, period, nodal_sync);
 }
 
 void
@@ -1228,7 +1234,8 @@ PML::FillBoundary (amrex::MultiFab & mf_pml, PatchType patch_type, std::optional
         m_geom->periodicity() :
         m_cgeom->periodicity();
 
-    ablastr::utils::communication::FillBoundary(mf_pml, WarpX::do_single_precision_comms, period, nodal_sync);
+    const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
+    ablastr::utils::communication::FillBoundary(mf_pml, do_single_precision_comms, period, nodal_sync);
 }
 
 void

--- a/Source/BoundaryConditions/PML_RZ.H
+++ b/Source/BoundaryConditions/PML_RZ.H
@@ -45,9 +45,9 @@ public:
 #endif
 
     void FillBoundaryE (ablastr::fields::MultiFabRegister& fields, PatchType patch_type,
-        bool do_single_precision_comms, std::optional<bool> nodal_sync=std::nullopt);
+        std::optional<bool> nodal_sync=std::nullopt);
     void FillBoundaryB (ablastr::fields::MultiFabRegister& fields, PatchType patch_type,
-        bool do_single_precision_comms, std::optional<bool> nodal_sync=std::nullopt);
+        std::optional<bool> nodal_sync=std::nullopt);
 
     void CheckPoint (ablastr::fields::MultiFabRegister& fields, std::string const& dir) const;
     void Restart (ablastr::fields::MultiFabRegister& fields, std::string const& dir);

--- a/Source/BoundaryConditions/PML_RZ.cpp
+++ b/Source/BoundaryConditions/PML_RZ.cpp
@@ -12,6 +12,7 @@
 #ifdef WARPX_USE_FFT
 #   include "FieldSolver/SpectralSolver/SpectralFieldDataRZ.H"
 #endif
+#include "Parallelization/Parallelization.H"
 #include "Utils/WarpXConst.H"
 
 #include <ablastr/utils/Communication.H>
@@ -33,6 +34,7 @@
 #include <memory>
 
 using namespace amrex::literals;
+using namespace warpx;
 using warpx::fields::FieldType;
 using ablastr::fields::Direction;
 
@@ -132,7 +134,7 @@ PML_RZ::ApplyDamping (amrex::MultiFab* Et_fp, amrex::MultiFab* Ez_fp,
 
 void
 PML_RZ::FillBoundaryE (ablastr::fields::MultiFabRegister& fields, PatchType patch_type,
-    const bool do_single_precision_comms, const std::optional<bool> nodal_sync)
+    const std::optional<bool> nodal_sync)
 {
     using ablastr::fields::Direction;
 
@@ -143,13 +145,16 @@ PML_RZ::FillBoundaryE (ablastr::fields::MultiFabRegister& fields, PatchType patc
     {
         amrex::Periodicity const& period = m_geom->periodicity();
         const amrex::Vector<amrex::MultiFab*> mf = {pml_Er, pml_Et};
-        ablastr::utils::communication::FillBoundary(mf, do_single_precision_comms, period, nodal_sync);
+        ablastr::utils::communication::FillBoundary(
+            mf,
+            parallelization::comms_in_single_precision_flag(),
+            period, nodal_sync);
     }
 }
 
 void
 PML_RZ::FillBoundaryB (ablastr::fields::MultiFabRegister& fields, PatchType patch_type,
-    const bool do_single_precision_comms, const std::optional<bool> nodal_sync)
+    const std::optional<bool> nodal_sync)
 {
     if (patch_type == PatchType::fine)
     {
@@ -160,7 +165,10 @@ PML_RZ::FillBoundaryB (ablastr::fields::MultiFabRegister& fields, PatchType patc
 
         amrex::Periodicity const& period = m_geom->periodicity();
         const amrex::Vector<amrex::MultiFab*> mf = {pml_Br, pml_Bt};
-        ablastr::utils::communication::FillBoundary(mf, do_single_precision_comms, period, nodal_sync);
+        ablastr::utils::communication::FillBoundary(
+            mf,
+            parallelization::comms_in_single_precision_flag(),
+            period, nodal_sync);
     }
 }
 

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -15,6 +15,7 @@
 #include "Diagnostics/FlushFormats/FlushFormat.H"
 #include "ComputeDiagFunctors/BackTransformParticleFunctor.H"
 #include "Fields.H"
+#include "Parallelization/Parallelization.H"
 #include "Utils/Algorithms/IsIn.H"
 #include "Utils/Parser/ParserUtils.H"
 #include "Utils/TextMsg.H"
@@ -48,6 +49,7 @@
 #include <vector>
 
 using namespace amrex::literals;
+using namespace warpx;
 using warpx::fields::FieldType;
 
 namespace
@@ -828,8 +830,9 @@ BTDiagnostics::PrepareFieldDataForOutput ()
         AMREX_ALWAYS_ASSERT( icomp_dst == m_cellcenter_varnames.size() );
         // fill boundary call is required to average_down (flatten) data to
         // the coarsest level.
+        const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
         ablastr::utils::communication::FillBoundary(*fields.get(m_cell_centered_data_name, lev),
-                                                    WarpX::do_single_precision_comms,
+                                                    do_single_precision_comms,
                                                     warpx.Geom(lev).periodicity());
     }
     // Flattening out MF over levels

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
@@ -7,6 +7,7 @@
 #include "BackTransformFunctor.H"
 
 #include "Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor.H"
+#include "Parallelization/Parallelization.H"
 #include "Utils/WarpXConst.H"
 #include "WarpX.H"
 
@@ -31,6 +32,7 @@
 #include <memory>
 
 using namespace amrex;
+using namespace warpx;
 
 BackTransformFunctor::BackTransformFunctor (amrex::MultiFab const * mf_src, int lev,
                                             const int ncomp, const int num_buffers,
@@ -99,10 +101,11 @@ BackTransformFunctor::operator ()(amrex::MultiFab& mf_dst, int /*dcomp*/, const 
         // Parallel copy the lab-frame data from "slice" MultiFab with
         // ncomp=10 and boosted-frame dmap to "tmp_slice_ptr" MultiFab with
         // ncomp=10 and dmap of the destination Multifab, which will store the final data
+        const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
         ablastr::utils::communication::ParallelCopy(*tmp_slice_ptr, *slice, 0, 0, slice->nComp(),
                                                     IntVect(AMREX_D_DECL(0, 0, 0)),
                                                     IntVect(AMREX_D_DECL(0, 0, 0)),
-                                                    WarpX::do_single_precision_comms);
+                                                    do_single_precision_comms);
         // Now we will cherry pick only the user-defined fields from
         // tmp_slice_ptr to dst_mf
         const int k_lab = m_k_index_zlab[i_buffer];

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -13,6 +13,7 @@
 #include "FlushFormats/FlushFormatPlotfile.H"
 #include "FlushFormats/FlushFormatSensei.H"
 #include "Particles/MultiParticleContainer.H"
+#include "Parallelization/Parallelization.H"
 #include "Utils/Algorithms/IsIn.H"
 #include "Utils/Parser/ParserUtils.H"
 #include "Utils/TextMsg.H"
@@ -37,6 +38,7 @@
 #include <string>
 
 using namespace amrex::literals;
+using namespace warpx;
 
 Diagnostics::Diagnostics (int i, std::string name, DiagTypes diag_type)
     : m_diag_type(diag_type), m_diag_name(std::move(name)), m_diag_index(i)
@@ -634,7 +636,8 @@ Diagnostics::ComputeAndPack ()
 
             // needed for contour plots of rho, i.e. ascent/sensei
             if (m_format == "sensei" || m_format == "ascent") {
-                ablastr::utils::communication::FillBoundary(m_mf_output[i_buffer][lev], WarpX::do_single_precision_comms,
+                const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
+                ablastr::utils::communication::FillBoundary(m_mf_output[i_buffer][lev], do_single_precision_comms,
                                                             warpx.Geom(lev).periodicity());
             }
         }

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -24,6 +24,7 @@
 #   endif
 #endif
 #include "Parallelization/GuardCellManager.H"
+#include "Parallelization/Parallelization.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Fluids/MultiFluidContainer.H"
 #include "Fluids/WarpXFluidContainer.H"
@@ -58,6 +59,7 @@
 #include <vector>
 
 using namespace amrex;
+using namespace warpx;
 using ablastr::utils::SignalHandling;
 
 namespace
@@ -529,18 +531,18 @@ WarpX::OneStep_nosub (Real cur_time)
 
         if (use_hybrid_QED) {
             FillBoundaryE(guard_cells.ng_alloc_EB);
-            FillBoundaryB(guard_cells.ng_alloc_EB, WarpX::sync_nodal_points);
+            FillBoundaryB(guard_cells.ng_alloc_EB, parallelization::sync_nodal_points_flag());
             WarpX::Hybrid_QED_Push(dt);
-            FillBoundaryE(guard_cells.ng_afterPushPSATD, WarpX::sync_nodal_points);
+            FillBoundaryE(guard_cells.ng_afterPushPSATD, parallelization::sync_nodal_points_flag());
         }
         else {
-            FillBoundaryE(guard_cells.ng_afterPushPSATD, WarpX::sync_nodal_points);
-            FillBoundaryB(guard_cells.ng_afterPushPSATD, WarpX::sync_nodal_points);
+            FillBoundaryE(guard_cells.ng_afterPushPSATD, parallelization::sync_nodal_points_flag());
+            FillBoundaryB(guard_cells.ng_afterPushPSATD, parallelization::sync_nodal_points_flag());
             if (WarpX::do_dive_cleaning || WarpX::do_pml_dive_cleaning) {
-                FillBoundaryF(guard_cells.ng_alloc_F, WarpX::sync_nodal_points);
+                FillBoundaryF(guard_cells.ng_alloc_F, parallelization::sync_nodal_points_flag());
             }
             if (WarpX::do_divb_cleaning || WarpX::do_pml_divb_cleaning) {
-                FillBoundaryG(guard_cells.ng_alloc_G, WarpX::sync_nodal_points);
+                FillBoundaryG(guard_cells.ng_alloc_G, parallelization::sync_nodal_points_flag());
             }
         }
     } else {
@@ -550,7 +552,7 @@ WarpX::OneStep_nosub (Real cur_time)
         FillBoundaryG(guard_cells.ng_FieldSolverG);
 
         EvolveB(0.5_rt * dt[0], SubcyclingHalf::FirstHalf, cur_time); // We now have B^{n+1/2}
-        FillBoundaryB(guard_cells.ng_FieldSolver, WarpX::sync_nodal_points);
+        FillBoundaryB(guard_cells.ng_FieldSolver, parallelization::sync_nodal_points_flag());
 
         if (m_em_solver_medium == MediumForEM::Vacuum) {
             // vacuum medium
@@ -561,7 +563,7 @@ WarpX::OneStep_nosub (Real cur_time)
         } else {
             WARPX_ABORT_WITH_MESSAGE("Medium for EM is unknown");
         }
-        FillBoundaryE(guard_cells.ng_FieldSolver, WarpX::sync_nodal_points);
+        FillBoundaryE(guard_cells.ng_FieldSolver, parallelization::sync_nodal_points_flag());
 
         EvolveF(0.5_rt * dt[0], /*rho_comp=*/1);
         EvolveG(0.5_rt * dt[0]);
@@ -569,10 +571,10 @@ WarpX::OneStep_nosub (Real cur_time)
 
         if (do_pml) {
             DampPML();
-            FillBoundaryE(guard_cells.ng_MovingWindow, WarpX::sync_nodal_points);
-            FillBoundaryB(guard_cells.ng_MovingWindow, WarpX::sync_nodal_points);
-            FillBoundaryF(guard_cells.ng_MovingWindow, WarpX::sync_nodal_points);
-            FillBoundaryG(guard_cells.ng_MovingWindow, WarpX::sync_nodal_points);
+            FillBoundaryE(guard_cells.ng_MovingWindow, parallelization::sync_nodal_points_flag());
+            FillBoundaryB(guard_cells.ng_MovingWindow, parallelization::sync_nodal_points_flag());
+            FillBoundaryF(guard_cells.ng_MovingWindow, parallelization::sync_nodal_points_flag());
+            FillBoundaryG(guard_cells.ng_MovingWindow, parallelization::sync_nodal_points_flag());
         }
 
         // E and B are up-to-date in the domain, but all guard cells are
@@ -963,13 +965,14 @@ WarpX::OneStep_JRhom (const amrex::Real cur_time)
     }
 
     // Exchange guard cells and synchronize nodal points
-    FillBoundaryE(guard_cells.ng_alloc_EB, WarpX::sync_nodal_points);
-    FillBoundaryB(guard_cells.ng_alloc_EB, WarpX::sync_nodal_points);
+    const auto do_sync_nodal_points = parallelization::sync_nodal_points_flag();
+    FillBoundaryE(guard_cells.ng_alloc_EB, do_sync_nodal_points);
+    FillBoundaryB(guard_cells.ng_alloc_EB, do_sync_nodal_points);
     if (WarpX::do_dive_cleaning || WarpX::do_pml_dive_cleaning) {
-        FillBoundaryF(guard_cells.ng_alloc_F, WarpX::sync_nodal_points);
+        FillBoundaryF(guard_cells.ng_alloc_F, do_sync_nodal_points);
     }
     if (WarpX::do_divb_cleaning || WarpX::do_pml_divb_cleaning) {
-        FillBoundaryG(guard_cells.ng_alloc_G, WarpX::sync_nodal_points);
+        FillBoundaryG(guard_cells.ng_alloc_G, do_sync_nodal_points);
     }
 
 #else
@@ -1037,9 +1040,9 @@ WarpX::OneStep_sub1 (Real cur_time)
     EvolveB(fine_lev, PatchType::fine, 0.5_rt*dt[fine_lev], SubcyclingHalf::FirstHalf, cur_time);
     EvolveF(fine_lev, PatchType::fine, 0.5_rt*dt[fine_lev], /*rho_comp=*/0);
     FillBoundaryB(fine_lev, PatchType::fine, guard_cells.ng_FieldSolver,
-                  WarpX::sync_nodal_points);
+                  parallelization::sync_nodal_points_flag());
     FillBoundaryF(fine_lev, PatchType::fine, guard_cells.ng_alloc_F,
-                  WarpX::sync_nodal_points);
+                  parallelization::sync_nodal_points_flag());
 
     EvolveE(fine_lev, PatchType::fine, dt[fine_lev], cur_time);
     FillBoundaryE(fine_lev, PatchType::fine, guard_cells.ng_FieldGather);
@@ -1086,9 +1089,9 @@ WarpX::OneStep_sub1 (Real cur_time)
     EvolveB(coarse_lev, PatchType::fine, 0.5_rt*dt[coarse_lev], SubcyclingHalf::FirstHalf, cur_time);
     EvolveF(coarse_lev, PatchType::fine, 0.5_rt*dt[coarse_lev], /*rho_comp=*/0);
     FillBoundaryB(coarse_lev, PatchType::fine, guard_cells.ng_FieldGather,
-                    WarpX::sync_nodal_points);
+                    parallelization::sync_nodal_points_flag());
     FillBoundaryF(coarse_lev, PatchType::fine, guard_cells.ng_FieldSolverF,
-                    WarpX::sync_nodal_points);
+                    parallelization::sync_nodal_points_flag());
 
     EvolveE(coarse_lev, PatchType::fine, 0.5_rt*dt[coarse_lev], cur_time);
     FillBoundaryE(coarse_lev, PatchType::fine, guard_cells.ng_FieldGather);
@@ -1125,7 +1128,7 @@ WarpX::OneStep_sub1 (Real cur_time)
 
     EvolveE(fine_lev, PatchType::fine, dt[fine_lev], cur_time + dt[fine_lev]);
     FillBoundaryE(fine_lev, PatchType::fine, guard_cells.ng_FieldSolver,
-                    WarpX::sync_nodal_points);
+                    parallelization::sync_nodal_points_flag());
 
     EvolveB(fine_lev, PatchType::fine, 0.5_rt*dt[fine_lev], SubcyclingHalf::SecondHalf, cur_time + 1.5_rt*dt[fine_lev]);
     EvolveF(fine_lev, PatchType::fine, 0.5_rt*dt[fine_lev], /*rho_comp=*/1);
@@ -1161,7 +1164,7 @@ WarpX::OneStep_sub1 (Real cur_time)
 
     EvolveE(fine_lev, PatchType::coarse, dt[fine_lev], cur_time + 0.5_rt * dt[fine_lev]);
     FillBoundaryE(fine_lev, PatchType::coarse, guard_cells.ng_FieldSolver,
-                  WarpX::sync_nodal_points);
+                  parallelization::sync_nodal_points_flag());
 
     EvolveB(fine_lev, PatchType::coarse, dt[fine_lev], SubcyclingHalf::SecondHalf, cur_time + 0.5_rt * dt[fine_lev]);
     EvolveF(fine_lev, PatchType::coarse, dt[fine_lev], /*rho_comp=*/1);
@@ -1174,13 +1177,13 @@ WarpX::OneStep_sub1 (Real cur_time)
     }
 
     FillBoundaryB(fine_lev, PatchType::coarse, guard_cells.ng_FieldSolver,
-                  WarpX::sync_nodal_points);
+                  parallelization::sync_nodal_points_flag());
     FillBoundaryF(fine_lev, PatchType::coarse, guard_cells.ng_FieldSolverF,
-                  WarpX::sync_nodal_points);
+                  parallelization::sync_nodal_points_flag());
 
     EvolveE(coarse_lev, PatchType::fine, 0.5_rt*dt[coarse_lev], cur_time + 0.5_rt*dt[coarse_lev]);
     FillBoundaryE(coarse_lev, PatchType::fine, guard_cells.ng_FieldSolver,
-                  WarpX::sync_nodal_points);
+                  parallelization::sync_nodal_points_flag());
 
     EvolveB(coarse_lev, PatchType::fine, 0.5_rt*dt[coarse_lev], SubcyclingHalf::SecondHalf, cur_time + 0.5_rt*dt[coarse_lev]);
     EvolveF(coarse_lev, PatchType::fine, 0.5_rt*dt[coarse_lev], /*rho_comp=*/1);
@@ -1191,19 +1194,19 @@ WarpX::OneStep_sub1 (Real cur_time)
             // regular B field MultiFab). This is required as B and F have just been
             // evolved.
             FillBoundaryB(coarse_lev, PatchType::fine, IntVect::TheZeroVector(),
-                          WarpX::sync_nodal_points);
+                          parallelization::sync_nodal_points_flag());
             FillBoundaryF(coarse_lev, PatchType::fine, IntVect::TheZeroVector(),
-                          WarpX::sync_nodal_points);
+                          parallelization::sync_nodal_points_flag());
         }
         DampPML(coarse_lev, PatchType::fine);
         if ( m_safe_guard_cells ) {
             FillBoundaryE(coarse_lev, PatchType::fine, guard_cells.ng_FieldSolver,
-                          WarpX::sync_nodal_points);
+                          parallelization::sync_nodal_points_flag());
         }
     }
     if ( m_safe_guard_cells ) {
         FillBoundaryB(coarse_lev, PatchType::fine, guard_cells.ng_FieldSolver,
-                      WarpX::sync_nodal_points);
+                      parallelization::sync_nodal_points_flag());
     }
 }
 

--- a/Source/FieldSolver/ElectrostaticSolvers/EffectivePotentialES.cpp
+++ b/Source/FieldSolver/ElectrostaticSolvers/EffectivePotentialES.cpp
@@ -11,11 +11,13 @@
 #include "Fluids/MultiFluidContainer_fwd.H"
 #include "EmbeddedBoundary/Enabled.H"
 #include "Fields.H"
+#include "Parallelization/Parallelization.H"
 #include "Particles/MultiParticleContainer_fwd.H"
 #include "Utils/Parser/ParserUtils.H"
 #include "WarpX.H"
 
 using namespace amrex;
+using namespace warpx;
 
 void EffectivePotentialES::InitData() {
     auto & warpx = WarpX::GetInstance();
@@ -254,7 +256,7 @@ void EffectivePotentialES::computePhi (
         WarpX::grid_type,
         false,
         EB::enabled(),
-        WarpX::do_single_precision_comms,
+        parallelization::comms_in_single_precision_flag(),
         warpx.refRatio(),
         post_phi_calculation,
         *m_poisson_boundary_handler,

--- a/Source/FieldSolver/ElectrostaticSolvers/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolvers/ElectrostaticSolver.cpp
@@ -10,12 +10,14 @@
 #include "ElectrostaticSolver.H"
 #include "EmbeddedBoundary/Enabled.H"
 #include "Fields.H"
+#include "Parallelization/Parallelization.H"
 #include "WarpX.H"
 
 #include <ablastr/fields/PoissonSolver.H>
 
 
 using namespace amrex;
+using namespace warpx;
 using warpx::fields::FieldType;
 
 ElectrostaticSolver::ElectrostaticSolver (int nlevs_max) : num_levels{nlevs_max}
@@ -198,6 +200,7 @@ ElectrostaticSolver::computePhi (
     bool const is_solver_igf_on_lev0 =
         WarpX::poisson_solver_id == PoissonSolverAlgo::IntegratedGreenFunction;
 
+    const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
     ablastr::fields::computePhi(
         sorted_rho,
         sorted_phi,
@@ -213,7 +216,7 @@ ElectrostaticSolver::computePhi (
         is_solver_igf_on_lev0,
         is_igf_2d,
         EB::enabled(),
-        WarpX::do_single_precision_comms,
+        do_single_precision_comms,
         warpx.refRatio(),
         post_phi_calculation,
         *m_poisson_boundary_handler,

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -15,11 +15,13 @@
 #include "EmbeddedBoundary/Enabled.H"
 #include "Python/callbacks.H"
 #include "Fields.H"
+#include "Parallelization/Parallelization.H"
 #include "Particles/MultiParticleContainer.H"
 #include "ExternalVectorPotential.H"
 #include "WarpX.H"
 
 using namespace amrex;
+using namespace warpx;
 using warpx::fields::FieldType;
 
 HybridPICModel::HybridPICModel ()
@@ -402,7 +404,7 @@ void HybridPICModel::CalculateElectronPressure(const int lev) const
     warpx.ApplyElectronPressureBoundary(lev, PatchType::fine);
     ablastr::utils::communication::FillBoundary(
         *electron_pressure_fp,
-        WarpX::do_single_precision_comms,
+        parallelization::comms_in_single_precision_flag(),
         warpx.Geom(lev).periodicity(),
         true);
 }

--- a/Source/FieldSolver/ImplicitSolvers/WarpXImplicitOps.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXImplicitOps.cpp
@@ -12,6 +12,7 @@
 #include "Fields.H"
 #include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver.H"
 #include "Parallelization/GuardCellManager.H"
+#include "Parallelization/Parallelization.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Particles/ParticleBoundaryBuffer.H"
 #include "Python/callbacks.H"
@@ -43,6 +44,8 @@
 #include <ostream>
 #include <vector>
 
+using namespace warpx;
+
 void
 WarpX::SetElectricFieldAndApplyBCs ( const WarpXSolverVec& a_E, amrex::Real a_time )
 {
@@ -57,7 +60,7 @@ WarpX::SetElectricFieldAndApplyBCs ( const WarpXSolverVec& a_E, amrex::Real a_ti
     amrex::MultiFab::Copy(*Efield_fp[0][0], *Evec[0][0], 0, 0, ncomps, Evec[0][0]->nGrowVect());
     amrex::MultiFab::Copy(*Efield_fp[0][1], *Evec[0][1], 0, 0, ncomps, Evec[0][1]->nGrowVect());
     amrex::MultiFab::Copy(*Efield_fp[0][2], *Evec[0][2], 0, 0, ncomps, Evec[0][2]->nGrowVect());
-    FillBoundaryE(guard_cells.ng_alloc_EB, WarpX::sync_nodal_points);
+    FillBoundaryE(guard_cells.ng_alloc_EB, parallelization::sync_nodal_points_flag());
     ApplyEfieldBoundary(0, PatchType::fine, a_time);
 }
 
@@ -75,7 +78,7 @@ WarpX::UpdateMagneticFieldAndApplyBCs( ablastr::fields::MultiLevelVectorField co
         amrex::MultiFab::Copy(*Bfp[2], *a_Bn[lev][2], 0, 0, ncomps, a_Bn[lev][2]->nGrowVect());
     }
     EvolveB(a_thetadt, SubcyclingHalf::None, start_time);
-    FillBoundaryB(guard_cells.ng_alloc_EB, WarpX::sync_nodal_points);
+    FillBoundaryB(guard_cells.ng_alloc_EB, parallelization::sync_nodal_points_flag());
 }
 
 void
@@ -86,7 +89,7 @@ WarpX::FinishMagneticFieldAndApplyBCs( ablastr::fields::MultiLevelVectorField co
 
     FinishImplicitField(m_fields.get_mr_levels_alldirs(FieldType::Bfield_fp, 0), a_Bn, a_theta);
     ApplyBfieldBoundary(0, PatchType::fine, SubcyclingHalf::None, a_time);
-    FillBoundaryB(guard_cells.ng_alloc_EB, WarpX::sync_nodal_points);
+    FillBoundaryB(guard_cells.ng_alloc_EB, parallelization::sync_nodal_points_flag());
 }
 
 void
@@ -117,8 +120,8 @@ WarpX::SpectralSourceFreeFieldAdvance (amrex::Real start_time)
     current_fp[2]->setVal(0._rt);
     if (rho_fp) { rho_fp->setVal(0._rt); }
     PushPSATD(start_time); // Note that this does dt/2
-    FillBoundaryE(guard_cells.ng_alloc_EB, WarpX::sync_nodal_points);
-    FillBoundaryB(guard_cells.ng_alloc_EB, WarpX::sync_nodal_points);
+    FillBoundaryE(guard_cells.ng_alloc_EB, parallelization::sync_nodal_points_flag());
+    FillBoundaryB(guard_cells.ng_alloc_EB, parallelization::sync_nodal_points_flag());
 
     // Restore the current_fp MultiFab. Note that this is only needed for diagnostics when
     // J is being written out (since current_fp is not otherwise used).

--- a/Source/FieldSolver/MagnetostaticSolver/MagnetostaticSolver.cpp
+++ b/Source/FieldSolver/MagnetostaticSolver/MagnetostaticSolver.cpp
@@ -10,6 +10,7 @@
 #include "FieldSolver/MagnetostaticSolver/MagnetostaticSolver.H"
 #include "EmbeddedBoundary/Enabled.H"
 #include "Parallelization/GuardCellManager.H"
+#include "Parallelization/Parallelization.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Particles/WarpXParticleContainer.H"
 #include "Python/callbacks.H"
@@ -57,6 +58,7 @@
 #include <string>
 
 using namespace amrex;
+using namespace warpx;
 
 void
 WarpX::ComputeMagnetostaticField()
@@ -219,7 +221,7 @@ WarpX::computeVectorPotential (ablastr::fields::MultiLevelVectorField const& cur
         this->grids,
         this->m_vector_poisson_boundary_handler,
         EB::enabled(),
-        WarpX::do_single_precision_comms,
+        parallelization::comms_in_single_precision_flag(),
         this->ref_ratio,
         post_A_calculation,
         gett_new(0),
@@ -403,9 +405,10 @@ void MagnetostaticSolver::EBCalcBfromVectorPotentialPerLevel::doInterp (amrex::M
     amrex::Real const * stencil_coeffs_z = warpx.device_field_centering_stencil_coeffs_z.data();
 
     // Synchronize the ghost cells, do halo exchange
+    const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
     ablastr::utils::communication::FillBoundary(src,
                                                 src.nGrowVect(),
-                                                WarpX::do_single_precision_comms);
+                                                do_single_precision_comms);
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())

--- a/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
@@ -9,6 +9,7 @@
  */
 #include "Fields.H"
 #include "FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H"
+#include "Parallelization/Parallelization.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Utils/TextMsg.H"
 #include "Fluids/MultiFluidContainer.H"
@@ -21,6 +22,7 @@
 
 
 using namespace amrex;
+using namespace warpx;
 
 void WarpX::HybridPICEvolveFields ()
 {
@@ -107,7 +109,7 @@ void WarpX::HybridPICEvolveFields ()
             m_eb_update_E,
             0.5_rt/sub_steps*dt[0],
             SubcyclingHalf::FirstHalf, guard_cells.ng_FieldSolver,
-            WarpX::sync_nodal_points
+            parallelization::sync_nodal_points_flag()
         );
     }
 
@@ -141,7 +143,7 @@ void WarpX::HybridPICEvolveFields ()
             m_eb_update_E,
             0.5_rt/sub_steps*dt[0],
             SubcyclingHalf::SecondHalf, guard_cells.ng_FieldSolver,
-            WarpX::sync_nodal_points
+            parallelization::sync_nodal_points_flag()
         );
     }
 
@@ -182,7 +184,7 @@ void WarpX::HybridPICEvolveFields ()
         m_fields.get_mr_levels_alldirs(FieldType::Bfield_fp, finest_level),
         m_fields.get_mr_levels(FieldType::rho_fp, finest_level),
         m_eb_update_E, false);
-    FillBoundaryE(guard_cells.ng_FieldSolver, WarpX::sync_nodal_points);
+    FillBoundaryE(guard_cells.ng_FieldSolver, parallelization::sync_nodal_points_flag());
 
     // Handle field splitting for Hybrid field push
     if (add_external_fields) {
@@ -263,11 +265,12 @@ void WarpX::HybridPICDepositRhoAndJ ()
     // SyncCurrent does not include a call to FillBoundary, but it is needed
     // for the hybrid-PIC solver since current values are interpolated to
     // a nodal grid
+    const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
     for (int lev = 0; lev <= finest_level; ++lev) {
         ablastr::utils::communication::FillBoundary(
             *m_fields.get(FieldType::rho_fp, lev),
             m_fields.get(FieldType::rho_fp, lev)->nGrowVect(),
-            WarpX::do_single_precision_comms,
+            do_single_precision_comms,
             Geom(lev).periodicity(),
             true
         );
@@ -275,7 +278,7 @@ void WarpX::HybridPICDepositRhoAndJ ()
             ablastr::utils::communication::FillBoundary(
                 *m_fields.get(FieldType::current_fp, Direction{idim}, lev),
                 m_fields.get(FieldType::current_fp, Direction{idim}, lev)->nGrowVect(),
-                WarpX::do_single_precision_comms,
+                do_single_precision_comms,
                 Geom(lev).periodicity(),
                 true
             );

--- a/Source/Fluids/WarpXFluidContainer.cpp
+++ b/Source/Fluids/WarpXFluidContainer.cpp
@@ -10,6 +10,7 @@
 
 #include "MusclHancockUtils.H"
 #include "Fluids/WarpXFluidContainer.H"
+#include "Parallelization/Parallelization.H"
 #include "Utils/Parser/ParserUtils.H"
 #include "Utils/WarpXUtil.H"
 #include "Utils/SpeciesUtils.H"
@@ -20,6 +21,7 @@
 
 using namespace ablastr::utils::communication;
 using namespace amrex;
+using namespace warpx;
 
 
 WarpXFluidContainer::WarpXFluidContainer(int ispecies, const std::string &name):
@@ -411,10 +413,11 @@ void WarpXFluidContainer::ApplyBcFluidsAndComms (ablastr::fields::MultiFabRegist
     }
 
     // Fill guard cells
-    FillBoundary(*fields.get(name_mf_N, lev), fields.get(name_mf_N, lev)->nGrowVect(), WarpX::do_single_precision_comms, period);
-    FillBoundary(*fields.get(name_mf_NU, Direction{0}, lev), fields.get(name_mf_NU, Direction{0}, lev)->nGrowVect(), WarpX::do_single_precision_comms, period);
-    FillBoundary(*fields.get(name_mf_NU, Direction{1}, lev), fields.get(name_mf_NU, Direction{1}, lev)->nGrowVect(), WarpX::do_single_precision_comms, period);
-    FillBoundary(*fields.get(name_mf_NU, Direction{2}, lev), fields.get(name_mf_NU, Direction{2}, lev)->nGrowVect(), WarpX::do_single_precision_comms, period);
+    const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
+    FillBoundary(*fields.get(name_mf_N, lev), fields.get(name_mf_N, lev)->nGrowVect(), do_single_precision_comms, period);
+    FillBoundary(*fields.get(name_mf_NU, Direction{0}, lev), fields.get(name_mf_NU, Direction{0}, lev)->nGrowVect(), do_single_precision_comms, period);
+    FillBoundary(*fields.get(name_mf_NU, Direction{1}, lev), fields.get(name_mf_NU, Direction{1}, lev)->nGrowVect(), do_single_precision_comms, period);
+    FillBoundary(*fields.get(name_mf_NU, Direction{2}, lev), fields.get(name_mf_NU, Direction{2}, lev)->nGrowVect(), do_single_precision_comms, period);
 }
 
 // Muscl Advection Update

--- a/Source/Initialization/DivCleaner/ProjectionDivCleaner.cpp
+++ b/Source/Initialization/DivCleaner/ProjectionDivCleaner.cpp
@@ -25,6 +25,7 @@
 #include "Fields.H"
 #include <Initialization/ExternalField.H>
 #include <ablastr/utils/Communication.H>
+#include "Parallelization/Parallelization.H"
 #include <Utils/WarpXProfilerWrapper.H>
 
 #include <map>
@@ -209,7 +210,7 @@ ProjectionDivCleaner::solve ()
         // Synchronize the ghost cells, do halo exchange
         ablastr::utils::communication::FillBoundary(*m_solution[ilev],
                                                 m_solution[ilev]->nGrowVect(),
-                                                WarpX::do_single_precision_comms,
+                                                parallelization::comms_in_single_precision_flag(),
                                                 geom[ilev].periodicity(),
                                                 true);
     }
@@ -237,17 +238,17 @@ ProjectionDivCleaner::setSourceFromField ()
         // generating source
         ablastr::utils::communication::FillBoundary(*Bx,
                 Bx->nGrowVect(),
-                WarpX::do_single_precision_comms,
+                parallelization::comms_in_single_precision_flag(),
                 geom[ilev].periodicity(),
                 true);
         ablastr::utils::communication::FillBoundary(*By,
                 By->nGrowVect(),
-                WarpX::do_single_precision_comms,
+                parallelization::comms_in_single_precision_flag(),
                 geom[ilev].periodicity(),
                 true);
         ablastr::utils::communication::FillBoundary(*Bz,
                 Bz->nGrowVect(),
-                WarpX::do_single_precision_comms,
+                parallelization::comms_in_single_precision_flag(),
                 geom[ilev].periodicity(),
                 true);
 
@@ -265,7 +266,7 @@ ProjectionDivCleaner::setSourceFromField ()
         // Synchronize the ghost cells, do halo exchange
         ablastr::utils::communication::FillBoundary(*m_source[ilev],
                                                 m_source[ilev]->nGrowVect(),
-                                                WarpX::do_single_precision_comms,
+                                                parallelization::comms_in_single_precision_flag(),
                                                 geom[ilev].periodicity(),
                                                 true);
     }
@@ -374,17 +375,17 @@ ProjectionDivCleaner::correctField ()
         // Synchronize the ghost cells, do halo exchange
         ablastr::utils::communication::FillBoundary(*Bx,
                                                     Bx->nGrowVect(),
-                                                    WarpX::do_single_precision_comms,
+                                                    parallelization::comms_in_single_precision_flag(),
                                                     geom[ilev].periodicity(),
                                                     true);
         ablastr::utils::communication::FillBoundary(*By,
                                                     By->nGrowVect(),
-                                                    WarpX::do_single_precision_comms,
+                                                    parallelization::comms_in_single_precision_flag(),
                                                     geom[ilev].periodicity(),
                                                     true);
         ablastr::utils::communication::FillBoundary(*Bz,
                                                     Bz->nGrowVect(),
-                                                    WarpX::do_single_precision_comms,
+                                                    parallelization::comms_in_single_precision_flag(),
                                                     geom[ilev].periodicity(),
                                                     true);
         amrex::Gpu::synchronize();

--- a/Source/Parallelization/CMakeLists.txt
+++ b/Source/Parallelization/CMakeLists.txt
@@ -2,6 +2,7 @@ foreach(D IN LISTS WarpX_DIMS)
     warpx_set_suffix_dims(SD ${D})
     target_sources(lib_${SD}
       PRIVATE
+        Parallelization.cpp
         GuardCellManager.cpp
         WarpXComm.cpp
         WarpXRegrid.cpp

--- a/Source/Parallelization/Make.package
+++ b/Source/Parallelization/Make.package
@@ -1,6 +1,7 @@
+CEXE_sources += GuardCellManager.cpp
+CEXE_sources += Parallelization.cpp
 CEXE_sources += WarpXComm.cpp
 CEXE_sources += WarpXRegrid.cpp
-CEXE_sources += GuardCellManager.cpp
 CEXE_sources += WarpXSumGuardCells.cpp
 
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Parallelization

--- a/Source/Parallelization/Parallelization.H
+++ b/Source/Parallelization/Parallelization.H
@@ -1,0 +1,40 @@
+/* Copyright 2025 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#ifndef WARPX_PARALLELIZATION_PARALLELIZATION_H_
+#define WARPX_PARALLELIZATION_PARALLELIZATION_H_
+
+namespace warpx::parallelization
+{
+    /**
+    * \brief Returns true if nodal points have to be synchronized
+    *
+    *  Note: currently this is hardcoded to "true"
+    */
+    constexpr bool sync_nodal_points_flag ()
+    {
+        return true;
+    }
+
+    /**
+    * \brief Returns true if field communications have to be performed in single precision, false otherwise
+    *
+    * The function returns "false" unless "warpx.do_single_precision_comms"
+    * is set to 1 in the inputfile.
+    */
+    bool comms_in_single_precision_flag ();
+
+    /**
+    * \brief Returns true if dynamic scheduling is enabled, false otherwise
+    *
+    * The function returns "true" unless "warpx.do_dynamic_scheduling"
+    * is set to 0 in the inputfile.
+    */
+    bool dynamic_scheduling_flag ();
+}
+
+#endif //WARPX_PARALLELIZATION_PARALLELIZATION_H_

--- a/Source/Parallelization/Parallelization.cpp
+++ b/Source/Parallelization/Parallelization.cpp
@@ -1,0 +1,43 @@
+/* Copyright 2025 Luca Fedeli
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#include "Parallelization.H"
+
+#include "ablastr/warn_manager/WarnManager.H"
+
+#include "AMReX_ParmParse.H"
+
+using namespace amrex;
+
+namespace warpx::parallelization
+{
+    bool comms_in_single_precision_flag()
+    {
+        bool do_single_precision_comms = false;
+        const auto pp_warpx = ParmParse{"warpx"};
+        pp_warpx.query("do_single_precision_comms", do_single_precision_comms);
+#ifdef AMREX_USE_FLOAT
+        if (do_single_precision_comms) {
+            do_single_precision_comms = false;
+            ablastr::warn_manager::WMRecordWarning(
+                "comms",
+                "Overwrote warpx.do_single_precision_comms to be 0, since WarpX was built in single precision.",
+                ablastr::warn_manager::WarnPriority::low);
+        }
+#endif
+        return do_single_precision_comms;
+    }
+
+    bool dynamic_scheduling_flag()
+    {
+        bool do_dynamic_scheduling = true;
+        const auto pp_warpx = ParmParse{"warpx"};
+        pp_warpx.query("do_dynamic_scheduling", do_dynamic_scheduling);
+
+        return do_dynamic_scheduling;
+    }
+}

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -19,6 +19,7 @@
 #include "Utils/WarpXProfilerWrapper.H"
 #include "WarpXComm_K.H"
 #include "WarpXSumGuardCells.H"
+#include "Parallelization/Parallelization.H"
 #include "Particles/MultiParticleContainer.H"
 
 #include <ablastr/fields/MultiFabRegister.H>
@@ -51,6 +52,7 @@
 #include <vector>
 
 using namespace amrex;
+using namespace warpx;
 using warpx::fields::FieldType;
 
 namespace
@@ -208,6 +210,8 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
     // Destination MultiFab (aux) always has nodal index type when this function is called
     const amrex::IntVect& dst_stag = amrex::IntVect::TheNodeVector();
 
+    const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
+
     // For level 0, we only need to do the average.
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
@@ -299,7 +303,7 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
                     // Copy Bfield_aux to Btmp, using up to ng_src (=ng_FieldGather) guard cells from
                     // Bfield_aux and filling up to ng (=nGrow) guard cells in Btmp
                     ablastr::utils::communication::ParallelCopy(*Btmp[i], *Bfield_aux[lev - 1][i], 0, 0, 1,
-                                                                ng_src, ng, WarpX::do_single_precision_comms, cperiod);
+                                                                ng_src, ng, do_single_precision_comms, cperiod);
                 }
 
                 const amrex::IntVect& refinement_ratio = refRatio(lev-1);
@@ -394,7 +398,7 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
                     // Copy Efield_aux to Etmp, using up to ng_src (=ng_FieldGather) guard cells from
                     // Efield_aux and filling up to ng (=nGrow) guard cells in Etmp
                     ablastr::utils::communication::ParallelCopy(*Etmp[i], *Efield_aux[lev - 1][i], 0, 0, 1,
-                                                                ng_src, ng, WarpX::do_single_precision_comms, cperiod);
+                                                                ng_src, ng, do_single_precision_comms, cperiod);
                 }
 
                 const amrex::IntVect& refinement_ratio = refRatio(lev-1);
@@ -471,6 +475,8 @@ WarpX::UpdateAuxilaryDataSameType ()
     // Update aux field, including guard cells, up to ng_FieldGather
     const amrex::IntVect& ng_src = guard_cells.ng_FieldGather;
 
+    const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
+
     using ablastr::fields::Direction;
     ablastr::fields::MultiLevelVectorField Efield_fp = m_fields.get_mr_levels_alldirs(FieldType::Efield_fp, finest_level);
     ablastr::fields::MultiLevelVectorField Bfield_fp = m_fields.get_mr_levels_alldirs(FieldType::Bfield_fp, finest_level);
@@ -520,15 +526,14 @@ WarpX::UpdateAuxilaryDataSameType ()
 
                 // Copy Bfield_aux to the dB MultiFabs, using up to ng_src (=ng_FieldGather) guard
                 // cells from Bfield_aux and filling up to ng (=nGrow) guard cells in the dB MultiFabs
-
                 ablastr::utils::communication::ParallelCopy(dBx, *Bfield_aux[lev - 1][0], 0, 0,
-                                                            Bfield_aux[lev - 1][0]->nComp(), ng_src, ng, WarpX::do_single_precision_comms,
+                                                            Bfield_aux[lev - 1][0]->nComp(), ng_src, ng, do_single_precision_comms,
                                                             crse_period);
                 ablastr::utils::communication::ParallelCopy(dBy, *Bfield_aux[lev - 1][1], 0, 0,
-                                                            Bfield_aux[lev - 1][1]->nComp(), ng_src, ng, WarpX::do_single_precision_comms,
+                                                            Bfield_aux[lev - 1][1]->nComp(), ng_src, ng, do_single_precision_comms,
                                                             crse_period);
                 ablastr::utils::communication::ParallelCopy(dBz, *Bfield_aux[lev - 1][2], 0, 0,
-                                                            Bfield_aux[lev - 1][2]->nComp(), ng_src, ng, WarpX::do_single_precision_comms,
+                                                            Bfield_aux[lev - 1][2]->nComp(), ng_src, ng, do_single_precision_comms,
                                                             crse_period);
 
                 if (m_fields.has_vector(FieldType::Bfield_cax, lev))
@@ -605,15 +610,15 @@ WarpX::UpdateAuxilaryDataSameType ()
                 // cells from Efield_aux and filling up to ng (=nGrow) guard cells in the dE MultiFabs
                 ablastr::utils::communication::ParallelCopy(dEx, *Efield_aux[lev - 1][0], 0, 0,
                                                             Efield_aux[lev - 1][0]->nComp(), ng_src, ng,
-                                                            WarpX::do_single_precision_comms,
+                                                            do_single_precision_comms,
                                                             crse_period);
                 ablastr::utils::communication::ParallelCopy(dEy, *Efield_aux[lev - 1][1], 0, 0,
                                                             Efield_aux[lev - 1][1]->nComp(), ng_src, ng,
-                                                            WarpX::do_single_precision_comms,
+                                                            do_single_precision_comms,
                                                             crse_period);
                 ablastr::utils::communication::ParallelCopy(dEz, *Efield_aux[lev - 1][2], 0, 0,
                                                             Efield_aux[lev - 1][2]->nComp(), ng_src, ng,
-                                                            WarpX::do_single_precision_comms,
+                                                            do_single_precision_comms,
                                                             crse_period);
 
                 if (m_fields.has_vector(FieldType::Efield_cax, lev))
@@ -778,7 +783,7 @@ WarpX::FillBoundaryE (const int lev, const PatchType patch_type, const amrex::In
 #if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
         if (pml_rz[lev])
         {
-            pml_rz[lev]->FillBoundaryE(m_fields, patch_type, do_single_precision_comms, nodal_sync);
+            pml_rz[lev]->FillBoundaryE(m_fields, patch_type, nodal_sync);
         }
 #endif
     }
@@ -791,6 +796,7 @@ WarpX::FillBoundaryE (const int lev, const PatchType patch_type, const amrex::In
             "Error: in FillBoundaryE, requested more guard cells than allocated");
 
         const amrex::IntVect nghost = (m_safe_guard_cells) ? mf[i]->nGrowVect() : ng;
+        const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
         ablastr::utils::communication::FillBoundary(*mf[i], nghost, do_single_precision_comms, period, nodal_sync);
     }
 }
@@ -843,7 +849,7 @@ WarpX::FillBoundaryB (const int lev, const PatchType patch_type, const amrex::In
 #if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
         if (pml_rz[lev])
         {
-            pml_rz[lev]->FillBoundaryB(m_fields, patch_type, do_single_precision_comms, nodal_sync);
+            pml_rz[lev]->FillBoundaryB(m_fields, patch_type, nodal_sync);
         }
 #endif
     }
@@ -856,6 +862,7 @@ WarpX::FillBoundaryB (const int lev, const PatchType patch_type, const amrex::In
             "Error: in FillBoundaryB, requested more guard cells than allocated");
 
         const amrex::IntVect nghost = (m_safe_guard_cells) ? mf[i]->nGrowVect() : ng;
+        const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
         ablastr::utils::communication::FillBoundary(*mf[i], nghost, do_single_precision_comms, period, nodal_sync);
     }
 }
@@ -872,6 +879,8 @@ WarpX::FillBoundaryE_avg (int lev, PatchType patch_type, IntVect ng)
 {
     bool const skip_lev0_coarse_patch = true;
 
+    const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
+
     if (patch_type == PatchType::fine)
     {
         if (do_pml && pml[lev]->ok())
@@ -882,16 +891,17 @@ WarpX::FillBoundaryE_avg (int lev, PatchType patch_type, IntVect ng)
         ablastr::fields::MultiLevelVectorField Efield_avg_fp = m_fields.get_mr_levels_alldirs(FieldType::Efield_avg_fp, finest_level);
 
         const amrex::Periodicity& period = Geom(lev).periodicity();
+
         if ( m_safe_guard_cells ){
             const Vector<MultiFab*> mf{Efield_avg_fp[lev][0],Efield_avg_fp[lev][1],Efield_avg_fp[lev][2]};
-            ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, period);
+            ablastr::utils::communication::FillBoundary(mf, do_single_precision_comms, period);
         } else {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 ng.allLE(Efield_avg_fp[lev][0]->nGrowVect()),
                 "Error: in FillBoundaryE_avg, requested more guard cells than allocated");
-            ablastr::utils::communication::FillBoundary(*Efield_avg_fp[lev][0], ng, WarpX::do_single_precision_comms, period);
-            ablastr::utils::communication::FillBoundary(*Efield_avg_fp[lev][1], ng, WarpX::do_single_precision_comms, period);
-            ablastr::utils::communication::FillBoundary(*Efield_avg_fp[lev][2], ng, WarpX::do_single_precision_comms, period);
+            ablastr::utils::communication::FillBoundary(*Efield_avg_fp[lev][0], ng, do_single_precision_comms, period);
+            ablastr::utils::communication::FillBoundary(*Efield_avg_fp[lev][1], ng, do_single_precision_comms, period);
+            ablastr::utils::communication::FillBoundary(*Efield_avg_fp[lev][2], ng, do_single_precision_comms, period);
         }
     }
     else if (patch_type == PatchType::coarse)
@@ -906,15 +916,15 @@ WarpX::FillBoundaryE_avg (int lev, PatchType patch_type, IntVect ng)
         const amrex::Periodicity& cperiod = Geom(lev-1).periodicity();
         if ( m_safe_guard_cells ) {
             const Vector<MultiFab*> mf{Efield_avg_cp[lev][0],Efield_avg_cp[lev][1],Efield_avg_cp[lev][2]};
-            ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, cperiod);
+            ablastr::utils::communication::FillBoundary(mf, do_single_precision_comms, cperiod);
 
         } else {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 ng.allLE(Efield_avg_cp[lev][0]->nGrowVect()),
                 "Error: in FillBoundaryE, requested more guard cells than allocated");
-            ablastr::utils::communication::FillBoundary(*Efield_avg_cp[lev][0], ng, WarpX::do_single_precision_comms, cperiod);
-            ablastr::utils::communication::FillBoundary(*Efield_avg_cp[lev][1], ng, WarpX::do_single_precision_comms, cperiod);
-            ablastr::utils::communication::FillBoundary(*Efield_avg_cp[lev][2], ng, WarpX::do_single_precision_comms, cperiod);
+            ablastr::utils::communication::FillBoundary(*Efield_avg_cp[lev][0], ng, do_single_precision_comms, cperiod);
+            ablastr::utils::communication::FillBoundary(*Efield_avg_cp[lev][1], ng, do_single_precision_comms, cperiod);
+            ablastr::utils::communication::FillBoundary(*Efield_avg_cp[lev][2], ng, do_single_precision_comms, cperiod);
         }
     }
 }
@@ -934,6 +944,8 @@ WarpX::FillBoundaryB_avg (int lev, PatchType patch_type, IntVect ng)
 
     bool const skip_lev0_coarse_patch = true;
 
+    const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
+
     if (patch_type == PatchType::fine)
     {
         if (do_pml && pml[lev]->ok())
@@ -946,14 +958,14 @@ WarpX::FillBoundaryB_avg (int lev, PatchType patch_type, IntVect ng)
         const amrex::Periodicity& period = Geom(lev).periodicity();
         if ( m_safe_guard_cells ) {
             const Vector<MultiFab*> mf{Bfield_avg_fp[lev][0],Bfield_avg_fp[lev][1],Bfield_avg_fp[lev][2]};
-            ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, period);
+            ablastr::utils::communication::FillBoundary(mf, do_single_precision_comms, period);
         } else {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 ng.allLE(m_fields.get(FieldType::Bfield_fp, Direction{0}, lev)->nGrowVect()),
                 "Error: in FillBoundaryB, requested more guard cells than allocated");
-            ablastr::utils::communication::FillBoundary(*Bfield_avg_fp[lev][0], ng, WarpX::do_single_precision_comms, period);
-            ablastr::utils::communication::FillBoundary(*Bfield_avg_fp[lev][1], ng, WarpX::do_single_precision_comms, period);
-            ablastr::utils::communication::FillBoundary(*Bfield_avg_fp[lev][2], ng, WarpX::do_single_precision_comms, period);
+            ablastr::utils::communication::FillBoundary(*Bfield_avg_fp[lev][0], ng, do_single_precision_comms, period);
+            ablastr::utils::communication::FillBoundary(*Bfield_avg_fp[lev][1], ng, do_single_precision_comms, period);
+            ablastr::utils::communication::FillBoundary(*Bfield_avg_fp[lev][2], ng, do_single_precision_comms, period);
         }
     }
     else if (patch_type == PatchType::coarse)
@@ -968,14 +980,14 @@ WarpX::FillBoundaryB_avg (int lev, PatchType patch_type, IntVect ng)
         const amrex::Periodicity& cperiod = Geom(lev-1).periodicity();
         if ( m_safe_guard_cells ){
             const Vector<MultiFab*> mf{Bfield_avg_cp[lev][0],Bfield_avg_cp[lev][1],Bfield_avg_cp[lev][2]};
-            ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, cperiod);
+            ablastr::utils::communication::FillBoundary(mf, do_single_precision_comms, cperiod);
         } else {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 ng.allLE(Bfield_avg_cp[lev][0]->nGrowVect()),
                 "Error: in FillBoundaryB_avg, requested more guard cells than allocated");
-            ablastr::utils::communication::FillBoundary(*Bfield_avg_cp[lev][0], ng, WarpX::do_single_precision_comms, cperiod);
-            ablastr::utils::communication::FillBoundary(*Bfield_avg_cp[lev][1], ng, WarpX::do_single_precision_comms, cperiod);
-            ablastr::utils::communication::FillBoundary(*Bfield_avg_cp[lev][2], ng, WarpX::do_single_precision_comms, cperiod);
+            ablastr::utils::communication::FillBoundary(*Bfield_avg_cp[lev][0], ng, do_single_precision_comms, cperiod);
+            ablastr::utils::communication::FillBoundary(*Bfield_avg_cp[lev][1], ng, do_single_precision_comms, cperiod);
+            ablastr::utils::communication::FillBoundary(*Bfield_avg_cp[lev][2], ng, do_single_precision_comms, cperiod);
         }
     }
 }
@@ -990,6 +1002,9 @@ WarpX::FillBoundaryF (int lev, IntVect ng, std::optional<bool> nodal_sync)
 void
 WarpX::FillBoundaryF (int lev, PatchType patch_type, IntVect ng, std::optional<bool> nodal_sync)
 {
+
+    const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
+
     if (patch_type == PatchType::fine)
     {
         if (do_pml && pml[lev] && pml[lev]->ok())
@@ -1006,7 +1021,7 @@ WarpX::FillBoundaryF (int lev, PatchType patch_type, IntVect ng, std::optional<b
         {
             const amrex::Periodicity& period = Geom(lev).periodicity();
             const amrex::IntVect& nghost = (m_safe_guard_cells) ? m_fields.get(FieldType::F_fp, lev)->nGrowVect() : ng;
-            ablastr::utils::communication::FillBoundary(*m_fields.get(FieldType::F_fp, lev), nghost, WarpX::do_single_precision_comms, period, nodal_sync);
+            ablastr::utils::communication::FillBoundary(*m_fields.get(FieldType::F_fp, lev), nghost, do_single_precision_comms, period, nodal_sync);
         }
     }
     else if (patch_type == PatchType::coarse)
@@ -1025,7 +1040,7 @@ WarpX::FillBoundaryF (int lev, PatchType patch_type, IntVect ng, std::optional<b
         {
             const amrex::Periodicity& period = Geom(lev-1).periodicity();
             const amrex::IntVect& nghost = (m_safe_guard_cells) ? m_fields.get(FieldType::F_cp, lev)->nGrowVect() : ng;
-            ablastr::utils::communication::FillBoundary(*m_fields.get(FieldType::F_cp, lev), nghost, WarpX::do_single_precision_comms, period, nodal_sync);
+            ablastr::utils::communication::FillBoundary(*m_fields.get(FieldType::F_cp, lev), nghost, do_single_precision_comms, period, nodal_sync);
         }
     }
 }
@@ -1042,6 +1057,9 @@ void WarpX::FillBoundaryG (int lev, IntVect ng, std::optional<bool> nodal_sync)
 
 void WarpX::FillBoundaryG (int lev, PatchType patch_type, IntVect ng, std::optional<bool> nodal_sync)
 {
+
+    const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
+
     if (patch_type == PatchType::fine)
     {
         if (do_pml && pml[lev] && pml[lev]->ok())
@@ -1059,7 +1077,7 @@ void WarpX::FillBoundaryG (int lev, PatchType patch_type, IntVect ng, std::optio
             const amrex::Periodicity& period = Geom(lev).periodicity();
             MultiFab* G_fp = m_fields.get(FieldType::G_fp,lev);
             const amrex::IntVect& nghost = (m_safe_guard_cells) ? G_fp->nGrowVect() : ng;
-            ablastr::utils::communication::FillBoundary(*G_fp, nghost, WarpX::do_single_precision_comms, period, nodal_sync);
+            ablastr::utils::communication::FillBoundary(*G_fp, nghost, do_single_precision_comms, period, nodal_sync);
         }
     }
     else if (patch_type == PatchType::coarse)
@@ -1079,7 +1097,7 @@ void WarpX::FillBoundaryG (int lev, PatchType patch_type, IntVect ng, std::optio
             const amrex::Periodicity& period = Geom(lev-1).periodicity();
             MultiFab* G_cp = m_fields.get(FieldType::G_cp,lev);
             const amrex::IntVect& nghost = (m_safe_guard_cells) ? G_cp->nGrowVect() : ng;
-            ablastr::utils::communication::FillBoundary(*G_cp, nghost, WarpX::do_single_precision_comms, period, nodal_sync);
+            ablastr::utils::communication::FillBoundary(*G_cp, nghost, do_single_precision_comms, period, nodal_sync);
         }
     }
 }
@@ -1100,12 +1118,14 @@ WarpX::FillBoundaryAux (int lev, IntVect ng)
     ablastr::fields::MultiLevelVectorField Bfield_aux = m_fields.get_mr_levels_alldirs(FieldType::Bfield_aux, finest_level);
 
     const amrex::Periodicity& period = Geom(lev).periodicity();
-    ablastr::utils::communication::FillBoundary(*Efield_aux[lev][0], ng, WarpX::do_single_precision_comms, period);
-    ablastr::utils::communication::FillBoundary(*Efield_aux[lev][1], ng, WarpX::do_single_precision_comms, period);
-    ablastr::utils::communication::FillBoundary(*Efield_aux[lev][2], ng, WarpX::do_single_precision_comms, period);
-    ablastr::utils::communication::FillBoundary(*Bfield_aux[lev][0], ng, WarpX::do_single_precision_comms, period);
-    ablastr::utils::communication::FillBoundary(*Bfield_aux[lev][1], ng, WarpX::do_single_precision_comms, period);
-    ablastr::utils::communication::FillBoundary(*Bfield_aux[lev][2], ng, WarpX::do_single_precision_comms, period);
+    const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
+
+    ablastr::utils::communication::FillBoundary(*Efield_aux[lev][0], ng, do_single_precision_comms, period);
+    ablastr::utils::communication::FillBoundary(*Efield_aux[lev][1], ng, do_single_precision_comms, period);
+    ablastr::utils::communication::FillBoundary(*Efield_aux[lev][2], ng, do_single_precision_comms, period);
+    ablastr::utils::communication::FillBoundary(*Bfield_aux[lev][0], ng, do_single_precision_comms, period);
+    ablastr::utils::communication::FillBoundary(*Bfield_aux[lev][1], ng, do_single_precision_comms, period);
+    ablastr::utils::communication::FillBoundary(*Bfield_aux[lev][2], ng, do_single_precision_comms, period);
 }
 
 void
@@ -1521,6 +1541,7 @@ void WarpX::AddCurrentFromFineLevelandSumBoundary (
     const int lev)
 {
     const amrex::Periodicity& period = Geom(lev).periodicity();
+    const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
 
     if (use_filter)
     {
@@ -1660,6 +1681,8 @@ void WarpX::AddRhoFromFineLevelandSumBoundary (
 
     ApplyFilterandSumBoundaryRho(charge_fp, charge_cp, lev, PatchType::fine, icomp, ncomp);
 
+    const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
+
     if (lev < finest_level){
 
         const amrex::Periodicity& period = Geom(lev).periodicity();
@@ -1687,7 +1710,7 @@ void WarpX::AddRhoFromFineLevelandSumBoundary (
             MultiFab::Add(rhofb, rhofc, 0, 0, ncomp, ng);
 
             ablastr::utils::communication::ParallelAdd(mf, rhofb, 0, 0, ncomp, ng, IntVect::TheZeroVector(),
-                                                       WarpX::do_single_precision_comms, period);
+                                                       do_single_precision_comms, period);
             WarpXSumGuardCells( *charge_cp[lev+1], rhofc, period, ng_depos_rho, icomp, ncomp );
         }
         else if (use_filter) // but no buffer
@@ -1699,7 +1722,7 @@ void WarpX::AddRhoFromFineLevelandSumBoundary (
             bilinear_filter.ApplyStencil(rf, *charge_cp[lev+1], lev+1, icomp, 0, ncomp);
 
             ablastr::utils::communication::ParallelAdd(mf, rf, 0, 0, ncomp, ng, IntVect::TheZeroVector(),
-                                                       WarpX::do_single_precision_comms, period);
+                                                       do_single_precision_comms, period);
             WarpXSumGuardCells( *charge_cp[lev+1], rf, period, ng_depos_rho, icomp, ncomp );
         }
         else if (charge_buffer[lev+1]) // but no filter
@@ -1712,7 +1735,7 @@ void WarpX::AddRhoFromFineLevelandSumBoundary (
             ablastr::utils::communication::ParallelAdd(mf, *charge_buffer[lev + 1], icomp, 0,
                                                        ncomp,
                                                        charge_buffer[lev + 1]->nGrowVect(),
-                                                       IntVect::TheZeroVector(), WarpX::do_single_precision_comms,
+                                                       IntVect::TheZeroVector(), do_single_precision_comms,
                                                        period);
             WarpXSumGuardCells(*(charge_cp[lev+1]), period, ng_depos_rho, icomp, ncomp);
         }
@@ -1721,7 +1744,7 @@ void WarpX::AddRhoFromFineLevelandSumBoundary (
             ng_depos_rho.min(ng);
             ablastr::utils::communication::ParallelAdd(mf, *charge_cp[lev + 1], icomp, 0, ncomp,
                                                        charge_cp[lev + 1]->nGrowVect(),
-                                                       IntVect::TheZeroVector(), WarpX::do_single_precision_comms,
+                                                       IntVect::TheZeroVector(), do_single_precision_comms,
                                                        period);
             WarpXSumGuardCells(*(charge_cp[lev+1]), period, ng_depos_rho, icomp, ncomp);
         }

--- a/Source/Parallelization/WarpXSumGuardCells.cpp
+++ b/Source/Parallelization/WarpXSumGuardCells.cpp
@@ -8,11 +8,12 @@
 
 #include "WarpXSumGuardCells.H"
 
+#include "Parallelization/Parallelization.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 
-#include "WarpX.H"
-
 #include <ablastr/utils/Communication.H>
+
+using namespace warpx;
 
 void
 WarpXSumGuardCells(amrex::MultiFab& mf, const amrex::Periodicity& period,
@@ -20,7 +21,8 @@ WarpXSumGuardCells(amrex::MultiFab& mf, const amrex::Periodicity& period,
                    const int icomp, const int ncomp)
 {
     amrex::IntVect const n_updated_guards = mf.nGrowVect();
-    ablastr::utils::communication::SumBoundary(mf, icomp, ncomp, src_ngrow, n_updated_guards, WarpX::do_single_precision_comms, period);
+    const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
+    ablastr::utils::communication::SumBoundary(mf, icomp, ncomp, src_ngrow, n_updated_guards, do_single_precision_comms, period);
 }
 
 

--- a/Source/Particles/Deposition/VarianceAccumulationBuffer.cpp
+++ b/Source/Particles/Deposition/VarianceAccumulationBuffer.cpp
@@ -9,6 +9,7 @@
 
 #include "Particles/Deposition/VarianceAccumulationBuffer.H"
 #include "Particles/Deposition/TemperatureDeposition.H"
+#include "Parallelization/Parallelization.H"
 #include "Parallelization/WarpXSumGuardCells.H"
 #include "Fields.H"
 
@@ -18,6 +19,7 @@
 #include <AMReX_REAL.H>
 
 using namespace amrex::literals;
+using namespace warpx;
 using namespace warpx::particles::deposition;
 
 VarianceAccumulationBuffer::VarianceAccumulationBuffer (ablastr::fields::MultiLevelVectorField const& T_vf, std::string const& species_name ) :
@@ -84,6 +86,8 @@ VarianceAccumulationBuffer::ConvertVarianceToTemperatureAndFilter (
     using ablastr::fields::Direction;
     auto &warpx = WarpX::GetInstance();
 
+    const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
+
     for (int lev = 0; lev <= warpx.finestLevel(); ++lev) {
         auto const& periodicity = warpx.Geom(lev).periodicity();
 
@@ -96,7 +100,7 @@ VarianceAccumulationBuffer::ConvertVarianceToTemperatureAndFilter (
             // Synchronize Ghost cells after normalization.
             ablastr::utils::communication::FillBoundary(
                 *var_vf[lev][Direction{idir}],
-                WarpX::do_single_precision_comms,
+                do_single_precision_comms,
                 periodicity,
                 true);
 
@@ -111,7 +115,7 @@ VarianceAccumulationBuffer::ConvertVarianceToTemperatureAndFilter (
                 // Re-synchronize MF after filtering
                 ablastr::utils::communication::FillBoundary(
                     *var_vf[lev][Direction{idir}],
-                    WarpX::do_single_precision_comms,
+                    do_single_precision_comms,
                     periodicity,
                     true);
             }

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -12,6 +12,7 @@
 #include "MultiParticleContainer.H"
 
 #include "Fields.H"
+#include "Parallelization/Parallelization.H"
 #include "Particles/ElementaryProcess/Ionization.H"
 #ifdef WARPX_QED
 #   include "Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H"
@@ -81,6 +82,7 @@
 #include <vector>
 
 using namespace amrex;
+using namespace warpx;
 using warpx::fields::FieldType;
 
 namespace
@@ -696,9 +698,10 @@ MultiParticleContainer::GetChargeDensity (int lev, bool local)
         const Geometry& gm = allcontainers[0]->Geom(lev);
         // Possible performance optimization:
         // pass less than `rho->nGrowVect()` in the fifth input variable `dst_ng`
+        const auto do_single_precision_comms = parallelization::comms_in_single_precision_flag();
         ablastr::utils::communication::SumBoundary(
             *rho, 0, rho->nComp(), rho->nGrowVect(), rho->nGrowVect(),
-            WarpX::do_single_precision_comms, gm.periodicity());
+            do_single_precision_comms, gm.periodicity());
     }
 
     return rho;

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -83,13 +83,13 @@ using namespace warpx;
 
 WarpXParIter::WarpXParIter (ContainerType& pc, int level)
     : amrex::ParIterSoA<PIdx::nattribs, 0>(pc, level,
-             MFItInfo().SetDynamic(parallelization::do_dynamic_scheduling))
+             MFItInfo().SetDynamic(parallelization::do_dynamic_scheduling_flag()))
 {
 }
 
 WarpXParIter::WarpXParIter (ContainerType& pc, int level, MFItInfo& info)
     : amrex::ParIterSoA<PIdx::nattribs, 0>(pc, level,
-                   info.SetDynamic(parallelization::do_dynamic_scheduling))
+                   info.SetDynamic(parallelization::do_dynamic_scheduling_flag()))
 {
 }
 

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -20,6 +20,7 @@
 #include "Fields.H"
 #include "Pusher/GetAndSetPosition.H"
 #include "Pusher/UpdatePosition.H"
+#include "Parallelization/Parallelization.H"
 #include "ParticleBoundaries_K.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
@@ -78,16 +79,17 @@
 #include <cmath>
 
 using namespace amrex;
+using namespace warpx;
 
 WarpXParIter::WarpXParIter (ContainerType& pc, int level)
     : amrex::ParIterSoA<PIdx::nattribs, 0>(pc, level,
-             MFItInfo().SetDynamic(WarpX::do_dynamic_scheduling))
+             MFItInfo().SetDynamic(parallelization::do_dynamic_scheduling))
 {
 }
 
 WarpXParIter::WarpXParIter (ContainerType& pc, int level, MFItInfo& info)
     : amrex::ParIterSoA<PIdx::nattribs, 0>(pc, level,
-                   info.SetDynamic(WarpX::do_dynamic_scheduling))
+                   info.SetDynamic(parallelization::do_dynamic_scheduling))
 {
 }
 
@@ -1713,7 +1715,7 @@ WarpXParticleContainer::DepositCharge (const ablastr::fields::MultiLevelScalarFi
                                                        rho[lev]->nComp(),
                                                        amrex::IntVect::TheZeroVector(),
                                                        amrex::IntVect::TheZeroVector(),
-                                                       WarpX::do_single_precision_comms,
+                                                       parallelization::comms_in_single_precision_flag(),
                                                        m_gdb->Geom(lev).periodicity());
         }
     }
@@ -1773,7 +1775,7 @@ WarpXParticleContainer::DepositCharge (amrex::MultiFab* rho,
         // pass less than `rho->nGrowVect()` in the fifth input variable `dst_ng`
         ablastr::utils::communication::SumBoundary(
             *rho, 0, rho->nComp(), rho->nGrowVect(), rho->nGrowVect(),
-            WarpX::do_single_precision_comms,
+            parallelization::comms_in_single_precision_flag(),
             m_gdb->Geom(lev).periodicity()
         );
     }

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -83,13 +83,13 @@ using namespace warpx;
 
 WarpXParIter::WarpXParIter (ContainerType& pc, int level)
     : amrex::ParIterSoA<PIdx::nattribs, 0>(pc, level,
-             MFItInfo().SetDynamic(parallelization::do_dynamic_scheduling_flag()))
+             MFItInfo().SetDynamic(parallelization::dynamic_scheduling_flag()))
 {
 }
 
 WarpXParIter::WarpXParIter (ContainerType& pc, int level, MFItInfo& info)
     : amrex::ParIterSoA<PIdx::nattribs, 0>(pc, level,
-                   info.SetDynamic(parallelization::do_dynamic_scheduling_flag()))
+                   info.SetDynamic(parallelization::dynamic_scheduling_flag()))
 {
 }
 

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -13,6 +13,7 @@
 #   include "BoundaryConditions/PML_RZ.H"
 #endif
 #include "Initialization/ExternalField.H"
+#include "Parallelization/Parallelization.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Fields.H"
 #include "Fluids/MultiFluidContainer.H"
@@ -56,6 +57,7 @@
 #include <string>
 
 using namespace amrex;
+using namespace warpx;
 
 namespace
 {
@@ -362,6 +364,8 @@ WarpX::MoveWindow (const int step, bool move_j)
     using warpx::fields::FieldType;
 
     bool const skip_lev0_coarse_patch = true;
+
+    const bool do_single_precision_comms = parallelization::comms_in_single_precision_flag();
 
     if (step == start_moving_window_step) {
         amrex::Print() << Utils::TextMsg::Info("Starting moving window");

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -230,9 +230,6 @@ public:
     //! (default is false for standard PSATD and true for Galilean PSATD)
     bool update_with_rho = false;
 
-    //! perform field communications in single precision
-    static bool do_single_precision_comms;
-
     //! used shared memory algorithm for charge deposition
     static bool do_shared_mem_charge_deposition;
 
@@ -320,7 +317,6 @@ public:
     //! If true, the code will compute max_step from the back transformed diagnostics
     static bool compute_max_step_from_btd;
 
-    static bool do_dynamic_scheduling;
     static bool refine_plasma;
 
     static utils::parser::IntervalsParser sort_intervals;
@@ -1359,9 +1355,6 @@ private:
 
     bool m_is_synchronized = true;
 
-    // Synchronization of nodal points
-    static constexpr bool sync_nodal_points = true;
-
     guardCellManager guard_cells;
 
     // Slice Parameters
@@ -1374,8 +1367,6 @@ private:
     int nox_fft = 16;
     int noy_fft = 16;
     int noz_fft = 16;
-
-
 
     //! If true, particles will be sorted in the order x -> y -> z -> ppc for faster deposition
 #if defined(AMREX_USE_CUDA)

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -121,7 +121,6 @@ Real WarpX::zmin_domain_boost_step_0 = 0._rt;
 
 bool WarpX::do_dive_cleaning = false;
 bool WarpX::do_divb_cleaning = false;
-bool WarpX::do_single_precision_comms = false;
 
 bool WarpX::do_shared_mem_charge_deposition = false;
 bool WarpX::do_shared_mem_current_deposition = false;
@@ -162,8 +161,6 @@ bool WarpX::refine_plasma     = false;
 
 utils::parser::IntervalsParser WarpX::sort_intervals;
 amrex::IntVect WarpX::sort_bin_size(AMREX_D_DECL(1,1,1));
-
-bool WarpX::do_dynamic_scheduling = true;
 
 IntVect WarpX::filter_npass_each_dir(1);
 
@@ -868,16 +865,6 @@ WarpX::ReadParameters ()
                 pp_warpx, "mirror_z_npoints", m_mirror_z_npoints, 0, m_num_mirrors);
         }
 
-        pp_warpx.query("do_single_precision_comms", do_single_precision_comms);
-#ifdef AMREX_USE_FLOAT
-        if (do_single_precision_comms) {
-            do_single_precision_comms = false;
-            ablastr::warn_manager::WMRecordWarning(
-                "comms",
-                "Overwrote warpx.do_single_precision_comms to be 0, since WarpX was built in single precision.",
-                ablastr::warn_manager::WarnPriority::low);
-        }
-#endif
         pp_warpx.query("do_shared_mem_charge_deposition", do_shared_mem_charge_deposition);
         pp_warpx.query("do_shared_mem_current_deposition", do_shared_mem_current_deposition);
 #if !(defined(AMREX_USE_HIP) || defined(AMREX_USE_CUDA)) || \
@@ -1068,8 +1055,6 @@ WarpX::ReadParameters ()
                     utils::parser::makeParser(ref_patch_function,{"x","y","z"}));
             }
         }
-
-        pp_warpx.query("do_dynamic_scheduling", do_dynamic_scheduling);
 
         // Integer that corresponds to the type of grid used in the simulation
         // (collocated, staggered, hybrid)


### PR DESCRIPTION
This PR removes the static variables `do_single_precision_comms`, `do_dynamic_scheduling`, and `sync_nodal_points` from the Warpx class. These parameters are now read whenever needed from the inputfile, using `ParmParse` (with the exception of `sync_nodal_points`, which is hard-coded as equal to `true`). The functions responsible for reading these parameters are implemented in the new source files `Parallelization/Parallelization.H/[.cpp]` , in the new `warpx::parallelization` namespace. 

The goals of this PR are:
- progressively eliminating static variables from the WarpX class
- start using the inputfile as a unique source of truth for some numerical parameters
- reduce the need to include the heavy `WarpX.H` header 
- simplify the WarpX class