### PR TITLE
Consistently use language:none for literal include in the documentation

### DIFF
--- a/Examples/Physics_applications/beam_beam_collision/README.rst
+++ b/Examples/Physics_applications/beam_beam_collision/README.rst
@@ -26,7 +26,7 @@ The PICMI input file is not available for this example yet.
 For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
 
 .. literalinclude:: inputs_test_3d_beam_beam_collision
-   :language: ini
+   :language: none
    :caption: You can copy this file from ``Examples/Physics_applications/beam_beam_collision/inputs_test_3d_beam_beam_collision``.
 
 

--- a/Examples/Physics_applications/free_electron_laser/README.rst
+++ b/Examples/Physics_applications/free_electron_laser/README.rst
@@ -25,7 +25,7 @@ Run
 This example can be run with the WarpX executable using an input file: ``warpx.1d inputs_test_1d_fel``. For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
 
 .. literalinclude:: inputs_test_1d_fel
-   :language: ini
+   :language: none
    :caption: You can copy this file from ``Examples/Physics_applications/free_electron_laser/inputs_test_1d_fel``.
 
 Visualize
@@ -42,5 +42,5 @@ emitted FEL radiation (red) slipping ahead of the beam.
 This figure was obtained with the script below, which can be run with ``python3 plot_sim.py``.
 
 .. literalinclude:: plot_sim.py
-   :language: ini
+   :language: none
    :caption: You can copy this file from ``Examples/Physics_applications/free_electron_laser/plot_sim.py``.

--- a/Examples/Physics_applications/laser_acceleration/README.rst
+++ b/Examples/Physics_applications/laser_acceleration/README.rst
@@ -38,7 +38,7 @@ For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with `
          .. tab-item:: Executable: Input File
 
              .. literalinclude:: inputs_base_3d
-                :language: ini
+                :language: none
                 :caption: You can copy this file from ``Examples/Physics_applications/laser_acceleration/inputs_base_3d``.
 
    .. tab-item:: RZ
@@ -59,7 +59,7 @@ For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with `
          .. tab-item:: Executable: Input File
 
              .. literalinclude:: inputs_base_rz
-                :language: ini
+                :language: none
                 :caption: You can copy this file from ``Examples/Physics_applications/laser_acceleration/inputs_base_rz``.
 
 Analyze

--- a/Examples/Physics_applications/laser_ion/README.rst
+++ b/Examples/Physics_applications/laser_ion/README.rst
@@ -43,7 +43,7 @@ This example can be run **either** as:
    .. tab-item:: Executable: Input File
 
       .. literalinclude:: inputs_test_2d_laser_ion_acc
-         :language: ini
+         :language: none
          :caption: You can copy this file from ``Examples/Physics_applications/laser_ion/inputs_test_2d_laser_ion_acc``.
 
 Analyze

--- a/Examples/Physics_applications/pierce_diode/README.rst
+++ b/Examples/Physics_applications/pierce_diode/README.rst
@@ -47,7 +47,7 @@ This example can be run with the WarpX executable using an input file: ``warpx.1
 For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
 
 .. literalinclude:: inputs_test_1d_pierce_diode
-   :language: ini
+   :language: none
    :caption: You can copy this file from ``Examples/Physics_applications/pierce_diode/inputs_test_1d_pierce_diode``.
 
 Visualize
@@ -62,5 +62,5 @@ The figure below shows the results of the simulation (orange curves), which agre
 This figure was obtained with the script below, which can be run with ``python3 plot_sim.py``.
 
 .. literalinclude:: plot_sim.py
-   :language: ini
+   :language: none
    :caption: You can copy this file from ``Examples/Physics_applications/pierce_diode/plot_sim.py``.

--- a/Examples/Physics_applications/plasma_acceleration/README.rst
+++ b/Examples/Physics_applications/plasma_acceleration/README.rst
@@ -44,7 +44,7 @@ For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with `
    .. tab-item:: Executable: Input File
 
       .. literalinclude:: inputs_base_3d
-         :language: ini
+         :language: none
          :caption: You can copy this file from ``Examples/Physics_applications/plasma_acceleration/inputs_base_3d``.
 
 Analyze

--- a/Examples/Physics_applications/plasma_mirror/README.rst
+++ b/Examples/Physics_applications/plasma_mirror/README.rst
@@ -34,7 +34,7 @@ For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with `
    .. tab-item:: Executable: Input File
 
       .. literalinclude:: inputs_test_2d_plasma_mirror
-         :language: ini
+         :language: none
          :caption: You can copy this file from ``Examples/Physics_applications/plasma_mirror/inputs_test_2d_plasma_mirror``.
 
 

--- a/Examples/Physics_applications/thomson_parabola_spectrometer/README.rst
+++ b/Examples/Physics_applications/thomson_parabola_spectrometer/README.rst
@@ -29,7 +29,7 @@ The PICMI input file is not available for this example yet.
 For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with ``mpiexec -n 4 ...`` or ``srun -n 4 ...``, depending on the system.
 
 .. literalinclude:: inputs_test_3d_thomson_parabola_spectrometer
-   :language: ini
+   :language: none
    :caption: You can copy this file from ``Examples/Physics_applications/thomson_parabola_spectrometer/inputs_test_3d_thomson_parabola_spectrometer``.
 
 Visualize
@@ -52,5 +52,5 @@ The :math:`x` coordinate represents the electric deflection, while :math:`y` the
    :width: 100%
 
 .. literalinclude:: analysis.py
-   :language: ini
+   :language: none
    :caption: You can copy this file from ``Examples/Physics_applications/thomson_parabola_spectrometer/analysis.py``.

--- a/Examples/Physics_applications/uniform_plasma/README.rst
+++ b/Examples/Physics_applications/uniform_plasma/README.rst
@@ -28,7 +28,7 @@ For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with `
             This example can be run **either** as WarpX **executable** using an input file: ``warpx.3d inputs_base_3d``
 
              .. literalinclude:: inputs_base_3d
-                :language: ini
+                :language: none
                 :caption: You can copy this file from ``usage/examples/lwfa/inputs_base_3d``.
 
    .. tab-item:: 2D
@@ -46,7 +46,7 @@ For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with `
             This example can be run **either** as WarpX **executable** using an input file: ``warpx.2d inputs_test_2d_uniform_plasma``
 
              .. literalinclude:: inputs_test_2d_uniform_plasma
-                :language: ini
+                :language: none
                 :caption: You can copy this file from ``usage/examples/lwfa/inputs_test_2d_uniform_plasma``.
 
 Analyze

--- a/Examples/Tests/field_ionization/README.rst
+++ b/Examples/Tests/field_ionization/README.rst
@@ -28,7 +28,7 @@ For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with `
             .. tab-item:: Executable: Input File
 
                 .. literalinclude:: inputs_test_2d_ionization_lab
-                    :language: ini
+                    :language: none
                     :caption: You can copy this file from ``Examples/Tests/field_ionization/inputs_test_2d_ionization_lab``.
 
    .. tab-item:: boosted frame
@@ -38,7 +38,7 @@ For `MPI-parallel <https://www.mpi-forum.org>`__ runs, prefix these lines with `
         * WarpX **executable** using an input file: ``warpx.2d inputs_test_2d_ionization_boost max_step=420``
 
         .. literalinclude:: inputs_test_2d_ionization_boost
-            :language: ini
+            :language: none
             :caption: You can copy this file from ``Examples/Tests/field_ionization/inputs_test_2d_ionization_boost``.
 
 Analyze


### PR DESCRIPTION
This is a follow-up of #6333 and makes these changes consistent across the documentation.