### PR TITLE
Docs: Fix :alt: figure text again

### DIFF
--- a/Docs/source/dataanalysis/picviewer.rst
+++ b/Docs/source/dataanalysis/picviewer.rst
@@ -2,7 +2,7 @@ PICViewer
 =========
 
 .. figure:: sample_image.png
-   :alt: Figure not found
+   :alt: PICViewer GUI interface for WarpX data visualization
 
 PICViewer is a visualization GUI implemented on PyQt.
 The toolkit provides various easy-to-use functions for data analysis of

--- a/Docs/source/dataanalysis/visit.rst
+++ b/Docs/source/dataanalysis/visit.rst
@@ -26,7 +26,7 @@ Assuming that you ran a 2D simulation, here are instructions for making a simple
 Your image should look similar to the one below
 
 .. figure:: Ez.png
-   :alt: Figure not found
+   :alt: Visit visualization of Ez field component
 
 
 In 3D, you must apply the “Operators” -> “Slicing”

--- a/Docs/source/dataanalysis/visualpic.rst
+++ b/Docs/source/dataanalysis/visualpic.rst
@@ -32,7 +32,7 @@ Example: ``vpic3d -s beam -rho -Ez diags/diag1/`` could be used to visualize the
 Example: ``vpic3d -Ex diags/diag1/`` could be used to visualize the transverse focusing field :math:`E_x` in a plasma wake behind a laser pulse (linearly polarized in :math:`E_y`), see below:
 
 .. figure:: https://user-images.githubusercontent.com/1353258/233236692-4d75b12f-de44-43dc-97bd-c96b04ee68ac.png
-   :alt: Figure not found
+   :alt: 3D visualization of plasma wake fields in VisualPIC
    :width: 100%
 
    Example view of a 3D rendering with VisualPIC.

--- a/Docs/source/dataanalysis/workflows/tunneling.rst
+++ b/Docs/source/dataanalysis/workflows/tunneling.rst
@@ -52,7 +52,7 @@ To close the connection down, do this:
   * ``Ctrl+C`` the SSH tunnel in terminal B
 
 .. figure:: https://user-images.githubusercontent.com/1353258/232120440-3965fa38-9ca6-4621-a100-2da74eb899cf.png
-   :alt: Figure not found
+   :alt: Remote Jupyter setup with SSH tunnel and local browser connection
    :width: 100%
 
    Example view of remote started Jupyter service, active SSH tunnel, and local browser connecting to the service.

--- a/Docs/source/theory/amr.rst
+++ b/Docs/source/theory/amr.rst
@@ -6,7 +6,7 @@ Mesh refinement
 .. _fig_ESAMR:
 
 .. figure:: ICNSP_2011_Vay_fig1.png
-   :alt: Figure not found
+   :alt: Mesh refinement implementation for electrostatic and electromagnetic solvers
    :width: 95%
 
    Sketches of the implementation of mesh refinement in WarpX with the electrostatic (left) and electromagnetic (right) solvers. In both cases, the charge/current from particles are deposited at the finest levels first, then interpolated recursively to coarser levels. In the electrostatic case, the potential is calculated first at the coarsest level :math:`L_0`, the solution interpolated to the boundaries of the refined patch :math:`r` at the next level :math:`L_{1}` and the potential calculated at :math:`L_1`. The procedure is repeated iteratively up to the highest level. In the electromagnetic case, the fields are computed independently on each grid and patch without interpolation at boundaries. Patches are terminated by absorbing layers (PML) to prevent the reflection of electromagnetic waves. Additional coarse patch :math:`c` and fine grid :math:`a` are needed so that the full solution is obtained by substitution on :math:`a` as :math:`F_{n+1}(a)=F_{n+1}(r)+I[F_n( s )-F_{n+1}( c )]` where :math:`F` is the field, and :math:`I` is a coarse-to-fine interpolation operator. In both cases, the field solution at a given level :math:`L_n` is unaffected by the solution at higher levels :math:`L_{n+1}` and up, allowing for mitigation of some spurious effects (see text) by providing a transition zone via extension of the patches by a few cells beyond the desired refined area (red & orange rectangles) in which the field is interpolated onto particles from the coarser parent level only.
