### PR TITLE
PEC_Insulator cleanup

### DIFF
--- a/Source/BoundaryConditions/PEC_Insulator.H
+++ b/Source/BoundaryConditions/PEC_Insulator.H
@@ -127,14 +127,14 @@ public:
      * \param[in] iside side to check, 0 is lower, 1 is upper
      * \return whether the E field is set on the boundary
      */
-    int IsESet(int idim, int iside) { return ( iside == 1 ? m_set_E_hi[idim] : m_set_E_lo[idim] ); }
+    int IsESet(int idim, int iside) const { return ( iside == 1 ? m_set_E_hi[idim] : m_set_E_lo[idim] ); }
 
     /* \brief Returns whether any B field is set on a boundary
      * \param[in] idim dimension to check
      * \param[in] iside side to check, 0 is lower, 1 is upper
      * \return whether the B field is set on the boundary
      */
-    int IsBSet(int idim, int iside) { return ( iside == 1 ? m_set_B_hi[idim] : m_set_B_lo[idim] ); }
+    int IsBSet(int idim, int iside) const { return ( iside == 1 ? m_set_B_hi[idim] : m_set_B_lo[idim] ); }
 
     /* \brief Returns whether the E field is set on a boundary
      * \param[in] idim dimension to check
@@ -142,7 +142,7 @@ public:
      * \param[in] ifield which field to check, 0, 1, or 2
      * \return whether the E field is set on the boundary
      */
-    int IsESet(int idim, int iside, int ifield);
+    int IsESet(int idim, int iside, int ifield) const;
 
     /* \brief Returns whether the B field is set on a boundary
      * \param[in] idim dimension to check
@@ -150,7 +150,7 @@ public:
      * \param[in] ifield which field to check, 0, 1, or 2
      * \return whether the B field is set on the boundary
      */
-    int IsBSet(int idim, int iside, int ifield);
+    int IsBSet(int idim, int iside, int ifield) const;
 
 private:
 

--- a/Source/BoundaryConditions/PEC_Insulator.H
+++ b/Source/BoundaryConditions/PEC_Insulator.H
@@ -122,6 +122,20 @@ public:
                                amrex::Vector<amrex::ParserExecutor<3>> const & Fy_parsers_hi,
                                amrex::Vector<amrex::ParserExecutor<3>> const & Fz_parsers_hi);
 
+    /* \brief Returns whether the E field is set on a boundary
+     * \param[in] idim dimension to check
+     * \param[in] iside side to check, 0 is lower, 1 is upper
+     * \return whether the E field is set on the boundary
+     */
+    int IsESet(int idim, int iside) { return ( iside == 1 ? m_set_E_hi[idim] : m_set_E_lo[idim] ); }
+
+    /* \brief Returns whether the B field is set on a boundary
+     * \param[in] idim dimension to check
+     * \param[in] iside side to check, 0 is lower, 1 is upper
+     * \return whether the B field is set on the boundary
+     */
+    int IsBSet(int idim, int iside) { return ( iside == 1 ? m_set_B_hi[idim] : m_set_B_lo[idim] ); }
+
 private:
 
     /* \brief Read in the parsers for the tangential fields, returning whether

--- a/Source/BoundaryConditions/PEC_Insulator.H
+++ b/Source/BoundaryConditions/PEC_Insulator.H
@@ -84,12 +84,12 @@ public:
      * \param[in]     time                current time of the simulation
      * \param[in]     split_pml_field     whether pml the multifab is the regular Efield or split pml field
      * \param[in]     E_like              whether the field is E like or B like
-     * \param[in]     set_fields_x_lo     the flags for the field along x at the lower boundary
-     * \param[in]     set_fields_y_lo     the flags for the field along y at the lower boundary
-     * \param[in]     set_fields_z_lo     the flags for the field along z at the lower boundary
-     * \param[in]     set_fields_x_hi     the flags for the field along x at the upper boundary
-     * \param[in]     set_fields_y_hi     the flags for the field along y at the upper boundary
-     * \param[in]     set_fields_z_hi     the flags for the field along z at the upper boundary
+     * \param[in]     set_Fx_lo           the flags for the field along x at the lower boundary
+     * \param[in]     set_Fy_lo           the flags for the field along y at the lower boundary
+     * \param[in]     set_Fz_lo           the flags for the field along z at the lower boundary
+     * \param[in]     set_Fx_hi           the flags for the field along x at the upper boundary
+     * \param[in]     set_Fy_hi           the flags for the field along y at the upper boundary
+     * \param[in]     set_Fz_hi           the flags for the field along z at the upper boundary
      * \param[in]     Fx_parsers_lo       the parsers for the field along x at the lower boundary
      * \param[in]     Fy_parsers_lo       the parsers for the field along y at the lower boundary
      * \param[in]     Fz_parsers_lo       the parsers for the field along z at the lower boundary
@@ -109,12 +109,12 @@ public:
                                amrex::Real time,
                                bool split_pml_field,
                                bool E_like,
-                               amrex::Vector<int> const & set_fields_x_lo,
-                               amrex::Vector<int> const & set_fields_y_lo,
-                               amrex::Vector<int> const & set_fields_z_lo,
-                               amrex::Vector<int> const & set_fields_x_hi,
-                               amrex::Vector<int> const & set_fields_y_hi,
-                               amrex::Vector<int> const & set_fields_z_hi,
+                               amrex::Vector<int> const & set_Fx_lo,
+                               amrex::Vector<int> const & set_Fy_lo,
+                               amrex::Vector<int> const & set_Fz_lo,
+                               amrex::Vector<int> const & set_Fx_hi,
+                               amrex::Vector<int> const & set_Fy_hi,
+                               amrex::Vector<int> const & set_Fz_hi,
                                amrex::Vector<amrex::ParserExecutor<3>> const & Fx_parsers_lo,
                                amrex::Vector<amrex::ParserExecutor<3>> const & Fy_parsers_lo,
                                amrex::Vector<amrex::ParserExecutor<3>> const & Fz_parsers_lo,
@@ -122,19 +122,35 @@ public:
                                amrex::Vector<amrex::ParserExecutor<3>> const & Fy_parsers_hi,
                                amrex::Vector<amrex::ParserExecutor<3>> const & Fz_parsers_hi);
 
-    /* \brief Returns whether the E field is set on a boundary
+    /* \brief Returns whether any E field is set on a boundary
      * \param[in] idim dimension to check
      * \param[in] iside side to check, 0 is lower, 1 is upper
      * \return whether the E field is set on the boundary
      */
     int IsESet(int idim, int iside) { return ( iside == 1 ? m_set_E_hi[idim] : m_set_E_lo[idim] ); }
 
