### PR TITLE
For PEC_insulator, fix the source on the boundary

### DIFF
--- a/Source/BoundaryConditions/PEC_Insulator.H
+++ b/Source/BoundaryConditions/PEC_Insulator.H
@@ -90,6 +90,25 @@ public:
                                        int lev, PatchType patch_type, amrex::Vector<amrex::IntVect> const & ref_ratios);
 
     /**
+     * \brief Zeros the scalar on the boundary
+     *        When the E field is being set, the scalar is zeroed everywhere, in both insulator and conductor.
+     *        When the B field id being set, the scalar is zeroed only in the conductor.
+     *
+     * \param[in,out] scalar
+     * \param[in]     field_boundary_lo   lower field boundary conditions
+     * \param[in]     field_boundary_hi   upper field boundary conditions
+     * \param[in]     geom                geometry object of level "lev"
+     * \param[in]     lev                 level of the Multifab
+     * \param[in]     patch_type          coarse or fine
+     * \param[in]     ref_ratios          vector containing the refinement ratios of the refinement levels
+     */
+    void ZeroParallelScalarInConductor (amrex::MultiFab* scalar,
+                                        amrex::Array<FieldBoundaryType,AMREX_SPACEDIM> const & field_boundary_lo,
+                                        amrex::Array<FieldBoundaryType,AMREX_SPACEDIM> const & field_boundary_hi,
+                                        amrex::Geometry const & geom, int lev, PatchType patch_type,
+                                        amrex::Vector<amrex::IntVect> const & ref_ratios);
+
+    /**
      * \brief The work routine applying the boundary condition
      *
      * \param[in,out] field

--- a/Source/BoundaryConditions/PEC_Insulator.H
+++ b/Source/BoundaryConditions/PEC_Insulator.H
@@ -80,14 +80,12 @@ public:
      * \param[in]     lev                 level of the Multifab
      * \param[in]     patch_type          coarse or fine
      * \param[in]     ref_ratios          vector containing the refinement ratios of the refinement levels
-     * \param[in]     time                current time of the simulation
      */
-    void ZeroParallelFieldInInsulator (std::array<amrex::MultiFab*, 3> field,
+    void ZeroParallelFieldInConductor (std::array<amrex::MultiFab*, 3> field,
                                        amrex::Array<FieldBoundaryType,AMREX_SPACEDIM> const & field_boundary_lo,
                                        amrex::Array<FieldBoundaryType,AMREX_SPACEDIM> const & field_boundary_hi,
                                        amrex::IntVect const & ng_fieldgather, amrex::Geometry const & geom,
-                                       int lev, PatchType patch_type, amrex::Vector<amrex::IntVect> const & ref_ratios,
-                                       amrex::Real time);
+                                       int lev, PatchType patch_type, amrex::Vector<amrex::IntVect> const & ref_ratios);
 
     /**
      * \brief The work routine applying the boundary condition
@@ -103,7 +101,7 @@ public:
      * \param[in]     time                current time of the simulation
      * \param[in]     split_pml_field     whether pml the multifab is the regular Efield or split pml field
      * \param[in]     E_like              whether the field is E like or B like
-     * \param[in]     only_zero_parallel_insulator only zero the field when it's parallel to the insulator
+     * \param[in]     only_zero_parallel_conductor only zero the parallel field in the conductor
      * \param[in]     set_Fx_lo           the flags for the x-field at the lower boundaries
      * \param[in]     set_Fy_lo           the flags for the y-field at the lower boundaries
      * \param[in]     set_Fz_lo           the flags for the z-field at the lower boundaries
@@ -129,7 +127,7 @@ public:
                                amrex::Real time,
                                bool split_pml_field,
                                bool E_like,
-                               bool only_zero_parallel_insulator,
+                               bool only_zero_parallel_conductor,
                                amrex::Vector<int> const & set_Fx_lo,
                                amrex::Vector<int> const & set_Fy_lo,
                                amrex::Vector<int> const & set_Fz_lo,
@@ -142,28 +140,6 @@ public:
                                amrex::Vector<amrex::ParserExecutor<3>> const & Fx_parsers_hi,
                                amrex::Vector<amrex::ParserExecutor<3>> const & Fy_parsers_hi,
                                amrex::Vector<amrex::ParserExecutor<3>> const & Fz_parsers_hi);
-
-    /**
-     * \brief Zeros the fields in the conductor region parallel to the boundary
-     *
-     * \param[in,out] field
-     * \param[in]     field_boundary_lo   lower field boundary conditions
-     * \param[in]     field_boundary_hi   upper field boundary conditions
-     * \param[in]     ng_fieldgather      number of guard cells used by field gather
-     * \param[in]     geom                geometry object of level "lev"
-     * \param[in]     lev                 level of the Multifab
-     * \param[in]     patch_type          coarse or fine
-     * \param[in]     ref_ratios          vector containing the refinement ratios of the refinement levels
-     */
-    void
-    ZeroParallelFieldInInsulatorDuplicate (std::array<amrex::MultiFab*, 3> field,
-                               amrex::Array<FieldBoundaryType,AMREX_SPACEDIM> const & field_boundary_lo,
-                               amrex::Array<FieldBoundaryType,AMREX_SPACEDIM> const & field_boundary_hi,
-                               amrex::IntVect const & ng_fieldgather,
-                               amrex::Geometry const & geom,
-                               int lev,
-                               PatchType patch_type,
-                               amrex::Vector<amrex::IntVect> const & ref_ratios);
 
     /* \brief Returns whether any E field is set on a boundary
      * \param[in] idim dimension to check

--- a/Source/BoundaryConditions/PEC_Insulator.H
+++ b/Source/BoundaryConditions/PEC_Insulator.H
@@ -69,6 +69,25 @@ public:
                                      amrex::IntVect const & ng_fieldgather, amrex::Geometry const & geom,
                                      int lev, PatchType patch_type, amrex::Vector<amrex::IntVect> const & ref_ratios,
                                      amrex::Real time);
+    /**
+     * \brief Zeros the fields in the conductor region parallel to the boundary
+     *
+     * \param[in,out] field
+     * \param[in]     field_boundary_lo   lower field boundary conditions
+     * \param[in]     field_boundary_hi   upper field boundary conditions
+     * \param[in]     ng_fieldgather      number of guard cells used by field gather
+     * \param[in]     geom                geometry object of level "lev"
+     * \param[in]     lev                 level of the Multifab
+     * \param[in]     patch_type          coarse or fine
+     * \param[in]     ref_ratios          vector containing the refinement ratios of the refinement levels
+     * \param[in]     time                current time of the simulation
+     */
+    void ZeroParallelFieldInInsulator (std::array<amrex::MultiFab*, 3> field,
+                                       amrex::Array<FieldBoundaryType,AMREX_SPACEDIM> const & field_boundary_lo,
+                                       amrex::Array<FieldBoundaryType,AMREX_SPACEDIM> const & field_boundary_hi,
+                                       amrex::IntVect const & ng_fieldgather, amrex::Geometry const & geom,
+                                       int lev, PatchType patch_type, amrex::Vector<amrex::IntVect> const & ref_ratios,
+                                       amrex::Real time);
 
     /**
      * \brief The work routine applying the boundary condition
@@ -84,6 +103,7 @@ public:
      * \param[in]     time                current time of the simulation
      * \param[in]     split_pml_field     whether pml the multifab is the regular Efield or split pml field
      * \param[in]     E_like              whether the field is E like or B like
+     * \param[in]     only_zero_parallel_insulator only zero the field when it's parallel to the insulator
      * \param[in]     set_Fx_lo           the flags for the x-field at the lower boundaries
      * \param[in]     set_Fy_lo           the flags for the y-field at the lower boundaries
      * \param[in]     set_Fz_lo           the flags for the z-field at the lower boundaries
@@ -109,6 +129,7 @@ public:
                                amrex::Real time,
                                bool split_pml_field,
                                bool E_like,
+                               bool only_zero_parallel_insulator,
                                amrex::Vector<int> const & set_Fx_lo,
                                amrex::Vector<int> const & set_Fy_lo,
                                amrex::Vector<int> const & set_Fz_lo,
@@ -121,6 +142,28 @@ public:
                                amrex::Vector<amrex::ParserExecutor<3>> const & Fx_parsers_hi,
                                amrex::Vector<amrex::ParserExecutor<3>> const & Fy_parsers_hi,
                                amrex::Vector<amrex::ParserExecutor<3>> const & Fz_parsers_hi);
+
+    /**
+     * \brief Zeros the fields in the conductor region parallel to the boundary
+     *
+     * \param[in,out] field
+     * \param[in]     field_boundary_lo   lower field boundary conditions
+     * \param[in]     field_boundary_hi   upper field boundary conditions
+     * \param[in]     ng_fieldgather      number of guard cells used by field gather
+     * \param[in]     geom                geometry object of level "lev"
+     * \param[in]     lev                 level of the Multifab
+     * \param[in]     patch_type          coarse or fine
+     * \param[in]     ref_ratios          vector containing the refinement ratios of the refinement levels
+     */
+    void
+    ZeroParallelFieldInInsulatorDuplicate (std::array<amrex::MultiFab*, 3> field,
+                               amrex::Array<FieldBoundaryType,AMREX_SPACEDIM> const & field_boundary_lo,
+                               amrex::Array<FieldBoundaryType,AMREX_SPACEDIM> const & field_boundary_hi,
+                               amrex::IntVect const & ng_fieldgather,
+                               amrex::Geometry const & geom,
+                               int lev,
+                               PatchType patch_type,
+                               amrex::Vector<amrex::IntVect> const & ref_ratios);
 
     /* \brief Returns whether any E field is set on a boundary
      * \param[in] idim dimension to check

--- a/Source/BoundaryConditions/PEC_Insulator.H
+++ b/Source/BoundaryConditions/PEC_Insulator.H
@@ -173,20 +173,6 @@ public:
 
 private:
 
-    /* \brief Read in the parsers for the tangential fields, returning whether
-     *        the input parameter was specified.
-     * \param[in]  pp_insulator ParmParse instance
-     * \param[out] parsers vector holding the parsers generated from the input
-     * \param[in]  input_name the name of the input parameter
-     * \param[in]  coord1 the first coordinate in the plane
-     * \param[in]  coord2 the second coordinate in the plane
-     * \return wether the parameter was specified
-     */
-    bool ReadTangentialFieldParser (amrex::ParmParse const & pp_insulator,
-                                    amrex::Vector<std::unique_ptr<amrex::Parser>> & parsers,
-                                    std::string const & input_name,
-                                    std::string const & coord1,
-                                    std::string const & coord2);
 
     // Parsers specifying the region of each boundary that is insulator
     amrex::Vector<std::unique_ptr<amrex::Parser>> m_insulator_area_lo;

