### PR TITLE
Add Andes install scripts

### DIFF
--- a/Tools/machines/andes-olcf/andes_warpx.profile.example
+++ b/Tools/machines/andes-olcf/andes_warpx.profile.example
@@ -8,9 +8,8 @@ if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in yo
 # fix system defaults: do not escape $ with a \ on tab completion
 shopt -s direxpand
 
-module load gcc/9.3.0
+module load gcc/14.2.0
 module load openmpi/4.1.2
-module load hdf5/1.12.1 # is parallel enabled already
 module load miniforge3/24.11.3-2
 
 export SW_DIR="${HOME}/sw/andes"
@@ -26,13 +25,16 @@ fi
 # make output group-readable by default
 umask 0027
 
-export CMAKE_PREFIX_PATH=${SW_DIR}/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=${SW_DIR}/c-blosc2-2.23.1:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=${SW_DIR}/adios2-2.10.2:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=${SW_DIR}/hdf5-1.14.3:$CMAKE_PREFIX_PATH
 
-export LD_LIBRARY_PATH=${SW_DIR}/c-blosc-1.21.1/lib64:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${SW_DIR}/c-blosc2-2.23.1/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=${SW_DIR}/adios2-2.10.2/lib64:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${SW_DIR}/hdf5-1.14.3/lib:$LD_LIBRARY_PATH
 
 export PATH=${SW_DIR}/adios2-2.10.2/bin:$PATH
+export PATH=${SW_DIR}/hdf5-1.14.3/bin:$PATH
 
 # an alias to request an interactive batch node for one hour
 #   for paralle execution, start on the batch node: srun <command>

--- a/Tools/machines/andes-olcf/andes_warpx.profile.example
+++ b/Tools/machines/andes-olcf/andes_warpx.profile.example
@@ -1,0 +1,42 @@
+# please set your project account
+export proj=""  # change me!
+
+# remembers the location of this script
+export MY_PROFILE=$(cd $(dirname $BASH_SOURCE) && pwd)"/"$(basename $BASH_SOURCE)
+if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in your $MY_PROFILE file! Please edit its line 2 to continue!"; return; fi
+
+# fix system defaults: do not escape $ with a \ on tab completion
+shopt -s direxpand
+
+module load gcc/9.3.0
+module load openmpi/4.1.2
+module load hdf5/1.12.1 # is parallel enabled already
+module load miniforge3/24.11.3-2
+
+export SW_DIR="${HOME}/sw/andes"
+# On Andes, the access to the project directory doesn't have an environmental variable
+export PROJSCRATCH="/lustre/orion/proj-shared/${proj}"
+
+if [ -d "${SW_DIR}/venvs/warpx-andes" ]
+then
+  conda deactivate
+  source ${SW_DIR}/venvs/warpx-andes/bin/activate
+fi
+
+# make output group-readable by default
+umask 0027
+
+export CMAKE_PREFIX_PATH=${SW_DIR}/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=${SW_DIR}/adios2-2.10.2:$CMAKE_PREFIX_PATH
+
+export LD_LIBRARY_PATH=${SW_DIR}/c-blosc-1.21.1/lib64:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${SW_DIR}/adios2-2.10.2/lib64:$LD_LIBRARY_PATH
+
+export PATH=${SW_DIR}/adios2-2.10.2/bin:$PATH
+
+# an alias to request an interactive batch node for one hour
+#   for paralle execution, start on the batch node: srun <command>
+alias getNodeCpu="salloc -A $proj -J warpx -t 01:00:00 -p batch -N 1"
+# an alias to run a command on a batch node for up to 30min
+#   usage: runNode <command>
+alias runNode="srun -A $proj -J warpx -t 00:30:00 -p batch -N 1"

--- a/Tools/machines/andes-olcf/install_andes_analysis.sh
+++ b/Tools/machines/andes-olcf/install_andes_analysis.sh
@@ -91,7 +91,7 @@ python -m pip install --upgrade numpy
 python -m pip install --upgrade scipy
 
 # Extra packages for python ######################################################################
