### PR TITLE
Docs: Add STL Union Workflow

### DIFF
--- a/Docs/source/usage/workflows.rst
+++ b/Docs/source/usage/workflows.rst
@@ -16,6 +16,7 @@ This section collects typical user workflows and best practices for WarpX.
    workflows/generate_lookup_tables_with_tools
    workflows/plot_timestep_duration
    workflows/psatd_stencil
+   workflows/stl_geometry_preparation
    workflows/archiving
    workflows/ml_dataset_training
    workflows/optimas

--- a/Docs/source/usage/workflows/stl_geometry_preparation.rst
+++ b/Docs/source/usage/workflows/stl_geometry_preparation.rst
@@ -1,7 +1,7 @@
 .. _workflows-stl-geometry-preparation:
 
 STL Geometry Preparation for WarpX
-===================================
+==================================
 
 WarpX has the ability to define the embedded boundary (EB) in a simulation using externally provided STL (STereoLithography) files.
 STL files are a common format for representing 3D geometries and can be used to define complex embedded boundaries in WarpX simulations, without having to define extensive EB implicit functions.
@@ -14,7 +14,7 @@ However, there are some limitations to using STL files which must be resolved, i
 .. 2. The STL file shouldn't have duplicate faces or vertices, and overlapping vertices should be merged. (issues with vertices can cause the MLMG solver to crash)
 
 Step 1: Combining Multiple STL Files
--------------------------------------
+------------------------------------
 
 If your device consists of multiple parts stored in separate STL files, you'll need to combine them into a single STL file.
 
@@ -33,7 +33,7 @@ Using MeshLab
 7. Choose STL format and save
 
 Using Python with trimesh
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can also use Python with the ``trimesh`` library:
 
@@ -52,7 +52,7 @@ You can also use Python with the ``trimesh`` library:
    combined.export('device_combined.stl')
 
 Step 2: Making the Geometry Watertight and Removing and Merging Duplicate Faces and Vertices
----------------------------------------
+---------------------------------------------------------------------------------------------------
 
 
 WarpX requires that STL geometries be "watertight" (manifold), meaning the mesh has no holes, gaps, or open edges.
@@ -92,7 +92,7 @@ To check and repair a mesh in MeshLab:
       * An STL file with non-manifold edges won't necessarily crash a simulation, but may present other numerical issues.
 
 .. Using Python with trimesh
-.. ^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. .. code-block:: python
 
@@ -118,7 +118,7 @@ To check and repair a mesh in MeshLab:
 
 
 Step 3: Using STL Files in WarpX
----------------------------------
+--------------------------------
 
 Once you have a single, watertight STL file, you can use it in WarpX by setting the following parameters in your input file:
 
@@ -143,7 +143,7 @@ For more details on embedded boundary parameters, see:
 * `Embedded Boundary PICMI Input Parameters <https://warpx.readthedocs.io/en/latest/usage/python.html#pywarpx.picmi.EmbeddedBoundary:~:text=Custom%20class%20to,translated%20and%20inverted.>`__
 
 Tips and Best Practices
-------------------------
+-----------------------
 
 * *Units:* Ensure your STL file uses the same unit system as your WarpX simulation
 * *Scale:* If needed, scale your geometry in your CAD software or mesh editor before exporting

--- a/Docs/source/usage/workflows/stl_geometry_preparation.rst
+++ b/Docs/source/usage/workflows/stl_geometry_preparation.rst
@@ -91,30 +91,7 @@ To check and repair a mesh in MeshLab:
 
       * An STL file with non-manifold edges won't necessarily crash a simulation, but may present other numerical issues.
 
-.. Using Python with trimesh
-.. ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. .. code-block:: python
-
-..    import trimesh
-
-..    # Load the mesh
-..    mesh = trimesh.load('device_combined.stl')
-
-..    # Check if watertight
-..    print(f"Is watertight: {mesh.is_watertight}")
-..    print(f"Is manifold: {mesh.is_winding_consistent}")
-
-..    # Attempt to repair
-..    trimesh.repair.fix_normals(mesh)
-..    trimesh.repair.fill_holes(mesh)
-..    trimesh.repair.fix_inversion(mesh)
-
-..    # Check again
-..    print(f"After repair - Is watertight: {mesh.is_watertight}")
-
-..    # Export repaired mesh
-..    mesh.export('device_watertight.stl')
 
 
 Step 3: Using STL Files in WarpX

