### PR TITLE
Frontier build: bump cupy version + minor cleanup

### DIFF
--- a/Tools/machines/frontier-olcf/install_dependencies.sh
+++ b/Tools/machines/frontier-olcf/install_dependencies.sh
@@ -95,7 +95,7 @@ CC=cc CXX=CC \
 CUPY_INSTALL_USE_HIP=1  \
 ROCM_HOME=${ROCM_PATH}  \
 HCC_AMDGPU_TARGET=${AMREX_AMD_ARCH}  \
-  python3 -m pip install -v git+https://github.com/cupy/cupy.git@e669b994f976565bf2da4b1f82de51e10b58fbe1
+  python3 -m pip install -v git+https://github.com/cupy/cupy.git@66a29e2329b123ee5ce3bc89ba7ff1c49b9de2d1
 python3 -m pip install --upgrade numpy
 python3 -m pip install --upgrade h5py
 python3 -m pip install --upgrade pandas

--- a/Tools/machines/frontier-olcf/submit.sh
+++ b/Tools/machines/frontier-olcf/submit.sh
@@ -43,7 +43,4 @@ export FI_CXI_RX_MATCH_MODE=software
 export ROCFFT_RTC_CACHE_PATH=/dev/null
 
 export OMP_NUM_THREADS=1
-export WARPX_NMPI_PER_NODE=8
-export TOTAL_NMPI=$(( ${SLURM_JOB_NUM_NODES} * ${WARPX_NMPI_PER_NODE} ))
-srun -N${SLURM_JOB_NUM_NODES} -n${TOTAL_NMPI} --ntasks-per-node=${WARPX_NMPI_PER_NODE} \
-    ./warpx inputs > output.txt
+srun ./warpx inputs > output.txt


### PR DESCRIPTION
Building WarpX on OLCF Frontier recently, I saw two errors, one of which is fixed by this PR.

**First error** is same as described in PR https://github.com/BLAST-WarpX/warpx/pull/5991 .  Error is fixed in newer cupy, but Frontier build script's cupy commit hash (v14.0.0a) lacked the fix.  To address, one could:
* remove commit hash (gets v13.6.0 as of few days ago)
* bump commit hash to newer v14.x

This PR chooses latter option, in case there was a reason to prefer v14.x over v13.x in commit 7e41abd3a.

**Second error:** using suggested Frontier slurm script with `--gpu-bind=closest`, `--gpus-per-task=1`, etc., during warpx executable startup,
```
amrex::Abort::0::HIP error in file /[...build folder...]/_deps/fetchedamrex-src/Src/Base/AMReX_GpuDevice.cpp line 256 no ROCm-capable device is detected !!!
    SIGABRT
    See Backtrace.0 file for details
    MPICH ERROR [Rank 0] [... elided ...] - Abort(6) (rank 0 in comm 480): application called MPI_Abort(comm=0x84000001, 6) - process 0
```

I was able to fix (bypass?) by adding
```
export HIP_VISIBLE_DEVICES="0,1,2,3,4,5,6,7"
```
to the Slurm submit script.  But, not sure if it's sensible:
* is it best to handle here or elsewhere?
* which is preferred between `ROCR_VISIBLE_DEVICES` and `HIP_VISIBLE_DEVICES`, for WarpX specifically ?
* What device visibility is expected by WarpX / does it matter?  [AMD's doc](https://gpuopen.com/learn/amd-lab-notes/amd-lab-notes-affinity-affinity_part2/#hybrid-applications-that-run-on-cpu--gpu) suggests `export HIP_VISIBLE_DEVICES=$OMPI_COMM_WORLD_LOCAL_RANK` for OpenMPI to reveal only one device; is there a sensible MPICH equivalent?

This fix is not added to PR – if anyone can help provide input/advice, I can add extra commit to close out both errors.

**Lastly,** this PR cleans up no-longer-needed `srun` options; I verified that Frontier jobs run fine with bare `srun python3 inputs.py [...]`.