### PR TITLE
For implicit, set ng_fieldgather = ng_alloc_EB

### DIFF
--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -375,6 +375,14 @@ guardCellManager::Init (
         // for the field solve too.
         ng_FieldGather = ng_FieldGather.max(ng_FieldSolver);
 
+        if (evolve_scheme == EvolveScheme::ThetaImplicitEM ||
+            evolve_scheme == EvolveScheme::SemiImplicitEM ||
+            evolve_scheme == EvolveScheme::StrangImplicitSpectralEM) {
+            // For these implicit schemes, the number of ghost cells
+            // needs to be consistent for EB, J, and the field gather
+            ng_FieldGather = ng_alloc_EB;
+        }
+
         if (do_moving_window){
             ng_MovingWindow[moving_window_dir] = 1;
         }

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -378,7 +378,7 @@ guardCellManager::Init (
         // For these implicit schemes, the number of ghost cells
         // for EB gather must be consistent with those for J.
         ng_alloc_EB.max( ng_alloc_J );
-        ng_FieldGather = ng_alloc_J;
+        ng_FieldGather.max( ng_alloc_J );
     }
 
 }

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -322,14 +322,6 @@ guardCellManager::Init (
         ng_afterPushPSATD = ng_alloc_EB;
     }
 
-    if (evolve_scheme == EvolveScheme::ThetaImplicitEM ||
-        evolve_scheme == EvolveScheme::SemiImplicitEM ||
-        evolve_scheme == EvolveScheme::StrangImplicitSpectralEM) {
-        // For these implicit schemes, the number of ghost cells
-        // for EB must be at least as many as those for J.
-        ng_alloc_EB.max( ng_alloc_J );
-    }
-
     if (safe_guard_cells){
         // Run in safe mode: exchange all allocated guard cells at each
         // call of FillBoundary
@@ -375,16 +367,18 @@ guardCellManager::Init (
         // for the field solve too.
         ng_FieldGather = ng_FieldGather.max(ng_FieldSolver);
 
-        if (evolve_scheme == EvolveScheme::ThetaImplicitEM ||
-            evolve_scheme == EvolveScheme::SemiImplicitEM ||
-            evolve_scheme == EvolveScheme::StrangImplicitSpectralEM) {
-            // For these implicit schemes, the number of ghost cells
-            // needs to be consistent for EB, J, and the field gather
-            ng_FieldGather = ng_alloc_EB;
-        }
-
         if (do_moving_window){
             ng_MovingWindow[moving_window_dir] = 1;
         }
     }
+
+    if (evolve_scheme == EvolveScheme::ThetaImplicitEM ||
+        evolve_scheme == EvolveScheme::SemiImplicitEM ||
+        evolve_scheme == EvolveScheme::StrangImplicitSpectralEM) {
+        // For these implicit schemes, the number of ghost cells
+        // for EB gather must be consistent with those for J.
+        ng_alloc_EB.max( ng_alloc_J );
+        ng_FieldGather = ng_alloc_J;
+    }
+
 }


### PR DESCRIPTION
For the implicit solver, the values in the guard cells need to be consistent for the various grid operations.