### PR TITLE
Forward SoA Names to Temporary Tiles

### DIFF
--- a/Source/Diagnostics/ReducedDiags/FieldProbeParticleContainer.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbeParticleContainer.cpp
@@ -63,7 +63,9 @@ FieldProbeParticleContainer::AddNParticles (int lev,
     using PinnedTile = typename ContainerLike<amrex::PinnedArenaAllocator>::ParticleTileType;
 
     PinnedTile pinned_tile;
-    pinned_tile.define(NumRuntimeRealComps(), NumRuntimeIntComps());
+    auto soa_rdata_names = GetRealSoANames();
+    auto soa_idata_names = GetIntSoANames();
+    pinned_tile.define(NumRuntimeRealComps(), NumRuntimeIntComps(), &soa_rdata_names, &soa_idata_names);
 
     for (int i = 0; i < np; i++)
     {

--- a/Source/Particles/Sorting/Partition.cpp
+++ b/Source/Particles/Sorting/Partition.cpp
@@ -135,7 +135,9 @@ PhysicalParticleContainer::PartitionParticlesInBuffers(
     {
         // Prepare temporary particle tile to copy to
         ParticleTileType ptile_tmp;
-        ptile_tmp.define(NumRuntimeRealComps(), NumRuntimeIntComps());
+        auto soa_rdata_names = GetRealSoANames();
+        auto soa_idata_names = GetIntSoANames();
+        ptile_tmp.define(NumRuntimeRealComps(), NumRuntimeIntComps(), &soa_rdata_names, &soa_idata_names);
         ptile_tmp.resize(np);
 
         // Copy and re-order the data of the current particle tile

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -220,7 +220,9 @@ WarpXParticleContainer::AddNParticles (int /*lev*/, long n,
 
     using PinnedTile = typename ContainerLike<amrex::PinnedArenaAllocator>::ParticleTileType;
     PinnedTile pinned_tile;
-    pinned_tile.define(NumRuntimeRealComps(), NumRuntimeIntComps());
+    auto soa_rdata_names = GetRealSoANames();
+    auto soa_idata_names = GetIntSoANames();
+    pinned_tile.define(NumRuntimeRealComps(), NumRuntimeIntComps(), &soa_rdata_names, &soa_idata_names);
 
     const std::size_t np = iend-ibegin;
 


### PR DESCRIPTION
Ensure temporary particle tiles have access to SoA names, by passing in the names from their referenced PC.

Related to #6409