### PR TITLE
Use NoGpuSync for MLMG in computePhi

### DIFF
--- a/Source/ablastr/fields/PoissonSolver.H
+++ b/Source/ablastr/fields/PoissonSolver.H
@@ -404,6 +404,7 @@ computePhi (
         mlmg.setVerbose(verbosity);
         mlmg.setMaxIter(max_iters);
         mlmg.setConvergenceNormType(amrex::MLMGNormType::greater);
+        mlmg.setNoGpuSync(true);
 
         const int ng = int(grid_type == utils::enums::GridType::Collocated); // ghost cells
         if (ng) {


### PR DESCRIPTION
This gives a significant performance improvement when running small problem sizes in GPU.
See #6487