### PR TITLE
Fix ParticleHistogram2D Value Function

### DIFF
--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.H
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.H
@@ -65,7 +65,7 @@ public:
     std::string value_string;
 
 /// Parser to read expression for particle quantity from the input file.
-    /// 7 elements are t, x, y, z, ux, uy, uz, w
+    /// 8 elements are t, x, y, z, ux, uy, uz, w
     static constexpr int m_nvars = 8;
     std::unique_ptr<amrex::Parser> m_parser_abs;
     std::unique_ptr<amrex::Parser> m_parser_ord;
@@ -76,11 +76,11 @@ public:
     /// Whether the filter is activated
     bool m_do_parser_filter = false;
 
-    /// Optional parser to filter particles before doing the histogram
+    /// Optional parser to read particle quantity from input file (comments updated to match documentation)
     std::unique_ptr<amrex::Parser> m_parser_value;
 
-    /// Whether the filter is activated
-    bool m_do_parser_value;
+    /// Whether a custom value function is assigned
+    bool m_do_parser_value = false; // was uninitialized
 
     /**
      * This function computes a histogram of user defined quantity.

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.cpp
@@ -122,9 +122,12 @@ ParticleHistogram2D::ParticleHistogram2D (const std::string& rd_name)
     if (m_do_parser_value) {
         utils::parser::Store_parserString(
                 pp_rd_name,"value_function(t,x,y,z,ux,uy,uz,w)", value_string);
-        m_parser_value = std::make_unique<amrex::Parser>(
-                utils::parser::makeParser(value_string, {"t", "x", "y", "z", "ux", "uy", "uz", "w"}));
+    } else {
+        // default value function is particle weight
+        value_string = "w";
     }
+    m_parser_value = std::make_unique<amrex::Parser>(
+            utils::parser::makeParser(value_string,{"t","x","y","z","ux","uy","uz","w"}));
 }
 // end constructor
 
@@ -288,6 +291,7 @@ void ParticleHistogram2D::WriteToFile (int step) const
     f_mesh.setAttribute("function_abscissa", function_string_abs);
     f_mesh.setAttribute("function_ordinate", function_string_ord);
     f_mesh.setAttribute("filter", filter_string);
+    f_mesh.setAttribute("value_function", value_string); // records custom value function
 
     // record components
     auto data = f_mesh[io::RecordComponent::SCALAR];


### PR DESCRIPTION
The documentation and code comments list `ParticleHistogram2D'`s `value_function` as an optional flag, but when omitted, the code still calls the parser and accumulates 0 in every bin, yielding a histogram of all 0's without any warning or error message.  This is inconsistent with the 1D histogram, which defaults to summing over particle weight `w`.

Changes implemented:

- `m_do_parser_value` is assigned to `false' in the header if not declared
- In the constructor, `value_function` defaults to `"w"` when not provided and always builds a parser from the resolved string
- `value_function` is written to the OpenPMD file metadata
- Docs: clarify that the 2D parsers receive 8 arguments `(t, x, y, z, ux, uy, uz, w)` instead of 7; update wording so that "value" and "filter" definitions aren't conflated.

This should patch an issue I was encountering where 2D Particle Histogram writing produced all-0 arrays if value function was not manually set to `w`.

Edited: found an old issue of a user encountering an issue with the default implementation.  Fixes BLAST-WarpX/warpx#4540