### PR TITLE
Release 25.11

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,9 +1,9 @@
 {
     "version_warpx": "25.11",
-    "version_amrex": "25.10",
+    "version_amrex": "25.11",
     "version_pyamrex": "25.10",
     "version_picsar": "25.06",
-    "commit_amrex": "3c1f1c78f60530e4ee17f766cf195c2c776f7b00",
+    "commit_amrex": "25.11",
     "commit_pyamrex": "c356855ac49090a18dbe807cfaf7a53ab2ce26b3",
     "commit_picsar": "0c329e66010267662a82219f7de7abbd231463f4"
 }

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,9 +1,9 @@
 {
     "version_warpx": "25.11",
     "version_amrex": "25.11",
-    "version_pyamrex": "25.10",
+    "version_pyamrex": "25.11",
     "version_picsar": "25.06",
     "commit_amrex": "25.11",
-    "commit_pyamrex": "c356855ac49090a18dbe807cfaf7a53ab2ce26b3",
+    "commit_pyamrex": "25.11",
     "commit_picsar": "25.06"
 }

--- a/dependencies.json
+++ b/dependencies.json
@@ -5,5 +5,5 @@
     "version_picsar": "25.06",
     "commit_amrex": "25.11",
     "commit_pyamrex": "c356855ac49090a18dbe807cfaf7a53ab2ce26b3",
-    "commit_picsar": "0c329e66010267662a82219f7de7abbd231463f4"
+    "commit_picsar": "25.06"
 }


### PR DESCRIPTION
Prepare the November release of WarpX:
```bash
# update dependencies
./Tools/Release/update_dependencies.py --amrex --release
./Tools/Release/update_dependencies.py --picsar --release # no changes, still 25.04
./Tools/Release/update_dependencies.py --pyamrex --release
# bump version number
./Tools/Release/update_dependencies.py --warpx --release
```

This pull request was created with the script `./Tools/Release/releasePR.py`,
following the instructions described in https://warpx.readthedocs.io/en/latest/maintenance/release.html#create-a-new-warpx-release.