--- a/Docs/source/usage/workflows/stl_geometry_preparation.rst
+++ b/Docs/source/usage/workflows/stl_geometry_preparation.rst
@@ -35,7 +35,7 @@ Using MeshLab
 Using Python with trimesh
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You can also use Python with the ``trimesh`` library:
+You can also use Python with the `trimesh <https://github.com/mikedh/trimesh>`__ library:
 
 .. code-block:: python
 

--- a/Docs/source/usage/workflows/stl_geometry_preparation.rst
+++ b/Docs/source/usage/workflows/stl_geometry_preparation.rst
@@ -66,13 +66,13 @@ Using MeshLab
 To check and repair a mesh in MeshLab:
 
 1. **Check for issues:**
-   
+
    * ``Filters -> Quality Measure and Computations -> Compute Topological Measures``
    * Look for holes in the output
    * Look for non-manifold edges and vertices in the output
-   
+
 2. **Repair the mesh:**
-   
+
    * When loading in the mesh, there is an option to ``Unify Duplicated Vertices in STL files``, this will perform the next steps automatically, but gives the user less control.
    * ``Filters -> Cleaning and Repairing -> Remove Duplicate Faces``
    * ``Filters -> Cleaning and Repairing -> Remove Duplicate Vertices``
@@ -84,11 +84,11 @@ To check and repair a mesh in MeshLab:
    .. * ``Filters -> Remeshing, Simplification and Reconstruction -> Close Holes``
 
 3. **Verify the mesh is watertight:**
-   
+
    * Run ``Filters -> Quality Measure and Computations -> Compute Topological Measures`` again
    * Check that the mesh has no holes
    * Check that the mesh is manifold (no warnings about non-manifold edges)
-   
+
       * An STL file with non-manifold edges won't necessarily crash a simulation, but may present other numerical issues.
 
 .. Using Python with trimesh
@@ -126,7 +126,7 @@ Once you have a single, watertight STL file, you can use it in WarpX by setting 
 
    # Specify that the embedded boundary comes from an STL file
    eb2.geom_type = stl
-   
+
    # Path to your STL file
    eb2.stl_file = path/to/device_watertight.stl
 
@@ -161,7 +161,7 @@ Examples
 .. note::
 
    **TODO**: WarpX does not yet have examples that use STL files for embedded boundaries.
-   
+
    Current embedded boundary examples in ``Examples/Tests/embedded_boundary_*`` use analytical
    functions to define geometries. A complete example demonstrating STL file usage will be
    added in the future.

