### PR TITLE
fusion reaction modifications

### DIFF
--- a/Examples/Tests/nuclear_fusion/analysis_two_product_fusion.py
+++ b/Examples/Tests/nuclear_fusion/analysis_two_product_fusion.py
@@ -65,7 +65,7 @@ if re.search("tritium", warpx_used_inputs):
     reactant_species = ["deuterium", "tritium"]
     product_species = ["helium4", "neutron"]
     ntests = 2
-    E_fusion = 17.58929696 * MeV_to_Joule  # Energy released during the fusion reaction
+    E_fusion = 17.58929696 * MeV_to_Joule
 else:
     # else, this is the D+D test
     reaction_type = "DD"

--- a/Examples/Tests/nuclear_fusion/analysis_two_product_fusion.py
+++ b/Examples/Tests/nuclear_fusion/analysis_two_product_fusion.py
@@ -65,21 +65,21 @@ if re.search("tritium", warpx_used_inputs):
     reactant_species = ["deuterium", "tritium"]
     product_species = ["helium4", "neutron"]
     ntests = 2
-    E_fusion = 17.5893 * MeV_to_Joule  # Energy released during the fusion reaction
+    E_fusion = 17.58929696 * MeV_to_Joule  # Energy released during the fusion reaction
 else:
     # else, this is the D+D test
     reaction_type = "DD"
     reactant_species = ["deuterium", "hydrogen2"]
     product_species = ["helium3", "neutron"]
     ntests = 1
