### PR TITLE
Add an alias warpx.step for warpx.evolve

### DIFF
--- a/Docs/source/usage/workflows/python_extend.rst
+++ b/Docs/source/usage/workflows/python_extend.rst
@@ -39,7 +39,7 @@ Extend a Simulation with Python
          # register callbacks ...
 
          # advance simulation until the last time step
-         sim.evolve()
+         sim.step()
 
       .. dropdown:: Full Example
 
@@ -121,6 +121,10 @@ This object is the Python equivalent to the C++ ``WarpX`` simulation class.
    .. py:method:: evolve(numsteps=-1)
 
       Evolve the simulation the specified number of steps.
+
+   .. py:method:: step(numsteps=-1)
+
+      An alias to the evolve method.
 
    .. autofunction:: pywarpx.picmi.Simulation.extension.finalize
 

--- a/Examples/Physics_applications/laser_acceleration/inputs_test_3d_laser_acceleration_python.py
+++ b/Examples/Physics_applications/laser_acceleration/inputs_test_3d_laser_acceleration_python.py
@@ -57,4 +57,4 @@ def my_advanced_callback():
 
 
 # Advance simulation until the last time step
-sim.evolve()
+sim.step()

--- a/Examples/Tests/plasma_lens/inputs_test_3d_plasma_lens_python.py
+++ b/Examples/Tests/plasma_lens/inputs_test_3d_plasma_lens_python.py
@@ -68,4 +68,4 @@ diag1.diag_type = "Full"
 diag1.electrons.variables = "x", "y", "z", "ux", "uy", "uz"
 
 warpx.init()
-warpx.evolve(max_step)
+warpx.step(max_step)

--- a/Python/pywarpx/WarpX.py
+++ b/Python/pywarpx/WarpX.py
@@ -167,6 +167,10 @@ class WarpX(Bucket):
     def evolve(self, nsteps=-1):
         libwarpx.warpx.evolve(nsteps)
 
+    def step(self, nsteps=-1):
+        """An alias of evolve, to be consistent with the PICMI Simulation class"""
+        self.evolve(nsteps)
+
     def finalize(self, finalize_mpi=1):
         libwarpx.finalize(finalize_mpi)
 

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -3405,7 +3405,7 @@ class Simulation(picmistandard.PICMI_Simulation):
                 nsteps = self.max_steps
             else:
                 nsteps = -1
-        pywarpx.warpx.evolve(nsteps)
+        pywarpx.warpx.step(nsteps)
 
     def finalize(self):
         if self.warpx_initialized:


### PR DESCRIPTION
This adds the alias warp.step to be consistent with Simulation.step. This is to avoid confusion since in various examples warpx and Simulation are used interchangeably - the method for running the simulation should be the same.

Should the warpx.evolve just be removed (i.e. renamed "step")?