### PR TITLE
Limit verbosity of particle sorting

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -696,7 +696,7 @@ void WarpX::HandleParticlesAtBoundaries (int step, amrex::Real cur_time, int num
     }
 
     if (sort_intervals.contains(step+1)) {
-        if (verbose) {
+        if (verbose && !m_limit_verbose_step) {
             amrex::Print() << Utils::TextMsg::Info("re-sorting particles");
         }
         mypc->SortParticlesByBin(


### PR DESCRIPTION
Super small change here, maybe not relevant. I'd like to propose to limit the sorting verbosity in case the warpx output verbosity is limited. At the moment, if I run with 
```
warpx.verbose = 1
warpx.limit_verbose_step = 1
```
the stdout looks something like this
```
STEP 1100 ends. TIME = 7.87731526e-14 DT = 7.161195691e-17
Evolve time = 44.17611283 s; This step = 0.031813776 s; Avg. per step = 0.04016010257 s

--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
--- INFO    : re-sorting particles
STEP 1200 starts ...
--- INFO    : re-sorting particles
STEP 1200 ends. TIME = 8.593434829e-14 DT = 7.161195691e-17
Evolve time = 47.03899439 s; This step = 0.037334873 s; Avg. per step = 0.03919916199 s
```
I don't know if there's any reason to keep the sorting information active with a limited verbosity, but without any step information associated I don't find it very informative and kind of clutters the output.
Let me know if this makes sense.