@@ -25,7 +25,7 @@ A sketch of the implementation of mesh refinement in WarpX is given in :numref:`
 .. _fig_ESselfforce:
 
 .. figure:: ICNSP_2011_Vay_fig2.png
-   :alt: Figure not found
+   :alt: Particle trajectory near metallic boundary with different refinement methods
    :width: 95%
 
    Position history of one charged particle attracted by its image induced by a nearby metallic (dirichlet) boundary. The particle is initialized at rest. Without refinement patch (reference case), the particle is accelerated by its image, is reflected specularly at the wall, then decelerates until it reaches its initial position at rest. If the particle is initialized inside a refinement patch, the particle is initially accelerated toward the wall but is spuriously reflected before it reaches the boundary of the patch whether using the method implemented in WarpX or the MC method. Providing a surrounding transition region 2 or 4 cells wide in which the potential is interpolated from the parent coarse solution reduces significantly the effect of the spurious self-force.
@@ -35,7 +35,7 @@ The presence of the self-force is illustrated on a simple test case that was int
 .. _fig_ESselfforcemap:
 
 .. figure:: ICNSP_2011_Vay_fig3.png
-   :alt: Figure not found
+   :alt: Maps and lineouts of spurious self-force in refinement patch
    :width: 95%
 
    (left) Maps of the magnitude of the spurious self-force :math:`\epsilon` in arbitrary units within one quarter of the refined patch, defined as :math:`\epsilon=\sqrt{(E_x-E_x^{ref})^2+(E_y-E_y^{ref})^2}`, where :math:`E_x` and :math:`E_y` are the electric field components within the patch experienced by one particle at a given location and :math:`E_x^{ref}` and :math:`E_y^{ref}` are the electric field from a reference solution. The map is given for the WarpX and the MC mesh refinement algorithms and for linear and quadratic interpolation at the patch refinement boundary. (right) Lineouts of the maximum (taken over neighboring cells) of the spurious self-force. Close to the interface boundary (x=0), the spurious self-force decreases at a rate close to one order of magnitude per cell (red line), then at about one order of magnitude per six cells (green line).

--- a/Docs/source/theory/boosted_frame.rst
+++ b/Docs/source/theory/boosted_frame.rst
@@ -8,7 +8,7 @@ The simulations of plasma accelerators from first principles are extremely compu
 .. _fig_Boosted_frame:
 
 .. figure:: Boosted_frame.png
-   :alt: Figure not found
+   :alt: Scale transformation in boosted frame simulation
 
    A first principle simulation of a short driver beam (laser or charged particles) propagating through a plasma that is orders of magnitude longer necessitates a very large number of time steps. Recasting the simulation in a frame of reference that is moving close to the speed of light in the direction of the driver beam leads to simulating a driver beam that appears longer propagating through a plasma that appears shorter than in the laboratory. Thus, this relativistic transformation of space and time reduces the disparity of scales, and thereby the number of time steps to complete the simulation, by orders of magnitude.
 

--- a/Docs/source/theory/boosted_frame/input_output.rst
+++ b/Docs/source/theory/boosted_frame/input_output.rst
@@ -15,7 +15,7 @@ Inputs and outputs in a boosted frame simulation
 .. _fig_inputoutput:
 
 .. figure:: Input_output.png
-   :alt: Figure not found
+   :alt: Particle beam interactions with injection plane and diagnostic stations
    :width: 100%
 
    (top) Snapshot of a particle beam showing “frozen" (grey spheres) and “active" (colored spheres) macroparticles traversing the injection plane (red rectangle). (bottom) Snapshot of the beam macroparticles (colored spheres) passing through the background of electrons (dark brown streamlines) and the diagnostic stations (red rectangles). The electrons, the injection plane and the diagnostic stations are fixed in the laboratory plane, and are thus counter-propagating to the beam in a boosted frame.

--- a/Docs/source/theory/boundary_conditions.rst
+++ b/Docs/source/theory/boundary_conditions.rst
@@ -294,7 +294,7 @@ the right boundary is reflecting.
 .. _fig_PEC_boundary_deposition:
 
 .. figure:: https://user-images.githubusercontent.com/40245517/221491318-b0a2bcbc-b04f-4b8c-8ec5-e9c92e55ee53.png
-   :alt: Figure not found
+   :alt: Current deposition at absorbing and reflecting PEC boundaries
    :width: 100%
 
    PEC boundary current deposition along the ``x``-axis. The left boundary is absorbing while the right boundary is reflecting.

--- a/Docs/source/theory/cold_fluid_model.rst
+++ b/Docs/source/theory/cold_fluid_model.rst
@@ -45,7 +45,7 @@ Implementation details
 .. _fig_fluid_loop:
 
 .. figure:: https://github.com/BLAST-WarpX/warpx/assets/69021085/dcbcc0e4-7899-43e4-b580-f57eb359b457
-   :alt: Figure not found
+   :alt: Fluid time step integration within PIC loop
 
    Fluid loop embedded within the overall PIC loop.
 

--- a/Docs/source/theory/intro.rst
+++ b/Docs/source/theory/intro.rst
@@ -18,7 +18,7 @@ such as the maximum time step size, the time staggering of the fields and partic
 .. _fig-pic:
 
 .. figure:: PIC.png
-   :alt: figure not found
+   :alt: Core PIC algorithm cycle showing field and particle operations
 
    The core Particle-In-Cell (PIC) algorithm involves four operations at each time step: 1) evolve the field equation on the grid,  2) deposit the charge and/or current densities through interpolation from the particles distributions onto the grid, 3) evolve the fields on the grid, 4) interpolate the fields from the grid onto the particles for the next particle push.
 

--- a/Docs/source/theory/maxwell_solvers.rst
+++ b/Docs/source/theory/maxwell_solvers.rst
@@ -63,7 +63,7 @@ is described in, e.g., :cite:t:`pt-VayCSD12,pt-Vaycpc04`.
 .. _fig_yee_grid:
 
 .. figure:: Yee_grid.png
-   :alt: Figure not found
+   :alt: Yee grid layout and leapfrog time integration
 
    (left) Layout of field components on the staggered “Yee” grid. Current densities and electric fields are defined on the edges of the cells and magnetic fields on the faces. (right) Time integration using a second-order finite-difference "leapfrog" integrator.
 
@@ -346,7 +346,7 @@ During these subintervals, :math:`\boldsymbol{\widetilde{J}}` and :math:`\wideti
 .. _fig-psatd_jrhom:
 
 .. figure:: https://gist.githubusercontent.com/oshapoval/88a73cada764364ad4ffce13563cedf1/raw/697ce1897cde0416bebdde8f1c1e8fcf859cb419/psatd_jrhom.png
