### PR TITLE
WarpXParticleContainer class: remove unused PairIndex

### DIFF
--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -674,7 +674,6 @@ protected:
     amrex::Vector<amrex::FArrayBox> local_Szz;
 
 public:
-    using PairIndex = std::pair<int, int>;
 
     int getIonizationInitialLevel () const noexcept {return ionization_initial_level;}
 


### PR DESCRIPTION
`PairIndex` seems to be unused. So this PR removes it.