### PR TITLE
Add verbosity level for Checkpoint diagnostic output

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -3736,6 +3736,9 @@ class Checkpoint(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
     warpx_file_min_digits: integer
         Minimum number of digits for the time step number in the checkpoint
         directory name.
+
+    warpx_verbose: int, optional
+        Verbosity level to use for printing diagnostic output information.
     """
 
     def __init__(self, period=1, write_dir=None, name=None, **kw):
@@ -3748,6 +3751,8 @@ class Checkpoint(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
         if self.name is None:
             self.name = "chkpoint"
 
+        self.verbose = kw.pop("warpx_verbose", None)
+
         self.handle_init(kw)
 
     def diagnostic_initialize_inputs(self):
@@ -3757,6 +3762,7 @@ class Checkpoint(picmistandard.base._ClassWithInit, WarpXDiagnosticBase):
         self.diagnostic.diag_type = "Full"
         self.diagnostic.format = "checkpoint"
         self.diagnostic.file_min_digits = self.file_min_digits
+        self.diagnostic.set_or_replace_attr("verbose", self.verbose)
 
         self.set_write_dir()
 


### PR DESCRIPTION
This repeats the pattern in https://github.com/BLAST-WarpX/warpx/pull/6092 which addressed verbosity (`warpx_verbose`) for FieldDiagnostic and ParticleDiagnostic only.  There's no reason the behavior of Checkpoint should be different.

This style does start to look like a hodgepodge since the same pattern is repeated for five different diagnostic types.  It might be cleaner to implement this argument warpx_verbose parameter in `WarpXDiagnosticBase` but `super().__init__(**kw)` would need to be called uniformly, where it isn't right now. 

I'll admit some confusion.
It looks to me like that [pull request 6092](https://github.com/BLAST-WarpX/warpx/pull/6092) would by default turn off (warpx_verbose=None) FieldDiagnostic, ParticleDiagnostic (and the two other derivatives) verbosity due to the four lines in picmi.py and the default None value,
```
         self.verbose = kw.pop("warpx_verbose", None)
```

That's not what I observe, however.  When the diagnostic constructors are called *without* a warpx_verbose argument, they seem to inherit from the Simulation's verbose setting.   I'm not seeing how that happens.