### PR TITLE
Fix the periodic 1D Poisson solver

### DIFF
--- a/Examples/Tests/energy_conserving_thermal_plasma/CMakeLists.txt
+++ b/Examples/Tests/energy_conserving_thermal_plasma/CMakeLists.txt
@@ -10,3 +10,13 @@ add_warpx_test(
     "analysis_default_regression.py --path diags/diag1000500"  # checksum
     OFF  # dependency
 )
+
+add_warpx_test(
+    test_1d_energy_conserving_thermal_plasma  # name
+    1  # dims
+    2  # nprocs
+    inputs_test_1d_energy_conserving_thermal_plasma  # inputs
+    "analysis.py"  # analysis
+    "analysis_default_regression.py --path diags/diag1000500"  # checksum
+    OFF  # dependency
+)

--- a/Examples/Tests/energy_conserving_thermal_plasma/inputs_test_1d_energy_conserving_thermal_plasma
+++ b/Examples/Tests/energy_conserving_thermal_plasma/inputs_test_1d_energy_conserving_thermal_plasma
@@ -1,0 +1,82 @@
+#################################
+####### GENERAL PARAMETERS ######
+#################################
+max_step = 500
+amr.n_cell =  8
+amr.max_level = 0
+geometry.dims = 1
+
+warpx.do_electrostatic = labframe
+algo.field_gathering = energy-conserving
+algo.particle_shape = 2
+warpx.use_filter = 0
+
+#################################
+############ CONSTANTS #############
+#################################
+my_constants.n0 = 1.e30          # plasma density, m^-3
+my_constants.Ti = 100.           # ion temperature, eV
+my_constants.Te = 100.           # electron temperature, eV
+my_constants.wpe = q_e*sqrt(n0/(m_e*epsilon0))  # electron plasma frequency, radians/s
+my_constants.de0 = clight/wpe    # skin depth, m
+my_constants.dt = ( 0.2 )/wpe        # time step size, s
+warpx.const_dt = dt
+
+#################################
+####### GENERAL PARAMETERS ######
+#################################
+geometry.prob_lo = 0.0
+geometry.prob_hi = 10.*de0
+warpx.serialize_initial_conditions = 1
+warpx.verbose = 1
+
+#################################
+###### BOUNDARY CONDITIONS ######
+#################################
+boundary.field_lo = periodic
+boundary.field_hi = periodic
+boundary.particle_lo = periodic
+boundary.particle_hi = periodic
+
+#################################
+############ PLASMA #############
+#################################
+particles.species_names = electrons protons
+
+electrons.species_type = electron
+electrons.injection_style = "NUniformPerCell"
+electrons.num_particles_per_cell_each_dim = 4
+electrons.profile = constant
+electrons.density = n0
+electrons.momentum_distribution_type = gaussian
+electrons.ux_th = sqrt(Te*q_e/m_e)/clight
+electrons.uy_th = sqrt(Te*q_e/m_e)/clight
+electrons.uz_th = sqrt(Te*q_e/m_e)/clight
+electrons.xmin = 0
+electrons.xmax = 10.*de0
+electrons.zmin =  0
+electrons.zmax =10.*de0
+
+protons.species_type = proton
+protons.injection_style = "NUniformPerCell"
+protons.num_particles_per_cell_each_dim = 4
+protons.profile = constant
+protons.density = n0
+protons.momentum_distribution_type = gaussian
+protons.ux_th = sqrt(Ti*q_e/m_p)/clight
+protons.uy_th = sqrt(Ti*q_e/m_p)/clight
+protons.uz_th = sqrt(Ti*q_e/m_p)/clight
+protons.xmin = 0
+protons.xmax = 10.*de0
+protons.zmin =  0
+protons.zmax =10.*de0
+
+diagnostics.diags_names = diag1
+diag1.intervals = 500
+diag1.diag_type = Full
+
+warpx.reduced_diags_names = EP EF
+EP.type = ParticleEnergy
+EP.intervals = 100
+EF.type = FieldEnergy
+EF.intervals =100

