### PR TITLE
refactor direct deposit for Mass Matrices.

### DIFF
--- a/Source/Particles/Deposition/MassMatricesDeposition.H
+++ b/Source/Particles/Deposition/MassMatricesDeposition.H
@@ -90,16 +90,14 @@ void setMassMatricesKernels ( const amrex::ParticleReal qs,
 
 /**
  * \brief Kernel for the direct deposition of J and S (mass matrices) for thread thread_num
- * \tparam depos_order deposition order
+ * \tparam depos_order             deposition order
+ * \tparam full_mass_matrices      Whether to deposit the full mass matrices
  * \param xp, yp, zp               The particle positions.
  * \param wqx,wqy,wqz              The particle velocity multiplied by the charge / volume
  * \param fpxx,fpxy,fpxz           Mass matrix kernels for Jx
  * \param fpyx,fpyy,fpyz           Mass matrix kernels for Jy
  * \param fpzx,fpzy,fpzz           Mass matrix kernels for Jz
  * \param jx_arr,jy_arr,jz_arr     Array4 of current density, either full array or tile.
- * \param Sxx_nComp                number of Sxx components
- * \param Syy_nComp                number of Syy components
- * \param Szz_nComp                number of Szz components
  * \param Sxx_arr,Sxy_arr,Sxz_arr  Array4 of mass matrices for Jx, either full array or tile.
  * \param Syx_arr,Syy_arr,Syz_arr  Array4 of mass matrices for Jy, either full array or tile.
  * \param Szx_arr,Szy_arr,Szz_arr  Array4 of mass matrices for Jz, either full array or tile.
@@ -108,7 +106,7 @@ void setMassMatricesKernels ( const amrex::ParticleReal qs,
  * \param xyzmin                   The lower bounds of the domain
  * \param lo                       Index lower bounds of domain.
  */
-template <int depos_order>
+template <int depos_order, bool full_mass_matrices>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void doDirectJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::ParticleReal xp,
                                          [[maybe_unused]] const amrex::ParticleReal yp,
@@ -128,9 +126,6 @@ void doDirectJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::ParticleR
                                          amrex::Array4<amrex::Real> const& jx_arr,
                                          amrex::Array4<amrex::Real> const& jy_arr,
                                          amrex::Array4<amrex::Real> const& jz_arr,
-                                         [[maybe_unused]] int Sxx_nComp,
-                                         [[maybe_unused]] int Syy_nComp,
-                                         [[maybe_unused]] int Szz_nComp,
                                          amrex::Array4<amrex::Real> const& Sxx_arr,
                                          [[maybe_unused]] amrex::Array4<amrex::Real> const& Sxy_arr,
                                          [[maybe_unused]] amrex::Array4<amrex::Real> const& Sxz_arr,
@@ -282,14 +277,11 @@ void doDirectJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::ParticleR
         amrex::Gpu::Atomic::AddNoRet(
             &jz_arr(lo.x+l_jz+iz, 0, 0, 0),
             sz_jz[iz]*wqz);
-        for (int aa=0; aa<=depos_order; aa++){
-            //  Deposit mass matrices for X-current
-            if (Sxx_nComp==1 && aa==iz) {
-                amrex::Gpu::Atomic::AddNoRet(
-                    &Sxx_arr(lo.x+l_jx+iz, 0, 0, 0),
-                    sz_jx[iz]*sz_jx[aa]*fpxx);
-            }
-            else if (Sxx_nComp>1) {
+
+        // Deposit mass matrices
+        if constexpr (full_mass_matrices) {
+            for (int aa=0; aa<=depos_order; aa++){
+                //  Deposit mass matrices for X-current
                 int Nc = depos_order + aa - iz;
                 amrex::Gpu::Atomic::AddNoRet(
                     &Sxx_arr(lo.x+l_jx+iz, 0, 0, Nc),
@@ -302,15 +294,9 @@ void doDirectJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::ParticleR
                 amrex::Gpu::Atomic::AddNoRet(
                     &Sxz_arr(lo.x+l_jx+iz, 0, 0, Nc),
                     sz_jx[iz]*sz_jz[aa]*fpxz);
-            }
-            //  Deposit mass matrices for Y-current
-            if (Syy_nComp==1 && aa==iz) {
-                amrex::Gpu::Atomic::AddNoRet(
-                    &Syy_arr(lo.x+l_jy+iz, 0, 0, 0),
-                    sz_jy[iz]*sz_jy[aa]*fpyy);
-            }
-            else if (Syy_nComp>1) {
-                int Nc = depos_order + shift[0]*offset_xy[0] + aa - iz;
+
+                //  Deposit mass matrices for Y-current
+                Nc = depos_order + shift[0]*offset_xy[0] + aa - iz;
                 amrex::Gpu::Atomic::AddNoRet(
                     &Syx_arr(lo.x+l_jy+iz, 0, 0, Nc),
                     sz_jy[iz]*sz_jx[aa]*fpyx);
@@ -322,15 +308,9 @@ void doDirectJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::ParticleR
                 amrex::Gpu::Atomic::AddNoRet(
                     &Syz_arr(lo.x+l_jy+iz, 0, 0, Nc),
                     sz_jy[iz]*sz_jz[aa]*fpyz);
-            }
-            //  Deposit mass matrices for Z-current
-            if (Szz_nComp==1 && aa==iz) {
-                amrex::Gpu::Atomic::AddNoRet(
-                    &Szz_arr(lo.x+l_jz+iz, 0, 0, 0),
-                    sz_jz[iz]*sz_jz[aa]*fpzz);
-            }
-            else if(Szz_nComp>1) {
-                int Nc = depos_order + 1 - shift[0]*offset_xz[0] + aa - iz;
+
+                //  Deposit mass matrices for Z-current
+                Nc = depos_order + 1 - shift[0]*offset_xz[0] + aa - iz;
                 amrex::Gpu::Atomic::AddNoRet(
                     &Szx_arr(lo.x+l_jz+iz, 0, 0, Nc),
                     sz_jz[iz]*sz_jx[aa]*fpzx);
@@ -343,6 +323,17 @@ void doDirectJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::ParticleR
                     &Szz_arr(lo.x+l_jz+iz, 0, 0, Nc),
                     sz_jz[iz]*sz_jz[aa]*fpzz);
             }
+        }
+        else {  //  Deposit mass matrices for diagonal PC only
+            amrex::Gpu::Atomic::AddNoRet(
+                &Sxx_arr(lo.x+l_jx+iz, 0, 0, 0),
+                sz_jx[iz]*fpxx);
+            amrex::Gpu::Atomic::AddNoRet(
+                &Syy_arr(lo.x+l_jy+iz, 0, 0, 0),
+                sz_jy[iz]*fpyy);
+            amrex::Gpu::Atomic::AddNoRet(
+                &Szz_arr(lo.x+l_jz+iz, 0, 0, 0),
+                sz_jz[iz]*fpzz);
         }
     }
 #elif defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
@@ -383,18 +374,16 @@ void doDirectJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::ParticleR
             amrex::Gpu::Atomic::AddNoRet(
                 &jz_arr(lo.x+j_jz+ix, lo.y+l_jz+iz, 0, 0),
                 weight_Jz*wqz);
-            for (int bb=0; bb<=depos_order; bb++){
-                for (int aa=0; aa<=depos_order; aa++){
-                    const amrex::Real weight_Ex = sx_jx[aa]*sz_jx[bb];
-                    const amrex::Real weight_Ey = sx_jy[aa]*sz_jy[bb];
-                    const amrex::Real weight_Ez = sx_jz[aa]*sz_jz[bb];
-                    //  Deposit mass matrices for X-current
-                    if (Sxx_nComp==1 && aa==ix && bb==iz) {
-                        amrex::Gpu::Atomic::AddNoRet(
-                            &Sxx_arr(lo.x+j_jx+ix, lo.y+l_jx+iz, 0, 0),
-                            weight_Jx*weight_Ex*fpxx);
-                    }
-                    else if (Sxx_nComp>1) {
+
+            //  Deposit mass matrices
+            if constexpr (full_mass_matrices) {
+                for (int bb=0; bb<=depos_order; bb++){
+                    for (int aa=0; aa<=depos_order; aa++){
+                        const amrex::Real weight_Ex = sx_jx[aa]*sz_jx[bb];
+                        const amrex::Real weight_Ey = sx_jy[aa]*sz_jy[bb];
+                        const amrex::Real weight_Ez = sx_jz[aa]*sz_jz[bb];
+
+                        //  Deposit mass matrices for X-current
                         int offset = base_offset;
                         int Nc =  depos_order + aa - ix
                                + (depos_order + bb - iz)*offset;
@@ -413,17 +402,11 @@ void doDirectJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::ParticleR
                         amrex::Gpu::Atomic::AddNoRet(
                             &Sxz_arr(lo.x+j_jx+ix, lo.y+l_jx+iz, 0, Nc),
                             weight_Jx*weight_Ez*fpxz);
-                    }
-                    //  Deposit mass matrices for Y-current
-                    if (Syy_nComp==1 && aa==ix && bb==iz) {
-                        amrex::Gpu::Atomic::AddNoRet(
-                            &Syy_arr(lo.x+j_jy+ix, lo.y+l_jy+iz, 0, 0),
-                            weight_Jy*weight_Ey*fpyy);
-                    }
-                    else if (Syy_nComp>1) {
-                        int offset = base_offset;
-                        int Nc =  depos_order + aa - ix
-                               + (depos_order + bb - iz)*offset;
+
+                        //  Deposit mass matrices for Y-current
+                        offset = base_offset;
+                        Nc =  depos_order + aa - ix
+                           + (depos_order + bb - iz)*offset;
                         amrex::Gpu::Atomic::AddNoRet(
                             &Syy_arr(lo.x+j_jy+ix, lo.y+l_jy+iz, 0, Nc),
                             weight_Jy*weight_Ey*fpyy);
@@ -439,17 +422,11 @@ void doDirectJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::ParticleR
                         amrex::Gpu::Atomic::AddNoRet(
                             &Syz_arr(lo.x+j_jy+ix, lo.y+l_jy+iz, 0, Nc),
                             weight_Jy*weight_Ez*fpyz);
-                    }
-                    //  Deposit mass matrices for Z-current
-                    if (Szz_nComp==1 && aa==ix && bb==iz) {
-                        amrex::Gpu::Atomic::AddNoRet(
-                            &Szz_arr(lo.x+j_jz+ix, lo.y+l_jz+iz, 0, 0),
-                            weight_Jz*weight_Ez*fpzz);
-                    }
-                    else if (Szz_nComp>1) {
-                        int offset = base_offset;
-                        int Nc =  depos_order + aa - ix
-                               + (depos_order + bb - iz)*offset;
+
+                        //  Deposit mass matrices for Z-current
+                        offset = base_offset;
+                        Nc =  depos_order + aa - ix
+                           + (depos_order + bb - iz)*offset;
                         amrex::Gpu::Atomic::AddNoRet(
                             &Szz_arr(lo.x+j_jz+ix, lo.y+l_jz+iz, 0, Nc),
                             weight_Jz*weight_Ez*fpzz);
@@ -467,6 +444,17 @@ void doDirectJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::ParticleR
                             weight_Jz*weight_Ey*fpzy);
                     }
                 }
+            }
+            else {  //  Deposit mass matrices for diagonal PC only
+                amrex::Gpu::Atomic::AddNoRet(
+                    &Syy_arr(lo.x+j_jy+ix, lo.y+l_jy+iz, 0, 0),
+                    weight_Jy*fpyy);
+                amrex::Gpu::Atomic::AddNoRet(
+                    &Sxx_arr(lo.x+j_jx+ix, lo.y+l_jx+iz, 0, 0),
+                    weight_Jx*fpxx);
+                amrex::Gpu::Atomic::AddNoRet(
+                    &Szz_arr(lo.x+j_jz+ix, lo.y+l_jz+iz, 0, 0),
+                    weight_Jz*fpzz);
             }
         }
     }
@@ -486,16 +474,22 @@ void doDirectJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::ParticleR
                 amrex::Gpu::Atomic::AddNoRet(
                     &jz_arr(lo.x+j_jz+ix, lo.y+k_jz+iy, lo.z+l_jz+iz),
                     weight_Jz*wqz);
-                //
-                amrex::Gpu::Atomic::AddNoRet(
-                    &Sxx_arr(lo.x+j_jx+ix, lo.y+k_jx+iy, lo.z+l_jx+iz, 0),
-                    weight_Jx*weight_Jx*fpxx);
-                amrex::Gpu::Atomic::AddNoRet(
-                    &Syy_arr(lo.x+j_jy+ix, lo.y+k_jy+iy, lo.z+l_jy+iz, 0),
-                    weight_Jy*weight_Jy*fpyy);
-                amrex::Gpu::Atomic::AddNoRet(
-                    &Szz_arr(lo.x+j_jz+ix, lo.y+k_jz+iy, lo.z+l_jz+iz, 0),
-                    weight_Jz*weight_Jz*fpzz);
+
+                // Deposit mass matrices
+                if constexpr (full_mass_matrices) {
+                    // Should not be here. Full mass matrices not yet implemented in 3D
+                }
+                else {  //  Deposit mass matrices for diagonal PC only
+                    amrex::Gpu::Atomic::AddNoRet(
+                        &Sxx_arr(lo.x+j_jx+ix, lo.y+k_jx+iy, lo.z+l_jx+iz, 0),
+                        weight_Jx*fpxx);
+                    amrex::Gpu::Atomic::AddNoRet(
+                        &Syy_arr(lo.x+j_jy+ix, lo.y+k_jy+iy, lo.z+l_jy+iz, 0),
+                        weight_Jy*fpyy);
+                    amrex::Gpu::Atomic::AddNoRet(
+                        &Szz_arr(lo.x+j_jz+ix, lo.y+k_jz+iy, lo.z+l_jz+iz, 0),
+                        weight_Jz*fpzz);
+                }
             }
         }
     }
