### PR TITLE
PML: move some static functions MakeBoxArray,  MakeBoxArray_single, and MakeBoxArray_multiple to anonymous namespace in PML.cpp

### DIFF
--- a/Source/BoundaryConditions/PML.H
+++ b/Source/BoundaryConditions/PML.H
@@ -227,28 +227,6 @@ private:
     }
 #endif
 
-    static amrex::BoxArray MakeBoxArray (bool single_box_domain,
-                                         const amrex::Box& regular_domain,
-                                         const amrex::Geometry& geom,
-                                         const amrex::BoxArray& grid_ba,
-                                         const amrex::IntVect& ncell,
-                                         int do_pml_in_domain,
-                                         const amrex::IntVect& do_pml_Lo,
-                                         const amrex::IntVect& do_pml_Hi);
-
-    static amrex::BoxArray MakeBoxArray_single (const amrex::Box& regular_domain,
-                                                const amrex::BoxArray& grid_ba,
-                                                const amrex::IntVect& ncell,
-                                                const amrex::IntVect& do_pml_Lo,
-                                                const amrex::IntVect& do_pml_Hi);
-
-    static amrex::BoxArray MakeBoxArray_multiple (const amrex::Geometry& geom,
-                                                  const amrex::BoxArray& grid_ba,
-                                                  const amrex::IntVect& ncell,
-                                                  int do_pml_in_domain,
-                                                  const amrex::IntVect& do_pml_Lo,
-                                                  const amrex::IntVect& do_pml_Hi);
-
     static void CopyToPML (amrex::MultiFab& pml, amrex::MultiFab& reg, const amrex::Geometry& geom);
 };
 

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -145,6 +145,144 @@ namespace
         });
     }
 #endif
+
+
+    BoxArray
+    MakeBoxArray_single (
+        const amrex::Box& regular_domain, const amrex::BoxArray& grid_ba,
+        const amrex::IntVect& ncell, const amrex::IntVect& do_pml_Lo,
+        const amrex::IntVect& do_pml_Hi)
+    {
+        BoxList bl;
+        const auto grid_ba_size = static_cast<int>(grid_ba.size());
+        for (int i = 0; i < grid_ba_size; ++i) {
+            Box const& b = grid_ba[i];
+            for (OrientationIter oit; oit.isValid(); ++oit) {
+                // In 3d, a Box has 6 faces.  This iterates over the 6 faces.
+                // 3 of them are on the lower side and the others are on the
+                // higher side.
+                const Orientation ori = oit();
+                const int idim = ori.coordDir(); // either 0 or 1 or 2 (i.e., x, y, z-direction)
+                bool pml_bndry = false;
+                if (ori.isLow() && do_pml_Lo[idim]) {  // This is one of the lower side faces.
+                    pml_bndry = b.smallEnd(idim) == regular_domain.smallEnd(idim);
+                } else if (ori.isHigh() && do_pml_Hi[idim]) { // This is one of the higher side faces.
+                    pml_bndry = b.bigEnd(idim) == regular_domain.bigEnd(idim);
+                }
+                if (pml_bndry) {
+                    Box bbox = amrex::adjCell(b, ori, ncell[idim]);
+                    for (int jdim = 0; jdim < idim; ++jdim) {
+                        if (do_pml_Lo[jdim] &&
+                            bbox.smallEnd(jdim) == regular_domain.smallEnd(jdim)) {
+                            bbox.growLo(jdim, ncell[jdim]);
+                        }
+                        if (do_pml_Hi[jdim] &&
+                            bbox.bigEnd(jdim) == regular_domain.bigEnd(jdim)) {
+                            bbox.growHi(jdim, ncell[jdim]);
+                        }
+                    }
+                    bl.push_back(bbox);
+                }
+            }
+        }
+
+        return BoxArray(std::move(bl));
+    }
+
+
+    BoxArray
+    MakeBoxArray_multiple (
+        const amrex::Geometry& geom, const amrex::BoxArray& grid_ba,
+        const amrex::IntVect& ncell, int do_pml_in_domain,
+        const amrex::IntVect& do_pml_Lo, const amrex::IntVect& do_pml_Hi)
+    {
+        Box domain = geom.Domain();
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            if (do_pml_Lo[idim]){
+                domain.growLo(idim, ncell[idim]);
+            }
+            if (do_pml_Hi[idim]){
+                domain.growHi(idim, ncell[idim]);
+            }
+        }
+        BoxList bl;
+        const auto grid_ba_size = static_cast<int>(grid_ba.size());
+        for (int i = 0; i < grid_ba_size; ++i)
+        {
+            const Box& grid_bx = grid_ba[i];
+            const IntVect& grid_bx_sz = grid_bx.size();
+
+            if (do_pml_in_domain == 0) {
+                // Make sure that, in the case of several distinct refinement patches,
+                //  the PML cells surrounding these patches cannot overlap
+                // The check is only needed along the axis where PMLs are being used.
+                for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                    if (do_pml_Lo[idim] || do_pml_Hi[idim]) {
+                        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                            grid_bx.length(idim) > ncell[idim],
+                            "Consider using larger amr.blocking_factor with PMLs");
+                    }
+                }
+            }
+
+            Box bx = grid_bx;
+            bx.grow(ncell);
+            bx &= domain;
+
+            Vector<Box> bndryboxes;
+    #if defined(WARPX_DIM_3D)
+            const int kbegin = -1, kend = 1;
+    #else
+            const int kbegin =  0, kend = 0;
+    #endif
+            for (int kk = kbegin; kk <= kend; ++kk) {
+                for (int jj = -1; jj <= 1; ++jj) {
+                    for (int ii = -1; ii <= 1; ++ii) {
+                        if (ii != 0 || jj != 0 || kk != 0) {
+                            Box b = grid_bx;
+                            b.shift(grid_bx_sz * IntVect{AMREX_D_DECL(ii,jj,kk)});
+                            b &= bx;
+                            if (b.ok()) {
+                                bndryboxes.push_back(b);
+                            }
+                        }
+                    }
+                }
+            }
+
+            const BoxList& noncovered = grid_ba.complementIn(bx);
+            for (const Box& b : noncovered) {
+                for (const auto& bb : bndryboxes) {
+                    const Box ib = b & bb;
+                    if (ib.ok()) {
+                        bl.push_back(ib);
+                    }
+                }
+            }
+        }
+
+        BoxArray ba(bl);
+        ba.removeOverlap(false);
+
+        return ba;
+    }
+
+
+    BoxArray
+    MakeBoxArray (bool is_single_box_domain, const amrex::Box& regular_domain,
+                    const amrex::Geometry& geom, const amrex::BoxArray& grid_ba,
+                    const amrex::IntVect& ncell, int do_pml_in_domain,
+                    const amrex::IntVect& do_pml_Lo, const amrex::IntVect& do_pml_Hi)
+    {
+        if (is_single_box_domain) {
+            return MakeBoxArray_single(regular_domain, grid_ba, ncell, do_pml_Lo, do_pml_Hi);
+        } else { // the union of the regular grids is *not* a single rectangular domain
+            return MakeBoxArray_multiple(geom, grid_ba, ncell, do_pml_in_domain, do_pml_Lo, do_pml_Hi);
+        }
+    }
+
+
+
 }
 
 
