### PR TITLE
Add flag to skip phi domain boundary values update

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2131,6 +2131,9 @@ class ElectrostaticSolver(picmistandard.PICMI_ElectrostaticSolver):
     warpx_max_dt: float, optional
         The maximum allowable timestep when `warpx_dt_update_interval > 0`.
 
+    warpx_skip_domain_bc_value_update: bool, default=False
+        Flag to skip updating the domain boundary values during the simulation.
+        Only applicable if Dirichlet boundaries are used.
     """
 
     def init(self, kw):
@@ -2160,6 +2163,9 @@ class ElectrostaticSolver(picmistandard.PICMI_ElectrostaticSolver):
         self.cfl = kw.pop("warpx_cfl", None)
         self.dt_update_interval = kw.pop("warpx_dt_update_interval", None)
         self.max_dt = kw.pop("warpx_max_dt", None)
+        self.skip_domain_bc_value_update = kw.pop(
+            "warpx_skip_domain_bc_value_update", None
+        )
 
     def solver_initialize_inputs(self):
         # Open BC means FieldBoundaryType::Open for electrostatic sims, rather than perfectly-matched layer
@@ -2171,6 +2177,7 @@ class ElectrostaticSolver(picmistandard.PICMI_ElectrostaticSolver):
         pywarpx.warpx.cfl = self.cfl
         pywarpx.warpx.dt_update_interval = self.dt_update_interval
         pywarpx.warpx.max_dt = self.max_dt
+        pywarpx.warpx.skip_domain_bc_value_update = self.skip_domain_bc_value_update
 
         if self.relativistic:
             pywarpx.warpx.do_electrostatic = "relativistic"

--- a/Source/FieldSolver/ElectrostaticSolvers/ElectrostaticSolver.H
+++ b/Source/FieldSolver/ElectrostaticSolvers/ElectrostaticSolver.H
@@ -144,6 +144,7 @@ public:
 
     /** Boundary handler object to set potential for EB and on the domain boundary */
     std::unique_ptr<PoissonBoundaryHandler> m_poisson_boundary_handler;
+    bool m_skip_domain_bc_value_update = false;
 
     /** Parameters for MLMG Poisson solve */
     amrex::Real self_fields_required_precision = 1e-11;

--- a/Source/FieldSolver/ElectrostaticSolvers/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolvers/ElectrostaticSolver.cpp
@@ -39,12 +39,16 @@ void ElectrostaticSolver::ReadParameters () {
         pp_warpx, "self_fields_absolute_tolerance", self_fields_absolute_tolerance);
     utils::parser::queryWithParser(
         pp_warpx, "self_fields_max_iters", self_fields_max_iters);
-   utils::parser::queryWithParser(
+    utils::parser::queryWithParser(
         pp_warpx, "self_fields_verbosity", self_fields_verbosity);
 
     // FFT solver flags
-   utils::parser::queryWithParser(
+    utils::parser::queryWithParser(
         pp_warpx, "use_2d_slices_fft_solver", is_igf_2d_slices);
+
+    // Flag setting whether the domain boundary values should not be updated every step
+    utils::parser::queryWithParser(
+        pp_warpx, "skip_domain_bc_value_update", m_skip_domain_bc_value_update);
 }
 
 void
@@ -53,6 +57,9 @@ ElectrostaticSolver::setPhiBC (
     amrex::Real t
 ) const
 {
+    // skip if user set the skip_domain_bc_value_update flag
+    if (m_skip_domain_bc_value_update) { return; }
+
     // check if any dimension has non-periodic boundary conditions
     if (!m_poisson_boundary_handler->has_non_periodic) { return; }
 


### PR DESCRIPTION
This PR adds a user input for the electrostatic solvers which allows skipping the update of the domain boundary potential values. This in turn allows a potential profile to be imposed from Python callbacks.
It also allows a small performance improvement by skipping unneeded loops over the domain when the Dirichlet boundary values are not changed during the simulation.