### PR TITLE
Fix path to petsc directory in tuolumne install scripts

### DIFF
--- a/Tools/machines/tuolumne-llnl/install_cpu_dependencies.sh
+++ b/Tools/machines/tuolumne-llnl/install_cpu_dependencies.sh
@@ -181,7 +181,7 @@ then
 else
   git clone -b v3.24.0 https://gitlab.com/petsc/petsc.git ${SRC_DIR}/petsc
 fi
-cd petsc
+cd ${SRC_DIR}/petsc
 ./configure    \
     CC=${CC}   \
     CXX=${CXX} \

--- a/Tools/machines/tuolumne-llnl/install_mi300a_dependencies.sh
+++ b/Tools/machines/tuolumne-llnl/install_mi300a_dependencies.sh
@@ -181,7 +181,7 @@ then
 else
   git clone -b v3.24.0 https://gitlab.com/petsc/petsc.git ${SRC_DIR}/petsc
 fi
-cd petsc
+cd ${SRC_DIR}/petsc
 ./configure               \
     COPTFLAGS="-g -O3"    \
     FOPTFLAGS="-g -O3"    \


### PR DESCRIPTION
Use the absolute path to 'petsc' directory in tuolumne install scripts. The relative path to 'petsc' fails when the current working directory is not SRC_DIR.

Follow-up to #6270