### PR TITLE
Update runtime names to access particles from Python

### DIFF
--- a/Examples/Tests/particle_boundary_interaction/inputs_test_rz_particle_boundary_interaction_picmi.py
+++ b/Examples/Tests/particle_boundary_interaction/inputs_test_rz_particle_boundary_interaction_picmi.py
@@ -132,7 +132,7 @@ def mirror_reflection():
             "electrons", "eb", "deltaTimeScraped", lev
         )
     )
-    r = concat(buffer.get_particle_scraped_this_step("electrons", "eb", "x", lev))
+    r = concat(buffer.get_particle_scraped_this_step("electrons", "eb", "r", lev))
     theta = concat(
         buffer.get_particle_scraped_this_step("electrons", "eb", "theta", lev)
     )

--- a/Examples/Tests/secondary_ion_emission/inputs_test_rz_secondary_ion_emission_picmi.py
+++ b/Examples/Tests/secondary_ion_emission/inputs_test_rz_secondary_ion_emission_picmi.py
@@ -188,7 +188,7 @@ def secondary_emission():
     elect_pc = particle_containers.ParticleContainerWrapper("electrons")
 
     if n != 0:
-        r = concat(buffer.get_particle_scraped_this_step("ions", "eb", "x", lev))
+        r = concat(buffer.get_particle_scraped_this_step("ions", "eb", "r", lev))
         theta = concat(
             buffer.get_particle_scraped_this_step("ions", "eb", "theta", lev)
         )

--- a/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
+++ b/Source/Diagnostics/ParticleDiag/ParticleDiag.cpp
@@ -38,6 +38,7 @@ ParticleDiag::ParticleDiag (
             for (auto& var : variables){
 #if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
                 // we reconstruct to Cartesian x,y,z for RZ particle output
+                if (var == "x") { var = "r"; }
                 if (var == "y") { var = "theta"; }
 #endif
 #if defined(WARPX_DIM_RSPHERE)

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -71,13 +71,13 @@ struct PIdx
     static constexpr auto names = {"x", "z", "w", "ux", "uy", "uz"};
 #elif defined(WARPX_DIM_RZ)
     enum                          { x ,  z ,  w ,  ux ,  uy ,  uz ,  theta,        nattribs};
-    static constexpr auto names = {"x", "z", "w", "ux", "uy", "uz", "theta"};
+    static constexpr auto names = {"r", "z", "w", "ux", "uy", "uz", "theta"};
 #elif defined(WARPX_DIM_RCYLINDER)
     enum                          { x ,  w ,  ux ,  uy ,  uz ,  theta,             nattribs};
-    static constexpr auto names = {"x", "w", "ux", "uy", "uz", "theta"};
+    static constexpr auto names = {"r", "w", "ux", "uy", "uz", "theta"};
 #elif defined(WARPX_DIM_RSPHERE)
     enum                          { x ,  w ,  ux ,  uy ,  uz ,  theta ,  phi,      nattribs};
-    static constexpr auto names = {"x", "w", "ux", "uy", "uz", "theta", "phi"};
+    static constexpr auto names = {"r", "w", "ux", "uy", "uz", "theta", "phi"};
 #elif defined(WARPX_DIM_3D)
     enum                          { x ,  y,   z,   w,   ux,   uy,   uz,            nattribs};
     static constexpr auto names = {"x", "y", "z", "w", "ux", "uy", "uz"};


### PR DESCRIPTION
This ensures that, when the user tries to get the `r` position of a particle from Python, they do not need to type `"x"` instead of `"r"`.