### PR TITLE
Document how to extend simulations via Python (first step): add overview section

### DIFF
--- a/Docs/source/index.rst
+++ b/Docs/source/index.rst
@@ -20,7 +20,7 @@ In addition, WarpX is a *highly-parallel and highly-optimized code*:
     - Can run on multi-core CPUs as well as NVIDIA, AMD or Intel GPUs
     - Scales to the world's largest supercomputers and includes load balancing capabilities. WarpX was awarded the `2022 ACM Gordon Bell Prize <https://www.exascaleproject.org/ecp-supported-collaborative-teams-win-the-2022-acm-gordon-bell-prize-and-special-prize/>`__.
     - Multi-platform code that can run on Linux, macOS and Windows.
-    - Can be run and extended via its Python interface, e.g., to couple to other codes or AI/ML frameworks.
+    - Can be run and :ref:`extended via its Python interface <usage-python-extend>`, e.g., to couple to other codes or AI/ML frameworks.
 
 .. _contact:
 

--- a/Docs/source/usage/workflows/python_extend.rst
+++ b/Docs/source/usage/workflows/python_extend.rst
@@ -3,6 +3,24 @@
 Extend a Simulation with Python
 ===============================
 
+Overview
+--------
+
+WarpX's Python bindings let you integrate Python code directly into a WarpX simulation.
+Through this interface, you can **access and modify simulation data** -- such as particle properties, field values -- as the simulation runs.
+This versatility opens the door to a wide range of workflows, including:
+
+   - **Adding a custom physics module** (for instance, a specific collision model) that may not yet be available in WarpX's C++ implementation, and that can be quickly implemented in Python.
+   - **Coupling WarpX with another simulation tool** that has a Python interface, enabling both codes to operate on the same particle or field data.
+   - **Incorporating AI-based surrogate models** built in Python (e.g., with PyTorch or TensorFlow) to emulate complex physical processes.
+
+If your custom Python code uses high-performance, GPU-accelerated libraries -- such as `cupy <https://cupy.dev/>`__, `pytorch <https://pytorch.org/>`__,
+or `numba <https://numba.pydata.org/>`__ -- the extra computations are unlikely to significantly impact simulation speed.
+Note that WarpX's Python bindings provide direct access to particle and field data without creating copies, resulting in very low overhead.
+
+How to run a simulation with Python extensions
+----------------------------------------------
+
 .. tab-set::
 
    .. tab-item:: PICMI


### PR DESCRIPTION
Add an overview section that motivates the Python extensions:
<img width="748" height="626" alt="Screenshot 2025-11-05 at 3 39 07 PM" src="https://github.com/user-attachments/assets/afb848a1-4c05-41e5-b1dd-e41bdcfa6e8b" />

