### PR TITLE
Docs: inputs section cleanup - parser and constants

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -17,8 +17,8 @@ Examples of inputs files can be found in the :ref:`Examples <usage-examples>` se
 
 .. _running-cpp-parameters-parser:
 
-Math parser and constants
--------------------------
+Parsers and constants
+---------------------
 
 WarpX uses AMReX's math parser that reads expressions in the input file.
 It can be used in all input parameters that consist of one or more integers or floats.
@@ -62,8 +62,8 @@ For example:
 * ``my_constants.n0 = 1e22``
 * ``my_constants.wp = sqrt(n0*q_e**2/(epsilon0*m_e))``
 
-Coordinates
-^^^^^^^^^^^
+Spatial coordinates
+^^^^^^^^^^^^^^^^^^^
 
 For profiles that depend on spatial coordinates (e.g., the plasma momentum distribution or the laser field, see below :ref:`Particle initialization <running-cpp-parameters-particle>` and :ref:`Laser initialization <running-cpp-parameters-laser>`), the parser interprets some variables as spatial coordinates.
 These are specified in the input parameter, i.e., ``density_function(x,y,z)`` and ``field_function(X,Y,t)``.
@@ -74,6 +74,47 @@ The names are case sensitive.
 The factor ``(x>0)`` equals ``1`` where ``x>0`` and ``0`` where ``x<=0``.
 It allows the user to define functions by intervals.
 Alternatively, the expression above can be written as ``if(x>0, a0*x**2 * (1-y*1e2), 0)``.
+
+Time intervals
+^^^^^^^^^^^^^^
+
+WarpX can parse time step interval expressions of the form ``start:stop:period``, e.g., ``1:2:3, 4::, 5:6, :, ::10``.
+A comma is used as a separator between groups of intervals, which we call slices.
+The resulting time intervals are the `union set <https://en.wikipedia.org/wiki/Union_(set_theory)>`__ of all given slices.
+White spaces are ignored.
+A single slice can have 0, 1 or 2 colons ``:``, just as `NumPy slices <https://numpy.org/doc/stable/reference/generated/numpy.s_.html>`__, but with inclusive upper bound for ``stop``:
+
+* With no colon, the given value is the period.
+
+* With 1 colon, the given string is of the type ``start:stop``.
+
+* With 2 colons, the given string is of the type ``start:stop:period``.
+
+Any value that is not given is set to default.
+Default is ``0`` for the start, ``std::numeric_limits<int>::max()`` for the stop, and ``1`` for the period.
+For the syntax with 1 or 2 colons, having values in the string is optional (e.g., ``::5``, ``100 ::10``, and ``100 :`` are all valid).
+
+All values can be expressions that are parsed in the same way as other integer input parameters.
+
+Here are some examples of valid time interval expressions and their meaning:
+
+* ``something_intervals = 50``: do something at time steps 0, 50, 100, 150, etc. (equivalent to ``something_intervals = ::50``).
+
+* ``something_intervals = 300:600:100``: do something at time steps 300, 400, 500 and 600.
+
+* ``something_intervals = 300::50``: do something at time steps 300, 350, 400, 450, etc.
+
+* ``something_intervals = 105:108,205:208``: do something at time steps 105, 106, 107, 108, 205, 206, 207 and 208 (equivalent to ``something_intervals = 105 : 108 : , 205 : 208 :``).
+
+* ``something_intervals = :`` or  ``something_intervals = ::``: do something at every time step.
+
+* ``something_intervals = 167:167,253:253,275:425:50`` do something at time steps 167, 253, 275, 325, 375 and 425.
+
+This is similar to the Python slicing syntax, except that the stop is inclusive (e.g., ``0:100`` contains 100) and that no colon means that the given value is the period.
+
+Note that if a given period is zero or negative, the corresponding slice is disregarded.
+For example, ``something_intervals = -1`` deactivates ``something`` and ``something_intervals = ::-1,100:1000:25`` is equivalent to ``something_intervals = 100:1000:25``.
+
 
 .. _running-cpp-parameters-overall:
 
@@ -4118,54 +4159,6 @@ The checkpoint capability can be turned with regular diagnostics: ``<diag_name>.
 
 * ``warpx.write_diagnostics_on_restart`` (`bool`) optional (default `false`)
     When `true`, write the diagnostics after restart at the time of the restart.
