### PR TITLE
Allow loading applied fields from Python

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2575,6 +2575,86 @@ class LoadAppliedField(picmistandard.PICMI_LoadAppliedField):
             pywarpx.particles.B_ext_particle_init_style = "none"
 
 
+class LoadAppliedFieldFromPython(picmistandard.PICMI_LoadAppliedField):
+    """
+    Field Initializer that takes a function handle to be registered as a callback.
+    The function is expected to write the E and/or B particle fields into the
+    B/E_external_particle_field multifabs. The callback is installed
+    in the beforeInitEsolve hook. This should operate identically to loading from
+    a file.
+
+    Parameters
+    ----------
+    load_from_python : callable
+        The Python function handle that will write values to the applied field
+        multifabs.
+
+    load_E : bool, default=True
+        If True, load the external E field from file.
+
+    load_B : bool, default=True
+        If True, load the external B field from file.
+
+    warpx_E_time_function : str, optional
+        AMReX parser expression in variable `t` (seconds) that scales the
+        file-loaded E field uniformly in space and per level, e.g.
+        ``"cos(2*pi*2e6*t)"``. If not provided, defaults to ``"1.0"`` in C++.
+
+    warpx_B_time_function : str, optional
+        AMReX parser expression in variable `t` (seconds) that scales the
+        file-loaded B field uniformly in space and per level, e.g.
+        ``"cos(2*pi*2e6*t + pi/2)"``. If not provided, defaults to ``"1.0"`` in C++.
+
+    warpx_do_initial_div_cleaning : bool, optional
+        Run the projection-based B-field divergence cleaner after loading.
+
+    warpx_projection_div_cleaner_atol : float, optional
+        Absolute tolerance for the divergence cleaner solve.
+
+    warpx_projection_div_cleaner_rtol : float, optional
+        Relative tolerance for the divergence cleaner solve.
+    """
+
+    def __init__(self, **kw):
+        # If using load_from_python, a function handle is expected for callback
+        self.load_from_python = kw.get("load_from_python")
+
+        self.do_initial_div_cleaning = kw.pop("warpx_do_initial_div_cleaning", None)
+        self.div_cleaner_atol = kw.pop("warpx_projection_div_cleaner_atol", None)
+        self.div_cleaner_rtol = kw.pop("warpx_projection_div_cleaner_rtol", None)
+
+        self.warpx_E_time_function = kw.pop("warpx_E_time_function", None)
+        self.warpx_B_time_function = kw.pop("warpx_B_time_function", None)
+
+        super().__init__(**kw)
+
+    def applied_field_initialize_inputs(self):
+        if self.load_E:
+            pywarpx.particles.E_ext_particle_init_style = "load_from_python"
+            # pass time dependence via parser
+            if self.warpx_E_time_function:
+                pywarpx.particles.__setattr__(
+                    "read_fields_E_dependency(t)", self.warpx_E_time_function
+                )
+
+        if self.load_B:
+            pywarpx.particles.B_ext_particle_init_style = "load_from_python"
+            pywarpx.warpx.do_initial_div_cleaning = self.do_initial_div_cleaning
+            pywarpx.warpx.add_new_group_attr(
+                "projection_div_cleaner", "atol", self.div_cleaner_atol
+            )
+            pywarpx.warpx.add_new_group_attr(
+                "projection_div_cleaner", "rtol", self.div_cleaner_rtol
+            )
+            # pass time dependence via parser
+            if self.warpx_B_time_function:
+                pywarpx.particles.__setattr__(
+                    "read_fields_B_dependency(t)", self.warpx_B_time_function
+                )
+
+        pywarpx.callbacks.installloadExternalFields(self.load_from_python)
+
+
 class ConstantAppliedField(picmistandard.PICMI_ConstantAppliedField):
     def applied_field_initialize_inputs(self):
         # Note that lower and upper_bound are not used by WarpX

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2617,7 +2617,7 @@ class LoadAppliedFieldFromPython(picmistandard.PICMI_LoadAppliedField):
 
     def __init__(self, **kw):
         # If using load_from_python, a function handle is expected for callback
