### PR TITLE
[WIP] Docs: Rename inputs sections

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1,7 +1,7 @@
 .. _running-cpp-parameters:
 
-Inputs: Parameter List
-======================
+Raw Inputs
+==========
 
 This documents on how to use WarpX with an inputs file (e.g., ``warpx.3d input_3d``).
 

--- a/Docs/source/usage/python.rst
+++ b/Docs/source/usage/python.rst
@@ -1,8 +1,8 @@
 .. _usage-picmi:
 .. _usage-picmi-run:
 
-Inputs: PICMI Python Script
-===========================
+PICMI Inputs
+============
 
 This documents on how to use WarpX as a Python script (e.g., ``python3 PICMI_script.py``).
 


### PR DESCRIPTION
I would like to propose an audacious change, inspired by a comment from @aeriforme during the documentation hackathon, and rename the following sections:
- "Inputs: Parameter List": "Raw Inputs"
- "Inputs: PICMI Python Script": "PICMI Inputs"

Before this PR:
<img width="300" alt="Screenshot from 2025-11-06 17-01-48" src="https://github.com/user-attachments/assets/d440c255-dc8f-4a94-8569-2d2482559d4b" />

After this PR:
<img width="300" alt="Screenshot from 2025-11-06 17-02-49" src="https://github.com/user-attachments/assets/58528c8a-49b9-4225-afa1-232471758171" />