-    /* \brief Returns whether the B field is set on a boundary
+    /* \brief Returns whether any B field is set on a boundary
      * \param[in] idim dimension to check
      * \param[in] iside side to check, 0 is lower, 1 is upper
      * \return whether the B field is set on the boundary
      */
     int IsBSet(int idim, int iside) { return ( iside == 1 ? m_set_B_hi[idim] : m_set_B_lo[idim] ); }
+
+    /* \brief Returns whether the E field is set on a boundary
+     * \param[in] idim dimension to check
+     * \param[in] iside side to check, 0 is lower, 1 is upper
+     * \param[in] ifield which field to check, 0, 1, or 2
+     * \return whether the E field is set on the boundary
+     */
+    int IsESet(int idim, int iside, int ifield);
+
+    /* \brief Returns whether the B field is set on a boundary
+     * \param[in] idim dimension to check
+     * \param[in] iside side to check, 0 is lower, 1 is upper
+     * \param[in] ifield which field to check, 0, 1, or 2
+     * \return whether the B field is set on the boundary
+     */
+    int IsBSet(int idim, int iside, int ifield);
 
 private:
 
@@ -153,49 +169,64 @@ private:
                                     std::string const & coord1,
                                     std::string const & coord2);
 
+    // Parsers specifying the region of each boundary that is insulator
     amrex::Vector<std::unique_ptr<amrex::Parser>> m_insulator_area_lo;
     amrex::Vector<std::unique_ptr<amrex::Parser>> m_insulator_area_hi;
 
     amrex::Vector<amrex::ParserExecutor<2>> m_area_parsers_lo;
     amrex::Vector<amrex::ParserExecutor<2>> m_area_parsers_hi;
 
+    // Flags whether any B fields are specified on each boundary
     amrex::Vector<int> m_set_B_lo = {0, 0, 0};
     amrex::Vector<int> m_set_B_hi = {0, 0, 0};
 
+    // Parsers for the two B fields tangential to each boundary
     amrex::Vector<std::unique_ptr<amrex::Parser>> m_parsers_B1_lo;
     amrex::Vector<std::unique_ptr<amrex::Parser>> m_parsers_B2_lo;
     amrex::Vector<std::unique_ptr<amrex::Parser>> m_parsers_B1_hi;
     amrex::Vector<std::unique_ptr<amrex::Parser>> m_parsers_B2_hi;
 
+    // Flags whether any E fields are specified on each boundary
     amrex::Vector<int> m_set_E_lo = {0, 0, 0};
     amrex::Vector<int> m_set_E_hi = {0, 0, 0};
 
