### PR TITLE
Update .gitignore to exclude WARP.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,11 @@ cmake-build-*/
 ##########
 .vscode
 
+#################
+# Warp terminal #
+#################
+WARP.md
+
 # File-based project format:
 *.iws
 


### PR DESCRIPTION
Update `.gitignore` file to exclude optimization file generated by Warp terminal, called `WARP.md`.