--- a/Regression/Checksum/benchmarks_json/test_1d_energy_conserving_thermal_plasma.json
+++ b/Regression/Checksum/benchmarks_json/test_1d_energy_conserving_thermal_plasma.json
@@ -1,0 +1,29 @@
+{
+  "lev=0": {
+    "Bx": 0.0,
+    "By": 0.0,
+    "Bz": 0.0,
+    "Ex": 14828575152586.377,
+    "Ey": 0.0,
+    "Ez": 15137612617490.05,
+    "jx": 5.540159304744141e+18,
+    "jy": 7.091120321535793e+18,
+    "jz": 6.642877913575798e+18
+  },
+  "electrons": {
+    "particle_momentum_x": 7.607254284466359e-22,
+    "particle_momentum_y": 8.024587486899746e-22,
+    "particle_momentum_z": 8.135084188617331e-22,
+    "particle_position_x": 6.882297195442962e-06,
+    "particle_position_y": 6.860835757956751e-06,
+    "particle_weight": 2823958725036869.5
+  },
+  "protons": {
+    "particle_momentum_x": 3.1874892788353723e-20,
+    "particle_momentum_y": 3.3975490969622645e-20,
+    "particle_momentum_z": 3.3005745860923366e-20,
+    "particle_position_x": 6.805298104444865e-06,
+    "particle_position_y": 6.8011432681640676e-06,
+    "particle_weight": 2823958725036869.5
+  }
+}

--- a/Regression/Checksum/benchmarks_json/test_1d_energy_conserving_thermal_plasma.json
+++ b/Regression/Checksum/benchmarks_json/test_1d_energy_conserving_thermal_plasma.json
@@ -3,27 +3,25 @@
     "Bx": 0.0,
     "By": 0.0,
     "Bz": 0.0,
-    "Ex": 14828575152586.377,
+    "Ex": 0.0,
     "Ey": 0.0,
-    "Ez": 15137612617490.05,
-    "jx": 5.540159304744141e+18,
-    "jy": 7.091120321535793e+18,
-    "jz": 6.642877913575798e+18
-  },
-  "electrons": {
-    "particle_momentum_x": 7.607254284466359e-22,
-    "particle_momentum_y": 8.024587486899746e-22,
-    "particle_momentum_z": 8.135084188617331e-22,
-    "particle_position_x": 6.882297195442962e-06,
-    "particle_position_y": 6.860835757956751e-06,
-    "particle_weight": 2823958725036869.5
+    "Ez": 1843559918507.4597,
+    "jx": 7.023706407853532e+17,
+    "jy": 1.5451722266112904e+18,
+    "jz": 1.4550256783909258e+18
   },
   "protons": {
-    "particle_momentum_x": 3.1874892788353723e-20,
-    "particle_momentum_y": 3.3975490969622645e-20,
-    "particle_momentum_z": 3.3005745860923366e-20,
-    "particle_position_x": 6.805298104444865e-06,
-    "particle_position_y": 6.8011432681640676e-06,
-    "particle_weight": 2823958725036869.5
+    "particle_momentum_x": 5.176581699739823e-21,
+    "particle_momentum_y": 4.047932572682727e-21,
+    "particle_momentum_z": 4.91970564256278e-21,
+    "particle_position_x": 8.506989391921748e-07,
+    "particle_weight": 5.314093266999432e+22
+  },
+  "electrons": {
+    "particle_momentum_x": 9.376211171425484e-23,
+    "particle_momentum_y": 9.839757496156745e-23,
+    "particle_momentum_z": 9.990231703148866e-23,
+    "particle_position_x": 8.267155674804417e-07,
+    "particle_weight": 5.314093266999432e+22
   }
 }

--- a/Source/FieldSolver/ElectrostaticSolvers/LabFrameExplicitES.H
+++ b/Source/FieldSolver/ElectrostaticSolvers/LabFrameExplicitES.H
@@ -32,6 +32,11 @@ public:
         const ablastr::fields::MultiLevelScalarField& phi
     );
 
+    void computePhiTriDiagonal_periodic (
+        const ablastr::fields::MultiLevelScalarField& rho,
+        const ablastr::fields::MultiLevelScalarField& phi
+    );
+
 };
 
 #endif  // WARPX_LABFRAMEEXPLICITES_H_

