### PR TITLE
check for out of bounds particles with cropping in suborbits.

### DIFF
--- a/Source/Particles/Pusher/ImplicitPushPX.cpp
+++ b/Source/Particles/Pusher/ImplicitPushPX.cpp
@@ -151,6 +151,8 @@ namespace {
         zp = zp_n + dzp;
         setPosition(ip, xp, yp, zp);
 
+        // Propogate ballistically if the suborbit starts out of bounds, avoiding
+        // field gather and the possiblity that the particle orbit re-enters the domain.
         if (this_suborbit_out_of_bounds) { return true; }
 
         bool convergence = false;

--- a/Source/Particles/Pusher/ImplicitPushPX.cpp
+++ b/Source/Particles/Pusher/ImplicitPushPX.cpp
@@ -61,6 +61,7 @@ namespace {
         int const & ip,
         amrex::Real const & dt,
         SetParticlePosition<PIdx> const &  setPosition,
+        bool const this_suborbit_out_of_bounds,
         amrex::ParticleReal & xp,
         amrex::ParticleReal & yp,
         amrex::ParticleReal & zp,
@@ -149,6 +150,8 @@ namespace {
         yp = yp_n + dyp;
         zp = zp_n + dzp;
         setPosition(ip, xp, yp, zp);
+
+        if (this_suborbit_out_of_bounds) { return true; }
 
         bool convergence = false;
         for (int iter=0; iter < max_iterations; iter++) {
@@ -602,7 +605,7 @@ PhysicalParticleContainer::ImplicitPushXP (WarpXParIter & pti,
         amrex::ParticleReal Bzp = 0.0_prt;
         amrex::ParticleReal step_norm = 1._prt;
 
-        bool convergence = PushXPSingleStep<exteb_control, qed_control>(ip, dt, setPosition,
+        bool convergence = PushXPSingleStep<exteb_control, qed_control>(ip, dt, setPosition, false,
                              xp, yp, zp, ux, uy, uz, xp_n, yp_n, zp_n, ux_n[ip], uy_n[ip], uz_n[ip],
                              step_norm, particle_tolerance, max_iterations,
                              Ex_external_particle, Ey_external_particle, Ez_external_particle,
@@ -986,6 +989,11 @@ PhysicalParticleContainer::ImplicitPushXPSubOrbits (WarpXParIter& pti,
 
             amrex::Real const dt_suborbit = dt/nsuborbits[ip];
 
+            // Check if initial suborbit position is past an absorbing boundary.
+            bool this_suborbit_out_of_bounds = ParticleUtils::is_out_of_bounds(xp_n, yp_n, zp_n,
+                                                                               dinv, xyzmin,
+                                                                               domain_double, do_cropping);
+
             amrex::ParticleReal Bxp = 0.0_prt;
             amrex::ParticleReal Byp = 0.0_prt;
             amrex::ParticleReal Bzp = 0.0_prt;
@@ -993,6 +1001,7 @@ PhysicalParticleContainer::ImplicitPushXPSubOrbits (WarpXParIter& pti,
 
             // Try advancing the particle one suborbit step
             bool convergence = PushXPSingleStep<exteb_control, qed_control>(ip, dt_suborbit, setPosition,
+                                 this_suborbit_out_of_bounds,
                                  xp, yp, zp, ux, uy, uz, xp_n, yp_n, zp_n, uxp_n, uyp_n, uzp_n,
                                  step_norm, particle_tolerance, max_iterations,
                                  Ex_external_particle, Ey_external_particle, Ez_external_particle,
@@ -1010,7 +1019,7 @@ PhysicalParticleContainer::ImplicitPushXPSubOrbits (WarpXParIter& pti,
             // Don't change number of suborbits during linear stage of jfnk
             if (linear_stage_of_jfnk) { convergence = true; }
 
-            if (doing_deposition) {
+            if (doing_deposition && !this_suborbit_out_of_bounds) {
 
                 const amrex::ParticleReal xp_np1 = 2.0_prt*xp - xp_n;
                 const amrex::ParticleReal yp_np1 = 2.0_prt*yp - yp_n;

--- a/Source/Particles/Pusher/ImplicitPushPX.cpp
+++ b/Source/Particles/Pusher/ImplicitPushPX.cpp
@@ -980,6 +980,10 @@ PhysicalParticleContainer::ImplicitPushXPSubOrbits (WarpXParIter& pti,
         amrex::ParticleReal yp = yp_n;
         amrex::ParticleReal zp = zp_n;
 
+        ux[ip] = uxp_n;
+        uy[ip] = uyp_n;
+        uz[ip] = uzp_n;
+
         // For nonlinear stage, we first loop over all suborbits doing the push only to
         // check for non-convergence. If a suborbit does not convegence, then the number
         // of suborbits is increased and the loop starts over. This proceeds until all

--- a/Source/Utils/ParticleUtils.H
+++ b/Source/Utils/ParticleUtils.H
@@ -329,8 +329,7 @@ namespace ParticleUtils {
                            const amrex::GpuArray<amrex::GpuArray<bool,2>, AMREX_SPACEDIM> & do_cropping)
     {
 
-        // Check if particle's position is out of bounds
-        bool out_of_bounds = false;
+        // Store logical particle position (in grid units) in temporary array
         amrex::GpuArray<double,AMREX_SPACEDIM> xp_grid;
 #if defined(WARPX_DIM_3D)
         xp_grid[0] = (xp - xyzmin.x)*dinv.x;
@@ -350,6 +349,8 @@ namespace ParticleUtils {
         xp_grid[1] = (zp - xyzmin.z)*dinv.z;
 #endif
 #endif
+        // Check if particle's position is out of bounds
+        bool out_of_bounds = false;
         for (int dim = 0; dim < AMREX_SPACEDIM; dim++) {
             if (do_cropping[dim][0] && xp_grid[dim] <= domain_double[dim][0]) {
                 out_of_bounds = true;

--- a/Source/Utils/ParticleUtils.H
+++ b/Source/Utils/ParticleUtils.H
@@ -339,9 +339,6 @@ namespace ParticleUtils {
 #elif defined(WARPX_DIM_XZ)
         xp_grid[0] = (xp - xyzmin.x)*dinv.x;
         xp_grid[1] = (zp - xyzmin.z)*dinv.z;
-#elif defined(WARPX_DIM_RSPHERE)
-        const amrex::Real rp = std::sqrt(xp*xp + yp*yp + zp*zp);
-        xp_grid[0] = (rp - xyzmin.x)*dinv.x;
 #elif defined(WARPX_DIM_1D_Z)
         xp_grid[0] = (zp - xyzmin.z)*dinv.z;
 #elif defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
@@ -350,6 +347,9 @@ namespace ParticleUtils {
 #if defined(WARPX_DIM_RZ)
         xp_grid[1] = (zp - xyzmin.z)*dinv.z;
 #endif
+#elif defined(WARPX_DIM_RSPHERE)
+        const amrex::Real rp = std::sqrt(xp*xp + yp*yp + zp*zp);
+        xp_grid[0] = (rp - xyzmin.x)*dinv.x;
 #endif
 
         // Check if particle's position is out of bounds

--- a/Source/Utils/ParticleUtils.H
+++ b/Source/Utils/ParticleUtils.H
@@ -355,10 +355,10 @@ namespace ParticleUtils {
         // Check if particle's position is out of bounds
         for (int dim = 0; dim < AMREX_SPACEDIM; dim++) {
             if (do_cropping[dim][0] && xp_grid[dim] <= domain_double[dim][0]) {
-                return = true;
+                return true;
             }
             else if (do_cropping[dim][1] && xp_grid[dim] >= domain_double[dim][1]) {
-                return = true;
+                return true;
             }
         }
         return false;

--- a/Source/Utils/ParticleUtils.H
+++ b/Source/Utils/ParticleUtils.H
@@ -311,6 +311,57 @@ namespace ParticleUtils {
         }
     }
 
+    /* \brief Check if the particle position is out of bounds at a boundary
+     *        where orbit cropping is being performed.
+     * \param[in] xp, yp, zp      The particle position
+     * \param[in] dinv            3D cell size inverse
+     * \param[in] xyzmin          Physical lower bounds of domain
+     * \param[in] domain_double   The domain boundary indicies cast to double values
+     * \param[in] do_cropping     Whether to crop particle orbits at domain boundaries
+     */
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    bool is_out_of_bounds ([[maybe_unused]] double xp,
+                           [[maybe_unused]] double yp,
+                           [[maybe_unused]] double zp,
+                           const amrex::XDim3 & dinv,
+                           const amrex::XDim3 & xyzmin,
+                           const amrex::GpuArray<amrex::GpuArray<double,2>, AMREX_SPACEDIM> & domain_double,
+                           const amrex::GpuArray<amrex::GpuArray<bool,2>, AMREX_SPACEDIM> & do_cropping)
+    {
+
+        // Check if particle's position is out of bounds
+        bool out_of_bounds = false;
+        amrex::GpuArray<double,AMREX_SPACEDIM> xp_grid;
+#if defined(WARPX_DIM_3D)
+        xp_grid[0] = (xp - xyzmin.x)*dinv.x;
+        xp_grid[1] = (yp - xyzmin.y)*dinv.y;
+        xp_grid[2] = (zp - xyzmin.z)*dinv.z;
+#elif defined(WARPX_DIM_XZ)
+        xp_grid[0] = (xp - xyzmin.x)*dinv.x;
+        xp_grid[1] = (zp - xyzmin.z)*dinv.z;
+#elif defined(WARPX_DIM_RSPHERE)
+        const amrex::Real rp = std::sqrt(xp*xp + yp*yp + zp*zp);
+        xp_grid[0] = (rp - xyzmin.x)*dinv.x;
+#endif
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
+        const amrex::Real rp = std::sqrt(xp*xp + yp*yp);
+        xp_grid[0] = (rp - xyzmin.x)*dinv.x;
+#if defined(WARPX_DIM_RZ)
+        xp_grid[1] = (zp - xyzmin.z)*dinv.z;
+#endif
+#endif
+        for (int dim = 0; dim < AMREX_SPACEDIM; dim++) {
+            if (do_cropping[dim][0] && xp_grid[dim] <= domain_double[dim][0]) {
+                out_of_bounds = true;
+            }
+            else if (do_cropping[dim][1] && xp_grid[dim] >= domain_double[dim][1]) {
+                out_of_bounds = true;
+            }
+        }
+        return out_of_bounds;
+
+    }
+
     /* \brief Add or subtract a small percent of energy from a
      *        pair of particles such that momentum is not disturbed.
      *

--- a/Source/Utils/ParticleUtils.H
+++ b/Source/Utils/ParticleUtils.H
@@ -353,16 +353,15 @@ namespace ParticleUtils {
 #endif
 
         // Check if particle's position is out of bounds
-        bool out_of_bounds = false;
         for (int dim = 0; dim < AMREX_SPACEDIM; dim++) {
             if (do_cropping[dim][0] && xp_grid[dim] <= domain_double[dim][0]) {
-                out_of_bounds = true;
+                return = true;
             }
             else if (do_cropping[dim][1] && xp_grid[dim] >= domain_double[dim][1]) {
-                out_of_bounds = true;
+                return = true;
             }
         }
-        return out_of_bounds;
+        return false;
 
     }
 

--- a/Source/Utils/ParticleUtils.H
+++ b/Source/Utils/ParticleUtils.H
@@ -318,6 +318,7 @@ namespace ParticleUtils {
      * \param[in] xyzmin          Physical lower bounds of domain
      * \param[in] domain_double   The domain boundary indicies cast to double values
      * \param[in] do_cropping     Whether to crop particle orbits at domain boundaries
+     * return whether position is out of bounds
      */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     bool is_out_of_bounds ([[maybe_unused]] double xp,
@@ -341,14 +342,16 @@ namespace ParticleUtils {
 #elif defined(WARPX_DIM_RSPHERE)
         const amrex::Real rp = std::sqrt(xp*xp + yp*yp + zp*zp);
         xp_grid[0] = (rp - xyzmin.x)*dinv.x;
-#endif
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
+#elif defined(WARPX_DIM_1D_Z)
+        xp_grid[0] = (zp - xyzmin.z)*dinv.z;
+#elif defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
         const amrex::Real rp = std::sqrt(xp*xp + yp*yp);
         xp_grid[0] = (rp - xyzmin.x)*dinv.x;
 #if defined(WARPX_DIM_RZ)
         xp_grid[1] = (zp - xyzmin.z)*dinv.z;
 #endif
 #endif
+
         // Check if particle's position is out of bounds
         bool out_of_bounds = false;
         for (int dim = 0; dim < AMREX_SPACEDIM; dim++) {


### PR DESCRIPTION
Particle suborbits were added in PR #5969. Suborbits are needed for improved accuracy of particle orbits when using large time steps. Particle orbit cropping at physical boundaries was added in PR #5649. This is used to achieve rigorous charge conservation for outflow particles at physical boundaries (conductor and insulator).

A bug occurs when the initial position of a suborbit is out of bounds (past the physical boundary) where cropping is being done. In this scenario, the particle will deposit current when it should not be doing so, breaking energy and charge conservation. This PR fixes this bug by checking for particles with the initial position out of bounds in the suborbit routine and neglecting deposition for these suborbits.