### PR TITLE
Fix Perlmutter Container: CuPy Headers

### DIFF
--- a/Tools/machines/perlmutter-nersc/container/gpu/mpi/Containerfile
+++ b/Tools/machines/perlmutter-nersc/container/gpu/mpi/Containerfile
@@ -213,6 +213,7 @@ RUN python3 -m venv /opt/venv && \
         --upgrade        \
         build            \
         cmake            \
+        "nvidia-cuda-runtime-cu12==12.4.*" \
         cupy-cuda12x     \
         cython           \
         h5py             \

--- a/Tools/machines/perlmutter-nersc/container/gpu/mpi/Containerfile
+++ b/Tools/machines/perlmutter-nersc/container/gpu/mpi/Containerfile
@@ -217,6 +217,7 @@ RUN python3 -m venv /opt/venv && \
         cupy-cuda12x     \
         cython           \
         h5py             \
+        lasy             \
         matplotlib       \
         numpy            \
         openpmd-api      \

--- a/Tools/machines/perlmutter-nersc/container/gpu/mpi/entrypoint.sh
+++ b/Tools/machines/perlmutter-nersc/container/gpu/mpi/entrypoint.sh
@@ -6,6 +6,9 @@ export CMAKE_PREFIX_PATH=${WARPX_ROOT}:${CMAKE_PREFIX_PATH}
 export PATH=${WARPX_ROOT}/bin:${PATH}
 export LD_LIBRARY_PATH=${WARPX_ROOT}/lib:${LD_LIBRARY_PATH}
 
+# The usual HDF5 quirk for various FS and containers
+export HDF5_USE_FILE_LOCKING="FALSE"
+
 # Activate python venv
 source /opt/venv/bin/activate
 

--- a/Tools/machines/perlmutter-nersc/container/gpu/nompi/Containerfile
+++ b/Tools/machines/perlmutter-nersc/container/gpu/nompi/Containerfile
@@ -183,6 +183,7 @@ RUN python3 -m venv /opt/venv && \
         --upgrade        \
         build            \
         cmake            \
+        "nvidia-cuda-runtime-cu12==12.4.*" \
         cupy-cuda12x     \
         cython           \
         h5py             \

--- a/Tools/machines/perlmutter-nersc/container/gpu/nompi/Containerfile
+++ b/Tools/machines/perlmutter-nersc/container/gpu/nompi/Containerfile
@@ -187,6 +187,7 @@ RUN python3 -m venv /opt/venv && \
         cupy-cuda12x     \
         cython           \
         h5py             \
+        lasy             \
         matplotlib       \
         numpy            \
         openpmd-api      \

--- a/Tools/machines/perlmutter-nersc/container/gpu/nompi/entrypoint.sh
+++ b/Tools/machines/perlmutter-nersc/container/gpu/nompi/entrypoint.sh
@@ -6,6 +6,9 @@ export CMAKE_PREFIX_PATH=${WARPX_ROOT}:${CMAKE_PREFIX_PATH}
 export PATH=${WARPX_ROOT}/bin:${PATH}
 export LD_LIBRARY_PATH=${WARPX_ROOT}/lib:${LD_LIBRARY_PATH}
 
+# The usual HDF5 quirk for various FS and containers
+export HDF5_USE_FILE_LOCKING="FALSE"
+
 # Activate python venv
 source /opt/venv/bin/activate
 


### PR DESCRIPTION
Seen in Synapse with LASY scripts on GPU:

Installing `nvidia-cuda-runtime-cu12==12.4.*` provides otherwise unavailable headers that are needed for NVRTC runtime compilation inside CuPy.
https://docs.cupy.dev/en/stable/install.html#cupy-always-raises-nvrtc-error-compilation-6

CuPy uses NVRTC for nearly everything, e.g., to calculate `cupy.sqrt(x)` of an array `x`. Lasy uses CuPy by default, too.

- also install lasy (small, ok to ship)
- also disable HDF5 file locking (generally not needed, often a problem and seen to be an issue for writing the lasy file in the container)