+    // Parsers for the two B fields tangential to each boundary
     amrex::Vector<std::unique_ptr<amrex::Parser>> m_parsers_E1_lo;
     amrex::Vector<std::unique_ptr<amrex::Parser>> m_parsers_E2_lo;
     amrex::Vector<std::unique_ptr<amrex::Parser>> m_parsers_E1_hi;
     amrex::Vector<std::unique_ptr<amrex::Parser>> m_parsers_E2_hi;
 
-    amrex::Vector<int> m_set_Bfields_x_lo;
-    amrex::Vector<int> m_set_Bfields_y_lo;
-    amrex::Vector<int> m_set_Bfields_z_lo;
+    // For each B field, the flags specifying whether it is set on each boundary
+    amrex::Vector<int> m_set_Bx_lo;
+    amrex::Vector<int> m_set_By_lo;
+    amrex::Vector<int> m_set_Bz_lo;
+    amrex::Vector<int> m_set_Bx_hi;
+    amrex::Vector<int> m_set_By_hi;
+    amrex::Vector<int> m_set_Bz_hi;
 
-    amrex::Vector<int> m_set_Bfields_x_hi;
-    amrex::Vector<int> m_set_Bfields_y_hi;
-    amrex::Vector<int> m_set_Bfields_z_hi;
+    // For each B field, the parsers for the field value on each boundary
+    amrex::Vector<amrex::ParserExecutor<3>> m_Bx_parsers_lo;
+    amrex::Vector<amrex::ParserExecutor<3>> m_By_parsers_lo;
+    amrex::Vector<amrex::ParserExecutor<3>> m_Bz_parsers_lo;
+    amrex::Vector<amrex::ParserExecutor<3>> m_Bx_parsers_hi;
+    amrex::Vector<amrex::ParserExecutor<3>> m_By_parsers_hi;
+    amrex::Vector<amrex::ParserExecutor<3>> m_Bz_parsers_hi;
 
-    amrex::Vector<amrex::ParserExecutor<3>> m_Bx_parsers_lo, m_By_parsers_lo, m_Bz_parsers_lo;
-    amrex::Vector<amrex::ParserExecutor<3>> m_Bx_parsers_hi, m_By_parsers_hi, m_Bz_parsers_hi;
+    // For each E field, the flags specifying whether it is set on each boundary
+    amrex::Vector<int> m_set_Ex_lo;
+    amrex::Vector<int> m_set_Ey_lo;
+    amrex::Vector<int> m_set_Ez_lo;
+    amrex::Vector<int> m_set_Ex_hi;
+    amrex::Vector<int> m_set_Ey_hi;
+    amrex::Vector<int> m_set_Ez_hi;
 
-    amrex::Vector<int> m_set_Efields_x_lo;
-    amrex::Vector<int> m_set_Efields_y_lo;
-    amrex::Vector<int> m_set_Efields_z_lo;
-
-    amrex::Vector<int> m_set_Efields_x_hi;
-    amrex::Vector<int> m_set_Efields_y_hi;
-    amrex::Vector<int> m_set_Efields_z_hi;
-
-    amrex::Vector<amrex::ParserExecutor<3>> m_Ex_parsers_lo, m_Ey_parsers_lo, m_Ez_parsers_lo;
-    amrex::Vector<amrex::ParserExecutor<3>> m_Ex_parsers_hi, m_Ey_parsers_hi, m_Ez_parsers_hi;
+    // For each E field, the parsers for the field value on each boundary
+    amrex::Vector<amrex::ParserExecutor<3>> m_Ex_parsers_lo;
+    amrex::Vector<amrex::ParserExecutor<3>> m_Ey_parsers_lo;
+    amrex::Vector<amrex::ParserExecutor<3>> m_Ez_parsers_lo;
+    amrex::Vector<amrex::ParserExecutor<3>> m_Ex_parsers_hi;
+    amrex::Vector<amrex::ParserExecutor<3>> m_Ey_parsers_hi;
+    amrex::Vector<amrex::ParserExecutor<3>> m_Ez_parsers_hi;
 
 };
 #endif // PEC_INSULATOR_H_

--- a/Source/BoundaryConditions/PEC_Insulator.H
+++ b/Source/BoundaryConditions/PEC_Insulator.H
@@ -84,18 +84,18 @@ public:
      * \param[in]     time                current time of the simulation
      * \param[in]     split_pml_field     whether pml the multifab is the regular Efield or split pml field
      * \param[in]     E_like              whether the field is E like or B like