-   :alt: Figure not found
+   :alt: Time dependencies of current and charge density in PSATD schemes
 
    Diagrams illustrating various time dependencies of the current density :math:`\boldsymbol{\widetilde{J}}` and charge density :math:`\widetilde{\rho}` for constant/linear (CL), both constant (CC), linear (LL) and quadratic (QQ) dependencies with :math:`m` subintervals: (first column) :math:`m=1`, (second) :math:`m=2` and (third) :math:`m=4`. CL1 corresponds to the standard PSATD PIC method. The triangle and circle glyphs represent the times at which the macroparticles deposit :math:`\boldsymbol{\widetilde{J}}` and :math:`\widetilde{\rho}` on the grid, respectively. The dashed and solid lines represent the assumed time dependency of :math:`\boldsymbol{\widetilde{J}}` and :math:`\widetilde{\rho}` within one time step, when integrating the Maxwell equations analytically.
 
@@ -394,7 +394,7 @@ Here, :math:`\boldsymbol{a_J}, \boldsymbol{b_J}, \boldsymbol{c_J}, a_{\rho}, b_{
 .. _fig-j_rho_table:
 
 .. figure:: https://gist.githubusercontent.com/oshapoval/88a73cada764364ad4ffce13563cedf1/raw/ebc249f8e875a952c65a5319fd523821baccfd5a/j_rho_table.png
-   :alt: Figure not found
+   :alt: Table of polynomial coefficients for current and charge density time evolution
 
    Polynomial coefficients based on the time dependency of the current and charge densities :math:`{\boldsymbol{\widetilde{J}}}(t)` and :math:`\widetilde{\rho}(t)` over one time subinterval, :math:`\delta t = \Delta t/m`.
 

--- a/Docs/source/theory/multiphysics/collisions.rst
+++ b/Docs/source/theory/multiphysics/collisions.rst
@@ -160,7 +160,7 @@ See for example :cite:t:`b-Lim2007` for a derivation. The result is that given a
 The impact of incorporating relativistic effects in the MCC routine can be seen in the plots below where high energy collisions are considered with both a classical and relativistic implementation of MCC. It is observed that the classical version of MCC reproduces the classical limit of the above equation but especially for ions, this result differs substantially from the fully relativistic result.
 
 .. figure:: https://user-images.githubusercontent.com/40245517/170900079-74e505a5-2790-44f5-ac84-5847eda954e6.png
-   :alt: Figure not found
+   :alt: Comparison of classical and relativistic MCC collision results
    :width: 96%
 
    Classical v. relativistic MCC.

--- a/Docs/source/usage/faq.rst
+++ b/Docs/source/usage/faq.rst
@@ -65,7 +65,7 @@ What about Back-transformed diagnostics (BTD)?
 ----------------------------------------------
 
 .. figure:: https://user-images.githubusercontent.com/10621396/198702232-9dd595ad-479e-4170-bd25-51e2b72cd50a.png
-   :alt: Figure not found
+   :alt: Minkowski diagram showing BTD features and time relationships
 
    Minkowski diagram indicating several features of the back-transformed diagnostic (BTD). The diagram explains why the first BTD begins to fill at boosted time :math:`t'=0` but this doesn't necessarily correspond to lab time :math:`t=0`, how the BTD grid-spacing is determined by the boosted time step :math:`\Delta t'`, hence why the snapshot length don't correspond to the grid spacing and length in the input script, and how the BTD snapshots complete when the effective snapshot length is covered in the boosted frame.
 

