### PR TITLE
Replace WarpXUtilIO::WriteBinaryDataOnFile with a one-liner

### DIFF
--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -1395,7 +1395,7 @@ MultiParticleContainer::QuantumSyncGenerateTable ()
 
         m_shr_p_qs_engine->compute_lookup_tables(ctrl, qs_minimum_chi_part);
         const auto data = m_shr_p_qs_engine->export_lookup_tables_data();
-        std::ofstream{table_name}.write(data.data(), data.size());
+        std::ofstream{table_nam, std::ios::binary}.write(data.data(), data.size());
     }
 
     ParallelDescriptor::Barrier();
@@ -1479,7 +1479,7 @@ MultiParticleContainer::BreitWheelerGenerateTable ()
 
         m_shr_p_bw_engine->compute_lookup_tables(ctrl, bw_minimum_chi_part);
         const auto data = m_shr_p_bw_engine->export_lookup_tables_data();
-        std::ofstream{table_name}.write(data.data(), data.size());
+        std::ofstream{table_name, std::ios::binary}.write(data.data(), data.size());
     }
 
     ParallelDescriptor::Barrier();

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -74,6 +74,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <fstream>
 #include <limits>
 #include <map>
 #include <string>
@@ -1394,8 +1395,7 @@ MultiParticleContainer::QuantumSyncGenerateTable ()
 
         m_shr_p_qs_engine->compute_lookup_tables(ctrl, qs_minimum_chi_part);
         const auto data = m_shr_p_qs_engine->export_lookup_tables_data();
-        WarpXUtilIO::WriteBinaryDataOnFile(table_name,
-            Vector<char>{data.begin(), data.end()});
+        std::ofstream{table_name}.write(data.data(), data.size());
     }
 
     ParallelDescriptor::Barrier();
@@ -1479,8 +1479,7 @@ MultiParticleContainer::BreitWheelerGenerateTable ()
 
         m_shr_p_bw_engine->compute_lookup_tables(ctrl, bw_minimum_chi_part);
         const auto data = m_shr_p_bw_engine->export_lookup_tables_data();
-        WarpXUtilIO::WriteBinaryDataOnFile(table_name,
-            Vector<char>{data.begin(), data.end()});
+        std::ofstream{table_name}.write(data.data(), data.size());
     }
 
     ParallelDescriptor::Barrier();

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -1395,7 +1395,7 @@ MultiParticleContainer::QuantumSyncGenerateTable ()
 
         m_shr_p_qs_engine->compute_lookup_tables(ctrl, qs_minimum_chi_part);
         const auto data = m_shr_p_qs_engine->export_lookup_tables_data();
-        std::ofstream{table_nam, std::ios::binary}.write(data.data(), data.size());
+        std::ofstream{table_name, std::ios::binary}.write(data.data(), data.size());
     }
 
     ParallelDescriptor::Barrier();

--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -96,17 +96,6 @@ void NullifyMF (
     amrex::Real zmax
 );
 
-namespace WarpXUtilIO{
-/**
- * A helper function to write binary data on disk.
- * @param[in] filename where to write
- * @param[in] data Vector containing binary data to write on disk
- * return true if it succeeds, false otherwise
- */
-bool WriteBinaryDataOnFile(const std::string& filename, const amrex::Vector<char>& data);
-
-}
-
 namespace WarpXUtilLoadBalance
 {
     /** \brief We only want to update the cost data if the grids we are working on

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -280,16 +280,6 @@ void NullifyMF (
     NullifyMFinstance ( mf, lev, zmin, zmax);
 }
 
-namespace WarpXUtilIO{
-    bool WriteBinaryDataOnFile(const std::string& filename, const amrex::Vector<char>& data)
-    {
-        std::ofstream of{filename, std::ios::binary};
-        of.write(data.data(), data.size());
-        of.close();
-        return  of.good();
-    }
-}
-
 void CheckGriddingForRZSpectral ()
 {
 #ifdef WARPX_DIM_RZ


### PR DESCRIPTION
`WarpXUtilIO::WriteBinaryDataOnFile` is unnecessary, since it can be easily replaced with a one-liner. 