### PR TITLE
TemperatureDeposition.H and VarianceAccumulationBuffer.cpp : fix inclusion of WarpX.H

### DIFF
--- a/Source/Particles/Deposition/TemperatureDeposition.H
+++ b/Source/Particles/Deposition/TemperatureDeposition.H
@@ -21,8 +21,6 @@
 #   include "Utils/WarpX_Complex.H"
 #endif
 
-#include "WarpX.H" // todo: remove include and pass globals as args
-
 #include "TemperatureDepositionTypes.H"
 
 #include <AMReX.H>

--- a/Source/Particles/Deposition/VarianceAccumulationBuffer.cpp
+++ b/Source/Particles/Deposition/VarianceAccumulationBuffer.cpp
@@ -10,6 +10,7 @@
 #include "Particles/Deposition/VarianceAccumulationBuffer.H"
 #include "Particles/Deposition/TemperatureDeposition.H"
 #include "Fields.H"
+#include "WarpX.H"
 
 #include <ablastr/utils/Communication.H>
 


### PR DESCRIPTION
this PR removes an unnecessary inclusion of the `WarpX.H` header in `TemperatureDeposition.H` and adds `#include "WarpX.H" ` in  `VarianceAccumulationBuffer.cpp`