### PR TITLE
Rename skip_current variable for more clarity

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -402,7 +402,7 @@ void WarpX::OneStep (
                 // push particles (half position and full momentum)
                 PushParticlesandDeposit(
                     a_cur_time,
-                    /*skip_current=*/true,
+                    /*skip_deposition=*/true,
                     PositionPushType::FirstHalf,
                     MomentumPushType::Full
                 );
@@ -418,7 +418,7 @@ void WarpX::OneStep (
                 // push particles (half position)
                 PushParticlesandDeposit(
                     a_cur_time,
-                    /*skip_current=*/true,
+                    /*skip_deposition=*/true,
                     PositionPushType::SecondHalf,
                     MomentumPushType::None
                 );
@@ -433,7 +433,7 @@ void WarpX::OneStep (
                 // push particles (half position)
                 PushParticlesandDeposit(
                     a_cur_time,
-                    /*skip_current=*/true,
+                    /*skip_deposition=*/true,
                     PositionPushType::Full,
                     MomentumPushType::Full
                 );
@@ -1250,7 +1250,7 @@ WarpX::doQEDEvents ()
 void
 WarpX::PushParticlesandDeposit (
     amrex::Real cur_time,
-    bool skip_current,
+    bool skip_deposition,
     PositionPushType position_push_type,
     MomentumPushType momentum_push_type,
     ImplicitOptions const * implicit_options
@@ -1263,7 +1263,7 @@ WarpX::PushParticlesandDeposit (
             lev,
             cur_time,
             SubcyclingHalf::None,
-            skip_current,
+            skip_deposition,
             position_push_type,
             momentum_push_type,
             implicit_options
@@ -1276,7 +1276,7 @@ WarpX::PushParticlesandDeposit (
     int lev,
     amrex::Real cur_time,
     SubcyclingHalf subcycling_half,
-    bool skip_current,
+    bool skip_deposition,
     PositionPushType position_push_type,
     MomentumPushType momentum_push_type,
     ImplicitOptions const * implicit_options
@@ -1307,13 +1307,13 @@ WarpX::PushParticlesandDeposit (
         cur_time,
         dt[lev],
         subcycling_half,
-        skip_current,
+        skip_deposition,
         position_push_type,
         momentum_push_type,
         implicit_options
     );
 
-    if (! skip_current) {
+    if (!skip_deposition) {
 #if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
         // This is called after all particles have deposited their current and charge.
         ApplyInverseVolumeScalingToCurrentDensity(
@@ -1347,7 +1347,7 @@ WarpX::PushParticlesandDeposit (
                          lev,
                          current_fp_string,
                          cur_time,
-                         skip_current
+                         skip_deposition
             );
         }
     }

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -733,7 +733,7 @@ void ImplicitSolver::PreRHSOp ( const amrex::Real  a_cur_time,
     // particle velocities by dt, then take average of old and new v,
     // deposit currents, giving J at n+1/2
     // This uses Efield_fp and Bfield_fp, the field at n+1/2 from the previous iteration.
-    const bool skip_current = false;
+    const bool skip_deposition = false;
 
     // Set the implict solver options for particles and setting the current density
     ImplicitOptions options;
@@ -754,7 +754,7 @@ void ImplicitSolver::PreRHSOp ( const amrex::Real  a_cur_time,
 
     if (m_use_mass_matrices && !a_from_jacobian) { // Called from non-linear stage of JFNK and using mass matrices
         options.deposit_mass_matrices = true;
-        m_WarpX->PushParticlesandDeposit(a_cur_time, skip_current, PositionPushType::Full, MomentumPushType::Full, &options);
+        m_WarpX->PushParticlesandDeposit(a_cur_time, skip_deposition, PositionPushType::Full, MomentumPushType::Full, &options);
         CumulateJ();
         if (m_use_mass_matrices_jacobian) { SaveE(); }
         if (m_use_mass_matrices_pc) {
@@ -767,14 +767,14 @@ void ImplicitSolver::PreRHSOp ( const amrex::Real  a_cur_time,
         if (m_particle_suborbits) {
             options.deposit_mass_matrices = false;
             options.evolve_suborbit_particles_only = true;
-            m_WarpX->PushParticlesandDeposit(a_cur_time, skip_current, PositionPushType::Full, MomentumPushType::Full, &options);
+            m_WarpX->PushParticlesandDeposit(a_cur_time, skip_deposition, PositionPushType::Full, MomentumPushType::Full, &options);
         }
         const bool J_from_MM_only = !options.evolve_suborbit_particles_only;
         ComputeJfromMassMatrices( J_from_MM_only );
     }
     else { // Conventional particle-suppressed JFNK
         options.deposit_mass_matrices = false;
-        m_WarpX->PushParticlesandDeposit(a_cur_time, skip_current, PositionPushType::Full, MomentumPushType::Full, &options);
+        m_WarpX->PushParticlesandDeposit(a_cur_time, skip_deposition, PositionPushType::Full, MomentumPushType::Full, &options);
     }
 
     // Apply BCs to J and communicate

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -630,12 +630,12 @@ public:
     void doQEDEvents ();
 #endif
 
-    void PushParticlesandDeposit (int lev, amrex::Real cur_time, SubcyclingHalf subcycling_half=SubcyclingHalf::None, bool skip_current=false,
+    void PushParticlesandDeposit (int lev, amrex::Real cur_time, SubcyclingHalf subcycling_half=SubcyclingHalf::None, bool skip_deposition=false,
                                   PositionPushType position_push_type=PositionPushType::Full,
                                   MomentumPushType momentum_push_type=MomentumPushType::Full,
                                   ImplicitOptions const * implicit_options = nullptr);
 
-    void PushParticlesandDeposit (amrex::Real cur_time, bool skip_current=false,
+    void PushParticlesandDeposit (amrex::Real cur_time, bool skip_deposition=false,
                                   PositionPushType position_push_type=PositionPushType::Full,
                                   MomentumPushType momentum_push_type=MomentumPushType::Full,
                                   ImplicitOptions const * implicit_options = nullptr);


### PR DESCRIPTION
I noticed in #6275 that the input `skip_current` of `PushParticlesandDeposit` was passed as the value of the input `skip_deposition` of `Evolve`, which uses that to control both charge and current deposition - not just current deposition.

I think using a sinlge name, `skip_deposition` instead of `skip_current`, is less misleading. This is along the same lines of what I did in #6008.