### PR TITLE
VirtualPhotonCreation.H: remove unnecessary #include "WarpX.H"

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/VirtualPhotonCreation.H
+++ b/Source/Particles/Collision/BinaryCollision/VirtualPhotonCreation.H
@@ -13,7 +13,6 @@
 #include "Particles/PhysicalParticleContainer.H"
 #include "Particles/ParticleCreation/SmartCopy.H"
 
-#include "WarpX.H"
 #include "Utils/TextMsg.H"
 #include "Utils/Parser/ParserUtils.H"
 


### PR DESCRIPTION
This PR removes an unnecessary include directive.