### PR TITLE
CMake: No Warn for No-MPI Tests

### DIFF
--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -36,7 +36,6 @@ function(add_warpx_test
 )
     # cannot run MPI tests w/o MPI build
     if(nprocs GREATER_EQUAL 2 AND NOT WarpX_MPI)
-        message(WARNING "${name}: cannot run MPI tests without MPI build")
         return()
     endif()
 


### PR DESCRIPTION
Our strategy for CMake is to enable tests that work in the current configuration, and silently not add other tests.

When building w/o MPI, we currently fill the terminal with warnings. This removes those.