### PR TITLE
WarpXParticleContainer_fwd.H: remove #include<AMReX_GpuAllocators.H>

### DIFF
--- a/Source/Particles/WarpXParticleContainer_fwd.H
+++ b/Source/Particles/WarpXParticleContainer_fwd.H
@@ -8,9 +8,6 @@
 #ifndef WARPX_WarpXParticleContainer_fwd_H_
 #define WARPX_WarpXParticleContainer_fwd_H_
 
-#include <AMReX_GpuAllocators.H>
-
-
 enum struct ParticleBC;
 enum struct ConvertDirection;
 


### PR DESCRIPTION
This include directive is not necessary here. So this PR removes it.