-     * \param[in]     set_Fx_lo           the flags for the field along x at the lower boundary
-     * \param[in]     set_Fy_lo           the flags for the field along y at the lower boundary
-     * \param[in]     set_Fz_lo           the flags for the field along z at the lower boundary
-     * \param[in]     set_Fx_hi           the flags for the field along x at the upper boundary
-     * \param[in]     set_Fy_hi           the flags for the field along y at the upper boundary
-     * \param[in]     set_Fz_hi           the flags for the field along z at the upper boundary
-     * \param[in]     Fx_parsers_lo       the parsers for the field along x at the lower boundary
-     * \param[in]     Fy_parsers_lo       the parsers for the field along y at the lower boundary
-     * \param[in]     Fz_parsers_lo       the parsers for the field along z at the lower boundary
-     * \param[in]     Fx_parsers_hi       the parsers for the field along x at the upper boundary
-     * \param[in]     Fy_parsers_hi       the parsers for the field along y at the upper boundary
-     * \param[in]     Fz_parsers_hi       the parsers for the field along z at the upper boundary
+     * \param[in]     set_Fx_lo           the flags for the x-field at the lower boundaries
+     * \param[in]     set_Fy_lo           the flags for the y-field at the lower boundaries
+     * \param[in]     set_Fz_lo           the flags for the z-field at the lower boundaries
+     * \param[in]     set_Fx_hi           the flags for the x-field at the upper boundaries
+     * \param[in]     set_Fy_hi           the flags for the y-field at the upper boundaries
+     * \param[in]     set_Fz_hi           the flags for the z-field at the upper boundaries
+     * \param[in]     Fx_parsers_lo       the parsers for the x-field at the lower boundaries
+     * \param[in]     Fy_parsers_lo       the parsers for the y-field at the lower boundaries
+     * \param[in]     Fz_parsers_lo       the parsers for the z-field at the lower boundaries
+     * \param[in]     Fx_parsers_hi       the parsers for the x-field at the upper boundaries
+     * \param[in]     Fy_parsers_hi       the parsers for the y-field at the upper boundaries
+     * \param[in]     Fz_parsers_hi       the parsers for the z-field at the upper boundaries
      */
     void
     ApplyPEC_InsulatortoField (std::array<amrex::MultiFab*, 3> field,

--- a/Source/BoundaryConditions/PEC_Insulator.cpp
+++ b/Source/BoundaryConditions/PEC_Insulator.cpp
@@ -249,16 +249,16 @@ namespace
      *
      * \param[in] set_field_lo      flags whether the insulator expressions were specified
      * \param[in] set_field_hi      flags whether the insulator expressions were specified
-     * \param[in] parser_field1_lo  the parser for the first transverse field at the low boundary
-     * \param[in] parser_field2_lo  the parser for the second transverse field at the low boundary
-     * \param[in] parser_field1_hi  the parser for the first transverse field at the high boundary
-     * \param[in] parser_field2_hi  the parser for the second transverse field at the high boundary
-     * \param[out] set_fields_x_lo  the flags for the field along x at the lower boundary
-     * \param[out] set_fields_y_lo  the flags for the field along y at the lower boundary
-     * \param[out] set_fields_z_lo  the flags for the field along z at the lower boundary
-     * \param[out] set_fields_x_hi  the flags for the field along x at the upper boundary
-     * \param[out] set_fields_y_hi  the flags for the field along y at the upper boundary
-     * \param[out] set_fields_z_hi  the flags for the field along z at the upper boundary
+     * \param[in] parser_F1_lo      the parser for the first transverse field at the low boundary
+     * \param[in] parser_F2_lo      the parser for the second transverse field at the low boundary
+     * \param[in] parser_F1_hi      the parser for the first transverse field at the high boundary
+     * \param[in] parser_F2_hi      the parser for the second transverse field at the high boundary
+     * \param[out] set_Fx_lo        the flags for the field along x at the lower boundary
+     * \param[out] set_Fy_lo        the flags for the field along y at the lower boundary
+     * \param[out] set_Fz_lo        the flags for the field along z at the lower boundary
+     * \param[out] set_Fx_hi        the flags for the field along x at the upper boundary
+     * \param[out] set_Fy_hi        the flags for the field along y at the upper boundary
+     * \param[out] set_Fz_hi        the flags for the field along z at the upper boundary
      * \param[out] Fx_parsers_lo    the parsers for the field along x at the lower boundary
      * \param[out] Fy_parsers_lo    the parsers for the field along y at the lower boundary
      * \param[out] Fz_parsers_lo    the parsers for the field along z at the lower boundary
@@ -268,16 +268,16 @@ namespace
     */
     void SetupFieldParsers(amrex::Vector<int> const & set_field_lo,
                            amrex::Vector<int> const & set_field_hi,
-                           amrex::Vector<std::unique_ptr<amrex::Parser>> const & parser_field1_lo,
-                           amrex::Vector<std::unique_ptr<amrex::Parser>> const & parser_field2_lo,
-                           amrex::Vector<std::unique_ptr<amrex::Parser>> const & parser_field1_hi,
-                           amrex::Vector<std::unique_ptr<amrex::Parser>> const & parser_field2_hi,
-                           amrex::Vector<int> & set_fields_x_lo,
-                           amrex::Vector<int> & set_fields_y_lo,
-                           amrex::Vector<int> & set_fields_z_lo,
-                           amrex::Vector<int> & set_fields_x_hi,
-                           amrex::Vector<int> & set_fields_y_hi,
-                           amrex::Vector<int> & set_fields_z_hi,
+                           amrex::Vector<std::unique_ptr<amrex::Parser>> const & parser_F1_lo,
+                           amrex::Vector<std::unique_ptr<amrex::Parser>> const & parser_F2_lo,
+                           amrex::Vector<std::unique_ptr<amrex::Parser>> const & parser_F1_hi,
+                           amrex::Vector<std::unique_ptr<amrex::Parser>> const & parser_F2_hi,
+                           amrex::Vector<int> & set_Fx_lo,
+                           amrex::Vector<int> & set_Fy_lo,
+                           amrex::Vector<int> & set_Fz_lo,
+                           amrex::Vector<int> & set_Fx_hi,
+                           amrex::Vector<int> & set_Fy_hi,
+                           amrex::Vector<int> & set_Fz_hi,
                            [[maybe_unused]]amrex::Vector<amrex::ParserExecutor<3>> & Fx_parsers_lo,
                            [[maybe_unused]]amrex::Vector<amrex::ParserExecutor<3>> & Fy_parsers_lo,
                            [[maybe_unused]]amrex::Vector<amrex::ParserExecutor<3>> & Fz_parsers_lo,
@@ -285,42 +285,42 @@ namespace
                            [[maybe_unused]]amrex::Vector<amrex::ParserExecutor<3>> & Fy_parsers_hi,
                            [[maybe_unused]]amrex::Vector<amrex::ParserExecutor<3>> & Fz_parsers_hi)
     {
-        set_fields_x_lo.resize(AMREX_SPACEDIM, false);
-        set_fields_y_lo.resize(AMREX_SPACEDIM, false);
-        set_fields_z_lo.resize(AMREX_SPACEDIM, false);
-        set_fields_x_hi.resize(AMREX_SPACEDIM, false);
-        set_fields_y_hi.resize(AMREX_SPACEDIM, false);
-        set_fields_z_hi.resize(AMREX_SPACEDIM, false);
+        set_Fx_lo.resize(AMREX_SPACEDIM, false);
+        set_Fy_lo.resize(AMREX_SPACEDIM, false);
+        set_Fz_lo.resize(AMREX_SPACEDIM, false);
+        set_Fx_hi.resize(AMREX_SPACEDIM, false);
+        set_Fy_hi.resize(AMREX_SPACEDIM, false);
+        set_Fz_hi.resize(AMREX_SPACEDIM, false);
 
 #ifndef WARPX_DIM_1D_Z
-        set_fields_y_lo[0] = set_field_lo[0];
-        set_fields_z_lo[0] = set_field_lo[0];
-        set_fields_y_hi[0] = set_field_hi[0];
-        set_fields_z_hi[0] = set_field_hi[0];
-        Fy_parsers_lo.push_back(parser_field1_lo[0]->compile<3>());
-        Fz_parsers_lo.push_back(parser_field2_lo[0]->compile<3>());
-        Fy_parsers_hi.push_back(parser_field1_hi[0]->compile<3>());
-        Fz_parsers_hi.push_back(parser_field2_hi[0]->compile<3>());
+        set_Fy_lo[0] = set_field_lo[0];
+        set_Fz_lo[0] = set_field_lo[0];
+        set_Fy_hi[0] = set_field_hi[0];
+        set_Fz_hi[0] = set_field_hi[0];
+        Fy_parsers_lo.push_back(parser_F1_lo[0]->compile<3>());
+        Fz_parsers_lo.push_back(parser_F2_lo[0]->compile<3>());
+        Fy_parsers_hi.push_back(parser_F1_hi[0]->compile<3>());
+        Fz_parsers_hi.push_back(parser_F2_hi[0]->compile<3>());
 #endif
 #if defined(WARPX_DIM_3D)
-        set_fields_x_lo[1] = set_field_lo[1];
-        set_fields_z_lo[1] = set_field_lo[1];
-        set_fields_x_hi[1] = set_field_hi[1];
-        set_fields_z_hi[1] = set_field_hi[1];
-        Fx_parsers_lo.push_back(parser_field1_lo[1]->compile<3>());
-        Fz_parsers_lo.push_back(parser_field2_lo[1]->compile<3>());
-        Fx_parsers_hi.push_back(parser_field1_hi[1]->compile<3>());
-        Fz_parsers_hi.push_back(parser_field2_hi[1]->compile<3>());
+        set_Fx_lo[1] = set_field_lo[1];
+        set_Fz_lo[1] = set_field_lo[1];
+        set_Fx_hi[1] = set_field_hi[1];
+        set_Fz_hi[1] = set_field_hi[1];
+        Fx_parsers_lo.push_back(parser_F1_lo[1]->compile<3>());
+        Fz_parsers_lo.push_back(parser_F2_lo[1]->compile<3>());
+        Fx_parsers_hi.push_back(parser_F1_hi[1]->compile<3>());
+        Fz_parsers_hi.push_back(parser_F2_hi[1]->compile<3>());
 #endif
 #if defined(WARPX_ZINDEX)
-        set_fields_x_lo[WARPX_ZINDEX] = set_field_lo[WARPX_ZINDEX];
-        set_fields_y_lo[WARPX_ZINDEX] = set_field_lo[WARPX_ZINDEX];
-        set_fields_x_hi[WARPX_ZINDEX] = set_field_hi[WARPX_ZINDEX];
-        set_fields_y_hi[WARPX_ZINDEX] = set_field_hi[WARPX_ZINDEX];
-        Fx_parsers_lo.push_back(parser_field1_lo[WARPX_ZINDEX]->compile<3>());
-        Fy_parsers_lo.push_back(parser_field2_lo[WARPX_ZINDEX]->compile<3>());
-        Fx_parsers_hi.push_back(parser_field1_hi[WARPX_ZINDEX]->compile<3>());
-        Fy_parsers_hi.push_back(parser_field2_hi[WARPX_ZINDEX]->compile<3>());
+        set_Fx_lo[WARPX_ZINDEX] = set_field_lo[WARPX_ZINDEX];
+        set_Fy_lo[WARPX_ZINDEX] = set_field_lo[WARPX_ZINDEX];
+        set_Fx_hi[WARPX_ZINDEX] = set_field_hi[WARPX_ZINDEX];
+        set_Fy_hi[WARPX_ZINDEX] = set_field_hi[WARPX_ZINDEX];
+        Fx_parsers_lo.push_back(parser_F1_lo[WARPX_ZINDEX]->compile<3>());
+        Fy_parsers_lo.push_back(parser_F2_lo[WARPX_ZINDEX]->compile<3>());
+        Fx_parsers_hi.push_back(parser_F1_hi[WARPX_ZINDEX]->compile<3>());
+        Fy_parsers_hi.push_back(parser_F2_hi[WARPX_ZINDEX]->compile<3>());
 #endif
     }
 
@@ -417,17 +417,55 @@ PEC_Insulator::PEC_Insulator ()
 
     ::SetupFieldParsers(m_set_B_lo, m_set_B_hi,
                         m_parsers_B1_lo, m_parsers_B2_lo, m_parsers_B1_hi, m_parsers_B2_hi,
-                        m_set_Bfields_x_lo, m_set_Bfields_y_lo, m_set_Bfields_z_lo,
-                        m_set_Bfields_x_hi, m_set_Bfields_y_hi, m_set_Bfields_z_hi,
+                        m_set_Bx_lo, m_set_By_lo, m_set_Bz_lo,
+                        m_set_Bx_hi, m_set_By_hi, m_set_Bz_hi,
                         m_Bx_parsers_lo, m_By_parsers_lo, m_Bz_parsers_lo,
                         m_Bx_parsers_hi, m_By_parsers_hi, m_Bz_parsers_hi);
 
     ::SetupFieldParsers(m_set_E_lo, m_set_E_hi,
                         m_parsers_E1_lo, m_parsers_E2_lo, m_parsers_E1_hi, m_parsers_E2_hi,
-                        m_set_Efields_x_lo, m_set_Efields_y_lo, m_set_Efields_z_lo,
-                        m_set_Efields_x_hi, m_set_Efields_y_hi, m_set_Efields_z_hi,
+                        m_set_Ex_lo, m_set_Ey_lo, m_set_Ez_lo,
+                        m_set_Ex_hi, m_set_Ey_hi, m_set_Ez_hi,
                         m_Ex_parsers_lo, m_Ey_parsers_lo, m_Ez_parsers_lo,
                         m_Ex_parsers_hi, m_Ey_parsers_hi, m_Ez_parsers_hi);
+}
+
+int
+PEC_Insulator::IsESet(int idim, int iside, int ifield) {
+    int result = 0;
+    switch (ifield) {
+        case 0:
+            result = ( iside == 1 ? m_set_Ex_hi[idim] : m_set_Ex_lo[idim] );
+            break;
+        case 1:
+            result = ( iside == 1 ? m_set_Ey_hi[idim] : m_set_Ey_lo[idim] );
+            break;
+        case 2:
+            result = ( iside == 1 ? m_set_Ez_hi[idim] : m_set_Ez_lo[idim] );
+            break;
+        default:
+            WARPX_ABORT_WITH_MESSAGE("IsESet: Invalid ifield value passed in");
+    }
+    return result;
+}
+
+int
+PEC_Insulator::IsBSet(int idim, int iside, int ifield) {
+    int result = 0;
+    switch (ifield) {
+        case 0:
+            result = ( iside == 1 ? m_set_Bx_hi[idim] : m_set_Bx_lo[idim] );
+            break;
+        case 1:
+            result = ( iside == 1 ? m_set_By_hi[idim] : m_set_By_lo[idim] );
+            break;
+        case 2:
+            result = ( iside == 1 ? m_set_Bz_hi[idim] : m_set_Bz_lo[idim] );
+            break;
+        default:
+            WARPX_ABORT_WITH_MESSAGE("IsBSet: Invalid ifield value passed in");
+    }
+    return result;
 }
 
 void
