### PR TITLE
WarpXParticleContainer : move DiagIdx from forward header to header

### DIFF
--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -112,6 +112,15 @@ struct IntIdx {
     static constexpr std::initializer_list<char const *> names = {};
 };
 
+struct DiagIdx
+{
+    enum {
+        w = 0,
+        x, y, z, ux, uy, uz,
+        nattribs
+    };
+};
+
 class WarpXParIter
     : public amrex::ParIterSoA<PIdx::nattribs, 0>
 {

--- a/Source/Particles/WarpXParticleContainer_fwd.H
+++ b/Source/Particles/WarpXParticleContainer_fwd.H
@@ -22,15 +22,6 @@ class WarpXParIter;
 
 class WarpXParticleContainer;
 
-struct DiagIdx
-{
-    enum {
-        w = 0,
-        x, y, z, ux, uy, uz,
-        nattribs
-    };
-};
-
 struct TmpIdx
 {
     enum {


### PR DESCRIPTION
I think that structure definitions should be in the header file, not in the forward header file.