### PR TITLE
Checkpoint/Plotfile: Robust Bounds Calc

### DIFF
--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -764,13 +764,16 @@ FullDiagnostics::InitializeBufferData (int i_buffer, int lev, bool restart ) {
         // Coarsen and refine so that the new BoxArray is coarsenable.
         ba.coarsen(m_crse_ratio).refine(m_crse_ratio);
 
+        // Box covering the extent of the user-defined diagnostic domain
+        amrex::Box const domain = ba.minimalBox();
+
         // Update the physical co-ordinates m_lo and m_hi using the final index values
         // from the coarsenable, cell-centered BoxArray, ba.
         for ( int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             diag_dom.setLo( idim, warpx.Geom(lev).ProbLo(idim) +
-                ba.getCellCenteredBox(0).smallEnd(idim) * warpx.Geom(lev).CellSize(idim));
+                domain.smallEnd(idim) * warpx.Geom(lev).CellSize(idim));
             diag_dom.setHi( idim, warpx.Geom(lev).ProbLo(idim) +
-                (ba.getCellCenteredBox( static_cast<int>(ba.size())-1 ).bigEnd(idim) + 1) * warpx.Geom(lev).CellSize(idim));
+                (domain.bigEnd(idim) + 1) * warpx.Geom(lev).CellSize(idim));
         }
 
     }

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -765,7 +765,8 @@ FullDiagnostics::InitializeBufferData (int i_buffer, int lev, bool restart ) {
         ba.coarsen(m_crse_ratio).refine(m_crse_ratio);
 
         // Box covering the extent of the user-defined diagnostic domain
-        amrex::Box const domain = ba.minimalBox();
+        amrex::Box domain = diag_box;
+        domain.coarsen(m_crse_ratio).refine(m_crse_ratio);
 
         // Update the physical co-ordinates m_lo and m_hi using the final index values
         // from the coarsenable, cell-centered BoxArray, ba.


### PR DESCRIPTION
The calculation of the bounds in plotfiles (incl. checkpoints) appears fishy. It relies on the order of the boxes in the box array, which is not always pointing to a box on the lower/upper bound of the simulation when load balancing is used.

This can corrupt checkpoints (plotfiles) when writing, by a) filtering out valid particles & fields and b) remembering the wrong simulation meta-data for the simulation geometry of fields/particles.

Related to #6392

Co-authored-by: @atmyers 
Co-authored-by: @RemiLehe 
Co-authored-by: @titoiride 

Introduced in #1085 (refined in #1241)

## Follow-up

`BTDiagnostics.cpp` contains similar assumptions/logic it seems and needs a similar fix.