### PR TITLE
Containers: More Shared Libs

### DIFF
--- a/Tools/machines/perlmutter-nersc/container/gpu/mpi/Containerfile
+++ b/Tools/machines/perlmutter-nersc/container/gpu/mpi/Containerfile
@@ -5,6 +5,14 @@
 # WarpX executables are installed in /usr/bin/
 # WarpX Python bindings are installed in /opt/venv
 #
+# To push this to the NERSC registry, first tag the full name and version,
+#   podman tag warpx-perlmutter:latest registry.nersc.gov/m558/superfacility/warpx-perlmutter:latest
+#   podman tag warpx-perlmutter:latest registry.nersc.gov/m558/superfacility/warpx-perlmutter:25.11
+# and then push
+#   podman login registry.nersc.gov
+#   podman push registry.nersc.gov/m558/superfacility/warpx-perlmutter:latest
+#   podman push registry.nersc.gov/m558/superfacility/warpx-perlmutter:25.11
+#
 # On Perlmutter, run WarpX like this:
 #   podman-hpc run --rm --gpu --cuda-mpi --nccl -v $PWD:/opt/pwd -it registry.nersc.gov/m558/superfacility/warpx-perlmutter:latest warpx.2d /opt/pwd/inputs_base_2d
 # Prefix this line with "srun ..." in job scripts, as usual:

--- a/Tools/machines/perlmutter-nersc/container/gpu/mpi/Containerfile
+++ b/Tools/machines/perlmutter-nersc/container/gpu/mpi/Containerfile
@@ -13,8 +13,8 @@
 #   podman push registry.nersc.gov/m558/superfacility/warpx-perlmutter:latest
 #   podman push registry.nersc.gov/m558/superfacility/warpx-perlmutter:25.11
 #
-# On Perlmutter, run WarpX like this:
-#   podman-hpc run --rm --gpu --cuda-mpi --nccl -v $PWD:/opt/pwd -it registry.nersc.gov/m558/superfacility/warpx-perlmutter:latest warpx.2d /opt/pwd/inputs_base_2d
+# On Perlmutter, copy your inputs file to your present working directory (PWD) and run WarpX like this:
+#   podman-hpc run --rm --gpu --cuda-mpi --nccl -v $PWD:/opt/pwd --workdir /opt/pwd -it registry.nersc.gov/m558/superfacility/warpx-perlmutter:latest warpx.2d /opt/pwd/inputs_base_2d
 # Prefix this line with "srun ..." in job scripts, as usual:
 #   srun --cpu-bind=cores bash -c "
 #     export CUDA_VISIBLE_DEVICES=\$((3-SLURM_LOCALID));

--- a/Tools/machines/perlmutter-nersc/container/gpu/mpi/Containerfile
+++ b/Tools/machines/perlmutter-nersc/container/gpu/mpi/Containerfile
@@ -116,6 +116,7 @@ RUN git clone                               \
       -S /tmp/c-blosc2                      \
       -B /tmp/c-blosc2-build                \
       -DCMAKE_INSTALL_PREFIX=/opt/warpx     \
+      -DBUILD_STATIC=OFF                    \
       -DBUILD_TESTS=OFF                     \
       -DBUILD_BENCHMARKS=OFF                \
       -DBUILD_EXAMPLES=OFF                  \
@@ -239,9 +240,10 @@ RUN git clone                       \
     cmake                           \
         -S /tmp/warpx-src           \
         -B /tmp/warpx-build         \
+        -DBUILD_SHARED_LIBS=ON      \
         -DCMAKE_INSTALL_PREFIX=/opt/warpx \
         -DWarpX_COMPUTE=CUDA        \
-        -DWarpX_DIMS="2;RZ"         \
+        -DWarpX_DIMS="1;2;RZ;3"     \
         -DWarpX_FFT=ON              \
         -DWarpX_PYTHON=ON           \
         -DWarpX_QED_TABLE_GEN=OFF   \
@@ -255,8 +257,11 @@ RUN git clone                       \
           -j${NJOBS}                \
                                  && \
     rm -rf /tmp/warpx*           && \
+    ln -s /opt/warpx/bin/warpx.1d* /opt/warpx/bin/warpx.1d  && \
     ln -s /opt/warpx/bin/warpx.2d* /opt/warpx/bin/warpx.2d  && \
