### PR TITLE
Fix Cursor issue when running Python through CTest

### DIFF
--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -190,27 +190,13 @@ function(add_warpx_test
     set_property(TEST ${name}.run APPEND PROPERTY ENVIRONMENT "OMP_NUM_THREADS=1")
 
     # Always use Python_EXECUTABLE for analysis/checksum scripts to ensure conda Python is used
-    if(analysis OR checksum)
+    if(python OR analysis OR checksum)
+        # Try to find Python if not already set
+        # This is more robust in virtual envs (conda, venv) than
+        # relying only on /usr/bin/env python3
         if(NOT Python_EXECUTABLE)
-            # Try to find Python if not already set
-            find_package(Python3 COMPONENTS Interpreter QUIET)
-            if(Python3_EXECUTABLE)
-                set(Python_EXECUTABLE ${Python3_EXECUTABLE})
-            else()
-                # Fallback to python3 from PATH
-                find_program(Python_EXECUTABLE python3)
-            endif()
+            find_package(Python COMPONENTS Interpreter)
         endif()
-        if(Python_EXECUTABLE)
-            set(THIS_Python_SCRIPT_EXE ${Python_EXECUTABLE})
-        else()
-            # Fallback to empty (will use shebang)
-            set(THIS_Python_SCRIPT_EXE "")
-        endif()
-    elseif(python OR WIN32)
-        set(THIS_Python_SCRIPT_EXE ${Python_EXECUTABLE})
-    else()
-        set(THIS_Python_SCRIPT_EXE "")
     endif()
 
     # test analysis
@@ -220,7 +206,7 @@ function(add_warpx_test
         add_test(
             NAME ${name}.analysis
             COMMAND
-                ${THIS_Python_SCRIPT_EXE}
+                ${Python_EXECUTABLE}
                 ${ANALYSIS_FILE}
                 ${ANALYSIS_ARGS}
             WORKING_DIRECTORY ${THIS_WORKING_DIR}
@@ -243,7 +229,7 @@ function(add_warpx_test
         add_test(
             NAME ${name}.checksum
             COMMAND
-                ${THIS_Python_SCRIPT_EXE}
+                ${Python_EXECUTABLE}
                 ${CHECKSUM_FILE}
                 ${CHECKSUM_ARGS}
             WORKING_DIRECTORY ${THIS_WORKING_DIR}

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -189,7 +189,25 @@ function(add_warpx_test
     # run all tests with 1 OpenMP thread by default
     set_property(TEST ${name}.run APPEND PROPERTY ENVIRONMENT "OMP_NUM_THREADS=1")
 
-    if(python OR WIN32)
+    # Always use Python_EXECUTABLE for analysis/checksum scripts to ensure conda Python is used
+    if(analysis OR checksum)
+        if(NOT Python_EXECUTABLE)
+            # Try to find Python if not already set
+            find_package(Python3 COMPONENTS Interpreter QUIET)
+            if(Python3_EXECUTABLE)
+                set(Python_EXECUTABLE ${Python3_EXECUTABLE})
+            else()
+                # Fallback to python3 from PATH
+                find_program(Python_EXECUTABLE python3)
+            endif()
+        endif()
+        if(Python_EXECUTABLE)
+            set(THIS_Python_SCRIPT_EXE ${Python_EXECUTABLE})
+        else()
+            # Fallback to empty (will use shebang)
+            set(THIS_Python_SCRIPT_EXE "")
+        endif()
+    elseif(python OR WIN32)
         set(THIS_Python_SCRIPT_EXE ${Python_EXECUTABLE})
     else()
         set(THIS_Python_SCRIPT_EXE "")

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -195,7 +195,7 @@ function(add_warpx_test
         # This is more robust in virtual envs (conda, venv) than
         # relying only on /usr/bin/env python3
         if(NOT Python_EXECUTABLE)
-            find_package(Python COMPONENTS Interpreter)
+            find_package(Python COMPONENTS Interpreter REQUIRED)
         endif()
     endif()
 


### PR DESCRIPTION
When asking Cursor to run `CTest` tests, it seems that it is unable to find the correct Python (in my case the `conda` one) and uses the system Python instead, thus not finding `numpy` and `yt`:

<img width="852" height="722" alt="Screenshot 2026-01-13 at 2 26 28 PM" src="https://github.com/user-attachments/assets/fc4ef6f8-b02c-4954-b7cb-0aec968c750c" />

Strangely, this error only happens on MacOS. (I don't get this error when running Cursor on Linux.)
Additionally, when I run the same command **myself directly in the Terminal**, I don't get the error (even on MacOS).

The changes made to the CMakeList.txt fix the issue, but were suggested by a coding assistant and I do not fully understand them. They should be simplified/updated before merging this PR.

- [x] follow-up PR: also add same change in ImpactX https://github.com/BLAST-ImpactX/impactx/pull/1267