--- a/Source/BoundaryConditions/PEC_Insulator.H
+++ b/Source/BoundaryConditions/PEC_Insulator.H
@@ -70,7 +70,9 @@ public:
                                      int lev, PatchType patch_type, amrex::Vector<amrex::IntVect> const & ref_ratios,
                                      amrex::Real time);
     /**
-     * \brief Zeros the fields in the conductor region parallel to the boundary
+     * \brief Zeros the parallel fields on the boundary
+     *        When the E field is being set, the field is zeroed everywhere, in both insulator and conductor.
+     *        When the B field id being set, the field is zeroed only in the conductor.
      *
      * \param[in,out] field
      * \param[in]     field_boundary_lo   lower field boundary conditions
@@ -101,7 +103,7 @@ public:
      * \param[in]     time                current time of the simulation
      * \param[in]     split_pml_field     whether pml the multifab is the regular Efield or split pml field
      * \param[in]     E_like              whether the field is E like or B like
-     * \param[in]     only_zero_parallel_conductor only zero the parallel field in the conductor
+     * \param[in]     only_zero_parallel_field only zero the parallel field on the boundary
      * \param[in]     set_Fx_lo           the flags for the x-field at the lower boundaries
      * \param[in]     set_Fy_lo           the flags for the y-field at the lower boundaries
      * \param[in]     set_Fz_lo           the flags for the z-field at the lower boundaries
@@ -127,7 +129,7 @@ public:
                                amrex::Real time,
                                bool split_pml_field,
                                bool E_like,
-                               bool only_zero_parallel_conductor,
+                               bool only_zero_parallel_field,
                                amrex::Vector<int> const & set_Fx_lo,
                                amrex::Vector<int> const & set_Fy_lo,
                                amrex::Vector<int> const & set_Fz_lo,

--- a/Source/BoundaryConditions/PEC_Insulator.cpp
+++ b/Source/BoundaryConditions/PEC_Insulator.cpp
@@ -744,3 +744,108 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
         }
     }
 }
+
+void
+PEC_Insulator::ZeroParallelScalarInConductor (
+    amrex::MultiFab* scalar,
+    amrex::Array<FieldBoundaryType,AMREX_SPACEDIM> const & field_boundary_lo,
+    amrex::Array<FieldBoundaryType,AMREX_SPACEDIM> const & field_boundary_hi,
+    amrex::Geometry const & geom,
+    int lev,
+    PatchType patch_type,
+    amrex::Vector<amrex::IntVect> const & ref_ratios)
+{
+    using namespace amrex::literals;
+    amrex::Box domain_box = geom.Domain();
+    if (patch_type == PatchType::coarse && (lev > 0)) {
+        domain_box.coarsen(ref_ratios[lev-1]);
+    }
+    amrex::IntVect const domain_lo = domain_box.smallEnd();
+    amrex::IntVect const domain_hi = domain_box.bigEnd();
+
+    amrex::IntVect const S_nodal = scalar->ixType().toIntVect();
+
+    // Apply boundary condition to ncomponents
+    int const nComp = scalar->nComp();
+
+    std::array<amrex::Real,3> const & dx = WarpX::CellSize(lev);
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    // The false flag here is to ensure that this loop does not use tiling.
+    // The boxes are grown to include transverse ghost cells prior to the reflection.
+    // Tiling is problematic because neighboring tiles will have overlapping boxes
+    // in the direction transverse to the boundary, thereby reflecting the value multiple
+    // times in the overlapping region.
+    for (amrex::MFIter mfi(*scalar, false); mfi.isValid(); ++mfi) {
+        // Extract scalar data
+        amrex::Array4<amrex::Real> const & S = scalar->array(mfi);
+
+        // Get nodal box that does not include ghost cells
+        amrex::Box const & valid_box = mfi.validbox();
+        amrex::Box const node_box = amrex::convert(valid_box, amrex::IntVect::TheNodeVector());
+
+        amrex::XDim3 const xyzmin = WarpX::LowerCorner(valid_box, lev, 0._rt);
+        amrex::IntVect const lo = valid_box.smallEnd();
+
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+
+            if (!(field_boundary_lo[idim] == FieldBoundaryType::PECInsulator) &&
+                !(field_boundary_hi[idim] == FieldBoundaryType::PECInsulator)) { continue; }
+
+            if ( (node_box.smallEnd()[idim] > domain_lo[idim]) &&
+                 (node_box.bigEnd()[idim] < domain_hi[idim]) ) { continue; }
+
+            // Extract tilebox for which to loop.
+            // Does not include guard cells.
+            amrex::Box tbox = mfi.tilebox(scalar->ixType().toIntVect());
+
+            // Loop over sides, iside = -1 (lo), iside = +1 (hi)
+            for (int iside = -1; iside <= +1; iside += 2) {
+
+                if ((iside == -1 && (field_boundary_lo[idim] != FieldBoundaryType::PECInsulator)) ||
+                    (iside == +1 && (field_boundary_hi[idim] != FieldBoundaryType::PECInsulator))) { continue; }
+
+                if ((iside == -1 && (node_box.smallEnd()[idim] > domain_lo[idim])) ||
+                    (iside == +1 && (node_box.bigEnd()[idim] < domain_hi[idim]))) { continue; }
+
+                amrex::Box tbox_boundary = tbox;
+
+                // Shrink the box to only include the boundary cells
+                if (iside == -1) {
+                    tbox_boundary.setBig(idim, node_box.smallEnd(idim));
+                } else {
+                    tbox_boundary.setSmall(idim, node_box.bigEnd(idim));
+                }
+
+                bool const set_S = ( (iside == -1) ? m_set_E_lo[idim] : m_set_E_hi[idim]);
+
+                amrex::ParserExecutor<2> const & area_parser = ( (iside == -1) ? m_area_parsers_lo[idim] : m_area_parsers_hi[idim]);
+
+                // loop over cells and update the scalar
+                amrex::ParallelFor(
+                    tbox_boundary, nComp,
+                    [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
+                        amrex::ignore_unused(j, k);
+
+                        amrex::IntVect const iv(AMREX_D_DECL(i, j, k));
+
+                        amrex::XDim3 const coords = ::ConvertIndexToCoordinate(iv, xyzmin, dx, lo, S_nodal);
+                        ::XDimTransverse tcoords = ::GetTransverseCoordinates(idim, coords);
+
+                        bool const is_insulator = (area_parser(tcoords.t1, tcoords.t2) > 0._rt);
+
+                        bool const E_like = false;
+                        bool const is_normal_to_boundary = false;
+                        amrex::Real const field_value = 0.;
+                        bool const only_zero_parallel_field = true;
+                        ::SetFieldOnPEC_Insulator(idim, iside, domain_lo, domain_hi, iv, n,
+                                                  S, E_like, S_nodal, is_insulator, is_normal_to_boundary,
+                                                  field_value, set_S, only_zero_parallel_field);
+                    }
+                );
+            }
+        }
+    }
+}

--- a/Source/BoundaryConditions/PEC_Insulator.cpp
+++ b/Source/BoundaryConditions/PEC_Insulator.cpp
@@ -146,7 +146,7 @@ namespace
         // when ig == 0.
         bool const on_nodal_boundary = (ig == 0);
 
-        if (only_zero_parallel_conductor) {
+        if (only_zero_parallel_conductor && set_field) {
             if (on_nodal_boundary && !is_insulator_boundary && !is_normal_to_boundary) {
                 field(ijk_vec, n) = 0._rt;
             }
@@ -524,14 +524,14 @@ PEC_Insulator::ZeroParallelFieldInConductor (
     bool const E_like = false;  // E_like will be unused
     bool const split_pml_field = false;
     amrex::Real const time = 0.;  // time will be unused
-    // since no fields are to be calculated, set_F is all false and dummy parsers are passed in
-    amrex::Vector<int> set_F(AMREX_SPACEDIM, false);
+    // The field is only zeroed out when the E field is being set
+    // since no fields are needed, dummy parsers are passed in
     amrex::Vector<amrex::ParserExecutor<3>> dummy_parsers(3, amrex::ParserExecutor<3>());
     ApplyPEC_InsulatortoField(field, field_boundary_lo, field_boundary_hi, ng_fieldgather, geom,
                               lev, patch_type, ref_ratios, time, split_pml_field,
                               E_like, only_zero_parallel_conductor,
-                              set_F, set_F, set_F,
-                              set_F, set_F, set_F,
+                              m_set_Ex_lo, m_set_Ey_lo, m_set_Ez_lo,
+                              m_set_Ex_hi, m_set_Ey_hi, m_set_Ez_hi,
                               dummy_parsers, dummy_parsers, dummy_parsers,
                               dummy_parsers, dummy_parsers, dummy_parsers);
 }

--- a/Source/BoundaryConditions/PEC_Insulator.cpp
+++ b/Source/BoundaryConditions/PEC_Insulator.cpp
@@ -648,12 +648,14 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
             // gather fields from in the guard-cell region are included.
             // Note that for simulations without particles or laser, ng_field_gather is 0
             // and the guard-cell values of the E-field multifab will not be modified.
+            amrex::IntVect ng = ng_fieldgather;
+            ng.min(field[0]->nGrowVect());
             amrex::Box tex = (split_pml_field) ? mfi.tilebox(field[0]->ixType().toIntVect())
-                                               : mfi.tilebox(field[0]->ixType().toIntVect(), ng_fieldgather);
+                                               : mfi.tilebox(field[0]->ixType().toIntVect(), ng);
             amrex::Box tey = (split_pml_field) ? mfi.tilebox(field[1]->ixType().toIntVect())
-                                               : mfi.tilebox(field[1]->ixType().toIntVect(), ng_fieldgather);
+                                               : mfi.tilebox(field[1]->ixType().toIntVect(), ng);
             amrex::Box tez = (split_pml_field) ? mfi.tilebox(field[2]->ixType().toIntVect())
-                                               : mfi.tilebox(field[2]->ixType().toIntVect(), ng_fieldgather);
+                                               : mfi.tilebox(field[2]->ixType().toIntVect(), ng);
 
             // Loop over sides, iside = -1 (lo), iside = +1 (hi)
             for (int iside = -1; iside <= +1; iside += 2) {

--- a/Source/BoundaryConditions/PEC_Insulator.cpp
+++ b/Source/BoundaryConditions/PEC_Insulator.cpp
@@ -96,9 +96,6 @@ namespace
      * \brief At the specified grid location, apply either the PEC or insulator boundary condition if
      *        the cell is on the boundary or in the guard cells.
      *
-     * \param[in] icomp        component of the field being updated
-     *                         (0=x, 1=y, 2=z in Cartesian)
-     *                         (0=r, 1=theta, 2=z in RZ)
      * \param[in] dom_lo       index value of the lower domain boundary (cell-centered)
      * \param[in] dom_hi       index value of the higher domain boundary (cell-centered)
      * \param[in] ijk_vec      indices along the x(i), y(j), z(k) of field Array4
@@ -108,13 +105,13 @@ namespace
      * \param[in] E_like       whether the field behaves like E field or B field
      * \param[in] is_nodal     staggering of the field data being updated.
      * \param[in] is_insulator_boundary Specifies whether the boundary is an insulator
+     * \param[in] is_normal_to_boundary Specified whether the vector is normal to the boundary
      * \param[in] field_value  the value of the field for the insulator boundary cell
      * \param[in] set_field    whether to set the field on the lower boundary
      */
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     void SetFieldOnPEC_Insulator (int idim,
                                   int iside,
-                                  int icomp,
                                   amrex::IntVect const & dom_lo,
                                   amrex::IntVect const & dom_hi,
                                   amrex::IntVect const & ijk_vec,
@@ -123,8 +120,10 @@ namespace
                                   bool const E_like,
                                   amrex::IntVect const & is_nodal,
                                   const bool is_insulator_boundary,
+                                  const int is_normal_to_boundary,
                                   amrex::Real const field_value,
-                                  bool const set_field)
+                                  bool const set_field,
+                                  bool const only_zero_parallel_insulator)
     {
         using namespace amrex::literals;
 
@@ -139,19 +138,6 @@ namespace
         int const ig = ((iside == -1) ? (dom_lo[idim] - ijk_vec[idim])
                                       : (ijk_vec[idim] - (dom_hi[idim] + is_nodal[idim])));
 
-#if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
-        // For 2D : for icomp==1, (Fy in XZ, Ftheta in RZ),
-        //          icomp=1 is not normal to x or z boundary
-        //          The logic below ensures that the flags are set right for 2D
-        bool const is_normal_to_boundary = (icomp == (2*idim));
-#elif (defined WARPX_DIM_1D_Z)
-        // For 1D : icomp=0 and icomp=1 (Fx and Fy are not normal to the z boundary)
-        //          The logic below ensures that the flags are set right for 1D
-        bool const is_normal_to_boundary = (icomp == 2);
-#else
-        bool const is_normal_to_boundary = (icomp == idim);
-#endif
-
         // For B fields, the parallel fields are cell centered, so are on the boundary
         // when ig == 1, the first cell beyond the boundary.
         bool const on_cell_boundary = (ig == 1);
@@ -159,6 +145,13 @@ namespace
         // For E fields, the parallel fields are node centered, so are on the boundary
         // when ig == 0.
         bool const on_nodal_boundary = (ig == 0);
+
+        if (only_zero_parallel_insulator) {
+            if (on_nodal_boundary && !is_insulator_boundary && !is_normal_to_boundary) {
+                field(ijk_vec, n) = 0._rt;
+            }
+            return;
+        }
 
         amrex::IntVect ijk_mirror = ijk_vec;
         amrex::IntVect ijk_boundary = ijk_vec;
@@ -488,9 +481,10 @@ PEC_Insulator::ApplyPEC_InsulatortoEfield (
     bool split_pml_field)
 {
     bool const E_like = true;
+    bool const only_zero_parallel_insulator = false;
     ApplyPEC_InsulatortoField(Efield, field_boundary_lo, field_boundary_hi, ng_fieldgather, geom,
                               lev, patch_type, ref_ratios, time, split_pml_field,
-                              E_like,
+                              E_like, only_zero_parallel_insulator,
                               m_set_Ex_lo, m_set_Ey_lo, m_set_Ez_lo,
                               m_set_Ex_hi, m_set_Ey_hi, m_set_Ez_hi,
                               m_Ex_parsers_lo, m_Ey_parsers_lo, m_Ez_parsers_lo,
@@ -508,15 +502,37 @@ PEC_Insulator::ApplyPEC_InsulatortoBfield (
 {
     bool const E_like = false;
     bool const split_pml_field = false;
+    bool const only_zero_parallel_insulator = false;
     ApplyPEC_InsulatortoField(Bfield, field_boundary_lo, field_boundary_hi, ng_fieldgather, geom,
                               lev, patch_type, ref_ratios, time, split_pml_field,
-                              E_like,
+                              E_like, only_zero_parallel_insulator,
                               m_set_Bx_lo, m_set_By_lo, m_set_Bz_lo,
                               m_set_Bx_hi, m_set_By_hi, m_set_Bz_hi,
                               m_Bx_parsers_lo, m_By_parsers_lo, m_Bz_parsers_lo,
                               m_Bx_parsers_hi, m_By_parsers_hi, m_Bz_parsers_hi);
 }
 
+void
+PEC_Insulator::ZeroParallelFieldInInsulator (
+    std::array<amrex::MultiFab*, 3> field,
+    amrex::Array<FieldBoundaryType,AMREX_SPACEDIM> const & field_boundary_lo,
+    amrex::Array<FieldBoundaryType,AMREX_SPACEDIM> const & field_boundary_hi,
+    amrex::IntVect const & ng_fieldgather, amrex::Geometry const & geom,
+    int lev, PatchType patch_type, amrex::Vector<amrex::IntVect> const & ref_ratios,
+    amrex::Real time)
+{
+    bool const E_like = true;
+    bool const split_pml_field = false;
+    bool const only_zero_parallel_insulator = true;
+    amrex::Vector<int> set_F(AMREX_SPACEDIM, false);
+    ApplyPEC_InsulatortoField(field, field_boundary_lo, field_boundary_hi, ng_fieldgather, geom,
+                              lev, patch_type, ref_ratios, time, split_pml_field,
+                              E_like, only_zero_parallel_insulator,
+                              set_F, set_F, set_F,
+                              set_F, set_F, set_F,
+                              m_Ex_parsers_lo, m_Ey_parsers_lo, m_Ez_parsers_lo,
+                              m_Ex_parsers_hi, m_Ey_parsers_hi, m_Ez_parsers_hi);
+}
 
 void
 PEC_Insulator::ApplyPEC_InsulatortoField (
@@ -531,6 +547,7 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
     amrex::Real time,
     bool split_pml_field,
     bool E_like,
+    bool only_zero_parallel_insulator,
     amrex::Vector<int> const & set_Fx_lo,
     amrex::Vector<int> const & set_Fy_lo,
     amrex::Vector<int> const & set_Fz_lo,
@@ -597,6 +614,19 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
             if ( (node_box.smallEnd()[idim] > domain_lo[idim]) &&
                  (node_box.bigEnd()[idim] < domain_hi[idim]) ) { continue; }
 
+            amrex::IntVectND<3> is_normal_to_boundary{0, 0, 0};
+
+#if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
+            // For 2D : for icomp==1, (Fy in XZ, Ftheta in RZ),
+            //          icomp=1 is not normal to x or z boundary
+            is_normal_to_boundary[2*idim] = 1;
+#elif (defined WARPX_DIM_1D_Z)
+            // For 1D : icomp=0 and icomp=1 (Fx and Fy are not normal to the z boundary)
+            is_normal_to_boundary[2] = 1;
+#else
+            is_normal_to_boundary[idim] = 1;
+#endif
+
             // Extract tileboxes for which to loop
             // if split field, the box includes nodal flag
             // For E-field used in Maxwell's update, nodal flag plus cells that particles
@@ -658,10 +688,9 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
                         bool const is_insulator = (area_parser(tcoords.t1, tcoords.t2) > 0._rt);
                         amrex::Real const field_value = (set_Fx ? Fx_parser(tcoords.t1, tcoords.t2, time) : 0._rt);
 
-                        int const icomp = 0;
-                        ::SetFieldOnPEC_Insulator(idim, iside, icomp, domain_lo, domain_hi, iv, n,
-                                                  Fx, E_like, Fx_nodal, is_insulator,
-                                                  field_value, set_Fx);
+                        ::SetFieldOnPEC_Insulator(idim, iside, domain_lo, domain_hi, iv, n,
+                                                  Fx, E_like, Fx_nodal, is_insulator, is_normal_to_boundary[0],
+                                                  field_value, set_Fx, only_zero_parallel_insulator);
                     },
                     tey_guard, nComp_y,
                     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
@@ -674,10 +703,9 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
                         bool const is_insulator = (area_parser(tcoords.t1, tcoords.t2) > 0._rt);
                         amrex::Real const field_value = (set_Fy ? Fy_parser(tcoords.t1, tcoords.t2, time) : 0._rt);
 
-                        int const icomp = 1;
-                        ::SetFieldOnPEC_Insulator(idim, iside, icomp, domain_lo, domain_hi, iv, n,
-                                                  Fy, E_like, Fy_nodal, is_insulator,
-                                                  field_value, set_Fy);
+                        ::SetFieldOnPEC_Insulator(idim, iside, domain_lo, domain_hi, iv, n,
+                                                  Fy, E_like, Fy_nodal, is_insulator, is_normal_to_boundary[1],
+                                                  field_value, set_Fy, only_zero_parallel_insulator);
                     },
                     tez_guard, nComp_z,
                     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
@@ -690,10 +718,194 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
                         bool const is_insulator = (area_parser(tcoords.t1, tcoords.t2) > 0._rt);
                         amrex::Real const field_value = (set_Fz ? Fz_parser(tcoords.t1, tcoords.t2, time) : 0._rt);
 
-                        int const icomp = 2;
-                        ::SetFieldOnPEC_Insulator(idim, iside, icomp, domain_lo, domain_hi, iv, n,
-                                                  Fz, E_like, Fz_nodal, is_insulator,
-                                                  field_value, set_Fz);
+                        ::SetFieldOnPEC_Insulator(idim, iside, domain_lo, domain_hi, iv, n,
+                                                  Fz, E_like, Fz_nodal, is_insulator, is_normal_to_boundary[2],
+                                                  field_value, set_Fz, only_zero_parallel_insulator);
+                    }
+                );
+            }
+        }
+    }
+}
+
+void
+PEC_Insulator::ZeroParallelFieldInInsulatorDuplicate (
+    std::array<amrex::MultiFab*, 3> field,
+    amrex::Array<FieldBoundaryType,AMREX_SPACEDIM> const & field_boundary_lo,
+    amrex::Array<FieldBoundaryType,AMREX_SPACEDIM> const & field_boundary_hi,
+    amrex::IntVect const & ng_fieldgather,
+    amrex::Geometry const & geom,
+    int lev,
+    PatchType patch_type,
+    amrex::Vector<amrex::IntVect> const & ref_ratios)
+{
+    using namespace amrex::literals;
+    amrex::Box domain_box = geom.Domain();
+    if (patch_type == PatchType::coarse && (lev > 0)) {
+        domain_box.coarsen(ref_ratios[lev-1]);
+    }
+    amrex::IntVect const domain_lo = domain_box.smallEnd();
+    amrex::IntVect const domain_hi = domain_box.bigEnd();
+
+    amrex::IntVect const Fx_nodal = field[0]->ixType().toIntVect();
+    amrex::IntVect const Fy_nodal = field[1]->ixType().toIntVect();
+    amrex::IntVect const Fz_nodal = field[2]->ixType().toIntVect();
+
+    // For each field multifab, apply boundary condition to ncomponents
+    // If not split field, the boundary condition is applied to the regular field used in Maxwell's eq.
+    // If split_pml_field is true, then boundary condition is applied to all the split field components.
+    int const nComp_x = field[0]->nComp();
+    int const nComp_y = field[1]->nComp();
+    int const nComp_z = field[2]->nComp();
+
+    std::array<amrex::Real,3> const & dx = WarpX::CellSize(lev);
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    // The false flag here is to ensure that this loop does not use tiling.
+    // The boxes are grown to include transverse ghost cells prior to the reflection.
+    // Tiling is problematic because neighboring tiles will have overlapping boxes
+    // in the direction transverse to the boundary, thereby reflecting the value multiple
+    // times in the overlapping region.
+    for (amrex::MFIter mfi(*field[0], false); mfi.isValid(); ++mfi) {
+        // Extract field data
+        amrex::Array4<amrex::Real> const & Fx = field[0]->array(mfi);
+        amrex::Array4<amrex::Real> const & Fy = field[1]->array(mfi);
+        amrex::Array4<amrex::Real> const & Fz = field[2]->array(mfi);
+
+        // Get nodal box that does not include ghost cells
+        amrex::Box const & valid_box = mfi.validbox();
+        amrex::Box const node_box = amrex::convert(valid_box, amrex::IntVect::TheNodeVector());
+
+        // The lower end of the box is the same for nodal and cell centered,
+        // so the same lower end can be used for the three fields even though
+        // they will have different centerings.
+        amrex::XDim3 const xyzmin = WarpX::LowerCorner(valid_box, lev, 0._rt);
+        amrex::IntVect const lo = valid_box.smallEnd();
+
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+
+            if (!(field_boundary_lo[idim] == FieldBoundaryType::PECInsulator) &&
+                !(field_boundary_hi[idim] == FieldBoundaryType::PECInsulator)) { continue; }
+
+            if ( (node_box.smallEnd()[idim] > domain_lo[idim]) &&
+                 (node_box.bigEnd()[idim] < domain_hi[idim]) ) { continue; }
+
+            amrex::IntVectND<3> is_normal_to_boundary{0, 0, 0};
+
+#if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
+            // For 2D : for icomp==1, (Fy in XZ, Ftheta in RZ),
+            //          icomp=1 is not normal to x or z boundary
+            is_normal_to_boundary[2*idim] = 1;
+#elif (defined WARPX_DIM_1D_Z)
+            // For 1D : icomp=0 and icomp=1 (Fx and Fy are not normal to the z boundary)
+            is_normal_to_boundary[2] = 1;
+#else
+            is_normal_to_boundary[idim] = 1;
+#endif
+
+            // Extract tileboxes for which to loop
+            // if split field, the box includes nodal flag
+            // For E-field used in Maxwell's update, nodal flag plus cells that particles
+            // gather fields from in the guard-cell region are included.
+            // Note that for simulations without particles or laser, ng_field_gather is 0
+            // and the guard-cell values of the E-field multifab will not be modified.
+            amrex::Box tex = mfi.tilebox(field[0]->ixType().toIntVect(), ng_fieldgather);
+            amrex::Box tey = mfi.tilebox(field[1]->ixType().toIntVect(), ng_fieldgather);
+            amrex::Box tez = mfi.tilebox(field[2]->ixType().toIntVect(), ng_fieldgather);
+
+            // Loop over sides, iside = -1 (lo), iside = +1 (hi)
+            for (int iside = -1; iside <= +1; iside += 2) {
+
+                if ((iside == -1 && (field_boundary_lo[idim] != FieldBoundaryType::PECInsulator)) ||
+                    (iside == +1 && (field_boundary_hi[idim] != FieldBoundaryType::PECInsulator))) { continue; }
+
+                if ((iside == -1 && (node_box.smallEnd()[idim] > domain_lo[idim])) ||
+                    (iside == +1 && (node_box.bigEnd()[idim] < domain_hi[idim]))) { continue; }
+
+                amrex::Box tex_guard = tex;
+                amrex::Box tey_guard = tey;
+                amrex::Box tez_guard = tez;
+
+                // Shrink the box to only include the guard and boundary cells
+                if (iside == -1) {
+                    tex_guard.setBig(idim, node_box.smallEnd(idim));
+                    tey_guard.setBig(idim, node_box.smallEnd(idim));
+                    tez_guard.setBig(idim, node_box.smallEnd(idim));
+                } else {
+                    tex_guard.setSmall(idim, node_box.bigEnd(idim));
+                    tey_guard.setSmall(idim, node_box.bigEnd(idim));
+                    tez_guard.setSmall(idim, node_box.bigEnd(idim));
+                }
+
+                amrex::ParserExecutor<2> const & area_parser = ( (iside == -1) ? m_area_parsers_lo[idim] : m_area_parsers_hi[idim]);
+
+                // loop over cells and update fields
+                amrex::ParallelFor(
+                    tex_guard, nComp_x,
+                    [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
+                        if (is_normal_to_boundary[0]) {
+                            return;
+                        }
+
+                        amrex::IntVect const iv(AMREX_D_DECL(i, j, k));
+
+                        amrex::XDim3 const coords = ::ConvertIndexToCoordinate(iv, xyzmin, dx, lo, Fx_nodal);
+                        ::XDimTransverse tcoords = ::GetTransverseCoordinates(idim, coords);
+
+                        bool const is_insulator = (area_parser(tcoords.t1, tcoords.t2) > 0._rt);
+
+                        int const ig = ((iside == -1) ? (domain_lo[idim] - iv[idim])
+                                                      : (iv[idim] - (domain_hi[idim] + Fx_nodal[idim])));
+
+                        bool const on_nodal_boundary = (ig == 0);
+
+                        if (on_nodal_boundary && !is_insulator) {
+                            Fx(i,j,k,n) = 0._rt;
+                        }
+                    },
+                    tey_guard, nComp_y,
+                    [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
+                        if (is_normal_to_boundary[1]) {
+                            return;
+                        }
+
+                        amrex::IntVect const iv(AMREX_D_DECL(i, j, k));
+                        amrex::XDim3 const coords = ::ConvertIndexToCoordinate(iv, xyzmin, dx, lo, Fy_nodal);
+                        ::XDimTransverse tcoords = ::GetTransverseCoordinates(idim, coords);
+
+                        bool const is_insulator = (area_parser(tcoords.t1, tcoords.t2) > 0._rt);
+
+                        int const ig = ((iside == -1) ? (domain_lo[idim] - iv[idim])
+                                                      : (iv[idim] - (domain_hi[idim] + Fz_nodal[idim])));
+
+                        bool const on_nodal_boundary = (ig == 0);
+
+                        if (on_nodal_boundary && !is_insulator) {
+                            Fy(i,j,k,n) = 0._rt;
+                        }
+                    },
+                    tez_guard, nComp_z,
+                    [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
+                        if (is_normal_to_boundary[2]) {
+                            return;
+                        }
+
+                        amrex::IntVect const iv(AMREX_D_DECL(i, j, k));
+                        amrex::XDim3 const coords = ::ConvertIndexToCoordinate(iv, xyzmin, dx, lo, Fz_nodal);
+                        ::XDimTransverse tcoords = ::GetTransverseCoordinates(idim, coords);
+
+                        bool const is_insulator = (area_parser(tcoords.t1, tcoords.t2) > 0._rt);
+
+                        int const ig = ((iside == -1) ? (domain_lo[idim] - iv[idim])
+                                                      : (iv[idim] - (domain_hi[idim] + Fz_nodal[idim])));
+
+                        bool const on_nodal_boundary = (ig == 0);
+
+                        if (on_nodal_boundary && !is_insulator) {
+                            Fz(i,j,k,n) = 0._rt;
+                        }
                     }
                 );
             }

--- a/Source/BoundaryConditions/PEC_Insulator.cpp
+++ b/Source/BoundaryConditions/PEC_Insulator.cpp
@@ -96,6 +96,8 @@ namespace
      * \brief At the specified grid location, apply either the PEC or insulator boundary condition if
      *        the cell is on the boundary or in the guard cells.
      *
+     * \param[in] idim         the dimension being updated
+     * \param[in] iside        the side being updated, either -1 or +1
      * \param[in] dom_lo       index value of the lower domain boundary (cell-centered)
      * \param[in] dom_hi       index value of the higher domain boundary (cell-centered)
      * \param[in] ijk_vec      indices along the x(i), y(j), z(k) of field Array4
@@ -108,6 +110,7 @@ namespace
      * \param[in] is_normal_to_boundary Specified whether the vector is normal to the boundary
      * \param[in] field_value  the value of the field for the insulator boundary cell
      * \param[in] set_field    whether to set the field on the lower boundary
+     * \param[in] only_zero_parallel_field only zero the parallel field on the boundary
      */
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
     void SetFieldOnPEC_Insulator (int idim,
@@ -123,7 +126,7 @@ namespace
                                   const int is_normal_to_boundary,
                                   amrex::Real const field_value,
                                   bool const set_field,
-                                  bool const only_zero_parallel_conductor)
+                                  bool const only_zero_parallel_field)
     {
         using namespace amrex::literals;
 
@@ -146,7 +149,7 @@ namespace
         // when ig == 0.
         bool const on_nodal_boundary = (ig == 0);
 
-        if (only_zero_parallel_conductor) {
+        if (only_zero_parallel_field) {
             if (on_nodal_boundary && (set_field || !is_insulator_boundary) && !is_normal_to_boundary) {
                 field(ijk_vec, n) = 0._rt;
             }
@@ -490,10 +493,10 @@ PEC_Insulator::ApplyPEC_InsulatortoEfield (
     bool split_pml_field)
 {
     bool const E_like = true;
-    bool const only_zero_parallel_conductor = false;
+    bool const only_zero_parallel_field = false;
     ApplyPEC_InsulatortoField(Efield, field_boundary_lo, field_boundary_hi, ng_fieldgather, geom,
                               lev, patch_type, ref_ratios, time, split_pml_field,
-                              E_like, only_zero_parallel_conductor,
+                              E_like, only_zero_parallel_field,
                               m_set_Ex_lo, m_set_Ey_lo, m_set_Ez_lo,
                               m_set_Ex_hi, m_set_Ey_hi, m_set_Ez_hi,
                               m_Ex_parsers_lo, m_Ey_parsers_lo, m_Ez_parsers_lo,
@@ -511,10 +514,10 @@ PEC_Insulator::ApplyPEC_InsulatortoBfield (
 {
     bool const E_like = false;
     bool const split_pml_field = false;
-    bool const only_zero_parallel_conductor = false;
+    bool const only_zero_parallel_field = false;
     ApplyPEC_InsulatortoField(Bfield, field_boundary_lo, field_boundary_hi, ng_fieldgather, geom,
                               lev, patch_type, ref_ratios, time, split_pml_field,
-                              E_like, only_zero_parallel_conductor,
+                              E_like, only_zero_parallel_field,
                               m_set_Bx_lo, m_set_By_lo, m_set_Bz_lo,
                               m_set_Bx_hi, m_set_By_hi, m_set_Bz_hi,
                               m_Bx_parsers_lo, m_By_parsers_lo, m_Bz_parsers_lo,
@@ -529,7 +532,7 @@ PEC_Insulator::ZeroParallelFieldInConductor (
     amrex::IntVect const & ng_fieldgather, amrex::Geometry const & geom,
     int lev, PatchType patch_type, amrex::Vector<amrex::IntVect> const & ref_ratios)
 {
-    bool const only_zero_parallel_conductor = true;
+    bool const only_zero_parallel_field = true;
     bool const E_like = false;  // E_like will be unused
     bool const split_pml_field = false;
     amrex::Real const time = 0.;  // time will be unused
@@ -539,7 +542,7 @@ PEC_Insulator::ZeroParallelFieldInConductor (
     amrex::Vector<amrex::ParserExecutor<3>> dummy_parsers(3, amrex::ParserExecutor<3>());
     ApplyPEC_InsulatortoField(field, field_boundary_lo, field_boundary_hi, ng_fieldgather, geom,
                               lev, patch_type, ref_ratios, time, split_pml_field,
-                              E_like, only_zero_parallel_conductor,
+                              E_like, only_zero_parallel_field,
                               m_set_E_lo, m_set_E_lo, m_set_E_lo,
                               m_set_E_hi, m_set_E_hi, m_set_E_hi,
                               dummy_parsers, dummy_parsers, dummy_parsers,
@@ -559,7 +562,7 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
     amrex::Real time,
     bool split_pml_field,
     bool E_like,
-    bool only_zero_parallel_conductor,
+    bool only_zero_parallel_field,
     amrex::Vector<int> const & set_Fx_lo,
     amrex::Vector<int> const & set_Fy_lo,
     amrex::Vector<int> const & set_Fz_lo,
@@ -702,7 +705,7 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
 
                         ::SetFieldOnPEC_Insulator(idim, iside, domain_lo, domain_hi, iv, n,
                                                   Fx, E_like, Fx_nodal, is_insulator, is_normal_to_boundary[0],
-                                                  field_value, set_Fx, only_zero_parallel_conductor);
+                                                  field_value, set_Fx, only_zero_parallel_field);
                     },
                     tey_guard, nComp_y,
                     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
@@ -717,7 +720,7 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
 
                         ::SetFieldOnPEC_Insulator(idim, iside, domain_lo, domain_hi, iv, n,
                                                   Fy, E_like, Fy_nodal, is_insulator, is_normal_to_boundary[1],
-                                                  field_value, set_Fy, only_zero_parallel_conductor);
+                                                  field_value, set_Fy, only_zero_parallel_field);
                     },
                     tez_guard, nComp_z,
                     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
@@ -732,7 +735,7 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
 
                         ::SetFieldOnPEC_Insulator(idim, iside, domain_lo, domain_hi, iv, n,
                                                   Fz, E_like, Fz_nodal, is_insulator, is_normal_to_boundary[2],
-                                                  field_value, set_Fz, only_zero_parallel_conductor);
+                                                  field_value, set_Fz, only_zero_parallel_field);
                     }
                 );
             }

--- a/Source/BoundaryConditions/PEC_Insulator.cpp
+++ b/Source/BoundaryConditions/PEC_Insulator.cpp
@@ -326,20 +326,29 @@ namespace
 #endif
     }
 
-}
+    /* \brief Read in the parsers for the tangential fields, returning whether
+     *        the input parameter was specified.
+     * \param[in]  pp_insulator ParmParse instance
+     * \param[out] parsers vector holding the parsers generated from the input
+     * \param[in]  input_name the name of the input parameter
+     * \param[in]  coord1 the first coordinate in the plane
+     * \param[in]  coord2 the second coordinate in the plane
+     * \return wether the parameter was specified
+     */
+    bool
+    ReadTangentialFieldParser (amrex::ParmParse const & pp_insulator,
+                               amrex::Vector<std::unique_ptr<amrex::Parser>> & parsers,
+                               std::string const & input_name,
+                               std::string const & coord1,
+                               std::string const & coord2)
+    {
+        std::string str = "0";
+        bool const specified = utils::parser::Query_parserString(pp_insulator, input_name, str);
+        parsers.push_back(
+            std::make_unique<amrex::Parser>(utils::parser::makeParser(str, {coord1, coord2, "t"})));
+        return specified;
+    }
 
-bool
-PEC_Insulator::ReadTangentialFieldParser (amrex::ParmParse const & pp_insulator,
-                                          amrex::Vector<std::unique_ptr<amrex::Parser>> & parsers,
-                                          std::string const & input_name,
-                                          std::string const & coord1,
-                                          std::string const & coord2)
-{
-    std::string str = "0";
-    bool const specified = utils::parser::Query_parserString(pp_insulator, input_name, str);
-    parsers.push_back(
-        std::make_unique<amrex::Parser>(utils::parser::makeParser(str, {coord1, coord2, "t"})));
-    return specified;
 }
 
 PEC_Insulator::PEC_Insulator ()
@@ -357,15 +366,15 @@ PEC_Insulator::PEC_Insulator ()
     m_insulator_area_hi.push_back(
         std::make_unique<amrex::Parser>(utils::parser::makeParser(str_area_x_hi, {"y", "z"})));
 
-    m_set_B_lo[0] |= ReadTangentialFieldParser(pp_insulator, m_parsers_B1_lo, "By_x_lo(y,z,t)", "y", "z");
-    m_set_B_lo[0] |= ReadTangentialFieldParser(pp_insulator, m_parsers_B2_lo, "Bz_x_lo(y,z,t)", "y", "z");
-    m_set_B_hi[0] |= ReadTangentialFieldParser(pp_insulator, m_parsers_B1_hi, "By_x_hi(y,z,t)", "y", "z");
-    m_set_B_hi[0] |= ReadTangentialFieldParser(pp_insulator, m_parsers_B2_hi, "Bz_x_hi(y,z,t)", "y", "z");
+    m_set_B_lo[0] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_B1_lo, "By_x_lo(y,z,t)", "y", "z");
+    m_set_B_lo[0] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_B2_lo, "Bz_x_lo(y,z,t)", "y", "z");
+    m_set_B_hi[0] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_B1_hi, "By_x_hi(y,z,t)", "y", "z");
+    m_set_B_hi[0] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_B2_hi, "Bz_x_hi(y,z,t)", "y", "z");
 