-# 
+#
 python -m pip install --upgrade pandas
 CC="mpicc -shared" CXX="mpicxx -shared" python -m pip install --upgrade mpi4py --no-cache-dir --no-build-isolation --no-binary mpi4py -v
 # This installs openpmd-api with MPI support

--- a/Tools/machines/andes-olcf/install_andes_analysis.sh
+++ b/Tools/machines/andes-olcf/install_andes_analysis.sh
@@ -21,27 +21,62 @@ then
     return
 fi
 
-# Install necessary dependencies for openpmd-api, as ADIOS2 version available on andes is too old
+# Install necessary dependencies for openpmd-api, as version available on andes is too old
 # tmpfs build directory: avoids issues often seen with $HOME and is faster
 build_dir=$(mktemp -d)
-echo "Building c-blosc"
-if [ -d ${SW_DIR}/c-blosc ]
+
+# HDF5 (parallel)
+echo "Building HDF5 (parallel)"
+HDF5_VERSION="1.14.3"
+HDF5_TAG="hdf5_${HDF5_VERSION//./_}"
+
+if [ -d ${SW_DIR}/hdf5 ]
 then
-  cd ${SW_DIR}/c-blosc
+  cd ${SW_DIR}/hdf5
   git fetch --prune
-  git checkout v1.21.1
+  git checkout ${HDF5_TAG}
   cd -
 else
-  git clone -b v1.21.1 https://github.com/Blosc/c-blosc ${SW_DIR}/c-blosc
+  git clone -b ${HDF5_TAG} https://github.com/HDFGroup/hdf5.git ${SW_DIR}/hdf5
 fi
-if [ -d ${build_dir}/c-blosc-build ]
+
+if [ -d ${build_dir}/hdf5-build ]
 then
-  rm -rf ${build_dir}/c-blosc-build
+  rm -rf ${build_dir}/hdf5-build
 fi
-CC=mpicc CXX=mpicxx cmake -S  ${SW_DIR}/c-blosc -B ${build_dir}/c-blosc-build -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/c-blosc-1.21.1
-cmake --build  ${build_dir}/c-blosc-build --target install --parallel 16
-rm -rf  ${build_dir}/c-blosc-build
-echo "c-blosc built"
+
+CC=mpicc CXX=mpicxx cmake \
+  -S ${SW_DIR}/hdf5 \
+  -B ${build_dir}/hdf5-build --fresh \
+  -DHDF5_ENABLE_PARALLEL=ON \
+  -DHDF5_BUILD_FORTRAN=OFF \
+  -DHDF5_BUILD_JAVA=OFF \
+  -DHDF5_BUILD_EXAMPLES=OFF \
+  -DBUILD_TESTING=OFF \
+  -DCMAKE_INSTALL_PREFIX=${SW_DIR}/hdf5-${HDF5_VERSION}
+
+cmake --build ${build_dir}/hdf5-build --target install --parallel 16
+rm -rf ${build_dir}/hdf5-build
+echo "HDF5 (parallel) built"
+
+echo "Building c-blosc 2"
+if [ -d ${SW_DIR}/c-blosc2 ]
+then
+  cd ${SW_DIR}/c-blosc2
+  git fetch --prune
+  git checkout v2.23.1
+  cd -
+else
+  git clone -b v2.23.1 https://github.com/Blosc/c-blosc2 ${SW_DIR}/c-blosc2
+fi
+if [ -d ${build_dir}/c-blosc2-build ]
+then
+  rm -rf ${build_dir}/c-blosc2-build
+fi
+CC=mpicc CXX=mpicxx cmake -S  ${SW_DIR}/c-blosc2 -B ${build_dir}/c-blosc2-build --fresh -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/c-blosc2-2.23.1
+cmake --build  ${build_dir}/c-blosc2-build --target install --parallel 16
+rm -rf  ${build_dir}/c-blosc2-build
+echo "c-blosc2 built"
 
 # ADIOS2
 echo "Building adios2"
