### PR TITLE
Python: Implement `mesh` on `MultiFab`

### DIFF
--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -129,6 +129,15 @@ class LibWarpX:
 
         self.__version__ = self.libwarpx_so.__version__
 
+        # Extend pybind11 types in libwarpx_so (and pyAMReX) with pure Python
+        from .extensions.MultiFab import register_warpx_MultiFab_extension
+        from .extensions.MultiFabRegister import (
+            register_warpx_MultiFabRegister_extension,
+        )
+
+        register_warpx_MultiFab_extension(self.amr)
+        register_warpx_MultiFabRegister_extension(self.libwarpx_so)
+
     def amrex_init(self, argv, mpi_comm=None):
         if mpi_comm is None:  # or MPI is None:
             self.libwarpx_so.amrex_init(argv)

--- a/Python/pywarpx/extensions/MultiFab.py
+++ b/Python/pywarpx/extensions/MultiFab.py
@@ -32,6 +32,8 @@ def mesh(self, direction, include_ghosts=False):
             idir = ["r", "z"].index(direction)
         elif libwarpx.geometry_dim == "1d":
             idir = ["z"].index(direction)
+        else:
+            raise Exception(f"Direction not implemented: {libwarpx.geometry_dim}")
     except ValueError:
         raise Exception("Inappropriate direction given")
 

--- a/Python/pywarpx/extensions/MultiFab.py
+++ b/Python/pywarpx/extensions/MultiFab.py
@@ -1,0 +1,53 @@
+"""
+This file is part of WarpX
+
+Copyright 2024 WarpX community
+Authors: Axel Huebl, David Grote
+License: BSD-3-Clause-LBNL
+"""
+
+
+def mesh(self, direction, include_ghosts=False):
+    """Returns the mesh along the specified direction with the appropriate centering.
+
+    Parameters
+    ----------
+    direction: string
+        In 3d, one of 'x', 'y', or 'z'.
+        In 2d, Cartesian, one of 'x', or 'z'.
+        In RZ, one of 'r', or 'z'
+        In Z, 'z'.
+
+    include_ghosts: bool, default = False
+        Whether the ghosts cells are included in the mesh
+    """
+    from .._libwarpx import libwarpx
+
+    try:
+        if libwarpx.geometry_dim == "3d":
+            idir = ["x", "y", "z"].index(direction)
+        elif libwarpx.geometry_dim == "2d":
+            idir = ["x", "z"].index(direction)
+        elif libwarpx.geometry_dim == "rz":
+            idir = ["r", "z"].index(direction)
+        elif libwarpx.geometry_dim == "1d":
+            idir = ["z"].index(direction)
+    except ValueError:
+        raise Exception("Inappropriate direction given")
+
+    # Cell size and lo are obtained from warpx, the imesh from the MultiFab
+    warpx = libwarpx.libwarpx_so.get_instance()
+    dd = warpx.Geom(self.level).data().CellSize(idir)
+    lo = warpx.Geom(self.level).ProbLo(idir)
+    imesh = self.imesh(idir, include_ghosts)
+    return lo + imesh * dd
+
+
+def register_warpx_MultiFab_extension(amr):
+    """MultiFab helper methods"""
+
+    # register properties for the MultiFab type
+    amr.MultiFab.level = None  # set by the WarpX getter
+
+    # register member functions for the MultiFab type
+    amr.MultiFab.mesh = mesh

--- a/Python/pywarpx/extensions/MultiFabRegister.py
+++ b/Python/pywarpx/extensions/MultiFabRegister.py
@@ -1,0 +1,48 @@
+"""
+This file is part of WarpX
+
+Copyright 2025 WarpX community
+Authors: Axel Huebl
+License: BSD-3-Clause-LBNL
+"""
+
+
+def get(self, name, dir=None, level=None):
+    """Return a MultiFab that is part of a vector/tensor field.
+
+    This throws a runtime error if the requested field is not present.
+
+    Parameters
+    ----------
+    self : MultiFabRegister
+        The MultiFabRegister.
+    name : str
+        The name of the field
+    dir : int or None, optional
+        The field component for vector fields ("direction" of the unit vector).
+        Required for vector/tensor fields, omitted for scalar fields.
+    level : int
+        The MR level.
+
+    Returns
+    -------
+    MultiFab
+        A non-owning reference to the MultiFab (field)
+    """
+    if level is None:
+        raise ValueError("level must be specified")
+
+    if dir is None:
+        mf = self._get(name=name, level=level)
+    else:
+        mf = self._get(name=name, dir=dir, level=level)
+
+    mf.level = level
+    return mf
+
+
+def register_warpx_MultiFabRegister_extension(libwarpx_so):
+    """MultiFabRegister helper methods"""
+
+    # register member functions for the MultiFabRegister type
+    libwarpx_so.MultiFabRegister.get = get