@@ -444,8 +482,8 @@ PEC_Insulator::ApplyPEC_InsulatortoEfield (
     ApplyPEC_InsulatortoField(Efield, field_boundary_lo, field_boundary_hi, ng_fieldgather, geom,
                               lev, patch_type, ref_ratios, time, split_pml_field,
                               E_like,
-                              m_set_Efields_x_lo, m_set_Efields_y_lo, m_set_Efields_z_lo,
-                              m_set_Efields_x_hi, m_set_Efields_y_hi, m_set_Efields_z_hi,
+                              m_set_Ex_lo, m_set_Ey_lo, m_set_Ez_lo,
+                              m_set_Ex_hi, m_set_Ey_hi, m_set_Ez_hi,
                               m_Ex_parsers_lo, m_Ey_parsers_lo, m_Ez_parsers_lo,
                               m_Ex_parsers_hi, m_Ey_parsers_hi, m_Ez_parsers_hi);
 }
@@ -464,8 +502,8 @@ PEC_Insulator::ApplyPEC_InsulatortoBfield (
     ApplyPEC_InsulatortoField(Bfield, field_boundary_lo, field_boundary_hi, ng_fieldgather, geom,
                               lev, patch_type, ref_ratios, time, split_pml_field,
                               E_like,
-                              m_set_Bfields_x_lo, m_set_Bfields_y_lo, m_set_Bfields_z_lo,
-                              m_set_Bfields_x_hi, m_set_Bfields_y_hi, m_set_Bfields_z_hi,
+                              m_set_Bx_lo, m_set_By_lo, m_set_Bz_lo,
+                              m_set_Bx_hi, m_set_By_hi, m_set_Bz_hi,
                               m_Bx_parsers_lo, m_By_parsers_lo, m_Bz_parsers_lo,
                               m_Bx_parsers_hi, m_By_parsers_hi, m_Bz_parsers_hi);
 }
