### PR TITLE
Free disk space in nvhpc CI

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -147,7 +147,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Dependencies
-      run: .github/workflows/dependencies/nvhpc.sh 25.1
+      run: |
+        .github/workflows/dependencies/ubuntu_free_disk_space.sh
+        .github/workflows/dependencies/nvhpc.sh 25.1
     - name: CCache Cache
       uses: actions/cache@v4
       with:

--- a/.github/workflows/dependencies/ubuntu_free_disk_space.sh
+++ b/.github/workflows/dependencies/ubuntu_free_disk_space.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023 The AMReX Community
+#
+# License: BSD-3-Clause-LBNL
+
+# Don't want to use the following line because apt-get remove may fail if
+# the package specfied does not exist.
+# set -eu -o pipefail
+
+# Large packages
+dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
+
+echo 'Removing some packages we do not need'
+
+df -h
+
+apt list --installed
+
+sudo apt-get remove -y '^apache.*'
+sudo apt-get remove -y '^aspnetcore.*'
+sudo apt-get remove -y '^azure.*'
+sudo apt-get remove -y '^dotnet.*'
+sudo apt-get remove -y '^firebird.*'
+sudo apt-get remove -y '^firefox.*'
+sudo apt-get remove -y '^google.*'
+sudo apt-get remove -y '^hhvm.*'
+sudo apt-get remove -y '^microsoft.*'
+sudo apt-get remove -y '^mongodb.*'
+sudo apt-get remove -y '^mono-.*'
+sudo apt-get remove -y '^monodoc-.*'
+sudo apt-get remove -y '^mysql.*'
+sudo apt-get remove -y '^php.*'
+sudo apt-get remove -y '^powershell.*'
+sudo apt-get remove -y '^snapd.*'
+sudo apt-get remove -y '^temurin.*'
+
+sudo apt-get autoremove -y
+
+df -h


### PR DESCRIPTION
The script is borrowed from AMReX. For the nvhpc CI using ubuntu-latest, the free space before was 18G, it becomes 23G after the cleanup.