@@ -58,7 +93,7 @@ if [ -d ${build_dir}/adios2-build ]
 then
   rm -rf ${build_dir}/adios2-build
 fi
-CC=mpicc CXX=mpicxx cmake -S ${SW_DIR}/adios2 -B ${build_dir}/adios2-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.10.2
+CC=mpicc CXX=mpicxx cmake -S ${SW_DIR}/adios2 -B ${build_dir}/adios2-build --fresh -DADIOS2_USE_Blosc2=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.10.2
 cmake --build ${build_dir}/adios2-build --target install --parallel 16
 rm -rf ${build_dir}/adios2-build
 echo "adios2 built"
@@ -91,15 +126,15 @@ python -m pip install --upgrade numpy
 python -m pip install --upgrade scipy
 
 # Extra packages for python ######################################################################
-# 
+#
 python -m pip install --upgrade pandas
-CC="mpicc -shared" CXX="mpicxx -shared" python -m pip install --upgrade mpi4py --no-cache-dir --no-build-isolation --no-binary mpi4py -v
-# This installs openpmd-api with MPI support
-CC="mpicc" CXX="mpicxx" openPMD_USE_MPI=ON openPMD_USE_ADIOS2=ON openPMD_USE_HDF5=ON python -m pip install openpmd-api --force-reinstall --no-binary openpmd-api -vv
+CC=mpicc CXX=mpicxx python -m pip install --upgrade mpi4py --no-cache-dir --no-build-isolation --no-binary mpi4py
+CC=mpicc CXX=mpicxx openPMD_USE_MPI=ON openPMD_USE_ADIOS2=ON openPMD_USE_HDF5=ON python -m pip install openpmd-api --no-binary openpmd-api -vv
 python -m pip install --upgrade openpmd_viewer
 python -m pip install --upgrade matplotlib
 python -m pip install --upgrade yt
 python -m pip install --upgrade dask
 python -m pip install --upgrade pyarrow
 python -m pip install --upgrade ipython
+python -m pip install --upgrade hepunits
 python -m pip install --upgrade numba