--- a/Source/FieldSolver/ElectrostaticSolvers/LabFrameExplicitES.cpp
+++ b/Source/FieldSolver/ElectrostaticSolvers/LabFrameExplicitES.cpp
@@ -103,6 +103,14 @@ void LabFrameExplicitES::computePhiTriDiagonal (
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(num_levels == 1,
     "The tridiagonal solver cannot be used with mesh refinement");
 
+    auto field_boundary_lo0 = WarpX::field_boundary_lo[0];
+    auto field_boundary_hi0 = WarpX::field_boundary_hi[0];
+
+    if (field_boundary_lo0 == FieldBoundaryType::Periodic) {
+        computePhiTriDiagonal_periodic(rho, phi);
+        return;
+    }
+
     const int lev = 0;
     auto & warpx = WarpX::GetInstance();
 
@@ -114,15 +122,11 @@ void LabFrameExplicitES::computePhiTriDiagonal (
     int nx_solve_min = 1;
     int nx_solve_max = nx_full_domain - 1;
 
-    auto field_boundary_lo0 = WarpX::field_boundary_lo[0];
-    auto field_boundary_hi0 = WarpX::field_boundary_hi[0];
-    if (field_boundary_lo0 == FieldBoundaryType::Neumann || field_boundary_lo0 == FieldBoundaryType::Periodic) {
-        // Neumann or periodic boundary condition
+    if (field_boundary_lo0 == FieldBoundaryType::Neumann) {
         // Solve for the point on the lower boundary
         nx_solve_min = 0;
     }
-    if (field_boundary_hi0 == FieldBoundaryType::Neumann || field_boundary_hi0 == FieldBoundaryType::Periodic) {
-        // Neumann or periodic boundary condition
+    if (field_boundary_hi0 == FieldBoundaryType::Neumann) {
         // Solve for the point on the upper boundary
         nx_solve_max = nx_full_domain;
     }
@@ -178,14 +182,6 @@ void LabFrameExplicitES::computePhiTriDiagonal (
             diag = 2._rt - zwork1d_arr(1,0,0);
             phi1d_arr(1,0,0) = (rho1d_arr(1,0,0) - (-1._rt)*phi1d_arr(1-1,0,0))/diag;
 
-        } else if (field_boundary_lo0 == FieldBoundaryType::Periodic) {
-
-            phi1d_arr(0,0,0) = rho1d_arr(0,0,0)/diag;
-
-            zwork1d_arr(1,0,0) = 1._rt/diag;
-            diag = 2._rt - zwork1d_arr(1,0,0);
-            phi1d_arr(1,0,0) = (rho1d_arr(1,0,0) - (-1._rt)*phi1d_arr(1-1,0,0))/diag;
-
         }
 
         // Loop upward, calculating the Gaussian elimination multipliers and right hand sides
@@ -198,7 +194,6 @@ void LabFrameExplicitES::computePhiTriDiagonal (
         }
 
         // The last value depend on the boundary condition
-        amrex::Real zwork_product = 1.; // Needed for parallel boundaries
         if (field_boundary_hi0 == FieldBoundaryType::PEC) {
 
             int const nxm1 = nx_full_domain - 1;
@@ -220,37 +215,119 @@ void LabFrameExplicitES::computePhiTriDiagonal (
                 phi1d_arr(nx_full_domain,0,0) = (rho1d_arr(nx_full_domain,0,0) - (-1._rt)*phi1d_arr(nx_full_domain-1,0,0))/diag;
             }
 
-        } else if (field_boundary_hi0 == FieldBoundaryType::Periodic) {
-
-            zwork1d_arr(nx_full_domain,0,0) = 1._rt/diag;
-
-            for (int i = 1 ; i <= nx_full_domain ; i++) {
-                zwork_product *= zwork1d_arr(i,0,0);
-            }
-
-            diag = 2._rt - zwork1d_arr(nx_full_domain,0,0) - zwork_product;
-            // Note that rho1d_arr(0,0,0) is used to ensure that the same value is used
-            // on both boundaries.
-            phi1d_arr(nx_full_domain,0,0) = (rho1d_arr(0,0,0) - (-1._rt)*phi1d_arr(nx_full_domain-1,0,0))/diag;
-
         }
 
-        // Loop downward to calculate the phi
-        if (field_boundary_lo0 == FieldBoundaryType::Periodic) {
 
-            // With periodic, the right hand column adds an extra term for all rows
-            for (int i_down = nx_full_domain-1 ; i_down >= 0 ; i_down--) {
-                zwork_product /= zwork1d_arr(i_down+1,0,0);
-                phi1d_arr(i_down,0,0) = phi1d_arr(i_down,0,0) + zwork1d_arr(i_down+1,0,0)*phi1d_arr(i_down+1,0,0) + zwork_product*phi1d_arr(nx_full_domain,0,0);
-            }
-
-        } else {
-
-            for (int i_down = nx_solve_max-1 ; i_down >= nx_solve_min ; i_down--) {
-                phi1d_arr(i_down,0,0) = phi1d_arr(i_down,0,0) + zwork1d_arr(i_down+1,0,0)*phi1d_arr(i_down+1,0,0);
-            }
-
+        for (int i_down = nx_solve_max-1 ; i_down >= nx_solve_min ; i_down--) {
+            phi1d_arr(i_down,0,0) = phi1d_arr(i_down,0,0) + zwork1d_arr(i_down+1,0,0)*phi1d_arr(i_down+1,0,0);
         }
+
+    }
+
+    // Copy phi1d to phi
+    phi[lev]->ParallelCopy(phi1d_mf, 0, 0, 1);
+}
+
+/* \brief Compute the potential by solving Poisson's equation
+ *        with periodic boundaries using
+          a 1D tridiagonal solve.
+          This makes use of the Sherman–Morrison formula.
+          The code is based on the code given in the Wikipedia page,
+          https://en.wikipedia.org/wiki/Tridiagonal_matrix_algorithm#Variants.
+
+   \param[in] rho The charge density a given species
+   \param[out] phi The potential to be computed by this function
+*/
+void LabFrameExplicitES::computePhiTriDiagonal_periodic (
+    const ablastr::fields::MultiLevelScalarField& rho,
+    const ablastr::fields::MultiLevelScalarField& phi)
+{
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(num_levels == 1,
+    "The tridiagonal solver cannot be used with mesh refinement");
+
+    const int lev = 0;
+    auto & warpx = WarpX::GetInstance();
+
+    const amrex::Real* dx = warpx.Geom(lev).CellSize();
+    const amrex::Real xmin = warpx.Geom(lev).ProbLo(0);
+    const amrex::Real xmax = warpx.Geom(lev).ProbHi(0);
+    const int nx = static_cast<int>( (xmax - xmin)/dx[0] + 0.5_rt );
+
+
+    // Create a 1-D MultiFab that covers all of x.
+    // The tridiag solve will be done in this MultiFab and then copied out afterwards.
+    const amrex::IntVect lo_full_domain(AMREX_D_DECL(0,0,0));
+    const amrex::IntVect hi_full_domain(AMREX_D_DECL(nx,0,0));
+    const amrex::Box box_full_domain_node(lo_full_domain, hi_full_domain, amrex::IntVect::TheNodeVector());
+    const BoxArray ba_full_domain_node(box_full_domain_node);
+    const amrex::Vector<int> pmap = {0}; // The data will only be on processor 0
+    const amrex::DistributionMapping dm_full_domain(pmap);
+
+    // Put the data in the pinned arena since the tridiag solver will be done on the CPU, but have
+    // the data readily accessible from the GPU.
+    auto phi1d_mf = MultiFab(ba_full_domain_node, dm_full_domain, 1, 0, MFInfo().SetArena(The_Pinned_Arena()));
+
+    // Work arrays
+    auto cmod_mf = MultiFab(ba_full_domain_node, dm_full_domain, 1, 0, MFInfo().SetArena(The_Pinned_Arena()));
+    auto u_mf = MultiFab(ba_full_domain_node, dm_full_domain, 1, 0, MFInfo().SetArena(The_Pinned_Arena()));
+
+    // Copy rho into phi1d_mf to start
+    phi1d_mf.ParallelCopy(*rho[lev], 0, 0, 1);
+
+    // Multiplier on the charge density
+    const amrex::Real norm = dx[0]*dx[0]/PhysConst::epsilon_0;
+    phi1d_mf.mult(norm);
+
+    // Use the MFIter loop since when parallel, only process zero has a FAB.
+    // This skips the loop on all other processors.
+    for (MFIter mfi(phi1d_mf); mfi.isValid(); ++mfi) {
+
+        const auto& x = phi1d_mf[mfi].array();
+        const auto& cmod = cmod_mf[mfi].array();
+        const auto& u = u_mf[mfi].array();
+
+        // The loops are always performed on the CPU
+
+        const amrex::Real alpha = -1.0_rt;
+        const amrex::Real beta = -1.0_rt;
+
+        /* arbitrary, but chosen such that division by zero is avoided */
+        const amrex::Real gamma = -2.0_rt;
+
+        cmod(0,0,0) = -1.0_rt / (2.0_rt - gamma);
+        u(0,0,0) = gamma / (2.0_rt - gamma);
+        x(0,0,0) /= (2.0_rt - gamma);
+
+        /* loop from 1 to nx - 2 inclusive */
+        for (int ix = 1; ix + 1 < nx; ix++) {
+            const amrex::Real m = 1.00_rt / (2.0_rt - -1.0_rt * cmod(ix - 1,0,0));
+            cmod(ix,0,0) = -1.0_rt * m;
+            u(ix,0,0) = (0.0f  - -1.0_rt * u(ix - 1,0,0)) * m;
+            x(ix,0,0) = (x(ix,0,0) - -1.0_rt * x(ix - 1,0,0)) * m;
+        }
+
+        /* handle nx - 1 */
+        const amrex::Real m = 1.00_rt / (2.0_rt - alpha * beta / gamma - -1.0_rt * cmod(nx - 2,0,0));
+        u(nx - 1,0,0) = (alpha    - -1.0_rt * u(nx - 2,0,0)) * m;
+        x(nx - 1,0,0) = (x(nx - 1,0,0) - -1.0_rt * x(nx - 2,0,0)) * m;
+
+        /* loop from nx - 2 to 0 inclusive */
+        for (int ix = nx - 2; ix >= 0; ix--) {
+            u(ix,0,0) -= cmod(ix,0,0) * u(ix + 1,0,0);
+            x(ix,0,0) -= cmod(ix,0,0) * x(ix + 1,0,0);
+        }
+
+        const amrex::Real fact = (x(0,0,0) + x(nx - 1,0,0) * alpha / gamma) / (1.00 + u(0,0,0) + u(nx - 1,0,0) * alpha / gamma);
+
+        /* loop from 0 to nx - 1 inclusive */
+        for (int ix = 0; ix < nx; ix++)
+            x(ix,0,0) -= fact * u(ix,0,0);
+
+        x(nx,0,0) = x(0,0,0);
+
+        // In a test case, this was giving an relative residual of around 1.e-10.
+        // A dozen or so SOR iterations could improve that by a factor of 10.
+        // Is it worth it?
 
     }
 

--- a/Source/FieldSolver/ElectrostaticSolvers/LabFrameExplicitES.cpp
+++ b/Source/FieldSolver/ElectrostaticSolvers/LabFrameExplicitES.cpp
@@ -288,6 +288,13 @@ void LabFrameExplicitES::computePhiTriDiagonal_periodic (
 
         // The loops are always performed on the CPU
 
+        {
+
+        // This code is adapted from the Wikipedia page on the Tridiagonal matrix algorithm
+        // https://en.wikipedia.org/wiki/Tridiagonal_matrix_algorithm#Variants.
+        // Licensed under CC BY-SA 4.0
+        // Modifications: The a, b, and c inputs are replaced with the fixed values.
+
         const amrex::Real alpha = -1.0_rt;
         const amrex::Real beta = -1.0_rt;
 
@@ -322,6 +329,8 @@ void LabFrameExplicitES::computePhiTriDiagonal_periodic (
         /* loop from 0 to nx - 1 inclusive */
         for (int ix = 0; ix < nx; ix++)
             x(ix,0,0) -= fact * u(ix,0,0);
+
+        }
 
         x(nx,0,0) = x(0,0,0);
 


### PR DESCRIPTION
There were problems with the implementation of the tridiagonal solver for phi with periodic boundaries. This PR replaces it with a more standard solver as given in the Wikipedia page https://en.wikipedia.org/wiki/Tridiagonal_matrix_algorithm#Variants.