-    E_fusion = 3.268911e6 * MeV_to_Joule
+    E_fusion = 3.26891111e6 * MeV_to_Joule
 
 mass = {
-    "deuterium": 2.01410177812 * scc.m_u,
-    "hydrogen2": 2.01410177812 * scc.m_u,
-    "tritium": 3.0160492779 * scc.m_u,
-    "helium3": 3.016029 * scc.m_u,
-    "helium4": 4.00260325413 * scc.m_u,
+    "deuterium": 2.01410177812 * scc.m_u - scc.m_e,
+    "hydrogen2": 2.01410177812 * scc.m_u - scc.m_e,
+    "tritium": 3.0160492779 * scc.m_u - scc.m_e,
+    "helium3": 3.016029 * scc.m_u - 2*scc.m_e,
+    "helium4": 4.00260325413 * scc.m_u - 2*scc.m_e,
     "neutron": 1.0013784193052508 * scc.m_p,
 }
 m_reduced = np.prod([mass[s] for s in reactant_species]) / np.sum(

--- a/Examples/Tests/nuclear_fusion/analysis_two_product_fusion.py
+++ b/Examples/Tests/nuclear_fusion/analysis_two_product_fusion.py
@@ -78,8 +78,8 @@ mass = {
     "deuterium": 2.01410177812 * scc.m_u - scc.m_e,
     "hydrogen2": 2.01410177812 * scc.m_u - scc.m_e,
     "tritium": 3.0160492779 * scc.m_u - scc.m_e,
-    "helium3": 3.016029 * scc.m_u - 2*scc.m_e,
-    "helium4": 4.00260325413 * scc.m_u - 2*scc.m_e,
+    "helium3": 3.016029 * scc.m_u - 2 * scc.m_e,
+    "helium4": 4.00260325413 * scc.m_u - 2 * scc.m_e,
     "neutron": 1.0013784193052508 * scc.m_p,
 }
 m_reduced = np.prod([mass[s] for s in reactant_species]) / np.sum(

--- a/Examples/Tests/nuclear_fusion/inputs_test_3d_deuterium_deuterium_fusion
+++ b/Examples/Tests/nuclear_fusion/inputs_test_3d_deuterium_deuterium_fusion
@@ -30,11 +30,14 @@ algo.particle_shape = 1
 ############ PLASMA #############
 #################################
 particles.species_names = deuterium_1 hydrogen2_1 helium3_1 neutron_1
-my_constants.m_deuterium = 2.01410177812*m_u
+my_constants.m_deuterium = 2.01410177812*m_u - m_e
+my_constants.m_helium3 = 3.01602932243*m_u - 2*m_e
 my_constants.keV_to_J = 1.e3*q_e
 my_constants.Energy_step = 22. * keV_to_J
 
 deuterium_1.species_type = deuterium
+deuterium_1.mass = m_deuterium
+deuterium_1.charge = q_e
 deuterium_1.injection_style = "NRandomPerCell"
 deuterium_1.num_particles_per_cell = 10000
 deuterium_1.profile = constant
@@ -47,6 +50,8 @@ deuterium_1.do_not_push = 1
 deuterium_1.do_not_deposit = 1
 
 hydrogen2_1.species_type = deuterium
+hydrogen2_1.mass = m_deuterium
+hydrogen2_1.charge = q_e
 hydrogen2_1.injection_style = "NRandomPerCell"
 hydrogen2_1.num_particles_per_cell = 10000
 hydrogen2_1.profile = constant
@@ -59,6 +64,8 @@ hydrogen2_1.do_not_push = 1
 hydrogen2_1.do_not_deposit = 1
 
 helium3_1.species_type = helium3
+helium3_1.mass = m_helium3
+helium3_1.charge = 2*q_e
 helium3_1.do_not_push = 1
 helium3_1.do_not_deposit = 1
 

--- a/Examples/Tests/nuclear_fusion/inputs_test_3d_deuterium_deuterium_fusion_intraspecies
+++ b/Examples/Tests/nuclear_fusion/inputs_test_3d_deuterium_deuterium_fusion_intraspecies
@@ -69,9 +69,14 @@ geometry.prob_hi =  1e-3  1e-3  1e-3
 geometry.prob_lo = -1e-3 -1e-3 -1e-3
 
 # helium3
+helium3.mass = 3.01602932243*m_u - 2*m_e
+helium3.charge = 2*q_e
 helium3.do_not_deposit = 1
 helium3.do_not_push = 1
 helium3.species_type = helium3
+
+deuterium.mass = 2.01410177812*m_u - m_e
+deuterium.charge = q_e
 
 # max_step
 max_step = 10

--- a/Examples/Tests/nuclear_fusion/inputs_test_3d_deuterium_tritium_fusion
+++ b/Examples/Tests/nuclear_fusion/inputs_test_3d_deuterium_tritium_fusion
@@ -33,13 +33,16 @@ algo.particle_shape = 1
 #################################
 particles.species_names = deuterium_1 tritium_1 helium4_1 neutron_1 deuterium_2 tritium_2 helium4_2 neutron_2
 
-my_constants.m_deuterium = 2.01410177812*m_u
-my_constants.m_tritium = 3.0160492779*m_u
+my_constants.m_deuterium = 2.01410177812*m_u - m_e
+my_constants.m_tritium = 3.0160492779*m_u - m_e
+my_constants.m_helium4 = 4.002603254*m_u - 2*m_e
 my_constants.m_reduced = m_deuterium*m_tritium/(m_deuterium+m_tritium)
 my_constants.keV_to_J = 1.e3*q_e
 my_constants.Energy_step = 22. * keV_to_J
 
 deuterium_1.species_type = deuterium
+deuterium_1.mass = m_deuterium
+deuterium_1.charge = q_e
 deuterium_1.injection_style = "NRandomPerCell"
 deuterium_1.num_particles_per_cell = 10000
 deuterium_1.profile = constant
@@ -53,6 +56,8 @@ deuterium_1.do_not_push = 1
 deuterium_1.do_not_deposit = 1
 
 tritium_1.species_type = tritium
+tritium_1.mass = m_tritium
+tritium_1.charge = q_e
 tritium_1.injection_style = "NRandomPerCell"
 tritium_1.num_particles_per_cell = 10000
 tritium_1.profile = constant
@@ -66,6 +71,8 @@ tritium_1.do_not_push = 1
 tritium_1.do_not_deposit = 1
 
 helium4_1.species_type = helium4
+helium4_1.mass = m_helium4
+helium4_1.charge = 2*q_e
 helium4_1.do_not_push = 1
 helium4_1.do_not_deposit = 1
 
@@ -79,6 +86,8 @@ my_constants.beam_dens = 1.e20
 ## A tenth of the macroparticles in each cell is made of immobile high-density background deuteriums.
 ## The other nine tenths are made of fast low-density beam deuteriums.
 deuterium_2.species_type = deuterium
+deuterium_2.mass = m_deuterium
+deuterium_2.charge = q_e
 deuterium_2.injection_sources = high_density low_density
 deuterium_2.profile = constant
 deuterium_2.high_density.injection_style = "NRandomPerCell"
@@ -96,6 +105,8 @@ deuterium_2.do_not_push = 1
 deuterium_2.do_not_deposit = 1
 
 tritium_2.species_type = tritium
+tritium_2.mass = m_tritium
+tritium_2.charge = q_e
 tritium_2.injection_style = "NRandomPerCell"
 tritium_2.num_particles_per_cell = 100
 tritium_2.profile = constant
@@ -105,6 +116,8 @@ tritium_2.do_not_push = 1
 tritium_2.do_not_deposit = 1
 
 helium4_2.species_type = helium4
+helium4_2.mass = m_helium4
+helium4_2.charge = 2*q_e
 helium4_2.do_not_push = 1
 helium4_2.do_not_deposit = 1
 

--- a/Examples/Tests/nuclear_fusion/inputs_test_rz_deuterium_tritium_fusion
+++ b/Examples/Tests/nuclear_fusion/inputs_test_rz_deuterium_tritium_fusion
@@ -31,13 +31,16 @@ algo.particle_shape = 1
 #################################
 particles.species_names = deuterium_1 tritium_1 helium4_1 neutron_1 deuterium_2 tritium_2 helium4_2 neutron_2
 
-my_constants.m_deuterium = 2.01410177812*m_u
-my_constants.m_tritium = 3.0160492779*m_u
+my_constants.m_deuterium = 2.01410177812*m_u - m_e
+my_constants.m_tritium = 3.0160492779*m_u - m_e
+my_constants.m_helium4 = 4.002603254*m_u - 2*m_e
 my_constants.m_reduced = m_deuterium*m_tritium/(m_deuterium+m_tritium)
 my_constants.keV_to_J = 1.e3*q_e
 my_constants.Energy_step = 22. * keV_to_J
 
 deuterium_1.species_type = deuterium
+deuterium_1.mass = m_deuterium
+deuterium_1.charge = q_e
 deuterium_1.injection_style = "NRandomPerCell"
 deuterium_1.num_particles_per_cell = 80000
 deuterium_1.profile = constant
@@ -51,6 +54,8 @@ deuterium_1.do_not_push = 1
 deuterium_1.do_not_deposit = 1
 
 tritium_1.species_type = tritium
+tritium_1.mass = m_tritium
+tritium_1.charge = q_e
 tritium_1.injection_style = "NRandomPerCell"
 tritium_1.num_particles_per_cell = 80000
 tritium_1.profile = constant
@@ -64,6 +69,8 @@ tritium_1.do_not_push = 1
 tritium_1.do_not_deposit = 1
 
 helium4_1.species_type = helium4
+helium4_1.mass = m_helium4
+helium4_1.charge = 2*q_e
 helium4_1.do_not_push = 1
 helium4_1.do_not_deposit = 1
 
@@ -75,6 +82,8 @@ my_constants.background_dens = 1.e26
 my_constants.beam_dens = 1.e20
 
 deuterium_2.species_type = deuterium
+deuterium_2.mass = m_deuterium
+deuterium_2.charge = q_e
 deuterium_2.injection_style = "NRandomPerCell"
 deuterium_2.num_particles_per_cell = 8000
 deuterium_2.profile = "parse_density_function"
@@ -90,6 +99,8 @@ deuterium_2.do_not_push = 1
 deuterium_2.do_not_deposit = 1
 
 tritium_2.species_type = tritium
+tritium_2.mass = m_tritium
+tritium_2.charge = q_e
 tritium_2.injection_style = "NRandomPerCell"
 tritium_2.num_particles_per_cell = 800
 tritium_2.profile = constant
@@ -99,6 +110,8 @@ tritium_2.do_not_push = 1
 tritium_2.do_not_deposit = 1
 
 helium4_2.species_type = helium4
+helium4_2.mass = m_helium4
+helium4_2.charge = 2*q_e
 helium4_2.do_not_push = 1
 helium4_2.do_not_deposit = 1
 

--- a/Regression/Checksum/benchmarks_json/test_3d_deuterium_deuterium_fusion.json
+++ b/Regression/Checksum/benchmarks_json/test_3d_deuterium_deuterium_fusion.json
@@ -3,75 +3,39 @@
     "rho": 0.0
   },
   "neutron_1": {
-    "particle_momentum_x": 1.7310714493106769e-15,
-    "particle_momentum_y": 1.7337662062303444e-15,
-    "particle_momentum_z": 1.7485449335777024e-15,
-    "particle_position_x": 152283.380694966,
-    "particle_position_y": 152069.83075250097,
-    "particle_position_z": 322577.923990014,
-    "particle_weight": 4.363892248697456e-28
+    "particle_momentum_x": 8.477106097580282e-16,
+    "particle_momentum_y": 8.494075080308136e-16,
+    "particle_momentum_z": 8.575905671646498e-16,
+    "particle_position_x": 151686.87937126803,
+    "particle_position_y": 151928.09288428642,
+    "particle_position_z": 324033.96747163753,
+    "particle_weight": 2.7171234012631196e-28
   },
-  "neutron_2": {
-    "particle_momentum_x": 1.5387619693344148e-15,
-    "particle_momentum_y": 1.5341905540771557e-15,
-    "particle_momentum_z": 1.56371311678065e-15,
-    "particle_position_x": 137063.00776354707,
-    "particle_position_y": 136567.75867578376,
-    "particle_position_z": 290047.8366438016,
-    "particle_weight": 6.36267828626072e+18
+  "hydrogen2_1": {
+    "particle_momentum_x": 0.0,
+    "particle_momentum_y": 0.0,
+    "particle_momentum_z": 2.636536939475031e-13,
+    "particle_position_x": 40958301.59165427,
+    "particle_position_y": 40961136.144767165,
+    "particle_position_z": 81920546.1918127,
+    "particle_weight": 1024.0000000000002
   },
   "deuterium_1": {
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 2.8872569136407634e-13,
-    "particle_position_x": 40958427.50992301,
-    "particle_position_y": 40959476.34450768,
-    "particle_position_z": 81921930.27522022,
+    "particle_momentum_z": 2.636536939475031e-13,
+    "particle_position_x": 40960140.729837954,
+    "particle_position_y": 40959772.6931011,
+    "particle_position_z": 81919021.52308556,
     "particle_weight": 1024.0000000000002
   },
-  "helium4_1": {
-    "particle_momentum_x": 1.7310714493106769e-15,
-    "particle_momentum_y": 1.7337662062303444e-15,
-    "particle_momentum_z": 1.7485449335777024e-15,
-    "particle_position_x": 152283.380694966,
-    "particle_position_y": 152069.83075250097,
-    "particle_position_z": 322577.923990014,
-    "particle_weight": 4.363892248697456e-28
-  },
-  "tritium_1": {
-    "particle_momentum_x": 0.0,
-    "particle_momentum_y": 0.0,
-    "particle_momentum_z": 2.887256913640763e-13,
-    "particle_position_x": 40959200.11081588,
-    "particle_position_y": 40960650.407891415,
-    "particle_position_z": 81920772.7986121,
-    "particle_weight": 1024.0000000000002
-  },
-  "deuterium_2": {
-    "particle_momentum_x": 0.0,
-    "particle_momentum_y": 0.0,
-    "particle_momentum_z": 3.3557636677529175e-14,
-    "particle_position_x": 4096177.5590849468,
-    "particle_position_y": 4096353.028787281,
-    "particle_position_z": 8192362.405430986,
-    "particle_weight": 1.0240001137714152e+30
-  },
-  "helium4_2": {
-    "particle_momentum_x": 1.5387619693344148e-15,
-    "particle_momentum_y": 1.5341905540771557e-15,
-    "particle_momentum_z": 1.7706755686053569e-15,
-    "particle_position_x": 137063.00776354707,
-    "particle_position_y": 136567.75867578376,
-    "particle_position_z": 290047.8366438016,
-    "particle_weight": 6.36267828626072e+18
-  },
-  "tritium_2": {
-    "particle_momentum_x": 0.0,
-    "particle_momentum_y": 0.0,
-    "particle_momentum_z": 0.0,
-    "particle_position_x": 409665.26647015393,
-    "particle_position_y": 409535.84596852644,
-    "particle_position_z": 819126.8984535292,
-    "particle_weight": 1.0239999999363732e+29
+  "helium3_1": {
+    "particle_momentum_x": 8.477106097580282e-16,
+    "particle_momentum_y": 8.494075080308136e-16,
+    "particle_momentum_z": 8.575905671646498e-16,
+    "particle_position_x": 151686.87937126803,
+    "particle_position_y": 151928.09288428642,
+    "particle_position_z": 324033.96747163753,
+    "particle_weight": 2.7171234012631196e-28
   }
 }

--- a/Regression/Checksum/benchmarks_json/test_3d_deuterium_deuterium_fusion.json
+++ b/Regression/Checksum/benchmarks_json/test_3d_deuterium_deuterium_fusion.json
@@ -3,39 +3,75 @@
     "rho": 0.0
   },
   "neutron_1": {
-    "particle_momentum_x": 8.477495602882156e-16,
-    "particle_momentum_y": 8.494465365620978e-16,
-    "particle_momentum_z": 8.576299715768024e-16,
-    "particle_position_x": 151686.87937126803,
-    "particle_position_y": 151928.09288428642,
-    "particle_position_z": 324033.96747163753,
-    "particle_weight": 2.7164741867515402e-28
+    "particle_momentum_x": 1.7310714493106769e-15,
+    "particle_momentum_y": 1.7337662062303444e-15,
+    "particle_momentum_z": 1.7485449335777024e-15,
+    "particle_position_x": 152283.380694966,
+    "particle_position_y": 152069.83075250097,
+    "particle_position_z": 322577.923990014,
+    "particle_weight": 4.363892248697456e-28
   },
-  "hydrogen2_1": {
-    "particle_momentum_x": 0.0,
-    "particle_momentum_y": 0.0,
-    "particle_momentum_z": 2.636896068972286e-13,
-    "particle_position_x": 40958301.59165427,
-    "particle_position_y": 40961136.144767165,
-    "particle_position_z": 81920546.1918127,
-    "particle_weight": 1024.0000000000002
+  "neutron_2": {
+    "particle_momentum_x": 1.5387619693344148e-15,
+    "particle_momentum_y": 1.5341905540771557e-15,
+    "particle_momentum_z": 1.56371311678065e-15,
+    "particle_position_x": 137063.00776354707,
+    "particle_position_y": 136567.75867578376,
+    "particle_position_z": 290047.8366438016,
+    "particle_weight": 6.36267828626072e+18
   },
   "deuterium_1": {
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 2.636896068972286e-13,
-    "particle_position_x": 40960140.729837954,
-    "particle_position_y": 40959772.6931011,
-    "particle_position_z": 81919021.52308556,
+    "particle_momentum_z": 2.8872569136407634e-13,
+    "particle_position_x": 40958427.50992301,
+    "particle_position_y": 40959476.34450768,
+    "particle_position_z": 81921930.27522022,
     "particle_weight": 1024.0000000000002
   },
-  "helium3_1": {
-    "particle_momentum_x": 8.477495602882156e-16,
-    "particle_momentum_y": 8.494465365620978e-16,
-    "particle_momentum_z": 8.576299715768024e-16,
-    "particle_position_x": 151686.87937126803,
-    "particle_position_y": 151928.09288428642,
-    "particle_position_z": 324033.96747163753,
-    "particle_weight": 2.7164741867515402e-28
+  "helium4_1": {
+    "particle_momentum_x": 1.7310714493106769e-15,
+    "particle_momentum_y": 1.7337662062303444e-15,
+    "particle_momentum_z": 1.7485449335777024e-15,
+    "particle_position_x": 152283.380694966,
+    "particle_position_y": 152069.83075250097,
+    "particle_position_z": 322577.923990014,
+    "particle_weight": 4.363892248697456e-28
+  },
+  "tritium_1": {
+    "particle_momentum_x": 0.0,
+    "particle_momentum_y": 0.0,
+    "particle_momentum_z": 2.887256913640763e-13,
+    "particle_position_x": 40959200.11081588,
+    "particle_position_y": 40960650.407891415,
+    "particle_position_z": 81920772.7986121,
+    "particle_weight": 1024.0000000000002
+  },
+  "deuterium_2": {
+    "particle_momentum_x": 0.0,
+    "particle_momentum_y": 0.0,
+    "particle_momentum_z": 3.3557636677529175e-14,
+    "particle_position_x": 4096177.5590849468,
+    "particle_position_y": 4096353.028787281,
+    "particle_position_z": 8192362.405430986,
+    "particle_weight": 1.0240001137714152e+30
+  },
+  "helium4_2": {
+    "particle_momentum_x": 1.5387619693344148e-15,
+    "particle_momentum_y": 1.5341905540771557e-15,
+    "particle_momentum_z": 1.7706755686053569e-15,
+    "particle_position_x": 137063.00776354707,
+    "particle_position_y": 136567.75867578376,
+    "particle_position_z": 290047.8366438016,
+    "particle_weight": 6.36267828626072e+18
+  },
+  "tritium_2": {
+    "particle_momentum_x": 0.0,
+    "particle_momentum_y": 0.0,
+    "particle_momentum_z": 0.0,
+    "particle_position_x": 409665.26647015393,
+    "particle_position_y": 409535.84596852644,
+    "particle_position_z": 819126.8984535292,
+    "particle_weight": 1.0239999999363732e+29
   }
 }

--- a/Regression/Checksum/benchmarks_json/test_3d_deuterium_deuterium_fusion_intraspecies.json
+++ b/Regression/Checksum/benchmarks_json/test_3d_deuterium_deuterium_fusion_intraspecies.json
@@ -1,34 +1,34 @@
 {
   "lev=0": {
     "rho": 0.0,
-    "rho_deuterium": 8203144355.757888,
-    "rho_helium3": 10.322073067238197
+    "rho_deuterium": 8203144355.80541,
+    "rho_helium3": 10.274550018890462
   },
   "helium3": {
-    "particle_momentum_x": 2.2755537529971356e-15,
-    "particle_momentum_y": 2.2763827374702e-15,
-    "particle_momentum_z": 2.2733584420781805e-15,
-    "particle_position_x": 61.9503391554242,
-    "particle_position_y": 61.83918251859879,
-    "particle_position_z": 61.76618143672486,
-    "particle_weight": 503322755.5969865
+    "particle_momentum_x": 2.2678057945495794e-15,
+    "particle_momentum_y": 2.2627608826105852e-15,
+    "particle_momentum_z": 2.2655751808270545e-15,
+    "particle_position_x": 62.0798083736711,
+    "particle_position_y": 61.614790911479886,
+    "particle_position_z": 61.699052665954255,
+    "particle_weight": 501005446.71020186
   },
   "deuterium": {
-    "particle_momentum_x": 1.3380470556589651e-14,
-    "particle_momentum_y": 1.3367685564720685e-14,
-    "particle_momentum_z": 1.3372922635283194e-14,
-    "particle_position_x": 2559.782513518522,
-    "particle_position_y": 2559.8747993471684,
-    "particle_position_z": 2560.2864832238383,
-    "particle_weight": 7.99999998993355e+17
+    "particle_momentum_x": 1.3376826124416158e-14,
+    "particle_momentum_y": 1.3364044614789138e-14,
+    "particle_momentum_z": 1.3369280258933295e-14,
+    "particle_position_x": 2559.7825135185212,
+    "particle_position_y": 2559.8747993471693,
+    "particle_position_z": 2560.2864832238374,
+    "particle_weight": 7.999999899979891e+17
   },
-    "neutron": {
-    "particle_momentum_x": 2.2589333563965173e-15,
-    "particle_momentum_y": 2.2597812963562692e-15,
-    "particle_momentum_z": 2.2596784569708825e-15,
-    "particle_position_x": 61.9503391554242,
-    "particle_position_y": 61.83918251859879,
-    "particle_position_z": 61.76618143672486,
-    "particle_weight": 503322755.5969865
+  "neutron": {
+    "particle_momentum_x": 2.2554227209562372e-15,
+    "particle_momentum_y": 2.25228229923665e-15,
+    "particle_momentum_z": 2.2485277078454835e-15,
+    "particle_position_x": 62.0798083736711,
+    "particle_position_y": 61.614790911479886,
+    "particle_position_z": 61.699052665954255,
+    "particle_weight": 501005446.71020186
   }
 }

--- a/Regression/Checksum/benchmarks_json/test_3d_deuterium_deuterium_fusion_intraspecies.json
+++ b/Regression/Checksum/benchmarks_json/test_3d_deuterium_deuterium_fusion_intraspecies.json
@@ -20,7 +20,7 @@
     "particle_position_x": 2559.7825135185212,
     "particle_position_y": 2559.8747993471693,
     "particle_position_z": 2560.2864832238374,
-    "particle_weight": 7.999999899979891e+17
+    "particle_weight": 7.999999989979891e+17
   },
   "neutron": {
     "particle_momentum_x": 2.2554227209562372e-15,

--- a/Regression/Checksum/benchmarks_json/test_3d_deuterium_tritium_fusion.json
+++ b/Regression/Checksum/benchmarks_json/test_3d_deuterium_tritium_fusion.json
@@ -3,13 +3,13 @@
     "rho": 0.0
   },
   "helium4_1": {
-    "particle_momentum_x": 1.7311199180516126e-15,
-    "particle_momentum_y": 1.7338147503562452e-15,
-    "particle_momentum_z": 1.7485938912536062e-15,
+    "particle_momentum_x": 1.731071449310677e-15,
+    "particle_momentum_y": 1.733766206230344e-15,
+    "particle_momentum_z": 1.748544933577702e-15,
     "particle_position_x": 152283.380694966,
     "particle_position_y": 152069.83075250097,
     "particle_position_z": 322577.923990014,
-    "particle_weight": 4.361993850388992e-28
+    "particle_weight": 4.363892248697456e-28
   },
   "tritium_2": {
     "particle_momentum_x": 0.0,
@@ -23,7 +23,7 @@
   "deuterium_1": {
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 2.887597874931968e-13,
+    "particle_momentum_z": 2.887256913640763e-13,
     "particle_position_x": 40958427.50992301,
     "particle_position_y": 40959476.34450768,
     "particle_position_z": 81921930.27522022,
@@ -32,46 +32,46 @@
   "deuterium_2": {
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 3.356220764978016e-14,
+    "particle_momentum_z": 3.355763667752917e-14,
     "particle_position_x": 4096177.5590849468,
     "particle_position_y": 4096353.028787281,
     "particle_position_z": 8192362.405430986,
     "particle_weight": 1.024000113771418e+30
   },
   "neutron_2": {
-    "particle_momentum_x": 1.5388034497124766e-15,
-    "particle_momentum_y": 1.5342319239526277e-15,
-    "particle_momentum_z": 1.5637518001781312e-15,
+    "particle_momentum_x": 1.538761969334415e-15,
+    "particle_momentum_y": 1.534190554077156e-15,
+    "particle_momentum_z": 1.563713116780650e-15,
     "particle_position_x": 137063.00776354707,
     "particle_position_y": 136567.75867578376,
     "particle_position_z": 290047.8366438016,
-    "particle_weight": 6.359804698260204e+18
+    "particle_weight": 6.362678286260720e+18
   },
   "tritium_1": {
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 2.887597874931969e-13,
+    "particle_momentum_z": 2.887256913640763e-13,
     "particle_position_x": 40959200.11081588,
     "particle_position_y": 40960650.407891415,
     "particle_position_z": 81920772.7986121,
     "particle_weight": 1024.0000000000002
   },
   "neutron_1": {
-    "particle_momentum_x": 1.7311199180516126e-15,
-    "particle_momentum_y": 1.7338147503562452e-15,
-    "particle_momentum_z": 1.7485938912536062e-15,
+    "particle_momentum_x": 1.731071449310677e-15,
+    "particle_momentum_y": 1.733766206230344e-15,
+    "particle_momentum_z": 1.748544933577702e-15,
     "particle_position_x": 152283.380694966,
     "particle_position_y": 152069.83075250097,
     "particle_position_z": 322577.923990014,
-    "particle_weight": 4.361993850388992e-28
+    "particle_weight": 4.363892248697456e-28
   },
   "helium4_2": {
-    "particle_momentum_x": 1.5388034497124766e-15,
-    "particle_momentum_y": 1.5342319239526277e-15,
-    "particle_momentum_z": 1.7707977198221455e-15,
+    "particle_momentum_x": 1.538761969334415e-15,
+    "particle_momentum_y": 1.534190554077156e-15,
+    "particle_momentum_z": 1.770675568605357e-15,
     "particle_position_x": 137063.00776354707,
     "particle_position_y": 136567.75867578376,
     "particle_position_z": 290047.8366438016,
-    "particle_weight": 6.359804698260204e+18
+    "particle_weight": 6.362678286260720e+18
   }
 }

--- a/Regression/Checksum/benchmarks_json/test_rz_deuterium_tritium_fusion.json
+++ b/Regression/Checksum/benchmarks_json/test_rz_deuterium_tritium_fusion.json
@@ -3,8 +3,8 @@
     "rho": 0.0
   },
   "deuterium_1": {
-    "particle_momentum_x": 1.838810652474529e-13,
-    "particle_momentum_y": 1.8378687912933116e-13,
+    "particle_momentum_x": 1.838593529702763e-13,
+    "particle_momentum_y": 1.8376517797344702e-13,
     "particle_momentum_z": 0.0,
     "particle_position_x": 40959919.49981932,
     "particle_position_y": 81919224.48541152,
@@ -12,8 +12,8 @@
     "particle_weight": 3216.9845548065423
   },
   "tritium_1": {
-    "particle_momentum_x": 1.8384658076563296e-13,
-    "particle_momentum_y": 1.8381593270738909e-13,
+    "particle_momentum_x": 1.838248725603091e-13,
+    "particle_momentum_y": 1.8379422812092149e-13,
     "particle_momentum_z": 0.0,
     "particle_position_x": 40961278.05265873,
     "particle_position_y": 81919046.80615619,
@@ -21,27 +21,27 @@
     "particle_weight": 3217.0912552970376
   },
   "neutron_1": {
-    "particle_momentum_x": 1.7123352747380779e-15,
-    "particle_momentum_y": 1.7121008623539103e-15,
-    "particle_momentum_z": 1.6991295402159603e-15,
+    "particle_momentum_x": 1.7122904597203425e-15,
+    "particle_momentum_y": 1.7120560377796358e-15,
+    "particle_momentum_z": 1.6990827219290997e-15,
     "particle_position_x": 153058.5396596282,
     "particle_position_y": 323829.80734903406,
     "particle_theta": 119401.22274685159,
     "particle_weight": 1.6082587046012702e-27
   },
   "neutron_2": {
-    "particle_momentum_x": 1.4997950543604016e-15,
-    "particle_momentum_y": 1.5086448920733112e-15,
-    "particle_momentum_z": 1.5199131819763022e-15,
+    "particle_momentum_x": 1.4997546514532024e-15,
+    "particle_momentum_y": 1.5086042404986442e-15,
+    "particle_momentum_z": 1.5198755020994225e-15,
     "particle_position_x": 134423.92337501387,
     "particle_position_y": 285577.6387703867,
     "particle_theta": 105680.28364348292,
     "particle_weight": 2.041726988733404e+19
   },
   "helium4_2": {
-    "particle_momentum_x": 1.4997950543604016e-15,
-    "particle_momentum_y": 1.5086448920733112e-15,
-    "particle_momentum_z": 1.7330116691673047e-15,
+    "particle_momentum_x": 1.4997546514532024e-15,
+    "particle_momentum_y": 1.5086042404986442e-15,
+    "particle_momentum_z": 1.7328894186014038e-15,
     "particle_position_x": 134423.92337501387,
     "particle_position_y": 285577.6387703867,
     "particle_theta": 105680.28364348292,
@@ -50,16 +50,16 @@
   "deuterium_2": {
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 3.33636409658059e-14,
+    "particle_momentum_z": 3.3359097037151443e-14,
     "particle_position_x": 4095908.9083809247,
     "particle_position_y": 8192069.080030458,
     "particle_theta": 3216444.3489102134,
     "particle_weight": 3.189841790201597e+29
   },
   "helium4_1": {
-    "particle_momentum_x": 1.8690759000444728e-15,
-    "particle_momentum_y": 1.859853519908541e-15,
-    "particle_momentum_z": 1.6991295402159603e-15,
+    "particle_momentum_x": 1.8689763544522273e-15,
+    "particle_momentum_y": 1.859757385280196e-15,
+    "particle_momentum_z": 1.6990827219290997e-15,
     "particle_position_x": 153058.5396596282,
     "particle_position_y": 323829.80734903406,
     "particle_theta": 119401.22274685159,

--- a/Regression/Checksum/benchmarks_json/test_rz_deuterium_tritium_fusion.json
+++ b/Regression/Checksum/benchmarks_json/test_rz_deuterium_tritium_fusion.json
@@ -27,7 +27,7 @@
     "particle_position_x": 153058.5396596282,
     "particle_position_y": 323829.80734903406,
     "particle_theta": 119401.22274685159,
-    "particle_weight": 1.6082587046012702e-27
+    "particle_weight": 1.608958422777692e-27
   },
   "neutron_2": {
     "particle_momentum_x": 1.4997546514532024e-15,
@@ -36,7 +36,7 @@
     "particle_position_x": 134423.92337501387,
     "particle_position_y": 285577.6387703867,
     "particle_theta": 105680.28364348292,
-    "particle_weight": 2.041726988733404e+19
+    "particle_weight": 2.042657487082456e+19
   },
   "helium4_2": {
     "particle_momentum_x": 1.4997546514532024e-15,
@@ -45,7 +45,7 @@
     "particle_position_x": 134423.92337501387,
     "particle_position_y": 285577.6387703867,
     "particle_theta": 105680.28364348292,
-    "particle_weight": 2.041726988733404e+19
+    "particle_weight": 2.042657487082456e+19
   },
   "deuterium_2": {
     "particle_momentum_x": 0.0,
@@ -63,7 +63,7 @@
     "particle_position_x": 153058.5396596282,
     "particle_position_y": 323829.80734903406,
     "particle_theta": 119401.22274685159,
-    "particle_weight": 1.6082587046012702e-27
+    "particle_weight": 1.608958422777692e-27
   },
   "tritium_2": {
     "particle_momentum_x": 0.0,

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.H
@@ -39,6 +39,10 @@ namespace BinaryCollisionUtils{
     NuclearFusionType get_nuclear_fusion_type (const std::string& collision_name,
                                                MultiParticleContainer const * mypc);
 
+    amrex::ParticleReal get_nuclear_fusion_energy (const std::string& collision_name,
+                                                   const NuclearFusionType fusion_type,
+                                               MultiParticleContainer const * mypc);
+
     CollisionType get_collision_type (const std::string& collision_name,
                                       MultiParticleContainer const * mypc);
 

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.H
@@ -39,12 +39,18 @@ namespace BinaryCollisionUtils{
     NuclearFusionType get_nuclear_fusion_type (const std::string& collision_name,
                                                MultiParticleContainer const * mypc);
 
+    amrex::ParticleReal get_reaction_energy (const std::string& collision_name,
+                                             const CollisionType collision_type,
+                                             MultiParticleContainer const * mypc);
+
     amrex::ParticleReal get_nuclear_fusion_energy (const std::string& collision_name,
-                                                   const NuclearFusionType fusion_type,
+                                                   const CollisionType collision_type,
                                                MultiParticleContainer const * mypc);
 
     CollisionType get_collision_type (const std::string& collision_name,
                                       MultiParticleContainer const * mypc);
+
+    bool is_fusion_type (const CollisionType collision_type);
 
     CollisionType nuclear_fusion_type_to_collision_type (NuclearFusionType fusion_type);
 

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
@@ -183,14 +183,30 @@ namespace BinaryCollisionUtils{
         return NuclearFusionType::Undefined;
     }
 
+    amrex::ParticleReal get_reaction_energy (const std::string& collision_name,
+                                             const CollisionType collision_type,
+                                             MultiParticleContainer const * const mypc)
+    {
+        amrex::ParticleReal reaction_energy = 0.0;
+        if (is_fusion_type(collision_type)) {
+            reaction_energy = get_nuclear_fusion_energy(collision_name,
+                                                        collision_type, mypc);
+        }
+        return reaction_energy;
+    }
+
     amrex::ParticleReal get_nuclear_fusion_energy (const std::string& collision_name,
-                                                   const NuclearFusionType fusion_type,
+                                                   const CollisionType collision_type,
                                               MultiParticleContainer const * const mypc)
     {
         using namespace amrex::literals;
 
+        // Check if collision type is fusion type
+        if (!is_fusion_type(collision_type)) { return 0.0; }
+
         const amrex::ParmParse pp_collision_name(collision_name);
 
+        // Compute the total mass of the colliding species
         amrex::Vector<std::string> species_names;
         pp_collision_name.getarr("species", species_names);
         amrex::ParticleReal mass_before = 0.0_prt;
@@ -199,6 +215,7 @@ namespace BinaryCollisionUtils{
             mass_before += species.getMass();
         }
 
+        // Compute the total mass of the product species
         amrex::Vector<std::string> product_species_names;
         pp_collision_name.getarr("product_species", product_species_names);
         amrex::ParticleReal mass_after = 0.0_prt;
@@ -207,38 +224,40 @@ namespace BinaryCollisionUtils{
             mass_after += product_species.getMass();
         }
 
+        // Compute the fusion energy
         amrex::ParticleReal fusion_energy = (mass_before - mass_after)*PhysConst::c2;
 
+        // Verify that the fusion energy is close to what is exected
         const amrex::ParticleReal energy_tolerance = PhysConst::m_e * PhysConst::c2 * PhysConst::q_e;
-        if (fusion_type == NuclearFusionType::DeuteriumTritiumToNeutronHelium) {
+        if (collision_type == CollisionType::DeuteriumTritiumToNeutronHeliumFusion) {
             const amrex::ParticleReal expected_fusion_energy = 17.58929696e6_prt * PhysConst::q_e;
             const amrex::ParticleReal energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 energy_error < energy_tolerance,
                 "ERROR: D + T -> He4 + n fusion energy error is too large. Make sure species mass are set properly.");
         }
-        if (fusion_type == NuclearFusionType::DeuteriumDeuteriumToProtonTritium) {
+        if (collision_type == CollisionType::DeuteriumDeuteriumToProtonTritiumFusion) {
             const amrex::ParticleReal expected_fusion_energy = 4.032653948e6_prt * PhysConst::q_e;
             const amrex::ParticleReal energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 energy_error < energy_tolerance,
                 "ERROR: D + D -> T + p fusion energy error is too large. Make sure species mass are set properly.");
         }
-        if (fusion_type == NuclearFusionType::DeuteriumDeuteriumToNeutronHelium) {
+        if (collision_type == CollisionType::DeuteriumDeuteriumToNeutronHeliumFusion) {
             const amrex::ParticleReal expected_fusion_energy = 3.26891111e6_prt * PhysConst::q_e;
             const amrex::ParticleReal energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 energy_error < energy_tolerance,
                 "ERROR: D + D -> He3 + n fusion energy error is too large. Make sure species mass are set properly.");
         }
-        if (fusion_type == NuclearFusionType::DeuteriumHeliumToProtonHelium) {
+        if (collision_type == CollisionType::DeuteriumHeliumToProtonHeliumFusion) {
             const amrex::ParticleReal expected_fusion_energy = 18.35303980e6_prt * PhysConst::q_e;
             const amrex::ParticleReal energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 energy_error < energy_tolerance,
                 "ERROR: D + He3 -> He4 + p fusion energy error is too large. Make sure species mass are set properly.");
         }
-        if (fusion_type == NuclearFusionType::ProtonBoronToAlphas) {
+        if (collision_type == CollisionType::ProtonBoronToAlphasFusion) {
             const amrex::ParticleReal expected_fusion_energy = 8.68212502e6_prt * PhysConst::q_e;
             const amrex::ParticleReal energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
@@ -268,5 +287,20 @@ namespace BinaryCollisionUtils{
         }
         WARPX_ABORT_WITH_MESSAGE("Invalid nuclear fusion type");
         return CollisionType::Undefined;
+    }
+
+    bool is_fusion_type (const CollisionType collision_type)
+    {
+        if ((collision_type == CollisionType::DeuteriumTritiumToNeutronHeliumFusion) ||
+            (collision_type == CollisionType::DeuteriumDeuteriumToProtonTritiumFusion) ||
+            (collision_type == CollisionType::DeuteriumDeuteriumToNeutronHeliumFusion) ||
+            (collision_type == CollisionType::DeuteriumHeliumToProtonHeliumFusion) ||
+            (collision_type == CollisionType::ProtonBoronToAlphasFusion))
+        {
+            return true;
+        }
+        else {
+            return false;
+        }
     }
 }

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
@@ -14,6 +14,7 @@
 #include <AMReX_Vector.H>
 
 #include <string>
+#include <sstream>
 
 #include "Utils/TextMsg.H"
 
@@ -224,46 +225,54 @@ namespace BinaryCollisionUtils{
             mass_after += product_species.getMass();
         }
 
+        // pB11 fusion only has one product species, but 3 are created
+        if (collision_type == CollisionType::ProtonBoronToAlphasFusion) {
+            mass_after *= 3.0_prt;
+        }
+
         // Compute the fusion energy
         amrex::ParticleReal fusion_energy = (mass_before - mass_after)*PhysConst::c2;
 
         // Verify that the fusion energy is close to what is exected
+        std::ostringstream error_msg;
+        amrex::ParticleReal expected_fusion_energy, energy_error;
         const amrex::ParticleReal energy_tolerance = PhysConst::m_e * PhysConst::c2;
         if (collision_type == CollisionType::DeuteriumTritiumToNeutronHeliumFusion) {
-            const amrex::ParticleReal expected_fusion_energy = 17.58929696e6_prt * PhysConst::q_e;
-            const amrex::ParticleReal energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
-            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                energy_error < energy_tolerance,
-                "ERROR: D + T -> He4 + n fusion energy error is too large. Make sure species mass are set properly.");
+            expected_fusion_energy = 17.58929696e6_prt * PhysConst::q_e;
+            energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
+            error_msg << "Fusion energy mismatch in D + T -> He4 + n\n";
         }
         if (collision_type == CollisionType::DeuteriumDeuteriumToProtonTritiumFusion) {
-            const amrex::ParticleReal expected_fusion_energy = 4.032653948e6_prt * PhysConst::q_e;
-            const amrex::ParticleReal energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
-            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                energy_error < energy_tolerance,
-                "ERROR: D + D -> T + p fusion energy error is too large. Make sure species mass are set properly.");
+            expected_fusion_energy = 4.032653948e6_prt * PhysConst::q_e;
+            energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
+            error_msg << "Fusion energy mismatch in D + D -> T + p\n";
         }
         if (collision_type == CollisionType::DeuteriumDeuteriumToNeutronHeliumFusion) {
-            const amrex::ParticleReal expected_fusion_energy = 3.26891111e6_prt * PhysConst::q_e;
-            const amrex::ParticleReal energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
-            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                energy_error < energy_tolerance,
-                "ERROR: D + D -> He3 + n fusion energy error is too large. Make sure species mass are set properly.");
+            expected_fusion_energy = 3.26891111e6_prt * PhysConst::q_e;
+            energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
+            error_msg << "Fusion energy mismatch in D + D -> He3 + n\n";
         }
         if (collision_type == CollisionType::DeuteriumHeliumToProtonHeliumFusion) {
-            const amrex::ParticleReal expected_fusion_energy = 18.35303980e6_prt * PhysConst::q_e;
-            const amrex::ParticleReal energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
-            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                energy_error < energy_tolerance,
-                "ERROR: D + He3 -> He4 + p fusion energy error is too large. Make sure species mass are set properly.");
+            expected_fusion_energy = 18.35303980e6_prt * PhysConst::q_e;
+            energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
+            error_msg << "Fusion energy mismatch in D + He3 -> He3 + p\n";
         }
         if (collision_type == CollisionType::ProtonBoronToAlphasFusion) {
-            const amrex::ParticleReal expected_fusion_energy = 8.68212502e6_prt * PhysConst::q_e;
-            const amrex::ParticleReal energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
-            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                energy_error < energy_tolerance,
-                "ERROR: p + B11 -> He4 + He4 + He4 fusion energy error is too large. Make sure species mass are set properly.");
+            expected_fusion_energy = 8.68212502e6_prt * PhysConst::q_e;
+            energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
+            error_msg << "Fusion energy mismatch in p + B11 -> 3 He4\n";
         }
+
+        error_msg << "  energy error [eV]           = " << energy_error / PhysConst::q_e << "\n"
+                  << "  energy tolerance [eV]       = " << energy_tolerance / PhysConst::q_e << "\n"
+                  << "  expected fusion energy [eV] = " << expected_fusion_energy / PhysConst::q_e << "\n"
+                  << "  computed fusion energy [eV] = " << fusion_energy / PhysConst::q_e<< "\n"
+                  << "Check that species masses are set correctly.";
+
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+            energy_error < energy_tolerance,
+            error_msg.str()
+        );
 
         return fusion_energy;
     }

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
@@ -243,7 +243,7 @@ namespace BinaryCollisionUtils{
             const amrex::ParticleReal energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 energy_error < energy_tolerance,
-                "ERROR: p +  -> He4 + He4 + He4 fusion energy error is too large. Make sure species mass are set properly.");
+                "ERROR: p + B11 -> He4 + He4 + He4 fusion energy error is too large. Make sure species mass are set properly.");
         }
 
         return fusion_energy;

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
@@ -228,7 +228,7 @@ namespace BinaryCollisionUtils{
         amrex::ParticleReal fusion_energy = (mass_before - mass_after)*PhysConst::c2;
 
         // Verify that the fusion energy is close to what is exected
-        const amrex::ParticleReal energy_tolerance = PhysConst::m_e * PhysConst::c2 * PhysConst::q_e;
+        const amrex::ParticleReal energy_tolerance = PhysConst::m_e * PhysConst::c2;
         if (collision_type == CollisionType::DeuteriumTritiumToNeutronHeliumFusion) {
             const amrex::ParticleReal expected_fusion_energy = 17.58929696e6_prt * PhysConst::q_e;
             const amrex::ParticleReal energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
@@ -15,6 +15,7 @@
 
 #include <string>
 #include <sstream>
+#include <limits>
 
 #include "Utils/TextMsg.H"
 
@@ -235,7 +236,8 @@ namespace BinaryCollisionUtils{
 
         // Verify that the fusion energy is close to what is exected
         std::ostringstream error_msg;
-        amrex::ParticleReal expected_fusion_energy, energy_error;
+        amrex::ParticleReal expected_fusion_energy = 0.0_prt;
+        amrex::ParticleReal energy_error = std::numeric_limits<amrex::ParticleReal>::max();
         const amrex::ParticleReal energy_tolerance = PhysConst::m_e * PhysConst::c2;
         if (collision_type == CollisionType::DeuteriumTritiumToNeutronHeliumFusion) {
             expected_fusion_energy = 17.58929696e6_prt * PhysConst::q_e;

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
@@ -138,11 +138,11 @@ namespace BinaryCollisionUtils{
                 ||(product_species1.AmIA<PhysicalSpecies::neutron>() && product_species2.AmIA<PhysicalSpecies::helium3>())){
                 return NuclearFusionType::DeuteriumDeuteriumToNeutronHelium;
             } else if (
-                (product_species1.AmIA<PhysicalSpecies::hydrogen3>() && product_species2.AmIA<PhysicalSpecies::hydrogen1>())
-                ||(product_species1.AmIA<PhysicalSpecies::hydrogen1>() && product_species2.AmIA<PhysicalSpecies::hydrogen3>())){
+                (product_species1.AmIA<PhysicalSpecies::hydrogen3>() && product_species2.AmIA<PhysicalSpecies::proton>())
+                ||(product_species1.AmIA<PhysicalSpecies::proton>() && product_species2.AmIA<PhysicalSpecies::hydrogen3>())){
                 return NuclearFusionType::DeuteriumDeuteriumToProtonTritium;
             } else {
-                WARPX_ABORT_WITH_MESSAGE("ERROR: Product species of deuterium-deuterium fusion must be of type helium3 and neutron, or hydrogen3 and hydrogen1");
+                WARPX_ABORT_WITH_MESSAGE("ERROR: Product species of deuterium-deuterium fusion must be of type helium3 and neutron, or tritium/hydrogen3 and proton");
             }
         }
         else if ((species1.AmIA<PhysicalSpecies::hydrogen2>() && species2.AmIA<PhysicalSpecies::helium3>())

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
@@ -183,6 +183,72 @@ namespace BinaryCollisionUtils{
         return NuclearFusionType::Undefined;
     }
 
+    amrex::ParticleReal get_nuclear_fusion_energy (const std::string& collision_name,
+                                                   const NuclearFusionType fusion_type,
+                                              MultiParticleContainer const * const mypc)
+    {
+        using namespace amrex::literals;
+
+        const amrex::ParmParse pp_collision_name(collision_name);
+
+        amrex::Vector<std::string> species_names;
+        pp_collision_name.getarr("species", species_names);
+        amrex::ParticleReal mass_before = 0.0_prt;
+        for (const auto& name : species_names) {
+            const auto& species = mypc->GetParticleContainerFromName(name);
+            mass_before += species.getMass();
+        }
+
+        amrex::Vector<std::string> product_species_names;
+        pp_collision_name.getarr("product_species", product_species_names);
+        amrex::ParticleReal mass_after = 0.0_prt;
+        for (const auto& name : product_species_names) {
+            const auto& product_species = mypc->GetParticleContainerFromName(name);
+            mass_after += product_species.getMass();
+        }
+
+        amrex::ParticleReal fusion_energy = (mass_before - mass_after)*PhysConst::c2;
+
+        const amrex::ParticleReal energy_tolerance = PhysConst::m_e * PhysConst::c2 * PhysConst::q_e;
+        if (fusion_type == NuclearFusionType::DeuteriumTritiumToNeutronHelium) {
+            const amrex::ParticleReal expected_fusion_energy = 17.58929696e6_prt * PhysConst::q_e;
+            const amrex::ParticleReal energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                energy_error < energy_tolerance,
+                "ERROR: D + T -> He4 + n fusion energy error is too large. Make sure species mass are set properly.");
+        }
+        if (fusion_type == NuclearFusionType::DeuteriumDeuteriumToProtonTritium) {
+            const amrex::ParticleReal expected_fusion_energy = 4.032653948e6_prt * PhysConst::q_e;
+            const amrex::ParticleReal energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                energy_error < energy_tolerance,
+                "ERROR: D + D -> T + p fusion energy error is too large. Make sure species mass are set properly.");
+        }
+        if (fusion_type == NuclearFusionType::DeuteriumDeuteriumToNeutronHelium) {
+            const amrex::ParticleReal expected_fusion_energy = 3.26891111e6_prt * PhysConst::q_e;
+            const amrex::ParticleReal energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                energy_error < energy_tolerance,
+                "ERROR: D + D -> He3 + n fusion energy error is too large. Make sure species mass are set properly.");
+        }
+        if (fusion_type == NuclearFusionType::DeuteriumHeliumToProtonHelium) {
+            const amrex::ParticleReal expected_fusion_energy = 18.35303980e6_prt * PhysConst::q_e;
+            const amrex::ParticleReal energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                energy_error < energy_tolerance,
+                "ERROR: D + He3 -> He4 + p fusion energy error is too large. Make sure species mass are set properly.");
+        }
+        if (fusion_type == NuclearFusionType::ProtonBoronToAlphas) {
+            const amrex::ParticleReal expected_fusion_energy = 8.68212502e6_prt * PhysConst::q_e;
+            const amrex::ParticleReal energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                energy_error < energy_tolerance,
+                "ERROR: p +  -> He4 + He4 + He4 fusion energy error is too large. Make sure species mass are set properly.");
+        }
+
+        return fusion_energy;
+    }
+
     CollisionType nuclear_fusion_type_to_collision_type (const NuclearFusionType fusion_type)
     {
         if (fusion_type == NuclearFusionType::DeuteriumTritiumToNeutronHelium) {

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
@@ -68,8 +68,6 @@ public:
         WARPX_ABORT_WITH_MESSAGE("Nuclear fusion module does not currently work with single precision");
 #endif
 
-        m_fusion_energy = BinaryCollisionUtils::get_nuclear_fusion_energy(collision_name, m_fusion_type, mypc);
-
         const amrex::ParmParse pp_collision_name(collision_name);
         utils::parser::queryWithParser(
             pp_collision_name, "event_multiplier", m_fusion_multiplier);
@@ -83,7 +81,6 @@ public:
         m_exe.m_probability_threshold = m_probability_threshold;
         m_exe.m_probability_target_value = m_probability_target_value;
         m_exe.m_fusion_type = m_fusion_type;
-        m_exe.m_fusion_energy = m_fusion_energy;
         m_exe.m_isSameSpecies = m_isSameSpecies;
     }
 
@@ -240,7 +237,6 @@ public:
         amrex::ParticleReal m_fusion_multiplier;
         amrex::ParticleReal m_probability_threshold;
         amrex::ParticleReal m_probability_target_value;
-        amrex::ParticleReal m_fusion_energy;
         NuclearFusionType m_fusion_type;
         bool m_computeSpeciesDensities = false;
         bool m_computeSpeciesTemperatures = false;
@@ -264,7 +260,6 @@ private:
     // the fusion multiplier should be reduced.
     amrex::ParticleReal m_probability_threshold;
     amrex::ParticleReal m_probability_target_value;
-    amrex::ParticleReal m_fusion_energy;
     NuclearFusionType m_fusion_type;
     bool m_isSameSpecies;
 

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
@@ -68,6 +68,8 @@ public:
         WARPX_ABORT_WITH_MESSAGE("Nuclear fusion module does not currently work with single precision");
 #endif
 
+        m_fusion_energy = BinaryCollisionUtils::get_nuclear_fusion_energy(collision_name, m_fusion_type, mypc);
+
         const amrex::ParmParse pp_collision_name(collision_name);
         utils::parser::queryWithParser(
             pp_collision_name, "event_multiplier", m_fusion_multiplier);
@@ -81,6 +83,7 @@ public:
         m_exe.m_probability_threshold = m_probability_threshold;
         m_exe.m_probability_target_value = m_probability_target_value;
         m_exe.m_fusion_type = m_fusion_type;
+        m_exe.m_fusion_energy = m_fusion_energy;
         m_exe.m_isSameSpecies = m_isSameSpecies;
     }
 
