### PR TITLE
ExternalField.H: use static_cast<int> to convert double/float to int

### DIFF
--- a/Source/Initialization/ExternalField.H
+++ b/Source/Initialization/ExternalField.H
@@ -81,9 +81,9 @@ struct ExternalFieldView
 #endif
 
         // Get index of the external field array
-        AMREX_D_TERM(int const i0 = std::floor( (pos[0]-offset[0])/dx[0] );,
-                     int const i1 = std::floor( (pos[1]-offset[1])/dx[1] );,
-                     int const i2 = std::floor( (pos[2]-offset[2])/dx[2] ));
+        AMREX_D_TERM(const auto i0 = static_cast<int>(std::floor( (pos[0]-offset[0])/dx[0] ));,
+                     const auto i1 = static_cast<int>(std::floor( (pos[1]-offset[1])/dx[1] ));,
+                     const auto i2 = static_cast<int>(std::floor( (pos[2]-offset[2])/dx[2] )));
 
         // Get coordinates of external grid point
         AMREX_D_TERM(amrex::Real const xx0 = offset[0] + i0 * dx[0];,


### PR DESCRIPTION
I've noticed this warning at the end of https://github.com/BLAST-WarpX/warpx/actions/runs/20027848504/job/57429402421?pr=6427 :

```
./Source/Initialization/ExternalField.H:84:26: warning: conversion from ‘double’ to ‘int’ may change value [-Wfloat-conversion]
   84 |         AMREX_D_TERM(int const i0 = std::floor( (pos[0]-offset[0])/dx[0] );,
      |                ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./Source/Initialization/ExternalField.H:84:87: warning: conversion from ‘double’ to ‘int’ may change value [-Wfloat-conversion]
   84 |         AMREX_D_TERM(int const i0 = std::floor( (pos[0]-offset[0])/dx[0] );,
      |                                                                                       ^                                 
./Source/Initialization/ExternalField.H:84:148: warning: conversion from ‘double’ to ‘int’ may change value [-Wfloat-conversion]
   84 |         AMREX_D_TERM(int const i0 = std::floor( (pos[0]-offset[0])/dx[0] );,
      |                                                                                   
```

This PR uses `static_cast` to silence the warning. This should fix the issue.

Note that `auto` here is used to avoid repeating `int` twice.