@@ -504,15 +498,13 @@ void doDirectJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::ParticleR
 
 /**
  * \brief direct deposition of J and mass matrices for thread thread_num
- * \tparam depos_order deposition order
+ * \tparam depos_order             deposition order
+ * \tparam full_mass_matrices      Whether to deposit the full mass matrices
  * \param GetPosition              A functor for returning the particle position.
  * \param wp                       Pointer to array of particle weights.
  * \param uxp_n,uyp_n,uzp_n        Pointer to arrays of particle momentum at time n.
  * \param uxp_nph,uyp_nph,uzp_nph  Pointer to arrays of particle momentum at time n+1/2.
  * \param jx_fab,jy_fab,jz_fab     FArrayBox of current density, either full array or tile.
- * \param Sxx_nComp                number of Sxx components
- * \param Syy_nComp                number of Syy components
- * \param Szz_nComp                number of Szz components
  * \param Sxx_arr,Sxy_arr,Sxz_arr  Array4 of mass matrices for Jx, either full array or tile.
  * \param Syx_arr,Syy_arr,Syz_arr  Array4 of mass matrices for Jy, either full array or tile.
  * \param Szx_arr,Szy_arr,Szz_arr  Array4 of mass matrices for Jz, either full array or tile.
@@ -526,7 +518,7 @@ void doDirectJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::ParticleR
  * \param qs                       Species charge.
  * \param ms                       Species mass.
  */
