### PR TITLE
Fix default tolerance in restart test

### DIFF
--- a/Examples/analysis_default_regression.py
+++ b/Examples/analysis_default_regression.py
@@ -15,14 +15,8 @@ def main(args):
     # parse test name from test directory
     test_name = os.path.split(os.getcwd())[1]
     if "_restart" in test_name:
-        rtol_restart = 1e-12
-        print(
-            f"Warning: Setting relative tolerance {rtol_restart} for restart checksum analysis"
-        )
         # use original test's checksums
         test_name = test_name.replace("_restart", "")
-        # reset relative tolerance
-        args.rtol = rtol_restart
     # TODO check environment and reset tolerance (portable, machine precision)
     # compare checksums
     evaluate_checksum(
@@ -45,12 +39,19 @@ if __name__ == "__main__":
         type=str,
     )
     # add arguments: relative tolerance
+    # Identify whether the test is a restart test,
+    # if it is, use a 1e-12 tolerance for the restart checksum analysis
+    test_name = os.path.split(os.getcwd())[1]
+    if "_restart" in test_name:
+        default_tolerance = 1e-12
+    else:
+        default_tolerance = 1e-9
     parser.add_argument(
         "--rtol",
         help="relative tolerance to compare checksums",
         type=float,
         required=False,
-        default=1e-9,
+        default=default_tolerance,
     )
     # add arguments: skip fields
     parser.add_argument(

--- a/Examples/analysis_default_regression.py
+++ b/Examples/analysis_default_regression.py
@@ -42,10 +42,7 @@ if __name__ == "__main__":
     # Identify whether the test is a restart test,
     # if it is, use a 1e-12 tolerance for the restart checksum analysis
     test_name = os.path.split(os.getcwd())[1]
-    if "_restart" in test_name:
-        default_tolerance = 1e-12
-    else:
-        default_tolerance = 1e-9
+    default_tolerance = 1e-12 if "_restart" in test_name else 1e-9
     parser.add_argument(
         "--rtol",
         help="relative tolerance to compare checksums",


### PR DESCRIPTION
The current script does not let the user choose which tolerance to use, in the case of restart tests.