### PR TITLE
Expose reduced Planck constant

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -41,6 +41,7 @@ WarpX provides a few pre-defined constants that can be used for any input parame
 ``mu0``      vacuum permeability
 ``clight``   speed of light
 ``kb``       Boltzmann's constant (J/K)
+``hbar``     Reduced Planck constant (J*s)
 ``pi``       math constant pi
 ============ ===================
 

--- a/Examples/Tests/linear_compton/inputs_test_3d_linear_compton_bunch_laser
+++ b/Examples/Tests/linear_compton/inputs_test_3d_linear_compton_bunch_laser
@@ -11,7 +11,8 @@ my_constants.bunch_sigma_z = 1.e-6
 my_constants.laser_energy = 1. # Joule
 my_constants.laser_radius = 10.e-6 # meters
 my_constants.laser_duration = 0.2e-12 # seconds
-my_constants.photon_energy = q_e # 1 eV
+my_constants.omega = 1.519267447878626e15  # rad/s
+my_constants.photon_energy = hbar * omega  # 1 eV
 my_constants.N_photons = laser_energy / photon_energy # Number of photons in the laser pulse
 # time
 my_constants.T = laser_duration + Lz / clight

--- a/Source/Initialization/WarpXAMReXInit.cpp
+++ b/Source/Initialization/WarpXAMReXInit.cpp
@@ -166,6 +166,8 @@ namespace {
         pp_constants.queryAdd("kb", tmp);
         tmp =       MathConst::pi;
         pp_constants.queryAdd("pi", tmp);
+        tmp =       PhysConst::hbar;
+        pp_constants.queryAdd("hbar", tmp);
     }
 
     /** Overwrite defaults in AMReX Inputs

--- a/Source/Initialization/WarpXAMReXInit.cpp
+++ b/Source/Initialization/WarpXAMReXInit.cpp
@@ -164,10 +164,10 @@ namespace {
         pp_constants.queryAdd("m_u", tmp);
         tmp =       PhysConst::kb;
         pp_constants.queryAdd("kb", tmp);
-        tmp =       MathConst::pi;
-        pp_constants.queryAdd("pi", tmp);
         tmp =       PhysConst::hbar;
         pp_constants.queryAdd("hbar", tmp);
+        tmp =       MathConst::pi;
+        pp_constants.queryAdd("pi", tmp);
     }
 
     /** Overwrite defaults in AMReX Inputs


### PR DESCRIPTION
## Overview

Expose the reduced Planck constant $\hbar$ to the user. 

## To do

- [x] Expose the constant.
- [x] Update the documentation.
- [x] Use the constant in at least one CI test.

## Notes

Suggested by @aeriforme in https://github.com/BLAST-WarpX/warpx/pull/6511#discussion_r2714988620.