### PR TITLE
Custom weights for initial DistributionMapping

### DIFF
--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -3517,8 +3517,10 @@ amrex::DistributionMapping
 WarpX::MakeDistributionMap (int lev, amrex::BoxArray const& ba)
 {
     bool roundrobin_sfc = false;
+    bool split_high_density_boxes = false;
     const ParmParse pp("warpx");
     pp.query("roundrobin_sfc", roundrobin_sfc);
+    pp.query("split_high_density_boxes", split_high_density_boxes);
 
     // If this is true, AMReX's RRSFC strategy is used to make
     // DistributionMapping. Note that the DistributionMapping made by the
@@ -3534,6 +3536,15 @@ WarpX::MakeDistributionMap (int lev, amrex::BoxArray const& ba)
         amrex::DistributionMapping dm(ba);
         amrex::DistributionMapping::strategy(old_strategy);
         return dm;
+    } else if (split_high_density_boxes &&
+               amrex::DistributionMapping::strategy() == amrex::DistributionMapping::SFC) {
+        // By default, amrex uses box volumes as weights when distributing
+        // boxes. But this would somewhat defeat the purpose of splitting
+        // high density boxes until the next load balance is
+        // performed. Thus, we are going building SFC assuming every boxes
+        // have the same weight.
+        amrex::Vector<amrex::Real> wgt(ba.size(), amrex::Real(1));
+        return amrex::DistributionMapping::makeSFC(wgt, ba, false);
     } else {
         return amrex::AmrCore::MakeDistributionMap(lev, ba);
     }


### PR DESCRIPTION
By default, amrex uses box volumes as weights when distributing boxes. But this would somewhat defeat the purpose of splitting high density boxes until the next load balance is performed. Thus, when splitting box is on, we are going to assume that the boxes have equal weights.

For a test based on #6158, this improves the initial load balance efficiency from 0.26 to 0.63 when running on 8 processes.

The figures below show the distribution mapping without and with this PR.

<img width="844" height="636" alt="Screenshot from 2025-12-11 16-07-56" src="https://github.com/user-attachments/assets/eb6b4c85-fc55-4e4e-ac68-b6a02ab9bf4d" />
