### PR TITLE
Small bugfix in particle container wrapper

### DIFF
--- a/Docs/source/usage/workflows/python_extend.rst
+++ b/Docs/source/usage/workflows/python_extend.rst
@@ -301,7 +301,7 @@ Particles
 
        # data access
        multi_pc = warpx.multi_particle_container()
-       pc = multi_pc.get_particle_container_from_name("electrons")
+       pc = multi_pc.get("electrons")
 
        # compute
        # iterate over mesh-refinement levels

--- a/Python/pywarpx/particle_containers.py
+++ b/Python/pywarpx/particle_containers.py
@@ -39,9 +39,7 @@ class ParticleContainerWrapper(object):
         if self._particle_container is None:
             try:
                 mypc = libwarpx.warpx.multi_particle_container()
-                self._particle_container = mypc.get_particle_container_from_name(
-                    self.name
-                )
+                self._particle_container = mypc.get(self.name)
             except AttributeError as e:
                 msg = "You must initialize WarpX before accessing a ParticleContainerWrapper's particle_container."
                 raise AttributeError(msg) from e


### PR DESCRIPTION
`get_particle_container_from_name()` no longer exists, instead it is now just called `get`.
This functionality is deprecated anyway but still worth fixing until we remove `particle_containers.py` completely.