-    m_set_E_lo[0] |= ReadTangentialFieldParser(pp_insulator, m_parsers_E1_lo, "Ey_x_lo(y,z,t)", "y", "z");
-    m_set_E_lo[0] |= ReadTangentialFieldParser(pp_insulator, m_parsers_E2_lo, "Ez_x_lo(y,z,t)", "y", "z");
-    m_set_E_hi[0] |= ReadTangentialFieldParser(pp_insulator, m_parsers_E1_hi, "Ey_x_hi(y,z,t)", "y", "z");
-    m_set_E_hi[0] |= ReadTangentialFieldParser(pp_insulator, m_parsers_E2_hi, "Ez_x_hi(y,z,t)", "y", "z");
+    m_set_E_lo[0] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_E1_lo, "Ey_x_lo(y,z,t)", "y", "z");
+    m_set_E_lo[0] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_E2_lo, "Ez_x_lo(y,z,t)", "y", "z");
+    m_set_E_hi[0] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_E1_hi, "Ey_x_hi(y,z,t)", "y", "z");
+    m_set_E_hi[0] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_E2_hi, "Ez_x_hi(y,z,t)", "y", "z");
 #endif
 
 #if defined(WARPX_DIM_3D)
@@ -378,15 +387,15 @@ PEC_Insulator::PEC_Insulator ()
     m_insulator_area_hi.push_back(
         std::make_unique<amrex::Parser>(utils::parser::makeParser(str_area_y_hi, {"x", "z"})));
 
