### PR TITLE
Document how to extent simulations with Python (second step): explain how to run

### DIFF
--- a/Docs/source/usage/workflows/python_extend.rst
+++ b/Docs/source/usage/workflows/python_extend.rst
@@ -21,7 +21,34 @@ Note that WarpX's Python bindings provide direct access to particle and field da
 How to run a simulation with Python extensions
 ----------------------------------------------
 
+- **Install WarpX with support for the Python interface**: for instance, if you :ref:`compile WarpX from source <install-build-code>`, this involves using ``-DWarpX_PYTHON=ON``.
+
+- **Write a Python script that extends the simulation**: this can be done starting from a simulation defined either with a :ref:`parameter list <running-cpp-parameters>` or with the :ref:`PICMI Python interface <usage-picmi>`.
+  The Python code typically contains :ref:`callback functions <usage-python-extend-callbacks>` that :ref:`access/modify <usage-python-extend-data-access>` the simulation data (see the sections below for more details).
+
 .. tab-set::
+
+   .. tab-item:: Parameter List
+
+      When starting from an :ref:`inputs file <running-cpp-parameters>`, one can transition to WarpX Python by loading it:
+
+      .. code-block:: python3
+
+         from pywarpx import warpx
+
+         sim = warpx
+         sim.load_inputs_file("./inputs_test_3d_laser_acceleration")
+
+         # register callbacks ...
+
+         # advance simulation until the last time step
+         sim.evolve()
+
+      .. dropdown:: Full Example
+
+         .. literalinclude:: inputs_test_3d_laser_acceleration_python.py
+            :language: python3
+            :caption: You can copy this file from ``Examples/Physics_applications/laser_acceleration/inputs_test_3d_laser_acceleration_python.py`` and it requires the files ``inputs_test_3d_laser_acceleration`` and ``inputs_base_3d`` from the same folder.
 
    .. tab-item:: PICMI
 
@@ -43,27 +70,16 @@ How to run a simulation with Python extensions
 
              # do something custom with the sim object
 
-   .. tab-item:: Inputs File
+- **Run the simulation by executing the Python script**: for instance using `mpirun` or `srun` on an HPC system.
 
-      When starting from an :ref:`inputs file <running-cpp-parameters>`, one can transition to WarpX Python by loading it:
+.. code-block:: bash
 
-      .. code-block:: python3
+   mpirun -np <n_ranks> python <python_script>
 
-         from pywarpx import warpx
+.. _usage-python-extend-callbacks:
 
-         sim = warpx
-         sim.load_inputs_file("./inputs_test_3d_laser_acceleration")
-
-         # register callbacks ...
-
-         # advance simulation until the last time step
-         sim.evolve()
-
-      .. dropdown:: Full Example
-
-         .. literalinclude:: inputs_test_3d_laser_acceleration_python.py
-            :language: python3
-            :caption: You can copy this file from ``Examples/Physics_applications/laser_acceleration/inputs_test_3d_laser_acceleration_python.py`` and it requires the files ``inputs_test_3d_laser_acceleration`` and ``inputs_base_3d`` from the same folder.
+Callback Functions
+------------------
 
 Installing `callback functions <https://en.wikipedia.org/wiki/Callback_(computer_programming)>`__ will execute a given Python function at a
 specific location in the WarpX simulation loop.
@@ -98,6 +114,8 @@ Important APIs include:
 * `amr.MultiFab <https://pyamrex.readthedocs.io/en/latest/usage/api.html#amrex.space3d.MultiFab>`__: MPI-parallel field data
 * `amr.ParticleContainer_* <https://pyamrex.readthedocs.io/en/latest/usage/api.html#amrex.space3d.ParticleContainer_1_1_2_1_default>`__: MPI-parallel particle data for a particle species
 
+
+.. _usage-python-extend-data-access:
 
 Data Access
 -----------

--- a/Docs/source/usage/workflows/python_extend.rst
+++ b/Docs/source/usage/workflows/python_extend.rst
@@ -24,13 +24,13 @@ How to run a simulation with Python extensions
 - **Install WarpX with support for the Python interface**: for instance, if you :ref:`compile WarpX from source <install-build-code>`, this involves using ``-DWarpX_PYTHON=ON``.
 
 - **Write a Python script that extends the simulation**: this can be done starting from a simulation defined either with a :ref:`parameter list <running-cpp-parameters>` or with the :ref:`PICMI Python interface <usage-picmi>`.
-  The Python code typically contains :ref:`callback functions <usage-python-extend-callbacks>` that :ref:`access/modify <usage-python-extend-data-access>` the simulation data (see the sections below for more details).
+  The Python script typically contains :ref:`callback functions <usage-python-extend-callbacks>` that :ref:`access/modify <usage-python-extend-data-access>` the simulation data (see the sections below for more details).
 
 .. tab-set::
 
    .. tab-item:: Parameter List
 
-      When starting from an :ref:`inputs file <running-cpp-parameters>`, one can transition to WarpX Python by loading it:
+      When starting from a :ref:`parameter list <running-cpp-parameters>`, write a Python script that loads the parameter list file using the :py:meth:`~pywarpx.picmi.Simulation.load_inputs_file` method:
 
       .. code-block:: python3
 
@@ -52,9 +52,7 @@ How to run a simulation with Python extensions
 
    .. tab-item:: PICMI
 
-      When running WarpX directly :ref:`from PICMI Python <usage-picmi>` it is possible to interact with the simulation.
-
-      For instance, with the :py:meth:`~pywarpx.picmi.Simulation.step` method of the simulation class, one could run ``sim.step(nsteps=1)`` in a loop:
+      When starting from a :ref:`PICMI Python script <usage-picmi>`, simply add the Python code that extends the simulation to this script, before the call to :py:meth:`~pywarpx.picmi.Simulation.step`.
 
       .. code-block:: python3
 
@@ -64,13 +62,10 @@ How to run a simulation with Python extensions
 
          # register callbacks ...
 
-         steps = 1000
-         for _ in range(steps):
-             sim.step(nsteps=1)
+         sim.step(nsteps=1000)
 
-             # do something custom with the sim object
 
-- **Run the simulation by executing the Python script**: for instance using `mpirun` or `srun` on an HPC system.
+- **Then, run the simulation by executing the Python script**: for instance using ``mpirun`` or ``srun`` on an HPC system.
 
 .. code-block:: bash
 


### PR DESCRIPTION
This improves the next section of the page:

<img width="614" height="701" alt="Screenshot 2025-11-05 at 5 04 41 PM" src="https://github.com/user-attachments/assets/97aece76-e473-4069-8b92-f0406fd28cfb" />