--- a/Python/pywarpx/fields.py
+++ b/Python/pywarpx/fields.py
@@ -202,9 +202,9 @@ class MultiFabWrapper(object):
             fields = warpx.multifab_register()
             if self.idir is not None:
                 direction = libwarpx.libwarpx_so.Direction(self.idir)
-                return fields.get(self.mf_name, direction, self.level)
+                return fields.get(self.mf_name, dir=direction, level=self.level)
             else:
-                return fields.get(self.mf_name, self.level)
+                return fields.get(self.mf_name, level=self.level)
 
     def create_new_MultiFab(self):
         warpx = libwarpx.libwarpx_so.get_instance()

--- a/Python/pywarpx/fields.py
+++ b/Python/pywarpx/fields.py
@@ -236,40 +236,6 @@ class MultiFabWrapper(object):
                 self.redistribute_on_remake,
             )
 
-    def mesh(self, direction, include_ghosts=False):
-        """Returns the mesh along the specified direction with the appropriate centering.
-
-        Parameters
-        ----------
-        direction: string
-            In 3d, one of 'x', 'y', or 'z'.
-            In 2d, Cartesian, one of 'x', or 'z'.
-            In RZ, one of 'r', or 'z'
-            In Z, 'z'.
-
-        include_ghosts: bool, default = False
-            Whether the ghosts cells are included in the mesh
-        """
-
-        try:
-            if libwarpx.geometry_dim == "3d":
-                idir = ["x", "y", "z"].index(direction)
-            elif libwarpx.geometry_dim == "2d":
-                idir = ["x", "z"].index(direction)
-            elif libwarpx.geometry_dim == "rz":
-                idir = ["r", "z"].index(direction)
-            elif libwarpx.geometry_dim == "1d":
-                idir = ["z"].index(direction)
-        except ValueError:
-            raise Exception("Inappropriate direction given")
-
-        # Cell size and lo are obtained from warpx, the imesh from the MultiFab
-        warpx = libwarpx.libwarpx_so.get_instance()
-        dd = warpx.Geom(self.level).data().CellSize(idir)
-        lo = warpx.Geom(self.level).ProbLo(idir)
-        imesh = self.mf.imesh(idir, include_ghosts)
-        return lo + imesh * dd
-
 
 def CustomNamedxWrapper(mf_name, level=0):
     return MultiFabWrapper(mf_name=mf_name, idir=0, level=level)

--- a/Source/Python/MultiFabRegister.cpp
+++ b/Source/Python/MultiFabRegister.cpp
@@ -155,7 +155,7 @@ void init_MultiFabRegister (py::module & m)
              py::arg("level")
         )
 
-        .def("get",
+        .def("_get",
              py::overload_cast<
                  std::string,
                  int
@@ -165,7 +165,7 @@ void init_MultiFabRegister (py::module & m)
              py::arg("level")
         )
 
-        .def("get",
+        .def("_get",
              py::overload_cast<
                  std::string,
                  ablastr::fields::Direction,

--- a/dependencies.json
+++ b/dependencies.json
@@ -4,6 +4,6 @@
     "version_pyamrex": "25.10",
     "version_picsar": "25.06",
     "commit_amrex": "3c1f1c78f60530e4ee17f766cf195c2c776f7b00",
-    "commit_pyamrex": "c356855ac49090a18dbe807cfaf7a53ab2ce26b3",
+    "commit_pyamrex": "f56da4a68868bc2eabf28a611d76315526ffabee",
     "commit_picsar": "0c329e66010267662a82219f7de7abbd231463f4"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ picmistandard==0.34.0
 # openpmd-viewer
 # matplotlib
 # pandas
+# dill

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 import sys
 
-from setuptools import Extension, setup
+from setuptools import Extension, find_packages, setup
 from setuptools.command.build import build
 from setuptools.command.build_ext import build_ext
 
@@ -288,8 +288,8 @@ setup(
     name="pywarpx",
     # note PEP-440 syntax: x.y.zaN but x.y.z.devN
     version=warpx_version,
-    packages=["pywarpx"],
-    package_dir={"pywarpx": "Python/pywarpx"},
+    packages=find_packages(where="Python"),
+    package_dir={"": "Python"},
     author="Jean-Luc Vay, David P. Grote, Maxence Thévenet, Rémi Lehe, Andrew Myers, Weiqun Zhang, Axel Huebl, et al.",
     author_email="jlvay@lbl.gov, grote1@llnl.gov, maxence.thevenet@desy.de, rlehe@lbl.gov, atmyers@lbl.gov, WeiqunZhang@lbl.gov, axelhuebl@lbl.gov",
     maintainer="Axel Huebl, David P. Grote, Rémi Lehe",  # wheel/pypi packages


### PR DESCRIPTION
Move from `MultiFabWrapper` to `MultiFab`. Will automatically be forwarded still to the `MultiFabWrapper`.