### PR TITLE
Streamline contact page

### DIFF
--- a/Docs/source/index.rst
+++ b/Docs/source/index.rst
@@ -27,13 +27,11 @@ In addition, WarpX is a *highly-parallel and highly-optimized code*:
 Contact us
 ^^^^^^^^^^
 
-If you are starting using WarpX, or if you have a user question, please pop in our `discussions page <https://github.com/BLAST-WarpX/warpx/discussions>`__ and get in touch with the community.
+The `WarpX GitHub repo <https://github.com/BLAST-WarpX/warpx>`__ is the main communication platform:
 
-The `WarpX GitHub repo <https://github.com/BLAST-WarpX/warpx>`__ is the main communication platform.
-Have a look at the action icons on the top right of the web page: feel free to watch the repo if you want to receive updates, or to star the repo to support the project.
-For bug reports or to request new features, you can also open a new `issue <https://github.com/BLAST-WarpX/warpx/issues>`__.
-
-We also have a `discussion page <https://github.com/BLAST-WarpX/warpx/discussions>`__ on which you can find already answered questions, add new questions, get help with installation procedures, discuss ideas or share comments.
+   - If you are new to WarpX or have a question, we encourage you to visit our `discussions page <https://github.com/BLAST-WarpX/warpx/discussions>`__ and connect with the community. This page is also a great place to browse answers to previously asked questions, post new ones, get help with installation, exchange ideas, and share feedback.
+   - You can also explore the action icons in the upper right corner of the `WarpX GitHub page <https://github.com/BLAST-WarpX/warpx>`__ : feel free to watch the repo if you want to receive updates, or to star the repo to support the project.
+   - For bug reports or feature requests, you can also open a new `issue <https://github.com/BLAST-WarpX/warpx/issues>`__.
 
 .. raw:: html
 

--- a/Docs/source/index.rst
+++ b/Docs/source/index.rst
@@ -27,11 +27,11 @@ In addition, WarpX is a *highly-parallel and highly-optimized code*:
 Contact us
 ^^^^^^^^^^
 
-The `WarpX GitHub repo <https://github.com/BLAST-WarpX/warpx>`__ is the main communication platform:
+The `WarpX GitHub repository <https://github.com/BLAST-WarpX/warpx>`__ is the main communication platform:
 
    - If you are new to WarpX or have a question, we encourage you to visit our `discussions page <https://github.com/BLAST-WarpX/warpx/discussions>`__ and connect with the community. This page is also a great place to browse answers to previously asked questions, post new ones, get help with installation, exchange ideas, and share feedback.
-   - You can also explore the action icons in the upper right corner of the `WarpX GitHub page <https://github.com/BLAST-WarpX/warpx>`__ : feel free to watch the repo if you want to receive updates, or to star the repo to support the project.
-   - For bug reports or feature requests, you can also open a new `issue <https://github.com/BLAST-WarpX/warpx/issues>`__.
+   - You can also explore the icons in the upper right corner of the `WarpX GitHub repository <https://github.com/BLAST-WarpX/warpx>`__ (e.g., ``Watch``, ``Star``, etc.): feel free to watch the repository if you want to receive updates, or to star the repository to support the project.
+   - For bug reports, feature requests, or installation issues, you can also open a new `issue <https://github.com/BLAST-WarpX/warpx/issues>`__.
 
 .. raw:: html
 


### PR DESCRIPTION
Streamline the page about how to get in contact.

New version:

<img width="763" height="321" alt="Screenshot 2025-11-01 at 9 34 23 AM" src="https://github.com/user-attachments/assets/86b1bc3c-8cba-46ac-8a4b-877761e82709" />

Previous version (mentioned the discussions page twice!):
<img width="891" height="421" alt="Screenshot 2025-11-01 at 9 35 10 AM" src="https://github.com/user-attachments/assets/305edca0-7fa2-40f9-b6b0-079dfaf51d4b" />