--- a/Docs/source/usage/workflows/stl_geometry_preparation.rst
+++ b/Docs/source/usage/workflows/stl_geometry_preparation.rst
@@ -1,0 +1,163 @@
+.. _workflows-stl-geometry-preparation:
+
+STL Geometry Preparation for WarpX
+===================================
+
+This workflow describes how to prepare multiple STL (STereoLithography) files of a device for input into WarpX.
+STL files are a common format for representing 3D geometries and can be used to define complex embedded boundaries in WarpX simulations.
+
+Overview
+--------
+
+When working with STL files in WarpX, you need to ensure that:
+
+1. Multiple STL files representing different parts of a device are combined into a single file
+2. The resulting geometry is "watertight" (no gaps or holes in the mesh)
+3. The STL file is properly formatted for WarpX input
+
+Step 1: Combining Multiple STL Files
+-------------------------------------
+
+If your device consists of multiple parts stored in separate STL files, you'll need to combine them into a single STL file.
+
+Using MeshLab
+^^^^^^^^^^^^^
+
+`MeshLab <https://www.meshlab.net/>`__ is a free, open-source tool for processing 3D meshes:
+
+1. Open MeshLab
+2. Import the first STL file: ``File -> Import Mesh``
+3. Import additional STL files: ``File -> Import Mesh`` (repeat for each file)
+4. All parts should now be visible in the same scene
+5. Export the combined mesh: ``File -> Export Mesh As``
+6. Choose STL format and save
+
+Using Python with trimesh
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can also use Python with the ``trimesh`` library:
+
+.. code-block:: python
+
+   import trimesh
+
+   # Load individual STL files
+   mesh1 = trimesh.load('part1.stl')
+   mesh2 = trimesh.load('part2.stl')
+   mesh3 = trimesh.load('part3.stl')
+
+   # Combine meshes
+   combined = trimesh.util.concatenate([mesh1, mesh2, mesh3])
+
+   # Export combined mesh
+   combined.export('device_combined.stl')
+
+Step 2: Making the Geometry Watertight
+---------------------------------------
+
+WarpX requires that STL geometries be "watertight" (manifold), meaning the mesh has no holes, gaps, or open edges.
+This ensures that WarpX can properly determine which regions are inside or outside the geometry.
+
+Using MeshLab
+^^^^^^^^^^^^^
+
+To check and repair a mesh in MeshLab:
+
+1. **Check for issues:**
+   
+   * ``Filters -> Quality Measure and Computations -> Compute Topological Measures``
+   * Look for non-manifold edges and vertices in the output
+
+2. **Repair the mesh:**
+   
+   * ``Filters -> Cleaning and Repairing -> Remove Duplicate Faces``
+   * ``Filters -> Cleaning and Repairing -> Remove Duplicate Vertices``
+   * ``Filters -> Cleaning and Repairing -> Remove Zero Area Faces``
+   * ``Filters -> Remeshing, Simplification and Reconstruction -> Close Holes``
+
+3. **Verify the mesh is watertight:**
+   
+   * Run ``Filters -> Quality Measure and Computations -> Compute Topological Measures`` again
+   * Check that the mesh is manifold (no warnings about non-manifold edges)
+
+Using Python with trimesh
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   import trimesh
+
+   # Load the mesh
+   mesh = trimesh.load('device_combined.stl')
+
+   # Check if watertight
+   print(f"Is watertight: {mesh.is_watertight}")
+   print(f"Is manifold: {mesh.is_winding_consistent}")
+
+   # Attempt to repair
+   trimesh.repair.fix_normals(mesh)
+   trimesh.repair.fill_holes(mesh)
+   trimesh.repair.fix_inversion(mesh)
+
+   # Check again
+   print(f"After repair - Is watertight: {mesh.is_watertight}")
+
+   # Export repaired mesh
+   mesh.export('device_watertight.stl')
+
+Using netfabb or Meshmixer
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Other popular tools for repairing STL files include:
+
+* `Autodesk Meshmixer <https://www.meshmixer.com/>`__: Free tool with analysis and repair features
+* `netfabb <https://www.autodesk.com/products/netfabb/overview>`__: Professional tool with automatic repair
+
+Step 3: Using STL Files in WarpX
+---------------------------------
+
+Once you have a single, watertight STL file, you can use it in WarpX by setting the following parameters in your input file:
+
+.. code-block:: text
+
+   # Specify that the embedded boundary comes from an STL file
+   eb2.geom_type = stl
+   
+   # Path to your STL file
+   eb2.stl_file = path/to/device_watertight.stl
+
+You can also optionally set an electric potential on the embedded boundary:
+
+.. code-block:: text
+
+   # Define electric potential at the embedded boundary (optional)
+   warpx.eb_potential(x,y,z,t) = "voltage_function"
+
+For more details on embedded boundary parameters, see :ref:`running-cpp-parameters-eb`.
+
+Tips and Best Practices
+------------------------
+
+* *Units:* Ensure your STL file uses the same unit system as your WarpX simulation
+* *Scale:* If needed, scale your geometry in your CAD software or mesh editor before exporting
+* *Orientation:* Check that your geometry is properly oriented relative to WarpX's coordinate system
+* *Resolution:* The STL mesh resolution should be appropriate for your simulation - too coarse may miss important features, too fine may slow down initialization
+* *Binary vs ASCII:* WarpX can read both binary and ASCII STL files, but binary files are typically smaller and faster to load
+
+Further Reading
+---------------
+
+* :ref:`running-cpp-parameters-eb` - Full documentation on embedded boundary parameters
+* `STL file format <https://en.wikipedia.org/wiki/STL_(file_format)>`__ - Wikipedia article on STL format
+* `AMReX Embedded Boundary documentation <https://amrex-codes.github.io/amrex/docs_html/EB.html>`__ - Details on how AMReX handles embedded boundaries
+
+Examples
+--------
+
+.. note::
+
+   **TODO**: WarpX does not yet have examples that use STL files for embedded boundaries.
+   
+   Current embedded boundary examples in ``Examples/Tests/embedded_boundary_*`` use analytical
+   functions to define geometries. A complete example demonstrating STL file usage will be
+   added in the future.

--- a/Docs/source/usage/workflows/stl_geometry_preparation.rst
+++ b/Docs/source/usage/workflows/stl_geometry_preparation.rst
@@ -3,17 +3,15 @@
 STL Geometry Preparation for WarpX
 ===================================
 