@@ -484,12 +522,12 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
     amrex::Real time,
     bool split_pml_field,
     bool E_like,
-    amrex::Vector<int> const & set_fields_x_lo,
-    amrex::Vector<int> const & set_fields_y_lo,
-    amrex::Vector<int> const & set_fields_z_lo,
-    amrex::Vector<int> const & set_fields_x_hi,
-    amrex::Vector<int> const & set_fields_y_hi,
-    amrex::Vector<int> const & set_fields_z_hi,
+    amrex::Vector<int> const & set_Fx_lo,
+    amrex::Vector<int> const & set_Fy_lo,
+    amrex::Vector<int> const & set_Fz_lo,
+    amrex::Vector<int> const & set_Fx_hi,
+    amrex::Vector<int> const & set_Fy_hi,
+    amrex::Vector<int> const & set_Fz_hi,
     amrex::Vector<amrex::ParserExecutor<3>> const & Fx_parsers_lo,
     amrex::Vector<amrex::ParserExecutor<3>> const & Fy_parsers_lo,
     amrex::Vector<amrex::ParserExecutor<3>> const & Fz_parsers_lo,
@@ -587,9 +625,9 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
                     tez_guard.setSmall(idim, node_box.bigEnd(idim));
                 }
 
-                bool const set_fieldx = ( (iside == -1) ? set_fields_x_lo[idim] : set_fields_x_hi[idim]);
-                bool const set_fieldy = ( (iside == -1) ? set_fields_y_lo[idim] : set_fields_y_hi[idim]);
-                bool const set_fieldz = ( (iside == -1) ? set_fields_z_lo[idim] : set_fields_z_hi[idim]);
+                bool const set_Fx = ( (iside == -1) ? set_Fx_lo[idim] : set_Fx_hi[idim]);
+                bool const set_Fy = ( (iside == -1) ? set_Fy_lo[idim] : set_Fy_hi[idim]);
+                bool const set_Fz = ( (iside == -1) ? set_Fz_lo[idim] : set_Fz_hi[idim]);
 
                 amrex::ParserExecutor<2> const & area_parser = ( (iside == -1) ? m_area_parsers_lo[idim] : m_area_parsers_hi[idim]);
 