-    m_set_B_lo[1] |= ReadTangentialFieldParser(pp_insulator, m_parsers_B1_lo, "Bx_y_lo(x,z,t)", "x", "z");
-    m_set_B_lo[1] |= ReadTangentialFieldParser(pp_insulator, m_parsers_B2_lo, "Bz_y_lo(x,z,t)", "x", "z");
-    m_set_B_hi[1] |= ReadTangentialFieldParser(pp_insulator, m_parsers_B1_hi, "Bx_y_hi(x,z,t)", "x", "z");
-    m_set_B_hi[1] |= ReadTangentialFieldParser(pp_insulator, m_parsers_B2_hi, "Bz_y_hi(x,z,t)", "x", "z");
+    m_set_B_lo[1] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_B1_lo, "Bx_y_lo(x,z,t)", "x", "z");
+    m_set_B_lo[1] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_B2_lo, "Bz_y_lo(x,z,t)", "x", "z");
+    m_set_B_hi[1] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_B1_hi, "Bx_y_hi(x,z,t)", "x", "z");
+    m_set_B_hi[1] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_B2_hi, "Bz_y_hi(x,z,t)", "x", "z");
 
-    m_set_E_lo[1] |= ReadTangentialFieldParser(pp_insulator, m_parsers_E1_lo, "Ex_y_lo(x,z,t)", "x", "z");
-    m_set_E_lo[1] |= ReadTangentialFieldParser(pp_insulator, m_parsers_E2_lo, "Ez_y_lo(x,z,t)", "x", "z");
-    m_set_E_hi[1] |= ReadTangentialFieldParser(pp_insulator, m_parsers_E1_hi, "Ex_y_hi(x,z,t)", "x", "z");
-    m_set_E_hi[1] |= ReadTangentialFieldParser(pp_insulator, m_parsers_E2_hi, "Ez_y_hi(x,z,t)", "x", "z");
+    m_set_E_lo[1] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_E1_lo, "Ex_y_lo(x,z,t)", "x", "z");
+    m_set_E_lo[1] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_E2_lo, "Ez_y_lo(x,z,t)", "x", "z");
+    m_set_E_hi[1] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_E1_hi, "Ex_y_hi(x,z,t)", "x", "z");
+    m_set_E_hi[1] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_E2_hi, "Ez_y_hi(x,z,t)", "x", "z");
 #endif
 
 #if defined(WARPX_ZINDEX)
