### PR TITLE
WarpXParticleContainer_fwd.H: remove unused struct TmpIdx

### DIFF
--- a/Source/Particles/WarpXParticleContainer_fwd.H
+++ b/Source/Particles/WarpXParticleContainer_fwd.H
@@ -16,7 +16,6 @@ enum struct ConvertDirection;
 
 struct PIdx;
 struct DiagIdx;
-struct TmpIdx;
 
 class WarpXParIter;
 
@@ -27,15 +26,6 @@ struct DiagIdx
     enum {
         w = 0,
         x, y, z, ux, uy, uz,
-        nattribs
-    };
-};
-
-struct TmpIdx
-{
-    enum {
-        xold = 0,
-        yold, zold, uxold, uyold, uzold,
         nattribs
     };
 };


### PR DESCRIPTION
This PR removes an unused struct.