-        self.load_from_python = kw.get("load_from_python")
+        self.load_from_python = kw.pop("load_from_python")
 
         self.do_initial_div_cleaning = kw.pop("warpx_do_initial_div_cleaning", None)
         self.div_cleaner_atol = kw.pop("warpx_projection_div_cleaner_atol", None)
@@ -2626,9 +2626,20 @@ class LoadAppliedFieldFromPython(picmistandard.PICMI_LoadAppliedField):
         self.warpx_E_time_function = kw.pop("warpx_E_time_function", None)
         self.warpx_B_time_function = kw.pop("warpx_B_time_function", None)
 
+        # Base class requires read_fields_from_path -> enforce it by a hack for now
+        kw["read_fields_from_path"] = ""
+
         super().__init__(**kw)
 
+        # hard-disable unwanted loaders set by the base ctor
+        if not self.load_E:
+            pywarpx.particles.E_ext_particle_init_style = "none"
+        if not self.load_B:
+            pywarpx.particles.B_ext_particle_init_style = "none"
+
     def applied_field_initialize_inputs(self):
+        pywarpx.particles.read_fields_from_path = self.read_fields_from_path
+
         if self.load_E:
             pywarpx.particles.E_ext_particle_init_style = "load_from_python"
             # pass time dependence via parser

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2626,7 +2626,7 @@ class LoadAppliedFieldFromPython(picmistandard.PICMI_LoadAppliedField):
         self.warpx_E_time_function = kw.pop("warpx_E_time_function", None)
         self.warpx_B_time_function = kw.pop("warpx_B_time_function", None)
 