@@ -399,15 +408,15 @@ PEC_Insulator::PEC_Insulator ()
     m_insulator_area_hi.push_back(
         std::make_unique<amrex::Parser>(utils::parser::makeParser(str_area_z_hi, {"x", "y"})));
 
-    m_set_B_lo[WARPX_ZINDEX] |= ReadTangentialFieldParser(pp_insulator, m_parsers_B1_lo, "Bx_z_lo(x,y,t)", "x", "y");
-    m_set_B_lo[WARPX_ZINDEX] |= ReadTangentialFieldParser(pp_insulator, m_parsers_B2_lo, "By_z_lo(x,y,t)", "x", "y");
-    m_set_B_hi[WARPX_ZINDEX] |= ReadTangentialFieldParser(pp_insulator, m_parsers_B1_hi, "Bx_z_hi(x,y,t)", "x", "y");
-    m_set_B_hi[WARPX_ZINDEX] |= ReadTangentialFieldParser(pp_insulator, m_parsers_B2_hi, "By_z_hi(x,y,t)", "x", "y");
+    m_set_B_lo[WARPX_ZINDEX] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_B1_lo, "Bx_z_lo(x,y,t)", "x", "y");
+    m_set_B_lo[WARPX_ZINDEX] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_B2_lo, "By_z_lo(x,y,t)", "x", "y");
+    m_set_B_hi[WARPX_ZINDEX] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_B1_hi, "Bx_z_hi(x,y,t)", "x", "y");
+    m_set_B_hi[WARPX_ZINDEX] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_B2_hi, "By_z_hi(x,y,t)", "x", "y");
 