-template <int depos_order>
+template <int depos_order, bool full_mass_matrices>
 void doDirectJandSigmaDeposition ( const GetParticlePosition<PIdx>& GetPosition,
                                    const amrex::ParticleReal* wp,
                                    const amrex::ParticleReal* uxp_n,
@@ -538,9 +530,6 @@ void doDirectJandSigmaDeposition ( const GetParticlePosition<PIdx>& GetPosition,
                                    amrex::FArrayBox& jx_fab,
                                    amrex::FArrayBox& jy_fab,
                                    amrex::FArrayBox& jz_fab,
-                                   int Sxx_nComp,
-                                   int Syy_nComp,
-                                   int Szz_nComp,
                                    amrex::Array4<amrex::Real> const& Sxx_arr,
                                    amrex::Array4<amrex::Real> const& Sxy_arr,
                                    amrex::Array4<amrex::Real> const& Sxz_arr,
@@ -617,13 +606,13 @@ void doDirectJandSigmaDeposition ( const GetParticlePosition<PIdx>& GetPosition,
                                     fpyx, fpyy, fpyz,
                                     fpzx, fpzy, fpzz );
 
-            doDirectJandSigmaDepositionKernel<depos_order>( xp_nph, yp_nph, zp_nph,
+            doDirectJandSigmaDepositionKernel<depos_order,full_mass_matrices>(
+                                                            xp_nph, yp_nph, zp_nph,
                                                             wqx, wqy, wqz,
                                                             fpxx, fpxy, fpxz,
                                                             fpyx, fpyy, fpyz,
                                                             fpzx, fpzy, fpzz,
                                                             jx_arr, jy_arr, jz_arr,
-                                                            Sxx_nComp, Syy_nComp, Szz_nComp,
                                                             Sxx_arr, Sxy_arr, Sxz_arr,
                                                             Syx_arr, Syy_arr, Syz_arr,
                                                             Szx_arr, Szy_arr, Szz_arr,

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -1095,10 +1095,6 @@ WarpXParticleContainer::DepositCurrentAndMassMatrices ( WarpXParIter& pti, const
     Array4<Real> const& Szz_arr = local_Szz[thread_num].array();
 #endif
 
-    const int Sxx_nComp = Sxx->nComp();
-    const int Syy_nComp = Syy->nComp();
-    const int Szz_nComp = Szz->nComp();
-
     const auto GetPosition = GetParticlePosition<PIdx>(pti, offset);
 
     // Lower corner of tile box physical domain
@@ -1134,6 +1130,8 @@ WarpXParticleContainer::DepositCurrentAndMassMatrices ( WarpXParIter& pti, const
     auto& uyp_n = pti.GetAttribs("uy_n");
     auto& uzp_n = pti.GetAttribs("uz_n");
 
+    const bool full_mass_matrices = (Szz->nComp() > 1 ? true : false);
+
     // Not doing shared memory deposition, call normal kernels
     if (WarpX::current_deposition_algo == CurrentDepositionAlgo::Villasenor) {
 #if !defined(WARPX_DIM_1D_Z)
@@ -1154,9 +1152,6 @@ WarpXParticleContainer::DepositCurrentAndMassMatrices ( WarpXParIter& pti, const
 #else
         const ParticleReal* zp_n_data = nullptr;
 #endif
-
-        bool full_mass_matrices = false;
-        if (Szz_nComp>1) { full_mass_matrices = true; }
 
         if (WarpX::nox == 1 && !full_mass_matrices){
             doVillasenorJandSigmaDeposition<1,false>(
@@ -1256,49 +1251,89 @@ WarpXParticleContainer::DepositCurrentAndMassMatrices ( WarpXParIter& pti, const
                 np_to_deposit, dt, dinv, xyzmin, lo, qs, mass);
         }
     } else { // Direct deposition
-        if        (WarpX::nox == 1){
-            doDirectJandSigmaDeposition<1>(
+        if        (WarpX::nox == 1 && !full_mass_matrices){
+            doDirectJandSigmaDeposition<1,false>(
                 GetPosition, wp.dataPtr() + offset,
                 uxp_n.dataPtr() + offset, uyp_n.dataPtr() + offset, uzp_n.dataPtr() + offset,
                 uxp.dataPtr() + offset, uyp.dataPtr() + offset, uzp.dataPtr() + offset,
                 jx_fab, jy_fab, jz_fab,
-                Sxx_nComp, Syy_nComp, Szz_nComp,
                 Sxx_arr, Sxy_arr, Sxz_arr,
                 Syx_arr, Syy_arr, Syz_arr,
                 Szx_arr, Szy_arr, Szz_arr,
                 Bx_arr, By_arr, Bz_arr, Bx_type, By_type, Bz_type,
                 np_to_deposit, dt, dinv, xyzmin, lo, qs, mass);
-        } else if (WarpX::nox == 2){
-            doDirectJandSigmaDeposition<2>(
+        } else if   (WarpX::nox == 1 && full_mass_matrices){
+            doDirectJandSigmaDeposition<1,true>(
                 GetPosition, wp.dataPtr() + offset,
                 uxp_n.dataPtr() + offset, uyp_n.dataPtr() + offset, uzp_n.dataPtr() + offset,
                 uxp.dataPtr() + offset, uyp.dataPtr() + offset, uzp.dataPtr() + offset,
                 jx_fab, jy_fab, jz_fab,
-                Sxx_nComp, Syy_nComp, Szz_nComp,
                 Sxx_arr, Sxy_arr, Sxz_arr,
                 Syx_arr, Syy_arr, Syz_arr,
                 Szx_arr, Szy_arr, Szz_arr,
                 Bx_arr, By_arr, Bz_arr, Bx_type, By_type, Bz_type,
                 np_to_deposit, dt, dinv, xyzmin, lo, qs, mass);
-        } else if (WarpX::nox == 3){
-            doDirectJandSigmaDeposition<3>(
+        } else if (WarpX::nox == 2 && !full_mass_matrices){
+            doDirectJandSigmaDeposition<2,false>(
                 GetPosition, wp.dataPtr() + offset,
                 uxp_n.dataPtr() + offset, uyp_n.dataPtr() + offset, uzp_n.dataPtr() + offset,
                 uxp.dataPtr() + offset, uyp.dataPtr() + offset, uzp.dataPtr() + offset,
                 jx_fab, jy_fab, jz_fab,
-                Sxx_nComp, Syy_nComp, Szz_nComp,
                 Sxx_arr, Sxy_arr, Sxz_arr,
                 Syx_arr, Syy_arr, Syz_arr,
                 Szx_arr, Szy_arr, Szz_arr,
                 Bx_arr, By_arr, Bz_arr, Bx_type, By_type, Bz_type,
                 np_to_deposit, dt, dinv, xyzmin, lo, qs, mass);
-        } else if (WarpX::nox == 4){
-            doDirectJandSigmaDeposition<4>(
+        } else if (WarpX::nox == 2 && full_mass_matrices){
+            doDirectJandSigmaDeposition<2,true>(
                 GetPosition, wp.dataPtr() + offset,
                 uxp_n.dataPtr() + offset, uyp_n.dataPtr() + offset, uzp_n.dataPtr() + offset,
                 uxp.dataPtr() + offset, uyp.dataPtr() + offset, uzp.dataPtr() + offset,
                 jx_fab, jy_fab, jz_fab,
-                Sxx_nComp, Syy_nComp, Szz_nComp,
+                Sxx_arr, Sxy_arr, Sxz_arr,
+                Syx_arr, Syy_arr, Syz_arr,
+                Szx_arr, Szy_arr, Szz_arr,
+                Bx_arr, By_arr, Bz_arr, Bx_type, By_type, Bz_type,
+                np_to_deposit, dt, dinv, xyzmin, lo, qs, mass);
+        } else if (WarpX::nox == 3 && !full_mass_matrices){
+            doDirectJandSigmaDeposition<3,false>(
+                GetPosition, wp.dataPtr() + offset,
+                uxp_n.dataPtr() + offset, uyp_n.dataPtr() + offset, uzp_n.dataPtr() + offset,
+                uxp.dataPtr() + offset, uyp.dataPtr() + offset, uzp.dataPtr() + offset,
+                jx_fab, jy_fab, jz_fab,
+                Sxx_arr, Sxy_arr, Sxz_arr,
+                Syx_arr, Syy_arr, Syz_arr,
+                Szx_arr, Szy_arr, Szz_arr,
+                Bx_arr, By_arr, Bz_arr, Bx_type, By_type, Bz_type,
+                np_to_deposit, dt, dinv, xyzmin, lo, qs, mass);
+        } else if (WarpX::nox == 3 && full_mass_matrices){
+            doDirectJandSigmaDeposition<3,true>(
+                GetPosition, wp.dataPtr() + offset,
+                uxp_n.dataPtr() + offset, uyp_n.dataPtr() + offset, uzp_n.dataPtr() + offset,
+                uxp.dataPtr() + offset, uyp.dataPtr() + offset, uzp.dataPtr() + offset,
+                jx_fab, jy_fab, jz_fab,
+                Sxx_arr, Sxy_arr, Sxz_arr,
+                Syx_arr, Syy_arr, Syz_arr,
+                Szx_arr, Szy_arr, Szz_arr,
+                Bx_arr, By_arr, Bz_arr, Bx_type, By_type, Bz_type,
+                np_to_deposit, dt, dinv, xyzmin, lo, qs, mass);
+        } else if (WarpX::nox == 4 && !full_mass_matrices){
+            doDirectJandSigmaDeposition<4,false>(
+                GetPosition, wp.dataPtr() + offset,
+                uxp_n.dataPtr() + offset, uyp_n.dataPtr() + offset, uzp_n.dataPtr() + offset,
+                uxp.dataPtr() + offset, uyp.dataPtr() + offset, uzp.dataPtr() + offset,
+                jx_fab, jy_fab, jz_fab,
+                Sxx_arr, Sxy_arr, Sxz_arr,
+                Syx_arr, Syy_arr, Syz_arr,
+                Szx_arr, Szy_arr, Szz_arr,
+                Bx_arr, By_arr, Bz_arr, Bx_type, By_type, Bz_type,
+                np_to_deposit, dt, dinv, xyzmin, lo, qs, mass);
+        } else if (WarpX::nox == 4 && full_mass_matrices){
+            doDirectJandSigmaDeposition<4,true>(
+                GetPosition, wp.dataPtr() + offset,
+                uxp_n.dataPtr() + offset, uyp_n.dataPtr() + offset, uzp_n.dataPtr() + offset,
+                uxp.dataPtr() + offset, uyp.dataPtr() + offset, uzp.dataPtr() + offset,
+                jx_fab, jy_fab, jz_fab,
                 Sxx_arr, Sxy_arr, Sxz_arr,
                 Syx_arr, Syy_arr, Syz_arr,
                 Szx_arr, Szy_arr, Szz_arr,


### PR DESCRIPTION
This PR makes a few modifications to the direct mass matrix deposition routine.

1) The switching between doing a full mass matrix deposition and just depositing the diagonal elements of the diagonal mass matrices for the preconditioner (PC) is now controlled with a template parameter just as it is in the villasenor deposition. This removes an if check inside hot loops.

2) The full mass matrices are deposited using the product of shape factors for current and field interpolation (`shape_J x shape_E`). In other words, for each particle location where current J is deposited, the code loops over all field interpolation points E (the same locations used for J) and deposits the corresponding mass matrix contribution with `shape_J x shape_E`. In the current development branch, when only the diagonal elements of the diagonal mass matrices are used for the PC, the deposition still uses `shape_J x shape_E`, which is non-conservative. With this PR, when operating in this way, the deposition instead uses only the current deposition shape factor (`shape_J`). This makes the deposition conservative, consistent with the J deposition scheme. Mathematically, this is equivalent to depositing to all E-location for each J-location (as is done for the full mass matrices) and summing the contributions. @RemiLehe