### PR TITLE
VirtualPhotonCreation.H : fix warning concerning  not explicitly initialized variables

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/VirtualPhotonCreation.H
+++ b/Source/Particles/Collision/BinaryCollision/VirtualPhotonCreation.H
@@ -70,13 +70,13 @@ void GenerateVirtualPhotons (MultiParticleContainer* mypc){
         const amrex::ParmParse pp_species_name(mypc->GetSpeciesNames()[vphotons_index]);
 
         // Minimum allowed energy of the virtual photons
-        amrex::Real vphoton_min_energy;
+        amrex::Real vphoton_min_energy = 0.0_rt;
         utils::parser::getWithParser(pp_species_name, "qed_virtual_photons_min_energy", vphoton_min_energy);
 
         // Sampling factor (a.k.a. multiplier):
         // the number of virtual photons generated is multiplied by this factor,
         // the weight of each virtual photon is divided by this factor
-        amrex::Real sampling_factor;
+        amrex::Real sampling_factor = 0.0_rt;
         utils::parser::getWithParser(pp_species_name, "qed_virtual_photons_multiplier", sampling_factor);
 
         amrex::Real const alpha_over_pi = PhysConst::alpha / MathConst::pi;


### PR DESCRIPTION
This PR fixes a warning that I got locally with the `nvcc` compiler concerning these two not explicitly initialized variables.