-    m_set_E_lo[WARPX_ZINDEX] |= ReadTangentialFieldParser(pp_insulator, m_parsers_E1_lo, "Ex_z_lo(x,y,t)", "x", "y");
-    m_set_E_lo[WARPX_ZINDEX] |= ReadTangentialFieldParser(pp_insulator, m_parsers_E2_lo, "Ey_z_lo(x,y,t)", "x", "y");
-    m_set_E_hi[WARPX_ZINDEX] |= ReadTangentialFieldParser(pp_insulator, m_parsers_E1_hi, "Ex_z_hi(x,y,t)", "x", "y");
-    m_set_E_hi[WARPX_ZINDEX] |= ReadTangentialFieldParser(pp_insulator, m_parsers_E2_hi, "Ey_z_hi(x,y,t)", "x", "y");
+    m_set_E_lo[WARPX_ZINDEX] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_E1_lo, "Ex_z_lo(x,y,t)", "x", "y");
+    m_set_E_lo[WARPX_ZINDEX] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_E2_lo, "Ey_z_lo(x,y,t)", "x", "y");
+    m_set_E_hi[WARPX_ZINDEX] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_E1_hi, "Ex_z_hi(x,y,t)", "x", "y");
+    m_set_E_hi[WARPX_ZINDEX] |= ::ReadTangentialFieldParser(pp_insulator, m_parsers_E2_hi, "Ey_z_hi(x,y,t)", "x", "y");
 #endif
 
     for(const auto & area_parser : m_insulator_area_lo) {

--- a/Source/BoundaryConditions/PEC_Insulator.cpp
+++ b/Source/BoundaryConditions/PEC_Insulator.cpp
@@ -146,8 +146,8 @@ namespace
         // when ig == 0.
         bool const on_nodal_boundary = (ig == 0);
 
-        if (only_zero_parallel_conductor && set_field) {
-            if (on_nodal_boundary && !is_insulator_boundary && !is_normal_to_boundary) {
+        if (only_zero_parallel_conductor) {
+            if (on_nodal_boundary && (set_field || !is_insulator_boundary) && !is_normal_to_boundary) {
                 field(ijk_vec, n) = 0._rt;
             }
             return;
@@ -524,14 +524,15 @@ PEC_Insulator::ZeroParallelFieldInConductor (
     bool const E_like = false;  // E_like will be unused
     bool const split_pml_field = false;
     amrex::Real const time = 0.;  // time will be unused
-    // The field is only zeroed out when the E field is being set
+    // The field is zeroed out everywhere when the E field is being set,
+    // and only in the conductor when the B field is being set.
     // since no fields are needed, dummy parsers are passed in
     amrex::Vector<amrex::ParserExecutor<3>> dummy_parsers(3, amrex::ParserExecutor<3>());
     ApplyPEC_InsulatortoField(field, field_boundary_lo, field_boundary_hi, ng_fieldgather, geom,
                               lev, patch_type, ref_ratios, time, split_pml_field,
                               E_like, only_zero_parallel_conductor,
-                              m_set_Ex_lo, m_set_Ey_lo, m_set_Ez_lo,
-                              m_set_Ex_hi, m_set_Ey_hi, m_set_Ez_hi,
+                              m_set_E_lo, m_set_E_lo, m_set_E_lo,
+                              m_set_E_hi, m_set_E_hi, m_set_E_hi,
                               dummy_parsers, dummy_parsers, dummy_parsers,
                               dummy_parsers, dummy_parsers, dummy_parsers);
 }

--- a/Source/BoundaryConditions/PEC_Insulator.cpp
+++ b/Source/BoundaryConditions/PEC_Insulator.cpp
@@ -123,7 +123,7 @@ namespace
                                   const int is_normal_to_boundary,
                                   amrex::Real const field_value,
                                   bool const set_field,
-                                  bool const only_zero_parallel_insulator)
+                                  bool const only_zero_parallel_conductor)
     {
         using namespace amrex::literals;
 
@@ -146,7 +146,7 @@ namespace
         // when ig == 0.
         bool const on_nodal_boundary = (ig == 0);
 
-        if (only_zero_parallel_insulator) {
+        if (only_zero_parallel_conductor) {
             if (on_nodal_boundary && !is_insulator_boundary && !is_normal_to_boundary) {
                 field(ijk_vec, n) = 0._rt;
             }
@@ -481,10 +481,10 @@ PEC_Insulator::ApplyPEC_InsulatortoEfield (
     bool split_pml_field)
 {
     bool const E_like = true;
-    bool const only_zero_parallel_insulator = false;
+    bool const only_zero_parallel_conductor = false;
     ApplyPEC_InsulatortoField(Efield, field_boundary_lo, field_boundary_hi, ng_fieldgather, geom,
                               lev, patch_type, ref_ratios, time, split_pml_field,
-                              E_like, only_zero_parallel_insulator,
+                              E_like, only_zero_parallel_conductor,
                               m_set_Ex_lo, m_set_Ey_lo, m_set_Ez_lo,
                               m_set_Ex_hi, m_set_Ey_hi, m_set_Ez_hi,
                               m_Ex_parsers_lo, m_Ey_parsers_lo, m_Ez_parsers_lo,
@@ -502,10 +502,10 @@ PEC_Insulator::ApplyPEC_InsulatortoBfield (
 {
     bool const E_like = false;
     bool const split_pml_field = false;
-    bool const only_zero_parallel_insulator = false;
+    bool const only_zero_parallel_conductor = false;
     ApplyPEC_InsulatortoField(Bfield, field_boundary_lo, field_boundary_hi, ng_fieldgather, geom,
                               lev, patch_type, ref_ratios, time, split_pml_field,
-                              E_like, only_zero_parallel_insulator,
+                              E_like, only_zero_parallel_conductor,
                               m_set_Bx_lo, m_set_By_lo, m_set_Bz_lo,
                               m_set_Bx_hi, m_set_By_hi, m_set_Bz_hi,
                               m_Bx_parsers_lo, m_By_parsers_lo, m_Bz_parsers_lo,
@@ -513,25 +513,27 @@ PEC_Insulator::ApplyPEC_InsulatortoBfield (
 }
 
 void
-PEC_Insulator::ZeroParallelFieldInInsulator (
+PEC_Insulator::ZeroParallelFieldInConductor (
     std::array<amrex::MultiFab*, 3> field,
     amrex::Array<FieldBoundaryType,AMREX_SPACEDIM> const & field_boundary_lo,
     amrex::Array<FieldBoundaryType,AMREX_SPACEDIM> const & field_boundary_hi,
     amrex::IntVect const & ng_fieldgather, amrex::Geometry const & geom,
-    int lev, PatchType patch_type, amrex::Vector<amrex::IntVect> const & ref_ratios,
-    amrex::Real time)
+    int lev, PatchType patch_type, amrex::Vector<amrex::IntVect> const & ref_ratios)
 {
-    bool const E_like = true;
+    bool const only_zero_parallel_conductor = true;
+    bool const E_like = false;  // E_like will be unused
     bool const split_pml_field = false;
-    bool const only_zero_parallel_insulator = true;
+    amrex::Real const time = 0.;  // time will be unused
+    // since no fields are to be calculated, set_F is all false and dummy parsers are passed in
     amrex::Vector<int> set_F(AMREX_SPACEDIM, false);
+    amrex::Vector<amrex::ParserExecutor<3>> dummy_parsers(3, amrex::ParserExecutor<3>());
     ApplyPEC_InsulatortoField(field, field_boundary_lo, field_boundary_hi, ng_fieldgather, geom,
                               lev, patch_type, ref_ratios, time, split_pml_field,
-                              E_like, only_zero_parallel_insulator,
+                              E_like, only_zero_parallel_conductor,
                               set_F, set_F, set_F,
                               set_F, set_F, set_F,
-                              m_Ex_parsers_lo, m_Ey_parsers_lo, m_Ez_parsers_lo,
-                              m_Ex_parsers_hi, m_Ey_parsers_hi, m_Ez_parsers_hi);
+                              dummy_parsers, dummy_parsers, dummy_parsers,
+                              dummy_parsers, dummy_parsers, dummy_parsers);
 }
 
 void
@@ -547,7 +549,7 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
     amrex::Real time,
     bool split_pml_field,
     bool E_like,
-    bool only_zero_parallel_insulator,
+    bool only_zero_parallel_conductor,
     amrex::Vector<int> const & set_Fx_lo,
     amrex::Vector<int> const & set_Fy_lo,
     amrex::Vector<int> const & set_Fz_lo,
@@ -690,7 +692,7 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
 
                         ::SetFieldOnPEC_Insulator(idim, iside, domain_lo, domain_hi, iv, n,
                                                   Fx, E_like, Fx_nodal, is_insulator, is_normal_to_boundary[0],
-                                                  field_value, set_Fx, only_zero_parallel_insulator);
+                                                  field_value, set_Fx, only_zero_parallel_conductor);
                     },
                     tey_guard, nComp_y,
                     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
@@ -705,7 +707,7 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
 
                         ::SetFieldOnPEC_Insulator(idim, iside, domain_lo, domain_hi, iv, n,
                                                   Fy, E_like, Fy_nodal, is_insulator, is_normal_to_boundary[1],
-                                                  field_value, set_Fy, only_zero_parallel_insulator);
+                                                  field_value, set_Fy, only_zero_parallel_conductor);
                     },
                     tez_guard, nComp_z,
                     [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
@@ -720,192 +722,7 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
 
                         ::SetFieldOnPEC_Insulator(idim, iside, domain_lo, domain_hi, iv, n,
                                                   Fz, E_like, Fz_nodal, is_insulator, is_normal_to_boundary[2],
-                                                  field_value, set_Fz, only_zero_parallel_insulator);
-                    }
-                );
-            }
-        }
-    }
-}
-
-void
-PEC_Insulator::ZeroParallelFieldInInsulatorDuplicate (
-    std::array<amrex::MultiFab*, 3> field,
-    amrex::Array<FieldBoundaryType,AMREX_SPACEDIM> const & field_boundary_lo,
-    amrex::Array<FieldBoundaryType,AMREX_SPACEDIM> const & field_boundary_hi,
-    amrex::IntVect const & ng_fieldgather,
-    amrex::Geometry const & geom,
-    int lev,
-    PatchType patch_type,
-    amrex::Vector<amrex::IntVect> const & ref_ratios)
-{
-    using namespace amrex::literals;
-    amrex::Box domain_box = geom.Domain();
-    if (patch_type == PatchType::coarse && (lev > 0)) {
-        domain_box.coarsen(ref_ratios[lev-1]);
-    }
-    amrex::IntVect const domain_lo = domain_box.smallEnd();
-    amrex::IntVect const domain_hi = domain_box.bigEnd();
-
-    amrex::IntVect const Fx_nodal = field[0]->ixType().toIntVect();
-    amrex::IntVect const Fy_nodal = field[1]->ixType().toIntVect();
-    amrex::IntVect const Fz_nodal = field[2]->ixType().toIntVect();
-
-    // For each field multifab, apply boundary condition to ncomponents
-    // If not split field, the boundary condition is applied to the regular field used in Maxwell's eq.
-    // If split_pml_field is true, then boundary condition is applied to all the split field components.
-    int const nComp_x = field[0]->nComp();
-    int const nComp_y = field[1]->nComp();
-    int const nComp_z = field[2]->nComp();
-
-    std::array<amrex::Real,3> const & dx = WarpX::CellSize(lev);
-
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-    // The false flag here is to ensure that this loop does not use tiling.
-    // The boxes are grown to include transverse ghost cells prior to the reflection.
-    // Tiling is problematic because neighboring tiles will have overlapping boxes
-    // in the direction transverse to the boundary, thereby reflecting the value multiple
-    // times in the overlapping region.
-    for (amrex::MFIter mfi(*field[0], false); mfi.isValid(); ++mfi) {
-        // Extract field data
-        amrex::Array4<amrex::Real> const & Fx = field[0]->array(mfi);
-        amrex::Array4<amrex::Real> const & Fy = field[1]->array(mfi);
-        amrex::Array4<amrex::Real> const & Fz = field[2]->array(mfi);
-
-        // Get nodal box that does not include ghost cells
-        amrex::Box const & valid_box = mfi.validbox();
-        amrex::Box const node_box = amrex::convert(valid_box, amrex::IntVect::TheNodeVector());
-
-        // The lower end of the box is the same for nodal and cell centered,
-        // so the same lower end can be used for the three fields even though
-        // they will have different centerings.
-        amrex::XDim3 const xyzmin = WarpX::LowerCorner(valid_box, lev, 0._rt);
-        amrex::IntVect const lo = valid_box.smallEnd();
-
-        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-
-            if (!(field_boundary_lo[idim] == FieldBoundaryType::PECInsulator) &&
-                !(field_boundary_hi[idim] == FieldBoundaryType::PECInsulator)) { continue; }
-
-            if ( (node_box.smallEnd()[idim] > domain_lo[idim]) &&
-                 (node_box.bigEnd()[idim] < domain_hi[idim]) ) { continue; }
-
-            amrex::IntVectND<3> is_normal_to_boundary{0, 0, 0};
-
-#if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
-            // For 2D : for icomp==1, (Fy in XZ, Ftheta in RZ),
-            //          icomp=1 is not normal to x or z boundary
-            is_normal_to_boundary[2*idim] = 1;
-#elif (defined WARPX_DIM_1D_Z)
-            // For 1D : icomp=0 and icomp=1 (Fx and Fy are not normal to the z boundary)
-            is_normal_to_boundary[2] = 1;
-#else
-            is_normal_to_boundary[idim] = 1;
-#endif
-
-            // Extract tileboxes for which to loop
-            // if split field, the box includes nodal flag
-            // For E-field used in Maxwell's update, nodal flag plus cells that particles
-            // gather fields from in the guard-cell region are included.
-            // Note that for simulations without particles or laser, ng_field_gather is 0
-            // and the guard-cell values of the E-field multifab will not be modified.
-            amrex::Box tex = mfi.tilebox(field[0]->ixType().toIntVect(), ng_fieldgather);
-            amrex::Box tey = mfi.tilebox(field[1]->ixType().toIntVect(), ng_fieldgather);
-            amrex::Box tez = mfi.tilebox(field[2]->ixType().toIntVect(), ng_fieldgather);
-
-            // Loop over sides, iside = -1 (lo), iside = +1 (hi)
-            for (int iside = -1; iside <= +1; iside += 2) {
-
-                if ((iside == -1 && (field_boundary_lo[idim] != FieldBoundaryType::PECInsulator)) ||
-                    (iside == +1 && (field_boundary_hi[idim] != FieldBoundaryType::PECInsulator))) { continue; }
-
-                if ((iside == -1 && (node_box.smallEnd()[idim] > domain_lo[idim])) ||
-                    (iside == +1 && (node_box.bigEnd()[idim] < domain_hi[idim]))) { continue; }
-
-                amrex::Box tex_guard = tex;
-                amrex::Box tey_guard = tey;
-                amrex::Box tez_guard = tez;
-
-                // Shrink the box to only include the guard and boundary cells
-                if (iside == -1) {
-                    tex_guard.setBig(idim, node_box.smallEnd(idim));
-                    tey_guard.setBig(idim, node_box.smallEnd(idim));
-                    tez_guard.setBig(idim, node_box.smallEnd(idim));
-                } else {
-                    tex_guard.setSmall(idim, node_box.bigEnd(idim));
-                    tey_guard.setSmall(idim, node_box.bigEnd(idim));
-                    tez_guard.setSmall(idim, node_box.bigEnd(idim));
-                }
-
-                amrex::ParserExecutor<2> const & area_parser = ( (iside == -1) ? m_area_parsers_lo[idim] : m_area_parsers_hi[idim]);
-
-                // loop over cells and update fields
-                amrex::ParallelFor(
-                    tex_guard, nComp_x,
-                    [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-                        if (is_normal_to_boundary[0]) {
-                            return;
-                        }
-
-                        amrex::IntVect const iv(AMREX_D_DECL(i, j, k));
-
-                        amrex::XDim3 const coords = ::ConvertIndexToCoordinate(iv, xyzmin, dx, lo, Fx_nodal);
-                        ::XDimTransverse tcoords = ::GetTransverseCoordinates(idim, coords);
-
-                        bool const is_insulator = (area_parser(tcoords.t1, tcoords.t2) > 0._rt);
-
-                        int const ig = ((iside == -1) ? (domain_lo[idim] - iv[idim])
-                                                      : (iv[idim] - (domain_hi[idim] + Fx_nodal[idim])));
-
-                        bool const on_nodal_boundary = (ig == 0);
-
-                        if (on_nodal_boundary && !is_insulator) {
-                            Fx(i,j,k,n) = 0._rt;
-                        }
-                    },
-                    tey_guard, nComp_y,
-                    [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-                        if (is_normal_to_boundary[1]) {
-                            return;
-                        }
-
-                        amrex::IntVect const iv(AMREX_D_DECL(i, j, k));
-                        amrex::XDim3 const coords = ::ConvertIndexToCoordinate(iv, xyzmin, dx, lo, Fy_nodal);
-                        ::XDimTransverse tcoords = ::GetTransverseCoordinates(idim, coords);
-
-                        bool const is_insulator = (area_parser(tcoords.t1, tcoords.t2) > 0._rt);
-
-                        int const ig = ((iside == -1) ? (domain_lo[idim] - iv[idim])
-                                                      : (iv[idim] - (domain_hi[idim] + Fz_nodal[idim])));
-
-                        bool const on_nodal_boundary = (ig == 0);
-
-                        if (on_nodal_boundary && !is_insulator) {
-                            Fy(i,j,k,n) = 0._rt;
-                        }
-                    },
-                    tez_guard, nComp_z,
-                    [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-                        if (is_normal_to_boundary[2]) {
-                            return;
-                        }
-
-                        amrex::IntVect const iv(AMREX_D_DECL(i, j, k));
-                        amrex::XDim3 const coords = ::ConvertIndexToCoordinate(iv, xyzmin, dx, lo, Fz_nodal);
-                        ::XDimTransverse tcoords = ::GetTransverseCoordinates(idim, coords);
-
-                        bool const is_insulator = (area_parser(tcoords.t1, tcoords.t2) > 0._rt);
-
-                        int const ig = ((iside == -1) ? (domain_lo[idim] - iv[idim])
-                                                      : (iv[idim] - (domain_hi[idim] + Fz_nodal[idim])));
-
-                        bool const on_nodal_boundary = (ig == 0);
-
-                        if (on_nodal_boundary && !is_insulator) {
-                            Fz(i,j,k,n) = 0._rt;
-                        }
+                                                  field_value, set_Fz, only_zero_parallel_conductor);
                     }
                 );
             }

--- a/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
+++ b/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
@@ -268,6 +268,12 @@ void WarpX::ApplyRhofieldBoundary (const int lev, MultiFab* rho,
             particle_boundary_lo, particle_boundary_hi,
             Geom(lev), lev, patch_type, ref_ratio);
     }