-        # Base class requires read_fields_from_path -> enforce it by a hack for now
+        # Base class requires read_fields_from_path -> enforce it with a hack
         kw["read_fields_from_path"] = ""
 
         super().__init__(**kw)

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -1686,6 +1686,7 @@ WarpX::LoadExternalFields (int const lev)
 
     if (lev == finestLevel()) {
         // Call Python callback which might write values to external field multifabs
+        // (possibly both external fields and particle fields)
         ExecutePythonCallback("loadExternalFields");
     }
 

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -137,7 +137,7 @@ WarpX::UpdateAuxilaryData ()
     for (int lev = 0; lev <= finest_level; ++lev) {
 
         // external particle E field maps
-        if (mypc->m_E_ext_particle_s == "read_from_file") {
+        if ((mypc->m_E_ext_particle_s == "read_from_file") || (mypc->m_E_ext_particle_s == "load_from_python")) {
             ablastr::fields::VectorField E_aux = m_fields.get_alldirs(FieldType::Efield_aux, lev);
             const auto& E_ext = m_fields.get_alldirs(FieldType::E_external_particle_field, lev);
 
@@ -165,7 +165,7 @@ WarpX::UpdateAuxilaryData ()
         }
 
         // external particle B field maps
-        if (mypc->m_B_ext_particle_s == "read_from_file") {
+        if ((mypc->m_B_ext_particle_s == "read_from_file") || (mypc->m_B_ext_particle_s == "load_from_python")) {
             ablastr::fields::VectorField B_aux = m_fields.get_alldirs(FieldType::Bfield_aux, lev);
             const auto& B_ext = m_fields.get_alldirs(FieldType::B_external_particle_field, lev);
 

--- a/Source/Particles/ExternalParticleFields.cpp
+++ b/Source/Particles/ExternalParticleFields.cpp
@@ -58,7 +58,7 @@ ExternalParticleFields::ReadParameters () {
 
     std::string e_init;
     pp_particles.query("E_ext_particle_init_style", e_init);
-    if ((e_init == "read_from_file") || (e_init == 'load_from_python')) {
+    if ((e_init == "read_from_file") || (e_init == "load_from_python")) {
 
         // Read in E field names
         std::vector<std::string> E_names;
@@ -116,7 +116,7 @@ ExternalParticleFields::ReadParameters () {
 
     std::string b_init;
     pp_particles.query("B_ext_particle_init_style", b_init);
-    if ((b_init == "read_from_file") or (b_init == 'load_from_python')) {
+    if ((b_init == "read_from_file") || (b_init == "load_from_python")) {
 
         // Read in B field names
         std::vector<std::string> B_names;

--- a/Source/Particles/ExternalParticleFields.cpp
+++ b/Source/Particles/ExternalParticleFields.cpp
@@ -58,7 +58,7 @@ ExternalParticleFields::ReadParameters () {
 
     std::string e_init;
     pp_particles.query("E_ext_particle_init_style", e_init);
-    if (e_init == "read_from_file") {
+    if ((e_init == "read_from_file") || (e_init == 'load_from_python')) {
 
         // Read in E field names
         std::vector<std::string> E_names;
@@ -116,7 +116,7 @@ ExternalParticleFields::ReadParameters () {
 
     std::string b_init;
     pp_particles.query("B_ext_particle_init_style", b_init);
-    if (b_init == "read_from_file") {
+    if ((b_init == "read_from_file") or (b_init == 'load_from_python')) {
 
         // Read in B field names
         std::vector<std::string> B_names;
@@ -127,7 +127,7 @@ ExternalParticleFields::ReadParameters () {
             m_B_field_metadata.emplace_back(read_named_spec(n, /*isE=*/false));
         }
 
-        // No E field names provided, initialize for single E field without name
+        // No B field names provided, initialize for single B field without name
         if (m_B_field_metadata.empty()) {
 
             // no B field names provided but read_from_file requested, force to

--- a/Source/Particles/Gather/GetExternalFields.cpp
+++ b/Source/Particles/Gather/GetExternalFields.cpp
@@ -83,15 +83,15 @@ GetExternalEBField::GetExternalEBField (const WarpXParIter& a_pti, long a_offset
         m_repeated_plasma_lens_strengths_B = mypc.d_repeated_plasma_lens_strengths_B.data();
     }
 
-    // When the external particle fields are read from file,
+    // When the external particle fields are read from file or loaded from python,
     // the external fields are not added directly inside the gather kernel.
     // (Hence of `None`, which ensures that the gather kernel is compiled without support
     // for external fields.) Instead, the external fields are added to the MultiFab
     // Efield_aux and Bfield_aux before the particles gather from these MultiFab.
-    if (mypc.m_E_ext_particle_s == "read_from_file") {
+    if ((mypc->m_E_ext_particle_s == "read_from_file") || (mypc->m_E_ext_particle_s == "load_from_python")) {
         m_Etype = ExternalFieldInitType::None;
     }
-    if (mypc.m_B_ext_particle_s == "read_from_file") {
+    if ((mypc->m_B_ext_particle_s == "read_from_file") || (mypc->m_B_ext_particle_s == "load_from_python")) {
         m_Btype = ExternalFieldInitType::None;
     }
 

--- a/Source/Particles/Gather/GetExternalFields.cpp
+++ b/Source/Particles/Gather/GetExternalFields.cpp
@@ -88,10 +88,10 @@ GetExternalEBField::GetExternalEBField (const WarpXParIter& a_pti, long a_offset
     // (Hence of `None`, which ensures that the gather kernel is compiled without support
     // for external fields.) Instead, the external fields are added to the MultiFab
     // Efield_aux and Bfield_aux before the particles gather from these MultiFab.
-    if ((mypc->m_E_ext_particle_s == "read_from_file") || (mypc->m_E_ext_particle_s == "load_from_python")) {
+    if ((mypc.m_E_ext_particle_s == "read_from_file") || (mypc.m_E_ext_particle_s == "load_from_python")) {
         m_Etype = ExternalFieldInitType::None;
     }
-    if ((mypc->m_B_ext_particle_s == "read_from_file") || (mypc->m_B_ext_particle_s == "load_from_python")) {
+    if ((mypc.m_B_ext_particle_s == "read_from_file") || (mypc.m_B_ext_particle_s == "load_from_python")) {
         m_Btype = ExternalFieldInitType::None;
     }
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -2812,7 +2812,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
             amrex::convert(ba, m_fields.get(FieldType::Bfield_fp,Direction{2},lev)->ixType()),
             dm, ncomps, ngEB, 0.0_rt);
     }
-    if (mypc->m_B_ext_particle_s == "read_from_file") {
+    if ((mypc->m_B_ext_particle_s == "read_from_file") || (mypc->m_B_ext_particle_s == "load_from_python")) {
         //  These fields will be added to the fields that the particles see, and need to match the index type
         auto *Bfield_aux_levl_0 = m_fields.get(FieldType::Bfield_aux, Direction{0}, lev);
         auto *Bfield_aux_levl_1 = m_fields.get(FieldType::Bfield_aux, Direction{1}, lev);
@@ -2838,7 +2838,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         m_fields.alloc_init(FieldType::Efield_fp_external, Direction{2}, lev, amrex::convert(ba, m_fields.get(FieldType::Efield_fp, Direction{2}, lev)->ixType()),
             dm, ncomps, ngEB, 0.0_rt);
     }
-    if (mypc->m_E_ext_particle_s == "read_from_file") {
+    if ((mypc->m_E_ext_particle_s == "read_from_file") || (mypc->m_E_ext_particle_s == "load_from_python")) {
         //  These fields will be added to the fields that the particles see, and need to match the index type
         auto *Efield_aux_levl_0 = m_fields.get(FieldType::Efield_aux, Direction{0}, lev);
         auto *Efield_aux_levl_1 = m_fields.get(FieldType::Efield_aux, Direction{1}, lev);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -2768,7 +2768,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
             m_fields.alias_init(FieldType::Efield_aux, FieldType::Efield_avg_fp, Direction{1}, lev, 0.0_rt);
             m_fields.alias_init(FieldType::Efield_aux, FieldType::Efield_avg_fp, Direction{2}, lev, 0.0_rt);
         } else {
-            if (mypc->m_B_ext_particle_s == "read_from_file") {
+            if ((mypc->m_B_ext_particle_s == "read_from_file") || (mypc->m_B_ext_particle_s == "load_from_python")) {
                 m_fields.alloc_init(FieldType::Bfield_aux, Direction{0}, lev, amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
                 m_fields.alloc_init(FieldType::Bfield_aux, Direction{1}, lev, amrex::convert(ba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
                 m_fields.alloc_init(FieldType::Bfield_aux, Direction{2}, lev, amrex::convert(ba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
@@ -2778,7 +2778,7 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
                 m_fields.alias_init(FieldType::Bfield_aux, FieldType::Bfield_fp, Direction{1}, lev, 0.0_rt);
                 m_fields.alias_init(FieldType::Bfield_aux, FieldType::Bfield_fp, Direction{2}, lev, 0.0_rt);
             }
-            if (mypc->m_E_ext_particle_s == "read_from_file") {
+            if ((mypc->m_E_ext_particle_s == "read_from_file") || (mypc->m_E_ext_particle_s == "load_from_python")) {
                 m_fields.alloc_init(FieldType::Efield_aux, Direction{0}, lev, amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
                 m_fields.alloc_init(FieldType::Efield_aux, Direction{1}, lev, amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
                 m_fields.alloc_init(FieldType::Efield_aux, Direction{2}, lev, amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt);


### PR DESCRIPTION
Currently the `B_external_particle_field` and `E_external_particle_field` multifabs are only initialized if those fields are loaded from file. This PR allows those fields to be set from a Python callback similar to how it can currently be done for the initial fields.