### PR TITLE
Remove project number left over in Perlmutter profile

### DIFF
--- a/Tools/machines/perlmutter-nersc/perlmutter_gpu_warpx.profile.example
+++ b/Tools/machines/perlmutter-nersc/perlmutter_gpu_warpx.profile.example
@@ -48,7 +48,7 @@ fi
 
 # an alias to request an interactive batch node for one hour
 #   for parallel execution, start on the batch node: srun <command>
-alias getNode="salloc -N 1 --ntasks-per-node=4 -t 1:00:00 -q interactive -C gpu --gpu-bind=none -c 32 -G 4 -A m3239 $proj"
+alias getNode="salloc -N 1 --ntasks-per-node=4 -t 1:00:00 -q interactive -C gpu --gpu-bind=none -c 32 -G 4 -A $proj"
 # an alias to run a command on a batch node for up to 30min
 #   usage: runNode <command>
 alias runNode="srun -N 1 --ntasks-per-node=4 -t 0:30:00 -q interactive -C gpu --gpu-bind=none -c 32 -G 4 -A $proj"


### PR DESCRIPTION
Follow up on #6414 and remove a project number that was left over in the Perlmutter profile. Noticed by @titoiride in https://github.com/BLAST-WarpX/warpx/pull/6414/files#r2551120689.