@@ -615,12 +653,12 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
                         ::XDimTransverse tcoords = ::GetTransverseCoordinates(idim, coords);
 
                         bool const is_insulator = (area_parser(tcoords.t1, tcoords.t2) > 0._rt);
-                        amrex::Real const field_value = (set_fieldx ? Fx_parser(tcoords.t1, tcoords.t2, time) : 0._rt);
+                        amrex::Real const field_value = (set_Fx ? Fx_parser(tcoords.t1, tcoords.t2, time) : 0._rt);
 
                         int const icomp = 0;
                         ::SetFieldOnPEC_Insulator(idim, iside, icomp, domain_lo, domain_hi, iv, n,
                                                   Fx, E_like, Fx_nodal, is_insulator,
-                                                  field_value, set_fieldx);
+                                                  field_value, set_Fx);
                     },
                     tey_guard, nComp_y,
                     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
@@ -631,12 +669,12 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
                         ::XDimTransverse tcoords = ::GetTransverseCoordinates(idim, coords);
 
                         bool const is_insulator = (area_parser(tcoords.t1, tcoords.t2) > 0._rt);
-                        amrex::Real const field_value = (set_fieldy ? Fy_parser(tcoords.t1, tcoords.t2, time) : 0._rt);
+                        amrex::Real const field_value = (set_Fy ? Fy_parser(tcoords.t1, tcoords.t2, time) : 0._rt);
 
                         int const icomp = 1;
                         ::SetFieldOnPEC_Insulator(idim, iside, icomp, domain_lo, domain_hi, iv, n,
                                                   Fy, E_like, Fy_nodal, is_insulator,
-                                                  field_value, set_fieldy);
+                                                  field_value, set_Fy);
                     },
                     tez_guard, nComp_z,
                     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