-    ln -s /opt/warpx/bin/warpx.rz* /opt/warpx/bin/warpx.rz
+    ln -s /opt/warpx/bin/warpx.rz* /opt/warpx/bin/warpx.rz  && \
+    ln -s /opt/warpx/bin/warpx.3d* /opt/warpx/bin/warpx.3d  && \
+    rm -rf /opt/warpx/lib/*.a
 
 # Reduce to runtime
 FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04 AS warpx
@@ -280,8 +285,6 @@ RUN apt-get update            && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy installed software from previous stage
-#   TODO: Check BLAS still works
-#   TODO: Check this does not copy CUDA devel packages
 COPY --from=warpx-dev /opt/warpx /opt/warpx
 COPY --from=warpx-dev /opt/venv /opt/venv
 

--- a/Tools/machines/perlmutter-nersc/container/gpu/nompi/Containerfile
+++ b/Tools/machines/perlmutter-nersc/container/gpu/nompi/Containerfile
@@ -86,6 +86,7 @@ RUN git clone                               \
       -S /tmp/c-blosc2                      \
       -B /tmp/c-blosc2-build                \
       -DCMAKE_INSTALL_PREFIX=/opt/warpx     \
+      -DBUILD_STATIC=OFF                    \
       -DBUILD_TESTS=OFF                     \
       -DBUILD_BENCHMARKS=OFF                \
       -DBUILD_EXAMPLES=OFF                  \
@@ -210,6 +211,7 @@ RUN git clone                       \
     cmake                           \
         -S /tmp/warpx-src           \
         -B /tmp/warpx-build         \
+        -DBUILD_SHARED_LIBS=ON      \
         -DCMAKE_INSTALL_PREFIX=/opt/warpx \
         -DWarpX_COMPUTE=CUDA        \
         -DWarpX_DIMS="1;2;RZ;3"     \
@@ -230,7 +232,8 @@ RUN git clone                       \
     ln -s /opt/warpx/bin/warpx.1d* /opt/warpx/bin/warpx.1d  && \
     ln -s /opt/warpx/bin/warpx.2d* /opt/warpx/bin/warpx.2d  && \
     ln -s /opt/warpx/bin/warpx.rz* /opt/warpx/bin/warpx.rz  && \
-    ln -s /opt/warpx/bin/warpx.3d* /opt/warpx/bin/warpx.3d
+    ln -s /opt/warpx/bin/warpx.3d* /opt/warpx/bin/warpx.3d  && \
+    rm -rf /opt/warpx/lib/*.a
 
 # Reduce to runtime
 FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04 AS warpx
@@ -255,8 +258,6 @@ RUN apt-get update            && \
     rm -rf /var/lib/apt/lists/*
 
 # Copy installed software from previous stage
-#   TODO: Check BLAS still works
-#   TODO: Check this does not copy CUDA devel packages
 COPY --from=warpx-dev /opt/warpx /opt/warpx
 COPY --from=warpx-dev /opt/venv /opt/venv
 

--- a/Tools/machines/perlmutter-nersc/container/gpu/nompi/Containerfile
+++ b/Tools/machines/perlmutter-nersc/container/gpu/nompi/Containerfile
@@ -13,8 +13,8 @@
 #   podman push registry.nersc.gov/m558/superfacility/warpx-perlmutter-nompi:latest
 #   podman push registry.nersc.gov/m558/superfacility/warpx-perlmutter-nompi:25.11
 #
-# On Perlmutter, run WarpX like this:
-#   podman-hpc run --rm --gpu -v $PWD:/opt/pwd -it registry.nersc.gov/m558/superfacility/warpx-perlmutter-nompi:latest warpx.2d /opt/pwd/inputs_base_2d
+# On Perlmutter, copy your inputs file to your present working directory (PWD) and run WarpX like this:
+#   podman-hpc run --rm --gpu -v $PWD:/opt/pwd --workdir /opt/pwd -it registry.nersc.gov/m558/superfacility/warpx-perlmutter-nompi:latest warpx.2d /opt/pwd/inputs_base_2d
 # Prefix this line with "srun ..." in job scripts, as usual:
 #   srun --cpu-bind=cores bash -c "
 #     export CUDA_VISIBLE_DEVICES=\$((3-SLURM_LOCALID));

--- a/Tools/machines/perlmutter-nersc/container/gpu/nompi/Containerfile
+++ b/Tools/machines/perlmutter-nersc/container/gpu/nompi/Containerfile
@@ -5,6 +5,14 @@
 # WarpX executables are installed in /opt/warpx/bin
 # WarpX Python bindings are installed in /opt/venv
 #
+# To push this to the NERSC registry, first tag the full name and version,
+#   podman tag warpx-perlmutter-nompi:latest registry.nersc.gov/m558/superfacility/warpx-perlmutter-nompi:latest
+#   podman tag warpx-perlmutter-nompi:latest registry.nersc.gov/m558/superfacility/warpx-perlmutter-nompi:25.11
+# and then push
+#   podman login registry.nersc.gov
+#   podman push registry.nersc.gov/m558/superfacility/warpx-perlmutter-nompi:latest
+#   podman push registry.nersc.gov/m558/superfacility/warpx-perlmutter-nompi:25.11
+#
 # On Perlmutter, run WarpX like this:
 #   podman-hpc run --rm --gpu -v $PWD:/opt/pwd -it registry.nersc.gov/m558/superfacility/warpx-perlmutter-nompi:latest warpx.2d /opt/pwd/inputs_base_2d
 # Prefix this line with "srun ..." in job scripts, as usual:


### PR DESCRIPTION
Build WarpX as shared lib, so Python and executable application can share the same lib (instead of copying the static lib twice). Remove all auxiliary static libs after build.

Size before: 4.99GiB (11.9 GiB total)
Size now: 2.92GiB (6.33 GiB total)
Legend: size shown on harbor registry, i.e., compressed (size on `podman images`, i.e. uncompressed)

- [x] runtime tested