### PR TITLE
Remove particles.photon_species inputs left over

### DIFF
--- a/Examples/Tests/ionization_dsmc/inputs_test_1d_photoneutralization_dsmc
+++ b/Examples/Tests/ionization_dsmc/inputs_test_1d_photoneutralization_dsmc
@@ -38,7 +38,6 @@ boundary.field_hi = pec
 #############################
 # Create species
 particles.species_names = Hneutral Hminus electrons photons
-particles.photon_species = photons
 
 Hminus.do_continuous_injection = 1
 Hminus.injection_style = NFluxPerCell

--- a/Examples/Tests/reduced_diags/inputs_test_3d_reduced_diags
+++ b/Examples/Tests/reduced_diags/inputs_test_3d_reduced_diags
@@ -34,7 +34,6 @@ warpx.cfl = 0.99999
 
 # Particles
 particles.species_names = electrons protons photons
-particles.photon_species = photons
 
 electrons.charge = -q_e
 electrons.mass = m_e


### PR DESCRIPTION
The `particles.photon_species` input parameter is deprecated since #6265.

On the other hand, I think this is an example of how deprecated parameters can still propagate in the code due to the fact that they still function (the one in `inputs_test_1d_photoneutralization_dsmc` was merged two days ago) - which was my concern behind https://github.com/BLAST-WarpX/warpx/pull/6265#discussion_r2440528311.