@@ -616,7 +754,7 @@ PML::PML (const int lev, const BoxArray& grid_ba,
     }
     Box const domain0 = grid_ba_reduced.minimalBox();
     const bool is_single_box_domain = domain0.numPts() == grid_ba_reduced.numPts();
-    const BoxArray& ba = MakeBoxArray(is_single_box_domain, domain0, *geom, grid_ba_reduced,
+    const BoxArray& ba = ::MakeBoxArray(is_single_box_domain, domain0, *geom, grid_ba_reduced,
                                       IntVect(ncell), do_pml_in_domain, do_pml_Lo, do_pml_Hi);
 
 
@@ -836,7 +974,7 @@ PML::PML (const int lev, const BoxArray& grid_ba,
         const IntVect cdelta = IntVect(delta)/ref_ratio;
 
         // Assuming that refinement ratio is equal in all dimensions
-        const BoxArray& cba = MakeBoxArray(is_single_box_domain, cdomain, *cgeom, grid_cba_reduced,
+        const BoxArray& cba = ::MakeBoxArray(is_single_box_domain, cdomain, *cgeom, grid_cba_reduced,
                                            cncells, do_pml_in_domain, do_pml_Lo, do_pml_Hi);
         DistributionMapping cdm;
         if (do_similar_dm_pml) {
@@ -911,136 +1049,6 @@ PML::PML (const int lev, const BoxArray& grid_ba,
 #endif
         }
     }
-}
-
-BoxArray
-PML::MakeBoxArray (bool is_single_box_domain, const amrex::Box& regular_domain,
-                   const amrex::Geometry& geom, const amrex::BoxArray& grid_ba,
-                   const amrex::IntVect& ncell, int do_pml_in_domain,
-                   const amrex::IntVect& do_pml_Lo, const amrex::IntVect& do_pml_Hi)
-{
-    if (is_single_box_domain) {
-        return MakeBoxArray_single(regular_domain, grid_ba, ncell, do_pml_Lo, do_pml_Hi);
-    } else { // the union of the regular grids is *not* a single rectangular domain
-        return MakeBoxArray_multiple(geom, grid_ba, ncell, do_pml_in_domain, do_pml_Lo, do_pml_Hi);
-    }
-}
-
-BoxArray
-PML::MakeBoxArray_single (const amrex::Box& regular_domain, const amrex::BoxArray& grid_ba,
-                          const amrex::IntVect& ncell, const amrex::IntVect& do_pml_Lo,
-                          const amrex::IntVect& do_pml_Hi)
-{
-    BoxList bl;
-    const auto grid_ba_size = static_cast<int>(grid_ba.size());
-    for (int i = 0; i < grid_ba_size; ++i) {
-        Box const& b = grid_ba[i];
-        for (OrientationIter oit; oit.isValid(); ++oit) {
-            // In 3d, a Box has 6 faces.  This iterates over the 6 faces.
-            // 3 of them are on the lower side and the others are on the
-            // higher side.
-            const Orientation ori = oit();
-            const int idim = ori.coordDir(); // either 0 or 1 or 2 (i.e., x, y, z-direction)
-            bool pml_bndry = false;
-            if (ori.isLow() && do_pml_Lo[idim]) {  // This is one of the lower side faces.
-                pml_bndry = b.smallEnd(idim) == regular_domain.smallEnd(idim);
-            } else if (ori.isHigh() && do_pml_Hi[idim]) { // This is one of the higher side faces.
-                pml_bndry = b.bigEnd(idim) == regular_domain.bigEnd(idim);
-            }
-            if (pml_bndry) {
-                Box bbox = amrex::adjCell(b, ori, ncell[idim]);
-                for (int jdim = 0; jdim < idim; ++jdim) {
-                    if (do_pml_Lo[jdim] &&
-                        bbox.smallEnd(jdim) == regular_domain.smallEnd(jdim)) {
-                        bbox.growLo(jdim, ncell[jdim]);
-                    }
-                    if (do_pml_Hi[jdim] &&
-                        bbox.bigEnd(jdim) == regular_domain.bigEnd(jdim)) {
-                        bbox.growHi(jdim, ncell[jdim]);
-                    }
-                }
-                bl.push_back(bbox);
-            }
-        }
-    }
-
-    return BoxArray(std::move(bl));
-}
-
-BoxArray
-PML::MakeBoxArray_multiple (const amrex::Geometry& geom, const amrex::BoxArray& grid_ba,
-                            const amrex::IntVect& ncell, int do_pml_in_domain,
-                            const amrex::IntVect& do_pml_Lo, const amrex::IntVect& do_pml_Hi)
-{
-    Box domain = geom.Domain();
-    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-        if (do_pml_Lo[idim]){
-            domain.growLo(idim, ncell[idim]);
-        }
-        if (do_pml_Hi[idim]){
-            domain.growHi(idim, ncell[idim]);
-        }
-    }
-    BoxList bl;
-    const auto grid_ba_size = static_cast<int>(grid_ba.size());
-    for (int i = 0; i < grid_ba_size; ++i)
-    {
-        const Box& grid_bx = grid_ba[i];
-        const IntVect& grid_bx_sz = grid_bx.size();
-
-        if (do_pml_in_domain == 0) {
-            // Make sure that, in the case of several distinct refinement patches,
-            //  the PML cells surrounding these patches cannot overlap
-            // The check is only needed along the axis where PMLs are being used.
-            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-                if (do_pml_Lo[idim] || do_pml_Hi[idim]) {
-                    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                        grid_bx.length(idim) > ncell[idim],
-                        "Consider using larger amr.blocking_factor with PMLs");
-                }
-            }
-        }
-
-        Box bx = grid_bx;
-        bx.grow(ncell);
-        bx &= domain;
-
-        Vector<Box> bndryboxes;
-#if defined(WARPX_DIM_3D)
-        const int kbegin = -1, kend = 1;
-#else
-        const int kbegin =  0, kend = 0;
-#endif
-        for (int kk = kbegin; kk <= kend; ++kk) {
-            for (int jj = -1; jj <= 1; ++jj) {
-                for (int ii = -1; ii <= 1; ++ii) {
-                    if (ii != 0 || jj != 0 || kk != 0) {
-                        Box b = grid_bx;
-                        b.shift(grid_bx_sz * IntVect{AMREX_D_DECL(ii,jj,kk)});
-                        b &= bx;
-                        if (b.ok()) {
-                            bndryboxes.push_back(b);
-                        }
-                    }
-                }
-            }
-        }
-
-        const BoxList& noncovered = grid_ba.complementIn(bx);
-        for (const Box& b : noncovered) {
-            for (const auto& bb : bndryboxes) {
-                const Box ib = b & bb;
-                if (ib.ok()) {
-                    bl.push_back(ib);
-                }
-            }
-        }
-    }
-
-    BoxArray ba(bl);
-    ba.removeOverlap(false);
-
-    return ba;
 }
 
 void


### PR DESCRIPTION
`MakeBoxArray`, `MakeBoxArray_single`, and `MakeBoxArray_multiple` are used only in `PML.cpp`, so this PR moves them there (inside an anonymous namespace) in order to simplify the interface of the PML class.