--- a/Docs/source/usage/pwfa.rst
+++ b/Docs/source/usage/pwfa.rst
@@ -26,7 +26,7 @@ The plasma, of total length L, has a density profile that consists of a lr long 
 With this configuration the driver excites a nonlinear plasma wake and drives the bubble depleted of plasma electrons where the beam accelerates, as can be seen in Fig. `[fig:PWFA] <#fig:PWFA>`__.
 
 .. figure:: PWFA.png
-   :alt: Figure not found
+   :alt: Driver, beam and plasma electron distribution in 2D PWFA simulation
 
    Plot of 2D PWFA example at dump 1000.
 

--- a/Docs/source/usage/workflows/ml_dataset_training.rst
+++ b/Docs/source/usage/workflows/ml_dataset_training.rst
@@ -33,7 +33,7 @@ Looking closer at the z-pz space, we see that some particles were not trapped in
 .. _fig_unclean_phase_space:
 
 .. figure:: https://gist.githubusercontent.com/RTSandberg/649a81cc0e7926684f103729483eff90/raw/095ac2daccbcf197fa4e18a8f8505711b27e807a/unclean_stage_0.png
-   :alt: Figure not found
+   :alt: Phase space projections showing partially accelerated beam particles
 
    The final phase space projections of a particle beam through a laser-plasma acceleration element where some beam particles were not accelerated.
 
@@ -45,7 +45,7 @@ After filtering, we can see in :numref:`fig_clean_phase_space` that the beam pha
 .. _fig_clean_phase_space:
 
 .. figure:: https://gist.githubusercontent.com/RTSandberg/649a81cc0e7926684f103729483eff90/raw/095ac2daccbcf197fa4e18a8f8505711b27e807a/clean_stage_0.png
-   :alt: Figure not found
+   :alt: Phase space projections of filtered beam particles
 
    The final phase space projections of a particle beam through a laser-plasma acceleration element after filtering out outlying particles.
 
@@ -246,14 +246,14 @@ When the test-loss starts to trend flat or even upward, the neural network is no
 .. _fig_train_test_loss:
 
 .. figure:: https://gist.githubusercontent.com/RTSandberg/649a81cc0e7926684f103729483eff90/raw/095ac2daccbcf197fa4e18a8f8505711b27e807a/beam_stage_0_training_testing_error.png
-   :alt: Figure not found
+   :alt: Training and testing loss evolution over epochs
 
    Training (in blue) and testing (in green) loss curves versus number of training epochs.
 
 .. _fig_train_evaluation:
 
 .. figure:: https://gist.githubusercontent.com/RTSandberg/649a81cc0e7926684f103729483eff90/raw/095ac2daccbcf197fa4e18a8f8505711b27e807a/beam_stage_0_model_evaluation.png
-   :alt: Figure not found
+   :alt: Model predictions compared with simulation results
 
    A comparison of model prediction (yellow-red dots, colored by mean-squared error) with simulation output (black dots).
 

--- a/Docs/source/usage/workflows/plot_distribution_mapping.rst
+++ b/Docs/source/usage/workflows/plot_distribution_mapping.rst
@@ -144,7 +144,7 @@ This generates plots like in `[fig:knapsack_sfc_distribution_mapping_2D] <#fig:k
    \centering
 
 .. figure:: knapsack_sfc_distribution_mapping_2D.png
-   :alt: Figure not found
+   :alt: Comparison of knapsack vs space-filling curve distribution mappings
    :name: fig:knapsack_sfc_distribution_mapping_2D
    :width: 15cm
 
@@ -177,7 +177,7 @@ This generates plots like in `[fig:knapsack_sfc_costs_2D] <#fig:knapsack_sfc_cos
    \centering
 
 .. figure:: knapsack_sfc_costs_2D.png
-   :alt: Figure not found
+   :alt: Computational cost comparison between knapsack and space-filling curve methods
    :name: fig:knapsack_sfc_costs_2D
    :width: 15cm
 
@@ -268,7 +268,7 @@ This generates plots like in `[fig:distribution_mapping_3D] <#fig:distribution_m
    \centering
 
 .. figure:: distribution_mapping_3D.png
-   :alt: Figure not found
+   :alt: 3D distribution mapping slices in the ik plane
    :name: fig:distribution_mapping_3D
    :width: 15cm
 


### PR DESCRIPTION
Follow up to #5386.

@ax3l pointed out that the :alt: text should always provide a concise description of the image for digital accessibility, even if the caption is also always accessible.