-
-Intervals parser
-----------------
-
-WarpX can parse time step interval expressions of the form ``start:stop:period``, e.g.
-``1:2:3, 4::, 5:6, :, ::10``.
-A comma is used as a separator between groups of intervals, which we call slices.
-The resulting time steps are the `union set <https://en.wikipedia.org/wiki/Union_(set_theory)>`_ of all given slices.
-White spaces are ignored.
-A single slice can have 0, 1 or 2 colons ``:``, just as `numpy slices <https://numpy.org/doc/stable/reference/generated/numpy.s_.html>`_, but with inclusive upper bound for ``stop``.
-
-* For 0 colon the given value is the period
-
-* For 1 colon the given string is of the type ``start:stop``
-
-* For 2 colons the given string is of the type ``start:stop:period``
-
-Any value that is not given is set to default.
-Default is ``0`` for the start, ``std::numeric_limits<int>::max()`` for the stop and ``1`` for the
-period.
-For the 1 and 2 colon syntax, actually having values in the string is optional
-(this means that ``::5``, ``100 ::10`` and ``100 :`` are all valid syntaxes).
-
-All values can be expressions that will be parsed in the same way as other integer input parameters.
-
-**Examples**
-
-* ``something_intervals = 50`` -> do something at timesteps 0, 50, 100, 150, etc.
-  (equivalent to ``something_intervals = ::50``)
-
-* ``something_intervals = 300:600:100`` -> do something at timesteps 300, 400, 500 and 600.
-
-* ``something_intervals = 300::50`` -> do something at timesteps 300, 350, 400, 450, etc.
-
-* ``something_intervals = 105:108,205:208`` -> do something at timesteps 105, 106, 107, 108,
-  205, 206, 207 and 208. (equivalent to ``something_intervals = 105 : 108 : , 205 : 208 :``)
-
-* ``something_intervals = :`` or  ``something_intervals = ::`` -> do something at every timestep.
-
-* ``something_intervals = 167:167,253:253,275:425:50`` do something at timesteps 167, 253, 275,
-  325, 375 and 425.
-
-This is essentially the python slicing syntax except that the stop is inclusive
-(``0:100`` contains 100) and that no colon means that the given value is the period.
-
-Note that if a given period is zero or negative, the corresponding slice is disregarded.
-For example, ``something_intervals = -1`` deactivates ``something`` and
-``something_intervals = ::-1,100:1000:25`` is equivalent to ``something_intervals = 100:1000:25``.
 
 
 .. _running-cpp-parameters-test-debug:

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -15,6 +15,66 @@ Examples of inputs files can be found in the :ref:`Examples <usage-examples>` se
 
    The AMReX parser (see :ref:`running-cpp-parameters-parser`) is used for the right-hand side of all input parameters that consist of one or more integers or floats. Expressions like ``<species_name>.density_max = "0.1+2.3"`` and expressions that include user-defined constants are accepted.
 
+.. _running-cpp-parameters-parser:
+
+Math parser and constants
+-------------------------
+
+WarpX uses AMReX's math parser that reads expressions in the input file.
+It can be used in all input parameters that consist of one or more integers or floats.
+Integer input parameters expecting boolean, 0 or 1, are not parsed.
+Note that when multiple values are expected, the expressions are space delimited.
+For integer input values, the expressions are evaluated as real numbers and the final result rounded to the nearest integer.
+See `this section <https://amrex-codes.github.io/amrex/docs_html/Basics.html#parser>`__ of the AMReX documentation for a complete list of functions supported by the math parser.
+
+WarpX constants
+^^^^^^^^^^^^^^^
+
+WarpX provides a few pre-defined constants that can be used for any input parameter that consists of one or more floats.
+
+============ ===================
+``q_e``      elementary charge
+``m_e``      electron mass
+``m_p``      proton mass
+``m_u``      unified atomic mass unit (Dalton)
+``epsilon0`` vacuum permittivity
+``mu0``      vacuum permeability
+``clight``   speed of light
+``kb``       Boltzmann's constant (J/K)
+``pi``       math constant pi
+============ ===================
+
+The numerical values of these constants are set in `Source/ablastr/constant.H <https://github.com/BLAST-WarpX/warpx/blob/development/Source/ablastr/constant.H>`__.
+
+User-defined constants
+^^^^^^^^^^^^^^^^^^^^^^
+
+Users can define their own constants in the inputs file.
+These constants can be used for any input parameter that consists of one or more integers or floats.
+User-defined constant names can contain only letters, numbers and the character ``_``.
+The name of each constant has to begin with a letter.
+The following names are used by WarpX, and cannot be used as user-defined constants: ``x``, ``y``, ``z``, ``X``, ``Y``, ``t``.
+The values of the constants can include the predefined WarpX constants listed above as well as other user-defined constants.
+For example:
+
+* ``my_constants.a0 = 3.0``
+* ``my_constants.z_plateau = 150e-6``
+* ``my_constants.n0 = 1e22``
+* ``my_constants.wp = sqrt(n0*q_e**2/(epsilon0*m_e))``
+
+Coordinates
+^^^^^^^^^^^
+
+For profiles that depend on spatial coordinates (e.g., the plasma momentum distribution or the laser field, see below :ref:`Particle initialization <running-cpp-parameters-particle>` and :ref:`Laser initialization <running-cpp-parameters-laser>`), the parser interprets some variables as spatial coordinates.
+These are specified in the input parameter, i.e., ``density_function(x,y,z)`` and ``field_function(X,Y,t)``.
+
+The parser reads Python-style expressions between double quotes.
+For example, ``"a0*x**2 * (1-y*1e2) * (x>0)"`` is a valid expression, where ``a0`` is a user-defined constant (see above) and ``x`` and ``y`` are spatial coordinates.
+The names are case sensitive.
+The factor ``(x>0)`` equals ``1`` where ``x>0`` and ``0`` where ``x<=0``.
+It allows the user to define functions by intervals.
+Alternatively, the expression above can be written as ``if(x>0, a0*x**2 * (1-y*1e2), 0)``.
+
 .. _running-cpp-parameters-overall:
 
 Overall simulation parameters
