### PR TITLE
Python Control of OMP Threads

### DIFF
--- a/Source/Python/WarpX.cpp
+++ b/Source/Python/WarpX.cpp
@@ -55,6 +55,41 @@ namespace warpx {
     struct Config {};
 }
 
+namespace detail
+{
+    /** Helper Function for Property Getters
+     *
+     * This queries an amrex::ParmParse entry. This throws a
+     * std::runtime_error if the entry is not found.
+     *
+     * This handles the most common throw exception logic in WarpX instead of
+     * going over library boundaries via amrex::Abort().
+     *
+     * @tparam T type of the amrex::ParmParse entry
+     * @param prefix the prefix, e.g., "warpx" or "amr"
+     * @param name the actual key of the entry, e.g., "particle_shape"
+     * @return the queried value (or throws if not found)
+     */
+    template< typename T>
+    auto get_or_throw (std::string const & prefix, std::string const & name)
+    {
+        using V = std::decay_t<T>;
+        V value;
+
+        bool has_name = false;
+        // TODO: if array do queryarr
+        // has_name = amrex::ParmParse(prefix).queryarr(name.c_str(), value);
+        if constexpr (std::is_same_v<V, bool> || std::is_same_v<V, std::string>)
+            has_name = amrex::ParmParse(prefix).query(name.c_str(), value);
+        else
+            has_name = amrex::ParmParse(prefix).queryWithParser(name.c_str(), value);
+
+        if (!has_name)
+            throw std::runtime_error(prefix + "." + name + " is not set yet");
+        return value;
+    }
+}
+
 void init_WarpX (py::module& m)
 {
     using ablastr::fields::Direction;
@@ -88,6 +123,20 @@ void init_WarpX (py::module& m)
         )
         .def("evolve", &WarpX::Evolve,
             "Evolve the simulation the specified number of steps"
+        )
+
+        .def_property("omp_threads",
+            [](WarpX & /* wx */){
+                return detail::get_or_throw<std::string>("amrex", "omp_threads");
+            },
+            [](WarpX & /* wx */, std::variant<int, std::string> omp_threads_var) {
+                std::visit([&]( auto && omp_threads) {
+                    amrex::ParmParse pp_amrex("amrex");
+                pp_amrex.add("omp_threads", omp_threads);
+                }, omp_threads_var);
+            },
+            "Controls the number of OpenMP threads to use (WarpX default: \"nosmt\").\n"
+            "https://amrex-codes.github.io/amrex/docs_html/InputsComputeBackends.html."
         )
 
         // from amrex::AmrCore / amrex::AmrMesh

--- a/Source/Python/WarpX.cpp
+++ b/Source/Python/WarpX.cpp
@@ -80,13 +80,16 @@ namespace detail
         bool has_name = false;
         // TODO: if array do queryarr
         // has_name = amrex::ParmParse(prefix).queryarr(name.c_str(), value);
-        if constexpr (std::is_same_v<V, bool> || std::is_same_v<V, std::string>)
+        if constexpr (std::is_same_v<V, bool> || std::is_same_v<V, std::string>) {
             has_name = amrex::ParmParse(prefix).query(name.c_str(), value);
-        else
+        }
+        else {
             has_name = amrex::ParmParse(prefix).queryWithParser(name.c_str(), value);
+        }
 
-        if (!has_name)
+        if (!has_name) {
             throw std::runtime_error(prefix + "." + name + " is not set yet");
+        }
         return value;
     }
 }

--- a/Source/Python/WarpX.cpp
+++ b/Source/Python/WarpX.cpp
@@ -42,6 +42,7 @@
 #include <AMReX_ParmParse.H>
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_SIMD.H>
+#include <AMReX_OpenMP.H>
 
 #if defined(AMREX_DEBUG) || defined(DEBUG)
 #   include <cstdio>
@@ -132,7 +133,13 @@ void init_WarpX (py::module& m)
             [](WarpX & /* wx */, std::variant<int, std::string> omp_threads_var) {
                 std::visit([&]( auto && omp_threads) {
                     amrex::ParmParse pp_amrex("amrex");
-                pp_amrex.add("omp_threads", omp_threads);
+                    pp_amrex.add("omp_threads", omp_threads);
+
+                    // set the value if not "system" or "nosmt"
+                    if constexpr(std::is_same_v<std::decay_t<decltype(omp_threads)>, int>) {
+                        amrex::Print() << "Changing WarpX threads to N=" << omp_threads << "\n";
+                        amrex::OpenMP::set_num_threads(omp_threads);
+                    }
                 }, omp_threads_var);
             },
             "Controls the number of OpenMP threads to use (WarpX default: \"nosmt\").\n"


### PR DESCRIPTION
Sometimes one cannot set the env var `OMP_NUM_THREADS`, so Pythonic control is desired.

```py
# PICMI code ...

sim.initialize_inputs()
sim.initialize_warpx()
# or sim.initialize()
 
sim.extension.warpx.omp_threads = 2  # new!

# Advance simulation until last time step
sim.step(max_steps)
```

Same as in ImpactX (https://github.com/BLAST-ImpactX/impactx/pull/999), but hidden as usual in our sub-PICMI extension layer.