-This workflow describes how to prepare multiple STL (STereoLithography) files of a device for input into WarpX.
-STL files are a common format for representing 3D geometries and can be used to define complex embedded boundaries in WarpX simulations.
+WarpX has the ability to define the embedded boundary (EB) in a simulation using externally provided STL (STereoLithography) files.
+STL files are a common format for representing 3D geometries and can be used to define complex embedded boundaries in WarpX simulations, without having to define extensive EB implicit functions.
+However, there are some limitations to using STL files which must be resolved, including:
 
-Overview
---------
-
-When working with STL files in WarpX, you need to ensure that:
-
-1. Multiple STL files representing different parts of a device are combined into a single file
-2. The resulting geometry is "watertight" (no gaps or holes in the mesh)
+1. Multiple STL files representing different parts of a device must be combined into a single file
+2. The STL geometry is "watertight" (The STL file shouldn't have duplicate faces or vertices, overlapping vertices should be merged, and there shouldn't be any gaps or holes in the mesh)
 3. The STL file is properly formatted for WarpX input
+
+.. 2. The STL file shouldn't have duplicate faces or vertices, and overlapping vertices should be merged. (issues with vertices can cause the MLMG solver to crash)
 
 Step 1: Combining Multiple STL Files
 -------------------------------------
@@ -29,8 +27,10 @@ Using MeshLab
 2. Import the first STL file: ``File -> Import Mesh``
 3. Import additional STL files: ``File -> Import Mesh`` (repeat for each file)
 4. All parts should now be visible in the same scene
-5. Export the combined mesh: ``File -> Export Mesh As``
-6. Choose STL format and save
+5. Create a union of the two parts, either by ``Filters -> Remeshing, Simplification and Reconstruction -> Mesh Boolean: Union``
+   or by right-clicking on one of the parts in the Layer Dialog panel on the right and clicking ``Mesh Boolean: Union``
+6. Select the union and export the combined mesh: ``File -> Export Mesh As``
+7. Choose STL format and save
 
 Using Python with trimesh
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -44,19 +44,21 @@ You can also use Python with the ``trimesh`` library:
    # Load individual STL files
    mesh1 = trimesh.load('part1.stl')
    mesh2 = trimesh.load('part2.stl')
-   mesh3 = trimesh.load('part3.stl')
 
    # Combine meshes
-   combined = trimesh.util.concatenate([mesh1, mesh2, mesh3])
+   combined = trimesh.util.concatenate([mesh1, mesh2])
 
    # Export combined mesh
    combined.export('device_combined.stl')
 
-Step 2: Making the Geometry Watertight
+Step 2: Making the Geometry Watertight and Removing and Merging Duplicate Faces and Vertices
 ---------------------------------------
+
 
 WarpX requires that STL geometries be "watertight" (manifold), meaning the mesh has no holes, gaps, or open edges.
 This ensures that WarpX can properly determine which regions are inside or outside the geometry.
+STL files that have overlapping or duplicate faces and vertices can cause the MLMG solver to crash, while a non-manifold file can be inherently leaky for Poynting flux in an EM simulation.
+These issues with the mesh might happen while exporting the STL file from a CAD program (such as SolidWorks)
 
 Using MeshLab
 ^^^^^^^^^^^^^
@@ -66,52 +68,54 @@ To check and repair a mesh in MeshLab:
 1. **Check for issues:**
    
    * ``Filters -> Quality Measure and Computations -> Compute Topological Measures``
+   * Look for holes in the output
    * Look for non-manifold edges and vertices in the output
-
+   
 2. **Repair the mesh:**
    
+   * When loading in the mesh, there is an option to ``Unify Duplicated Vertices in STL files``, this will perform the next steps automatically, but gives the user less control.
    * ``Filters -> Cleaning and Repairing -> Remove Duplicate Faces``
    * ``Filters -> Cleaning and Repairing -> Remove Duplicate Vertices``
-   * ``Filters -> Cleaning and Repairing -> Remove Zero Area Faces``
-   * ``Filters -> Remeshing, Simplification and Reconstruction -> Close Holes``
+   * ``Filters -> Cleaning and Repairing -> Merge Close Vertices``
+
+      * This filter gives the user an option to set an absolute or relative tolerance on the distance between the vertices to merge.
+
+   .. * ``Filters -> Cleaning and Repairing -> Remove Zero Area Faces``
+   .. * ``Filters -> Remeshing, Simplification and Reconstruction -> Close Holes``
 
 3. **Verify the mesh is watertight:**
    
    * Run ``Filters -> Quality Measure and Computations -> Compute Topological Measures`` again
