### PR TITLE
VirtualPhotonCreation.H: add checks for qed_virtual_photons_min_energy and qed_virtual_photons_multiplier

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/VirtualPhotonCreation.H
+++ b/Source/Particles/Collision/BinaryCollision/VirtualPhotonCreation.H
@@ -71,12 +71,19 @@ void GenerateVirtualPhotons (MultiParticleContainer* mypc){
         // Minimum allowed energy of the virtual photons
         amrex::Real vphoton_min_energy = 0.0_rt;
         utils::parser::getWithParser(pp_species_name, "qed_virtual_photons_min_energy", vphoton_min_energy);
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+            vphoton_min_energy > 0.0_rt,
+            "qed_virtual_photons_min_energy must be strictly positive.");
 
         // Sampling factor (a.k.a. multiplier):
         // the number of virtual photons generated is multiplied by this factor,
         // the weight of each virtual photon is divided by this factor
         amrex::Real sampling_factor = 0.0_rt;
         utils::parser::getWithParser(pp_species_name, "qed_virtual_photons_multiplier", sampling_factor);
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+            sampling_factor > 0.0_rt,
+            "qed_virtual_photons_multiplier must be strictly positive.");
+
 
         amrex::Real const alpha_over_pi = PhysConst::alpha / MathConst::pi;
         amrex::Real const inv_c2 = 1._rt / (PhysConst::c * PhysConst::c);


### PR DESCRIPTION
Yesterday https://github.com/BLAST-WarpX/warpx/pull/6538 was merged despite @aeriforme 's comment that `qed_virtual_photons_min_energy` must be strictly positive, since it goes into a log!

This PR attempts a temporary fix by introducing checks to ensure that both `qed_virtual_photons_min_energy` and `qed_virtual_photons_multiplier` are strictly positive (I believe that also `qed_virtual_photons_multiplier` must be strictly positive, maybe even close to an integer).

As @aeriforme commented in https://github.com/BLAST-WarpX/warpx/pull/6538, a better approach would be to choose sensible default values. 