+
+    if (::isAnyBoundary<FieldBoundaryType::PECInsulator>(field_boundary_lo, field_boundary_hi)) {
+        pec_insulator_boundary->ZeroParallelScalarInConductor(rho,
+            field_boundary_lo, field_boundary_hi,
+            Geom(lev), lev, patch_type, ref_ratio);
+    }
 }
 
 void WarpX::ApplyJfieldBoundary (const int lev, amrex::MultiFab* Jx,

--- a/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
+++ b/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
@@ -286,6 +286,13 @@ void WarpX::ApplyJfieldBoundary (const int lev, amrex::MultiFab* Jx,
             particle_boundary_lo, particle_boundary_hi,
             Geom(lev), lev, patch_type, ref_ratio);
     }
+
+    if (::isAnyBoundary<FieldBoundaryType::PECInsulator>(field_boundary_lo, field_boundary_hi)) {
+        pec_insulator_boundary->ZeroParallelFieldInConductor({Jx, Jy, Jz},
+            field_boundary_lo, field_boundary_hi,
+            get_ng_fieldgather(), Geom(lev),
+            lev, patch_type, ref_ratio);
+    }
 }
 
 #if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)


### PR DESCRIPTION
For PEC_insulator, the source (rho and J-parallel) need to be zeroed out on the boundary in the conductor region. Without this, the linear solvers for implicit can fail to converge.

This PR implements two versions of this to compare them.