### PR TITLE
MusclHancockUtils.H : fix uninitialized variables

### DIFF
--- a/Source/Fluids/MusclHancockUtils.H
+++ b/Source/Fluids/MusclHancockUtils.H
@@ -505,7 +505,7 @@ const amrex::Array4<amrex::Real>& U_plus,int i,int j,int k,amrex::Real clight, i
 {
     using namespace amrex::literals;
     // dir -> x, y, z -> 0, 1, 2
-    const auto [ip, jp, kp] = plus_index_offsets(i, j, k, comp);
+    const auto [ip, jp, kp] = plus_index_offsets(i, j, k, dir);
 
     const amrex::Real V_L_minus = V_calc(U_minus,ip,jp,kp,dir,clight);
     const amrex::Real V_I_minus = V_calc(U_minus,i,j,k,dir,clight);

--- a/Source/Fluids/MusclHancockUtils.H
+++ b/Source/Fluids/MusclHancockUtils.H
@@ -12,6 +12,8 @@
 #include <AMReX_Gpu.H>
 #include <AMReX_REAL.H>
 
+#include <tuple>
+
 
 // Euler push for momentum source (r-direction)
 // Note: assumes U normalized by c
@@ -163,9 +165,12 @@ amrex::Real ave_stage2 (amrex::Real dQ, amrex::Real a, amrex::Real b, amrex::Rea
 }
 // Returns the offset indices for the "plus" grid
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void plus_index_offsets (int i, int j, int k, int& ip, int& jp, int& kp, int comp)
+std::tuple<int,int,int> plus_index_offsets (int i, int j, int k, int comp)
 {
-    using namespace amrex::literals;
+    int ip = 0;
+    int jp = 0;
+    int kp = 0;
+
     // Find the correct offsets
 #if defined(WARPX_DIM_3D)
     if (comp == 0) { //x
@@ -190,7 +195,10 @@ void plus_index_offsets (int i, int j, int k, int& ip, int& jp, int& kp, int com
         ip =  i - 1; jp =  j; kp = k;
     }
 #endif
+
+    return {ip, jp, kp};
 }
+
 // Compute the zero edges
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void compute_U_edges (const amrex::Array4<amrex::Real>& Um, const amrex::Array4<amrex::Real>& Up, int i, int j, int k, amrex::Box box,
@@ -199,8 +207,7 @@ amrex::Real dU0x, amrex::Real dU1x, amrex::Real dU2x, amrex::Real dU3x, int comp
 {
     using namespace amrex::literals;
     // comp -> x, y, z -> 0, 1, 2
-    int ip, jp, kp;
-    plus_index_offsets(i, j, k, ip, jp, kp, comp);
+    const auto [ip, jp, kp] = plus_index_offsets(i, j, k, comp);
 
     if ( box.contains(i,j,k) ) {
         Um(i,j,k,0) = U_tilde0 + dU0x/2.0_rt;
@@ -223,8 +230,7 @@ const amrex::Array4<amrex::Real>& Up, int i, int j, int k, amrex::Box box, int c
 {
     using namespace amrex::literals;
     // comp -> x, y, z -> 0, 1, 2
-    int ip, jp, kp;
-    plus_index_offsets(i, j, k, ip, jp, kp, comp);
+    const auto [ip, jp, kp] = plus_index_offsets(i, j, k, comp);
 
     if ( box.contains(i,j,k) ) {
         Um(i,j,k,0) = 0.0_rt;
@@ -251,8 +257,7 @@ int comp)
 
     using namespace amrex::literals;
     // comp -> x, y, z -> 0, 1, 2
-    int ip, jp, kp;
-    plus_index_offsets(i, j, k, ip, jp, kp, comp);
+    const auto [ip, jp, kp] = plus_index_offsets(i, j, k, comp);
 
     // Set the edges to zero. If one edge in a cell is zero, we must self-consistently
     // set the slope to zero (hence why we have the three cases, the first is when
@@ -500,8 +505,7 @@ const amrex::Array4<amrex::Real>& U_plus,int i,int j,int k,amrex::Real clight, i
 {
     using namespace amrex::literals;
     // dir -> x, y, z -> 0, 1, 2
-    int ip, jp, kp;
-    plus_index_offsets(i, j, k, ip, jp, kp, dir);
+    const auto [ip, jp, kp] = plus_index_offsets(i, j, k, comp);
 
     const amrex::Real V_L_minus = V_calc(U_minus,ip,jp,kp,dir,clight);
     const amrex::Real V_I_minus = V_calc(U_minus,i,j,k,dir,clight);


### PR DESCRIPTION
This PR fixes the following compiler warning, by setting the initial values to zero.

```
In file included from /home/lfedeli/Projects/warpx/WarpX/build/_deps/fetchedamrex-src/Src/Base/AMReX_BaseFab.H:9,
                 from /home/lfedeli/Projects/warpx/WarpX/build/_deps/fetchedamrex-src/Src/Base/AMReX_MultiFab.H:7,
                 from /home/lfedeli/Projects/warpx/WarpX/Source/ablastr/fields/MultiFabRegister.H:15,
                 from /home/lfedeli/Projects/warpx/WarpX/Source/Fields.H:11,
                 from /home/lfedeli/Projects/warpx/WarpX/Source/Fluids/WarpXFluidContainer.cpp:7:
In member function ‘bool amrex::BoxND<dim>::contains(const amrex::IntVectND<dim>&) const [with int dim = 1]’,
    inlined from ‘bool amrex::BoxND<dim>::contains(const amrex::Dim3&) const [with int N = 1; typename std::enable_if<((1 <= N) && (N <= 3)), int>::type <anonymous> = 0; int dim = 1]’ at /home/lfedeli/Projects/warpx/WarpX/build/_deps/fetchedamrex-src/Src/Base/AMReX_Box.H:216:24,
    inlined from ‘bool amrex::BoxND<dim>::contains(int, int, int) const [with int N = 1; typename std::enable_if<((1 <= N) && (N <= 3)), int>::type <anonymous> = 0; int dim = 1]’ at /home/lfedeli/Projects/warpx/WarpX/build/_deps/fetchedamrex-src/Src/Base/AMReX_Box.H:224:24,
    inlined from ‘void set_U_edges_to_zero(const amrex::Array4<double>&, const amrex::Array4<double>&, int, int, int, amrex::Box, int)’ at /home/lfedeli/Projects/warpx/WarpX/Source/Fluids/MusclHancockUtils.H:236:22,
    inlined from ‘WarpXFluidContainer::AdvectivePush_Muscl(ablastr::fields::MultiFabRegister&, int)::<lambda(int, int, int)>’ at /home/lfedeli/Projects/warpx/WarpX/Source/Fluids/WarpXFluidContainer.cpp:787:40,
    inlined from ‘decltype (f(0, 0, 0, amrex::detail::call_f_intvect_inner::args ...)) amrex::detail::call_f_intvect_inner(std::index_sequence<Is ...>, const F&, amrex::IntVectND<1>, Args ...) [with F = WarpXFluidContainer::AdvectivePush_Muscl(ablastr::fields::MultiFabRegister&, int)::<lambda(int, int, int)>; long unsigned int ...Ns = {0}; Args = {}]’ at /home/lfedeli/Projects/warpx/WarpX/build/_deps/fetchedamrex-src/Src/Base/AMReX_GpuLaunchFunctsC.H:52:10,
    inlined from ‘decltype (amrex::detail::call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv)) amrex::detail::call_f_intvect_handler(const F&, amrex::IntVectND<old_dim>) [with F = WarpXFluidContainer::AdvectivePush_Muscl(ablastr::fields::MultiFabRegister&, int)::<lambda(int, int, int)>; int dim = 1]’ at /home/lfedeli/Projects/warpx/WarpX/build/_deps/fetchedamrex-src/Src/Base/AMReX_GpuLaunchFunctsC.H:96:29,
    inlined from ‘void amrex::detail::ParallelFor_impND(const L&, amrex::IntVectND<dim>, amrex::IntVectND<dim>, amrex::IntVectND<dim>) [with int idim = 1; L = WarpXFluidContainer::AdvectivePush_Muscl(ablastr::fields::MultiFabRegister&, int)::<lambda(int, int, int)>; int dim = 1]’ at /home/lfedeli/Projects/warpx/WarpX/build/_deps/fetchedamrex-src/Src/Base/AMReX_GpuLaunchFunctsC.H:303:35,
    inlined from ‘void amrex::ParallelFor(const BoxND<old_dim>&, const L&) [with L = WarpXFluidContainer::AdvectivePush_Muscl(ablastr::fields::MultiFabRegister&, int)::<lambda(int, int, int)>; int dim = 1]’ at /home/lfedeli/Projects/warpx/WarpX/build/_deps/fetchedamrex-src/Src/Base/AMReX_GpuLaunchFunctsC.H:334:35,
    inlined from ‘_ZN19WarpXFluidContainer19AdvectivePush_MusclERN7ablastr6fields16MultiFabRegisterEi._omp_fn.0’ at /home/lfedeli/Projects/warpx/WarpX/Source/Fluids/WarpXFluidContainer.cpp:550:27:
/home/lfedeli/Projects/warpx/WarpX/build/_deps/fetchedamrex-src/Src/Base/AMReX_Box.H:208:34: warning: ‘ip’ may be used uninitialized [-Wmaybe-uninitialized]
  208 |         return p.allGE(smallend) && p.allLE(bigend);
      |                ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
In file included from /home/lfedeli/Projects/warpx/WarpX/Source/Fluids/WarpXFluidContainer.cpp:11:
/home/lfedeli/Projects/warpx/WarpX/Source/Fluids/MusclHancockUtils.H: In function ‘_ZN19WarpXFluidContainer19AdvectivePush_MusclERN7ablastr6fields16MultiFabRegisterEi._omp_fn.0’:
/home/lfedeli/Projects/warpx/WarpX/Source/Fluids/MusclHancockUtils.H:226:9: note: ‘ip’ was declared here
  226 |     int ip, jp, kp;
      |         ^~
In file included from /home/lfedeli/Projects/warpx/WarpX/build/_deps/fetchedamrex-src/Src/Base/AMReX_Box.H:15:
In member function ‘U& amrex::Array4<T>::operator()(int, int, int, int) const [with U = double; typename std::enable_if<(! is_void_v<U>), int>::type <anonymous> = 0; T = double]’,
    inlined from ‘void set_U_edges_to_zero(const amrex::Array4<double>&, const amrex::Array4<double>&, int, int, int, amrex::Box, int)’ at /home/lfedeli/Projects/warpx/WarpX/Source/Fluids/MusclHancockUtils.H:237:11,
    inlined from ‘WarpXFluidContainer::AdvectivePush_Muscl(ablastr::fields::MultiFabRegister&, int)::<lambda(int, int, int)>’ at /home/lfedeli/Projects/warpx/WarpX/Source/Fluids/WarpXFluidContainer.cpp:787:40,
    inlined from ‘decltype (f(0, 0, 0, amrex::detail::call_f_intvect_inner::args ...)) amrex::detail::call_f_intvect_inner(std::index_sequence<Is ...>, const F&, amrex::IntVectND<1>, Args ...) [with F = WarpXFluidContainer::AdvectivePush_Muscl(ablastr::fields::MultiFabRegister&, int)::<lambda(int, int, int)>; long unsigned int ...Ns = {0}; Args = {}]’ at /home/lfedeli/Projects/warpx/WarpX/build/_deps/fetchedamrex-src/Src/Base/AMReX_GpuLaunchFunctsC.H:52:10,
    inlined from ‘decltype (amrex::detail::call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv)) amrex::detail::call_f_intvect_handler(const F&, amrex::IntVectND<old_dim>) [with F = WarpXFluidContainer::AdvectivePush_Muscl(ablastr::fields::MultiFabRegister&, int)::<lambda(int, int, int)>; int dim = 1]’ at /home/lfedeli/Projects/warpx/WarpX/build/_deps/fetchedamrex-src/Src/Base/AMReX_GpuLaunchFunctsC.H:96:29,
    inlined from ‘void amrex::detail::ParallelFor_impND(const L&, amrex::IntVectND<dim>, amrex::IntVectND<dim>, amrex::IntVectND<dim>) [with int idim = 1; L = WarpXFluidContainer::AdvectivePush_Muscl(ablastr::fields::MultiFabRegister&, int)::<lambda(int, int, int)>; int dim = 1]’ at /home/lfedeli/Projects/warpx/WarpX/build/_deps/fetchedamrex-src/Src/Base/AMReX_GpuLaunchFunctsC.H:303:35,
    inlined from ‘void amrex::ParallelFor(const BoxND<old_dim>&, const L&) [with L = WarpXFluidContainer::AdvectivePush_Muscl(ablastr::fields::MultiFabRegister&, int)::<lambda(int, int, int)>; int dim = 1]’ at /home/lfedeli/Projects/warpx/WarpX/build/_deps/fetchedamrex-src/Src/Base/AMReX_GpuLaunchFunctsC.H:334:35,
    inlined from ‘_ZN19WarpXFluidContainer19AdvectivePush_MusclERN7ablastr6fields16MultiFabRegisterEi._omp_fn.0’ at /home/lfedeli/Projects/warpx/WarpX/Source/Fluids/WarpXFluidContainer.cpp:550:27:
/home/lfedeli/Projects/warpx/WarpX/build/_deps/fetchedamrex-src/Src/Base/AMReX_Array4.H:144:36: warning: ‘jp’ may be used uninitialized [-Wmaybe-uninitialized]
  144 |             return p[(i-begin.x)+(j-begin.y)*jstride+(k-begin.z)*kstride+n*nstride];
      |                                  ~~^~~~~~~~~
/home/lfedeli/Projects/warpx/WarpX/Source/Fluids/MusclHancockUtils.H: In function ‘_ZN19WarpXFluidContainer19AdvectivePush_MusclERN7ablastr6fields16MultiFabRegisterEi._omp_fn.0’:
/home/lfedeli/Projects/warpx/WarpX/Source/Fluids/MusclHancockUtils.H:226:13: note: ‘jp’ was declared here
  226 |     int ip, jp, kp;
      |             ^~
In member function ‘U& amrex::Array4<T>::operator()(int, int, int, int) const [with U = double; typename std::enable_if<(! is_void_v<U>), int>::type <anonymous> = 0; T = double]’,
    inlined from ‘void set_U_edges_to_zero(const amrex::Array4<double>&, const amrex::Array4<double>&, int, int, int, amrex::Box, int)’ at /home/lfedeli/Projects/warpx/WarpX/Source/Fluids/MusclHancockUtils.H:237:11,
    inlined from ‘WarpXFluidContainer::AdvectivePush_Muscl(ablastr::fields::MultiFabRegister&, int)::<lambda(int, int, int)>’ at /home/lfedeli/Projects/warpx/WarpX/Source/Fluids/WarpXFluidContainer.cpp:787:40,
    inlined from ‘decltype (f(0, 0, 0, amrex::detail::call_f_intvect_inner::args ...)) amrex::detail::call_f_intvect_inner(std::index_sequence<Is ...>, const F&, amrex::IntVectND<1>, Args ...) [with F = WarpXFluidContainer::AdvectivePush_Muscl(ablastr::fields::MultiFabRegister&, int)::<lambda(int, int, int)>; long unsigned int ...Ns = {0}; Args = {}]’ at /home/lfedeli/Projects/warpx/WarpX/build/_deps/fetchedamrex-src/Src/Base/AMReX_GpuLaunchFunctsC.H:52:10,
    inlined from ‘decltype (amrex::detail::call_f_intvect_inner(std::make_index_sequence<dim>(), f, iv)) amrex::detail::call_f_intvect_handler(const F&, amrex::IntVectND<old_dim>) [with F = WarpXFluidContainer::AdvectivePush_Muscl(ablastr::fields::MultiFabRegister&, int)::<lambda(int, int, int)>; int dim = 1]’ at /home/lfedeli/Projects/warpx/WarpX/build/_deps/fetchedamrex-src/Src/Base/AMReX_GpuLaunchFunctsC.H:96:29,
    inlined from ‘void amrex::detail::ParallelFor_impND(const L&, amrex::IntVectND<dim>, amrex::IntVectND<dim>, amrex::IntVectND<dim>) [with int idim = 1; L = WarpXFluidContainer::AdvectivePush_Muscl(ablastr::fields::MultiFabRegister&, int)::<lambda(int, int, int)>; int dim = 1]’ at /home/lfedeli/Projects/warpx/WarpX/build/_deps/fetchedamrex-src/Src/Base/AMReX_GpuLaunchFunctsC.H:303:35,
    inlined from ‘void amrex::ParallelFor(const BoxND<old_dim>&, const L&) [with L = WarpXFluidContainer::AdvectivePush_Muscl(ablastr::fields::MultiFabRegister&, int)::<lambda(int, int, int)>; int dim = 1]’ at /home/lfedeli/Projects/warpx/WarpX/build/_deps/fetchedamrex-src/Src/Base/AMReX_GpuLaunchFunctsC.H:334:35,
    inlined from ‘_ZN19WarpXFluidContainer19AdvectivePush_MusclERN7ablastr6fields16MultiFabRegisterEi._omp_fn.0’ at /home/lfedeli/Projects/warpx/WarpX/Source/Fluids/WarpXFluidContainer.cpp:550:27:
/home/lfedeli/Projects/warpx/WarpX/build/_deps/fetchedamrex-src/Src/Base/AMReX_Array4.H:144:56: warning: ‘kp’ may be used uninitialized [-Wmaybe-uninitialized]
  144 |             return p[(i-begin.x)+(j-begin.y)*jstride+(k-begin.z)*kstride+n*nstride];
      |                                                      ~~^~~~~~~~~
/home/lfedeli/Projects/warpx/WarpX/Source/Fluids/MusclHancockUtils.H: In function ‘_ZN19WarpXFluidContainer19AdvectivePush_MusclERN7ablastr6fields16MultiFabRegisterEi._omp_fn.0’:
/home/lfedeli/Projects/warpx/WarpX/Source/Fluids/MusclHancockUtils.H:226:17: note: ‘kp’ was declared here
  226 |     int ip, jp, kp;
      |                 ^~

```