@@ -647,12 +685,12 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
                         ::XDimTransverse tcoords = ::GetTransverseCoordinates(idim, coords);
 
                         bool const is_insulator = (area_parser(tcoords.t1, tcoords.t2) > 0._rt);
-                        amrex::Real const field_value = (set_fieldz ? Fz_parser(tcoords.t1, tcoords.t2, time) : 0._rt);
+                        amrex::Real const field_value = (set_Fz ? Fz_parser(tcoords.t1, tcoords.t2, time) : 0._rt);
 
                         int const icomp = 2;
                         ::SetFieldOnPEC_Insulator(idim, iside, icomp, domain_lo, domain_hi, iv, n,
                                                   Fz, E_like, Fz_nodal, is_insulator,
-                                                  field_value, set_fieldz);
+                                                  field_value, set_Fz);
                     }
                 );
             }

--- a/Source/BoundaryConditions/PEC_Insulator.cpp
+++ b/Source/BoundaryConditions/PEC_Insulator.cpp
@@ -440,7 +440,7 @@ PEC_Insulator::PEC_Insulator ()
 }
 
 int
-PEC_Insulator::IsESet(int idim, int iside, int ifield) {
+PEC_Insulator::IsESet(int idim, int iside, int ifield) const {
     int result = 0;
     switch (ifield) {
         case 0:
@@ -459,7 +459,7 @@ PEC_Insulator::IsESet(int idim, int iside, int ifield) {
 }
 
 int
-PEC_Insulator::IsBSet(int idim, int iside, int ifield) {
+PEC_Insulator::IsBSet(int idim, int iside, int ifield) const {
     int result = 0;
     switch (ifield) {
         case 0:


### PR DESCRIPTION
This cleans up the variable names used in the PEC_Insulator class to increase clarity and readability. It also adds accessors allowing checks of whether there are E or B fields being set by the boundary condition.