@@ -795,64 +855,6 @@ Distribution across MPI ranks and parallelization
     During splitting high density boxes, if a Box's longest side is already
     less than or equal to this number, it will not be split.
 
-.. _running-cpp-parameters-parser:
-
-Math parser and user-defined constants
---------------------------------------
-
-WarpX uses AMReX's math parser that reads expressions in the input file.
-It can be used in all input parameters that consist of one or more integers or floats.
-Integer input expecting boolean, 0 or 1, are not parsed.
-Note that when multiple values are expected, the expressions are space delimited.
-For integer input values, the expressions are evaluated as real numbers and the final result rounded to the nearest integer.
-See `this section <https://amrex-codes.github.io/amrex/docs_html/Basics.html#parser>`__ of the AMReX documentation for a complete list of functions supported by the math parser.
-
-WarpX constants
-^^^^^^^^^^^^^^^
-
-WarpX provides a few pre-defined constants, that can be used for any parameter that consists of one or more floats.
-
-======== ===================
-q_e      elementary charge
-m_e      electron mass
-m_p      proton mass
-m_u      unified atomic mass unit (Dalton)
-epsilon0 vacuum permittivity
-mu0      vacuum permeability
-clight   speed of light
-kb       Boltzmann's constant (J/K)
-pi       math constant pi
-======== ===================
-
-See ``Source/Utils/WarpXConst.H`` for the values.
-
-User-defined constants
-^^^^^^^^^^^^^^^^^^^^^^
-
-Users can define their own constants in the input file.
-These constants can be used for any parameter that consists of one or more integers or floats.
-User-defined constant names can contain only letters, numbers and the character ``_``.
-The name of each constant has to begin with a letter. The following names are used
-by WarpX, and cannot be used as user-defined constants: ``x``, ``y``, ``z``, ``X``, ``Y``, ``t``.
-The values of the constants can include the predefined WarpX constants listed above as well as other user-defined constants.
-For example:
-
-* ``my_constants.a0 = 3.0``
-* ``my_constants.z_plateau = 150.e-6``
-* ``my_constants.n0 = 1.e22``
-* ``my_constants.wp = sqrt(n0*q_e**2/(epsilon0*m_e))``
-
-Coordinates
-^^^^^^^^^^^
-
-Besides, for profiles that depend on spatial coordinates (the plasma momentum distribution or the laser field, see below `Particle initialization` and `Laser initialization`), the parser will interpret some variables as spatial coordinates. These are specified in the input parameter, i.e., ``density_function(x,y,z)`` and ``field_function(X,Y,t)``.
-
-The parser reads python-style expressions between double quotes, for instance
-``"a0*x**2 * (1-y*1.e2) * (x>0)"`` is a valid expression where ``a0`` is a
-user-defined constant (see above) and ``x`` and ``y`` are spatial coordinates. The names are case sensitive. The factor
-``(x>0)`` is ``1`` where ``x>0`` and ``0`` where ``x<=0``. It allows the user to
-define functions by intervals.
-Alternatively the expression above can be written as ``if(x>0, a0*x**2 * (1-y*1.e2), 0)``.
 
 .. _running-cpp-parameters-particle:
 


### PR DESCRIPTION
Move and refine paragraph about math parser and constants. Split from #6355.