### PR TITLE
Doc: X-Ref Debugging

### DIFF
--- a/Docs/source/developers/how_to_guides.rst
+++ b/Docs/source/developers/how_to_guides.rst
@@ -3,6 +3,8 @@
 How-To Guides
 =============
 
+* :ref:`Debugging the code <debugging_warpx>`
+
 .. toctree::
    :maxdepth: 1
 


### PR DESCRIPTION
While we have debugging workflows traditionally in the user how-to section (to write better bug reports), it is equally important to be found (linked) from the developer section.