### PR TITLE
fix white space issue for add_warpx_test

### DIFF
--- a/.github/workflows/source/check_inputs.py
+++ b/.github/workflows/source/check_inputs.py
@@ -29,15 +29,15 @@ for dirpath, dirnames, filenames in os.walk(top="./Examples"):
                 line = line.lstrip()
                 # find lines where 'add_warpx_test' is called
                 if re.match("add_warpx_test", line):
-                    # strip leading whitespaces, remove end-of-line comments
-                    testname = next(f).lstrip().split(" ")[0]
+                    # strip whitespaces, remove end-of-line comments
+                    testname = next(f).strip().split()[0]
                     # skip lines related to other function arguments
                     # NOTE: update range call to reflect changes
                     #       in the interface of 'add_warpx_test'
                     for _ in range(2):  # skip over: dims, nprocs
                         next(f)
-                    # strip leading whitespaces, remove end-of-line comments
-                    testinput = next(f).lstrip().split(" ")[0]
+                    # strip whitespaces, remove end-of-line comments
+                    testinput = next(f).strip().split()[0]
                     # some Python input scripts are quoted
                     # to account for command-line arguments:
                     # strip initial quotation mark from string


### PR DESCRIPTION
This PR fixes a minor issue in the `add_warpx_test` function (observed in #6269):

Before, it stripped only the leading whitespaces and was splitting on space `" "`.
Therefore, a test like this

```
add_warpx_test(
  test_3d_load_external_field_particle_multi_time     # name
  3                                                   # dims
  1                                                   # nprocs
  inputs_test_3d_load_external_field_particle_multi_time
  "analysis_time_scaling.py --pf0 diags/diag1000000 --pfN diags/diag1000300 --component Bz --expected_ratio 0.0 --rtol 1e-12 --min_abs 1e-12"
  "analysis_default_regression.py --path diags/diag1000300"
  OFF
)
```

would fail, as the newline `\n` at the end of `inputs_test_3d_load_external_field_particle_multi_time` would be parsed.

This would lead to a mismatch between name and input:
```
NAME  : 'test_3d_load_external_field_particle_multi_time'
INPUT : 'inputs_test_3d_load_external_field_particle_multi_time\n'
```
leading the `check_inputs.py` file to fail:

```
Check that all test input files are tested...
Input not tested: ./Examples/Tests/load_external_field/inputs_test_3d_load_multi_external_field_particle_time
Input not tested: ./Examples/Tests/load_external_field/inputs_test_3d_load_multi_external_field_particle_time_picmi.py
NOTE: All test input files must be tested.
```

This PR fixes the issue by stripping not only the leading but all whitespace and by splitting on all separators. 