### PR TITLE
[WIP] Fix bug in energy-preserving explicit electrostatic PIC-MCC algorithm

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -406,8 +406,9 @@ void WarpX::OneStep (
                     MomentumPushType::Full
                 );
 
-                // communicate particle data
-                mypc->Redistribute();
+                // perform essential particle house keeping at the boundaries
+                // (inject, communicate, scrape, sort, etc.)
+                HandleParticlesAtBoundaries(a_step, a_cur_time, /*num_moved=*/0);
 
                 // perform particle collisions
                 ExecutePythonCallback("beforecollisions");


### PR DESCRIPTION
This may fix a bug that @kale-j observed in an electromagnetic simulation based on #6275, and that was troubleshooted by @oshapoval, @RemiLehe, and myself.

This PR takes care of the bug fix for the electrostatic case, originally implemented in #5955. The bug fix for the electromagnetic case is included in #6275.

This change may break a number of CI tests, so I flag the PR as "[WIP]" until the CI checks pass.