@@ -237,6 +240,7 @@ public:
         amrex::ParticleReal m_fusion_multiplier;
         amrex::ParticleReal m_probability_threshold;
         amrex::ParticleReal m_probability_target_value;
+        amrex::ParticleReal m_fusion_energy;
         NuclearFusionType m_fusion_type;
         bool m_computeSpeciesDensities = false;
         bool m_computeSpeciesTemperatures = false;
@@ -260,6 +264,7 @@ private:
     // the fusion multiplier should be reduced.
     amrex::ParticleReal m_probability_threshold;
     amrex::ParticleReal m_probability_target_value;
+    amrex::ParticleReal m_fusion_energy;
     NuclearFusionType m_fusion_type;
     bool m_isSameSpecies;
 

--- a/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
@@ -167,6 +167,7 @@ public:
         const int t_num_product_species = m_num_product_species;
         const int* AMREX_RESTRICT p_num_products_device = m_num_products_device.data();
         const CollisionType t_collision_type = m_collision_type;
+        const amrex::ParticleReal t_reaction_energy = m_reaction_energy;
 
         amrex::ParallelForRNG(n_total_pairs,
         [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
@@ -208,17 +209,15 @@ public:
                 }
                 else if ((t_collision_type == CollisionType::DeuteriumTritiumToNeutronHeliumFusion)
                       || (t_collision_type == CollisionType::DeuteriumDeuteriumToProtonTritiumFusion)
-                      || (t_collision_type == CollisionType::DeuteriumDeuteriumToNeutronHeliumFusion))
+                      || (t_collision_type == CollisionType::DeuteriumDeuteriumToNeutronHeliumFusion)
+                      || (t_collision_type == CollisionType::DeuteriumHeliumToProtonHeliumFusion))
                 {
-                    const amrex::ParticleReal mass_before = m1 + m2;
-                    const amrex::ParticleReal mass_after = products_mass_data[0] + products_mass_data[1];
-                    const amrex::ParticleReal fusion_energy = (mass_before - mass_after)*PhysConst::c2;
                     TwoProductFusionInitializeMomentum(soa_1, soa_2,
                         soa_products_data[0], soa_products_data[1],
                         p_pair_indices_1[i], p_pair_indices_2[i],
                         products_np_data[0] + 2*p_offsets[i]*p_num_products_device[0],
                         products_np_data[1] + 2*p_offsets[i]*p_num_products_device[1],
-                        m1, m2, products_mass_data[0], products_mass_data[1], fusion_energy, engine);
+                        m1, m2, products_mass_data[0], products_mass_data[1], t_reaction_energy, engine);
                 }
                 else if(t_collision_type == CollisionType::LinearBreitWheeler){
                     LinearBreitWheelerInitializeMomentum(soa_1, soa_2,
@@ -261,6 +260,7 @@ private:
     // for device) which is necessary with GPUs but redundant on CPU.
     amrex::Gpu::DeviceVector<int> m_num_products_device;
     amrex::Gpu::HostVector<int> m_num_products_host;
+    amrex::ParticleReal m_reaction_energy = 0.0;
     CollisionType m_collision_type;
 };
 

--- a/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
@@ -212,7 +212,7 @@ public:
                 {
                     const amrex::ParticleReal mass_before = m1 + m2;
                     const amrex::ParticleReal mass_after = products_mass_data[0] + products_mass_data[1];
-                    const amrex::ParticleReal fusion_energy = (mass_before - mass_after)*PhysConst::c*PhysConst::c;
+                    const amrex::ParticleReal fusion_energy = (mass_before - mass_after)*PhysConst::c2;
                     TwoProductFusionInitializeMomentum(soa_1, soa_2,
                         soa_products_data[0], soa_products_data[1],
                         p_pair_indices_1[i], p_pair_indices_2[i],

--- a/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
@@ -210,16 +210,9 @@ public:
                       || (t_collision_type == CollisionType::DeuteriumDeuteriumToProtonTritiumFusion)
                       || (t_collision_type == CollisionType::DeuteriumDeuteriumToNeutronHeliumFusion))
                 {
-                    amrex::ParticleReal fusion_energy = 0.0_prt;
-                    if (t_collision_type == CollisionType::DeuteriumTritiumToNeutronHeliumFusion) {
-                        fusion_energy = 17.5893e6_prt * PhysConst::q_e;
-                    }
-                    else if (t_collision_type == CollisionType::DeuteriumDeuteriumToProtonTritiumFusion) {
-                        fusion_energy = 4.032667e6_prt * PhysConst::q_e;
-                    }
-                    else if (t_collision_type == CollisionType::DeuteriumDeuteriumToNeutronHeliumFusion) {
-                        fusion_energy = 3.268911e6_prt * PhysConst::q_e;
-                    }
+                    const amrex::ParticleReal mass_before = m1 + m2;
+                    const amrex::ParticleReal mass_after = products_mass_data[0] + products_mass_data[1];
+                    const amrex::ParticleReal fusion_energy = (mass_before - mass_after)*PhysConst::c*PhysConst::c;
                     TwoProductFusionInitializeMomentum(soa_1, soa_2,
                         soa_products_data[0], soa_products_data[1],
                         p_pair_indices_1[i], p_pair_indices_2[i],

--- a/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.cpp
@@ -35,10 +35,11 @@ ParticleCreationFunc::ParticleCreationFunc (const std::string& collision_name,
 #endif
     }
     else if ((m_collision_type == CollisionType::DeuteriumTritiumToNeutronHeliumFusion)
-             || (m_collision_type == CollisionType::DeuteriumDeuteriumToProtonTritiumFusion)
-             || (m_collision_type == CollisionType::DeuteriumDeuteriumToNeutronHeliumFusion)
-             || (m_collision_type == CollisionType::LinearBreitWheeler)
-             || (m_collision_type == CollisionType::LinearCompton))
+          || (m_collision_type == CollisionType::DeuteriumDeuteriumToProtonTritiumFusion)
+          || (m_collision_type == CollisionType::DeuteriumDeuteriumToNeutronHeliumFusion)
+          || (m_collision_type == CollisionType::DeuteriumHeliumToProtonHeliumFusion)
+          || (m_collision_type == CollisionType::LinearBreitWheeler)
+          || (m_collision_type == CollisionType::LinearCompton))
     {
         m_num_product_species = 2;
         m_num_products_host.push_back(1);
@@ -53,6 +54,9 @@ ParticleCreationFunc::ParticleCreationFunc (const std::string& collision_name,
     {
         WARPX_ABORT_WITH_MESSAGE("Unknown collision type in ParticleCreationFunc");
     }
+
+    // This value is currently only used by the fusion modules
+    m_reaction_energy = BinaryCollisionUtils::get_reaction_energy(collision_name, m_collision_type, mypc);
 
 #ifdef AMREX_USE_GPU
      m_num_products_device.resize(m_num_product_species);


### PR DESCRIPTION
Currently, the product species of D + D => T + p fusion are required to be hydrogen3 and hydrogen1. hydrogen3 is the same as tritium, but hydrogen1 is not a proton. This PR updates the product species check to include a proton rather than hydrogen1. 

This PR also simplifies the hard-wired fusion energy of the reaction to be the difference in mass of the initial and product species. When all species are ions with mass computed as M = A*m_u - Z*m_e with the atomic mass numbers A given in SpeciesPhysicalProperties.cpp, this results in the following reaction energies:
```
D + T   => He4 + n: Q = 17.58929696 MeV
D + D   => T + p:   Q = 4.032653948 MeV
D + D   => He3 + n: Q = 3.26891111 MeV
D + He3 => He4 + p: Q = 18.35303980 MeV
p + B11 => 3He4:    Q = 8.68212502 MeV
```

- [x] Add check that fusion energy computed based on mass difference is close to expected value.

This PR also fixes a bug where the Particles from a D + He3 => He4 + p were never created.