+   * Check that the mesh has no holes
    * Check that the mesh is manifold (no warnings about non-manifold edges)
+   
+      * An STL file with non-manifold edges won't necessarily crash a simulation, but may present other numerical issues.
 
-Using Python with trimesh
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. Using Python with trimesh
+.. ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: python
+.. .. code-block:: python
 
-   import trimesh
+..    import trimesh
 
-   # Load the mesh
-   mesh = trimesh.load('device_combined.stl')
+..    # Load the mesh
+..    mesh = trimesh.load('device_combined.stl')
 
-   # Check if watertight
-   print(f"Is watertight: {mesh.is_watertight}")
-   print(f"Is manifold: {mesh.is_winding_consistent}")
+..    # Check if watertight
+..    print(f"Is watertight: {mesh.is_watertight}")
+..    print(f"Is manifold: {mesh.is_winding_consistent}")
 
-   # Attempt to repair
-   trimesh.repair.fix_normals(mesh)
-   trimesh.repair.fill_holes(mesh)
-   trimesh.repair.fix_inversion(mesh)
+..    # Attempt to repair
+..    trimesh.repair.fix_normals(mesh)
+..    trimesh.repair.fill_holes(mesh)
+..    trimesh.repair.fix_inversion(mesh)
 
-   # Check again
-   print(f"After repair - Is watertight: {mesh.is_watertight}")
+..    # Check again
+..    print(f"After repair - Is watertight: {mesh.is_watertight}")
 
-   # Export repaired mesh
-   mesh.export('device_watertight.stl')
+..    # Export repaired mesh
+..    mesh.export('device_watertight.stl')
 
-Using netfabb or Meshmixer
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Other popular tools for repairing STL files include:
-
-* `Autodesk Meshmixer <https://www.meshmixer.com/>`__: Free tool with analysis and repair features
-* `netfabb <https://www.autodesk.com/products/netfabb/overview>`__: Professional tool with automatic repair
 
 Step 3: Using STL Files in WarpX
 ---------------------------------
@@ -133,7 +137,10 @@ You can also optionally set an electric potential on the embedded boundary:
    # Define electric potential at the embedded boundary (optional)
    warpx.eb_potential(x,y,z,t) = "voltage_function"
 
-For more details on embedded boundary parameters, see :ref:`running-cpp-parameters-eb`.
+For more details on embedded boundary parameters, see:
+
+* `Embedded Boundary Input Parameters <https://warpx.readthedocs.io/en/latest/usage/parameters.html#embedded-boundary-conditions:~:text=in%20this%20case.-,Embedded%20Boundary%20Conditions,-%EF%83%81>`__
+* `Embedded Boundary PICMI Input Parameters <https://warpx.readthedocs.io/en/latest/usage/python.html#pywarpx.picmi.EmbeddedBoundary:~:text=Custom%20class%20to,translated%20and%20inverted.>`__
 
 Tips and Best Practices
 ------------------------
@@ -142,14 +149,11 @@ Tips and Best Practices
 * *Scale:* If needed, scale your geometry in your CAD software or mesh editor before exporting
 * *Orientation:* Check that your geometry is properly oriented relative to WarpX's coordinate system
 * *Resolution:* The STL mesh resolution should be appropriate for your simulation - too coarse may miss important features, too fine may slow down initialization
+
+      * It's generally a good idea to simplify your geometery and remove features that are significantly smaller than the WarpX simulation grid
+
 * *Binary vs ASCII:* WarpX can read both binary and ASCII STL files, but binary files are typically smaller and faster to load
 
-Further Reading
----------------
-
-* :ref:`running-cpp-parameters-eb` - Full documentation on embedded boundary parameters
-* `STL file format <https://en.wikipedia.org/wiki/STL_(file_format)>`__ - Wikipedia article on STL format
-* `AMReX Embedded Boundary documentation <https://amrex-codes.github.io/amrex/docs_html/EB.html>`__ - Details on how AMReX handles embedded boundaries
 
 Examples
 --------


### PR DESCRIPTION
This PR adds a workflow to the docs that describes how to work with multiple STL files and unify them for import into WarpX where they provide the configuration for embedded boundaries.

Credit goes to @agargone who authored the docs.