--- a/Tools/machines/andes-olcf/install_andes_analysis.sh
+++ b/Tools/machines/andes-olcf/install_andes_analysis.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+# Exit on first error encountered #############################################
+#
+set -eu -o pipefail
+
+
+# Check: ######################################################################
+#
+#   Was andes_warpx.profile sourced and configured correctly?
+if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in your andes_warpx.profile file! Please edit its line 2 to continue and make sure you sourced the file first!"; return; fi
+
+
+# Check $proj variable is correct and has a corresponding CFS directory #######
+#
+if [ ! -d "${PROJWORK}/${proj}/" ]
+then
+    echo "WARNING: The directory $PROJWORK/$proj/ does not exist!"
+    echo "Is the \$proj environment variable of value \"$proj\" correctly set? "
+    echo "Please edit line 2 of your andes_warpx.profile file to continue!"
+    return
+fi
+
+# Install necessary dependencies for openpmd-api, as ADIOS2 version available on andes is too old
+# tmpfs build directory: avoids issues often seen with $HOME and is faster
+build_dir=$(mktemp -d)
+echo "Building c-blosc"
+if [ -d ${SW_DIR}/c-blosc ]
+then
+  cd ${SW_DIR}/c-blosc
+  git fetch --prune
+  git checkout v1.21.1
+  cd -
+else
+  git clone -b v1.21.1 https://github.com/Blosc/c-blosc ${SW_DIR}/c-blosc
+fi
+if [ -d ${build_dir}/c-blosc-build ]
+then
+  rm -rf ${build_dir}/c-blosc-build
+fi
+CC=mpicc CXX=mpicxx cmake -S  ${SW_DIR}/c-blosc -B ${build_dir}/c-blosc-build -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/c-blosc-1.21.1
+cmake --build  ${build_dir}/c-blosc-build --target install --parallel 16
+rm -rf  ${build_dir}/c-blosc-build
+echo "c-blosc built"
+
+# ADIOS2
+echo "Building adios2"
+if [ -d ${SW_DIR}/adios2 ]
+then
+  cd ${SW_DIR}/adios2
+  git fetch --prune
+  git checkout v2.10.2
+  cd -
+else
+  git clone -b v2.10.2 https://github.com/ornladios/ADIOS2.git ${SW_DIR}/adios2
+fi
+if [ -d ${build_dir}/adios2-build ]
+then
+  rm -rf ${build_dir}/adios2-build
+fi
+CC=mpicc CXX=mpicxx cmake -S ${SW_DIR}/adios2 -B ${build_dir}/adios2-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.10.2
+cmake --build ${build_dir}/adios2-build --target install --parallel 16
+rm -rf ${build_dir}/adios2-build
+echo "adios2 built"
+
+# Remove old dependencies #####################################################
+#
+if [ -z ${SW_DIR-} ]; then echo "WARNING: The 'SW_DIR' variable is not set"; return; fi
+mkdir -p ${SW_DIR}
+
+# remove common user mistakes in python, located in .local instead of a venv
+python -m pip install --upgrade pip
+python -m pip uninstall -qq -y pywarpx
+python -m pip uninstall -qq -y warpx
+python -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
+# Python ######################################################################
+#
+python -m pip install --upgrade virtualenv
+python -m pip cache purge
+python -m venv ${SW_DIR}/venvs/warpx-andes
+source ${SW_DIR}/venvs/warpx-andes/bin/activate
+echo "Installing python dependencies"
+echo ""
+python -m pip install --upgrade pip
+python -m pip install --upgrade build
+python -m pip install --upgrade packaging
+python -m pip install --upgrade wheel
+python -m pip install --upgrade setuptools
+python -m pip install --upgrade "cython>=3.0"  # for latest mpi4py and everything else
+python -m pip install --upgrade numpy
+python -m pip install --upgrade scipy
+
+# Extra packages for python ######################################################################
+# 
+python -m pip install --upgrade pandas
+CC="mpicc -shared" CXX="mpicxx -shared" python -m pip install --upgrade mpi4py --no-cache-dir --no-build-isolation --no-binary mpi4py -v
+# This installs openpmd-api with MPI support
+CC="mpicc" CXX="mpicxx" openPMD_USE_MPI=ON openPMD_USE_ADIOS2=ON openPMD_USE_HDF5=ON python -m pip install openpmd-api --force-reinstall --no-binary openpmd-api -vv
+python -m pip install --upgrade openpmd_viewer
+python -m pip install --upgrade matplotlib
+python -m pip install --upgrade yt
+python -m pip install --upgrade dask
+python -m pip install --upgrade pyarrow
+python -m pip install --upgrade ipython
+python -m pip install --upgrade numba

--- a/Tools/machines/andes-olcf/submit.sh
+++ b/Tools/machines/andes-olcf/submit.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+#SBATCH -A <project id>
+#SBATCH -J job_name
+#SBATCH -o job_name-%j.out
+#SBATCH -N 2
+#SBATCH --exclusive
+#SBATCH -t 24:00:00
+#SBATCH -p batch
+
+srun -n <ntasks> your_application


### PR DESCRIPTION
Adding some useful scripts to install the WarpX analysis tools on Andes, OLCF. Andes is not a production machine, hence we don't need a WarpX installation on it. However, it is used for data analysis and its modules can be confusing.
I seem to have found a combination of modules for which the python libraries necessary for data analysis are correctly installed.
This script installs an MPI-enabled version of openPMD-api, since, in our experience, it helps when using inline tools such as `openpmd-pipe` on large datasets. However, this is not strictly necessary and it can be replaced with a standard pip installation.

Note: Andes only provides an updated version of python via miniforge, which is conda based and not ideal. To this date, other python versions are too old and/or not compatible with other modules (or at least I haven't found a combination that works for me). Using this version ensures python compatibility with `srun`, which is otherwise broken.