### PR TITLE
exploit symmetry to reduce deposit of diagonal mass matrices

### DIFF
--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
@@ -264,6 +264,11 @@ protected:
     void SetMassMatricesForPC ( const amrex::Real a_theta_dt );
 
     /**
+     * \brief Finish filling the mass matrices after deposit
+     */
+    void FinishMassMatrices ();
+
+    /**
      * \brief Add J from particles included in mass matrices at start of each Newton step
      */
     void CumulateJ ();

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
@@ -263,12 +263,10 @@ protected:
      */
     void SetMassMatricesForPC ( const amrex::Real a_theta_dt );
 
-#if AMREX_SPACEDIM < 3
     /**
      * \brief Finish filling the mass matrices after deposit
      */
     void FinishMassMatrices ();
-#endif
 
     /**
      * \brief Add J from particles included in mass matrices at start of each Newton step

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
@@ -263,10 +263,12 @@ protected:
      */
     void SetMassMatricesForPC ( const amrex::Real a_theta_dt );
 
+#if AMREX_SPACEDIM < 3
     /**
      * \brief Finish filling the mass matrices after deposit
      */
     void FinishMassMatrices ();
+#endif
 
     /**
      * \brief Add J from particles included in mass matrices at start of each Newton step

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -955,18 +955,20 @@ void ImplicitSolver::FinishMassMatrices ()
     const int ncomp_tot_zz = AMREX_D_TERM(m_ncomp_zz[0],*m_ncomp_zz[1],*m_ncomp_zz[2]);
 #endif
 
-    amrex::IntVect Sxx_width, Syy_width, Szz_width;
-    for (int dir=0; dir<AMREX_SPACEDIM; dir++) {
-        Sxx_width[dir] = (m_ncomp_xx[dir] - 1)/2;
-        Syy_width[dir] = (m_ncomp_yy[dir] - 1)/2;
-        Szz_width[dir] = (m_ncomp_zz[dir] - 1)/2;
+    amrex::GpuArray<int,3> ncomp_xx = {0,0,0};
+    amrex::GpuArray<int,3> ncomp_yy = {0,0,0};
+    amrex::GpuArray<int,3> ncomp_zz = {0,0,0};
+    amrex::GpuArray<int,3> Sxx_width = {0,0,0};
+    amrex::GpuArray<int,3> Syy_width = {0,0,0};
+    amrex::GpuArray<int,3> Szz_width = {0,0,0};
+    for (int dir = 0; dir < AMREX_SPACEDIM; dir++) {
+        ncomp_xx[dir] = m_ncomp_xx[dir];
+        ncomp_yy[dir] = m_ncomp_yy[dir];
+        ncomp_zz[dir] = m_ncomp_zz[dir];
+        Sxx_width[dir] = (ncomp_xx[dir] - 1)/2;
+        Syy_width[dir] = (ncomp_yy[dir] - 1)/2;
+        Szz_width[dir] = (ncomp_zz[dir] - 1)/2;
     }
-
-#if AMREX_SPACEDIM == 2
-    const amrex::IntVect ncomp_xx = m_ncomp_xx;
-    const amrex::IntVect ncomp_yy = m_ncomp_yy;
-    const amrex::IntVect ncomp_zz = m_ncomp_zz;
-#endif
 
     for (int lev = 0; lev < m_num_amr_levels; ++lev) {
 
@@ -1010,7 +1012,8 @@ void ImplicitSolver::FinishMassMatrices ()
                 for (int m = row_start; m < ncomp_xx[1]; m++) {
                     const int jj = m - Sxx_width[1];
                     if (j+jj < Sbx.smallEnd(1) || j+jj > Sbx.bigEnd(1)) { continue; }
-                    const int above_diag_extra = (m > Sxx_width[1] ? 1:0); // width increases by 1 when above row with diagonal term
+                    // Increase width by 1 when above row with diagonal term
+                    const int above_diag_extra = (m > Sxx_width[1] ? 1:0);
                     int width0 = std::min(m + above_diag_extra - row_start + 1, ncomp_xx[0]);
                     for (int n = 0; n < width0; n++) {
                         const int ii = Sxx_width[0] - n;
@@ -1041,7 +1044,8 @@ void ImplicitSolver::FinishMassMatrices ()
                 for (int m = row_start; m < ncomp_yy[1]; m++) {
                     const int jj = m - Syy_width[1];
                     if (j+jj < Sby.smallEnd(1) || j+jj > Sby.bigEnd(1)) { continue; }
-                    const int above_diag_extra = (m > Syy_width[1] ? 1:0); // width increases by 1 when above row with diagonal term
+                    // Increase width by 1 when above row with diagonal term
+                    const int above_diag_extra = (m > Syy_width[1] ? 1:0);
                     int width0 = std::min(m + above_diag_extra - row_start + 1, ncomp_yy[0]);
                     for (int n = 0; n < width0; n++) {
                         const int ii = Syy_width[0] - n;
@@ -1072,7 +1076,8 @@ void ImplicitSolver::FinishMassMatrices ()
                 for (int m = row_start; m < ncomp_zz[1]; m++) {
                     const int jj = m - Szz_width[1];
                     if (j+jj < Sbz.smallEnd(1) || j+jj > Sbz.bigEnd(1)) { continue; }
-                    const int above_diag_extra = (m > Szz_width[1] ? 1:0); // width increases by 1 when above row with diagonal term
+                    // Increase width by 1 when above row with diagonal term
+                    const int above_diag_extra = (m > Szz_width[1] ? 1:0);
                     int width0 = std::min(m - row_start + above_diag_extra + 1, ncomp_zz[0]);
                     for (int n = 0; n < width0; n++) {
                         const int ii = Szz_width[0] - n;

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -943,6 +943,7 @@ void ImplicitSolver::FinishMassMatrices ()
     // matrices to only deposit roughly half of the values. The remainder are
     // computed via copy here in this routine.
 
+#if AMREX_SPACEDIM < 3
     using ablastr::fields::Direction;
     using warpx::fields::FieldType;
 
@@ -1031,37 +1032,6 @@ void ImplicitSolver::FinishMassMatrices ()
 
                 }
 
-#elif AMREX_SPACEDIM == 3
-                const int plane_start = amrex::max(0, ncomp_xx[2] - ncomp_xx[1]);
-
-                for (int l = plane_start; l < ncomp_xx[2]; ++l) {
-                    const int kk = l - Sxx_width[2];
-
-                    const int above_diag_k = (l > Sxx_width[2]) ? 1 : 0;
-                    const int width1 = amrex::min(l + above_diag_k - plane_start + 1, ncomp_xx[1]);
-                    const int row_start = ncomp_xx[1] - width1;
-
-                    for (int m = row_start; m < ncomp_xx[1]; ++m) {
-                        const int jj = m - Sxx_width[1];
-
-                        const int above_diag_j = (m > Sxx_width[1]) ? 1 : 0;
-                        const int width0 = amrex::min(m + above_diag_j - row_start + 1, ncomp_xx[0]);
-
-                        for (int n = 0; n < width0; ++n) {
-                            const int ii = Sxx_width[0] - n;
-
-                            const amrex::IntVect iv_src = iv_dst + amrex::IntVect(AMREX_D_DECL(ii,jj,kk));
-                            if (!Sbx.contains(iv_src)) { continue; }
-
-                            const int dst_comp = ncomp_xx[0]*(m + ncomp_xx[1]*l +  1) - (n + 1);
-                            const int src_comp = ncomp_tot_xx - 1 - dst_comp;
-
-                            Sxx(iv_dst,dst_comp) = Sxx(iv_src,src_comp);
-                        }
-
-                    }
-
-                }
 #endif
             });
 
@@ -1104,8 +1074,6 @@ void ImplicitSolver::FinishMassMatrices ()
                     }
                 }
 
-#elif AMREX_SPACEDIM == 3
-
 #endif
             });
 
@@ -1147,10 +1115,12 @@ void ImplicitSolver::FinishMassMatrices ()
                         Szz(iv_dst,dst_comp) = Szz(iv_src,src_comp);
                     }
                 }
+
 #endif
             });
         }
     }
+#endif
 }
 
 void ImplicitSolver::PrintBaseImplicitSolverParameters () const

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -992,8 +992,9 @@ void ImplicitSolver::FinishMassMatrices ()
             Sbz.grow(SZ[2]->nGrowVect());
             Sby.grow(SY[1]->nGrowVect());
 
-            amrex::ParallelFor(
-            Sbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            amrex::ParallelFor( Sbx, Sby, Sbz,
+
+                [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 const amrex::IntVect iv_dst = amrex::IntVect(AMREX_D_DECL(i,j,k));
 
@@ -1033,10 +1034,9 @@ void ImplicitSolver::FinishMassMatrices ()
                 }
 
 #endif
-            });
+            },
 
-            amrex::ParallelFor(
-            Sby, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 const amrex::IntVect iv_dst = amrex::IntVect(AMREX_D_DECL(i,j,k));
 
@@ -1075,10 +1075,9 @@ void ImplicitSolver::FinishMassMatrices ()
                 }
 
 #endif
-            });
+            },
 
-            amrex::ParallelFor(
-            Sbz, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 const amrex::IntVect iv_dst = amrex::IntVect(AMREX_D_DECL(i,j,k));
 

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -799,7 +799,10 @@ void ImplicitSolver::PreRHSOp ( const amrex::Real  a_cur_time,
         options.deposit_mass_matrices = true;
         m_WarpX->PushParticlesandDeposit(a_cur_time, skip_deposition, PositionPushType::Full, MomentumPushType::Full, &options);
         CumulateJ();
-        if (m_use_mass_matrices_jacobian) { SaveE(); }
+        if (m_use_mass_matrices_jacobian) {
+            FinishMassMatrices();
+            SaveE();
+        }
         if (m_use_mass_matrices_pc) {
            SyncMassMatricesPCAndApplyBCs();
            const amrex::Real theta_dt = m_theta*m_dt;
@@ -930,6 +933,156 @@ void ImplicitSolver::SetMassMatricesForPC ( const amrex::Real a_theta_dt )
         }
     }
 
+}
+
+void ImplicitSolver::FinishMassMatrices ()
+{
+    BL_PROFILE("ImplicitSolver::FinishMassMatrices()");
+
+    // The MM deposit routine takes advantage of symmetry for the diagonal mass
+    // matrices to only deposit roughly half of the values. The remainder are
+    // computed via copy here in this routine.
+
+    using ablastr::fields::Direction;
+    using warpx::fields::FieldType;
+
+#if AMREX_SPACEDIM == 2
+    const int ncomp_tot_xx = AMREX_D_TERM(m_ncomp_xx[0],*m_ncomp_xx[1],*m_ncomp_xx[2]);
+    const int ncomp_tot_yy = AMREX_D_TERM(m_ncomp_yy[0],*m_ncomp_yy[1],*m_ncomp_yy[2]);
+    const int ncomp_tot_zz = AMREX_D_TERM(m_ncomp_zz[0],*m_ncomp_zz[1],*m_ncomp_zz[2]);
+#endif
+
+    amrex::IntVect Sxx_width, Syy_width, Szz_width;
+    for (int dir=0; dir<AMREX_SPACEDIM; dir++) {
+        Sxx_width[dir] = (m_ncomp_xx[dir] - 1)/2;
+        Syy_width[dir] = (m_ncomp_yy[dir] - 1)/2;
+        Szz_width[dir] = (m_ncomp_zz[dir] - 1)/2;
+    }
+
+#if AMREX_SPACEDIM == 2
+    const amrex::IntVect ncomp_xx = m_ncomp_xx;
+    const amrex::IntVect ncomp_yy = m_ncomp_yy;
+    const amrex::IntVect ncomp_zz = m_ncomp_zz;
+#endif
+
+    for (int lev = 0; lev < m_num_amr_levels; ++lev) {
+
+        ablastr::fields::VectorField SX = m_WarpX->m_fields.get_alldirs(FieldType::MassMatrices_X, lev);
+        ablastr::fields::VectorField SY = m_WarpX->m_fields.get_alldirs(FieldType::MassMatrices_Y, lev);
+        ablastr::fields::VectorField SZ = m_WarpX->m_fields.get_alldirs(FieldType::MassMatrices_Z, lev);
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+        for ( amrex::MFIter mfi(*SX[0], false); mfi.isValid(); ++mfi )
+        {
+
+            amrex::Array4<amrex::Real> const& Sxx = SX[0]->array(mfi);
+            amrex::Array4<amrex::Real> const& Syy = SY[1]->array(mfi);
+            amrex::Array4<amrex::Real> const& Szz = SZ[2]->array(mfi);
+
+            // Use grown boxes here with all S guard cells
+            amrex::Box Sbx = amrex::convert(mfi.validbox(),SX[0]->ixType());
+            amrex::Box Sby = amrex::convert(mfi.validbox(),SY[1]->ixType());
+            amrex::Box Sbz = amrex::convert(mfi.validbox(),SZ[2]->ixType());
+            Sbx.grow(SX[0]->nGrowVect());
+            Sbz.grow(SZ[2]->nGrowVect());
+            Sby.grow(SY[1]->nGrowVect());
+
+            amrex::ParallelFor(
+            Sbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            {
+#if AMREX_SPACEDIM == 1
+                const int idx[3] = {i, j, k};
+                const int width = std::min(Sxx_width[0],Sbx.bigEnd(0)-idx[0]);
+                // Symmetry for diagonal MM: Sxx(i,d + n) = Sxx(i+n,d - n),
+                // where d = width is the diagonal component
+                for (int n = 1; n <= width; n++) {
+                    const int dst_comp = Sxx_width[0] + n;
+                    const int src_comp = Sxx_width[0] - n;
+                    Sxx(i,j,k,dst_comp) = Sxx(i+n,j,k,src_comp);
+                }
+#elif AMREX_SPACEDIM == 2
+                const int row_start = std::max(0,ncomp_xx[1] - ncomp_xx[0]);
+                for (int m = row_start; m < ncomp_xx[1]; m++) {
+                    const int jj = m - Sxx_width[1];
+                    if (j+jj < Sbx.smallEnd(1) || j+jj > Sbx.bigEnd(1)) { continue; }
+                    const int above_diag_extra = (m > Sxx_width[1] ? 1:0); // width increases by 1 when above row with diagonal term
+                    int width0 = std::min(m + above_diag_extra - row_start + 1, ncomp_xx[0]);
+                    for (int n = 0; n < width0; n++) {
+                        const int ii = Sxx_width[0] - n;
+                        if (i+ii < Sbx.smallEnd(0) || i+ii > Sbx.bigEnd(0)) { continue; }
+                        const int dst_comp = ncomp_xx[0]*(m + 1) - (n + 1);
+                        const int src_comp = ncomp_tot_xx - 1 - dst_comp;
+                        Sxx(i,j,k,dst_comp) = Sxx(i+ii,j+jj,k,src_comp);
+                    }
+                }
+#endif
+            });
+
+            amrex::ParallelFor(
+            Sby, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            {
+#if AMREX_SPACEDIM == 1
+                const int idx[3] = {i, j, k};
+                const int width = std::min(Syy_width[0],Sby.bigEnd(0)-idx[0]);
+                // Symmetry for diagonal MM: Syy(i,d + n) = Syy(i+n,d - n),
+                // where d = width is the diagonal component
+                for (int n = 1; n <= width; n++) {
+                    const int dst_comp = Syy_width[0] + n;
+                    const int src_comp = Syy_width[0] - n;
+                    Syy(i,j,k,dst_comp) = Syy(i+n,j,k,src_comp);
+                }
+#elif AMREX_SPACEDIM == 2
+                const int row_start = 1;
+                for (int m = row_start; m < ncomp_yy[1]; m++) {
+                    const int jj = m - Syy_width[1];
+                    if (j+jj < Sby.smallEnd(1) || j+jj > Sby.bigEnd(1)) { continue; }
+                    const int above_diag_extra = (m > Syy_width[1] ? 1:0); // width increases by 1 when above row with diagonal term
+                    int width0 = std::min(m + above_diag_extra - row_start + 1, ncomp_yy[0]);
+                    for (int n = 0; n < width0; n++) {
+                        const int ii = Syy_width[0] - n;
+                        if (i+ii < Sby.smallEnd(0) || i+ii > Sby.bigEnd(0)) { continue; }
+                        const int dst_comp = ncomp_yy[0]*(m + 1) - (n + 1);
+                        const int src_comp = ncomp_tot_yy - 1 - dst_comp;
+                        Syy(i,j,k,dst_comp) = Syy(i+ii,j+jj,k,src_comp);
+                    }
+                }
+#endif
+            });
+
+            amrex::ParallelFor(
+            Sbz, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            {
+#if AMREX_SPACEDIM == 1
+                const int idx[3] = {i, j, k};
+                const int width_zz = std::min(Szz_width[0],Sbz.bigEnd(0)-idx[0]);
+                // Symmetry for diagonal MM: Szz(i,d + n) = Szz(i+n,d - n),
+                // where d = width is the diagonal component
+                for (int n = 1; n <= width_zz; n++) {
+                    const int dst_comp = Szz_width[0] + n;
+                    const int src_comp = Szz_width[0] - n;
+                    Szz(i,j,k,dst_comp) = Szz(i+n,j,k,src_comp);
+                }
+#elif AMREX_SPACEDIM == 2
+                const int row_start = std::max(0,ncomp_zz[1] - ncomp_zz[0]);
+                for (int m = row_start; m < ncomp_zz[1]; m++) {
+                    const int jj = m - Szz_width[1];
+                    if (j+jj < Sbz.smallEnd(1) || j+jj > Sbz.bigEnd(1)) { continue; }
+                    const int above_diag_extra = (m > Szz_width[1] ? 1:0); // width increases by 1 when above row with diagonal term
+                    int width0 = std::min(m - row_start + above_diag_extra + 1, ncomp_zz[0]);
+                    for (int n = 0; n < width0; n++) {
+                        const int ii = Szz_width[0] - n;
+                        if (i+ii < Sbz.smallEnd(0) || i+ii > Sbz.bigEnd(0)) { continue; }
+                        const int dst_comp = ncomp_zz[0]*(m + 1) - (n + 1);
+                        const int src_comp = ncomp_tot_zz - 1 - dst_comp;
+                        Szz(i,j,k,dst_comp) = Szz(i+ii,j+jj,k,src_comp);
+                    }
+                }
+#endif
+            });
+        }
+    }
 }
 
 void ImplicitSolver::PrintBaseImplicitSolverParameters () const

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -992,25 +992,50 @@ void ImplicitSolver::FinishMassMatrices ()
             Sbz.grow(SZ[2]->nGrowVect());
             Sby.grow(SY[1]->nGrowVect());
 
+#if AMREX_SPACEDIM == 1
             amrex::ParallelFor( Sbx, Sby, Sbz,
 
                 [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
-                const amrex::IntVect iv_dst = amrex::IntVect(AMREX_D_DECL(i,j,k));
-
-#if AMREX_SPACEDIM == 1
+                // Sxx(i,d + n) = Sxx(i + n,d - n), where d = Sxx_width[0]
                 const int width = amrex::min(Sxx_width[0],Sbx.bigEnd(0)-i);
-
-                // Symmetry for diagonal MM: Sxx(i,d + n) = Sxx(i + n,d - n),
-                // where d = Sxx_width[0] is the diagonal component
                 for (int n = 1; n <= width; ++n) {
                     const int dst_comp = Sxx_width[0] + n;
                     const int src_comp = Sxx_width[0] - n;
-                    Sxx(iv_dst,dst_comp) = Sxx(i + n,j,k,src_comp);
+                    Sxx(i,j,k,dst_comp) = Sxx(i + n,j,k,src_comp);
                 }
+            },
+
+                [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            {
+                // Syy(i,d + n) = Syy(i + n,d - n), where d = Syy_width[0]
+                const int width = std::min(Syy_width[0], Sby.bigEnd(0) - i);
+                for (int n = 1; n <= width; n++) {
+                    const int dst_comp = Syy_width[0] + n;
+                    const int src_comp = Syy_width[0] - n;
+                    Syy(i,j,k,dst_comp) = Syy(i + n,j,k,src_comp);
+                }
+            },
+
+                [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            {
+                // Szz(i,d + n) = Szz(i + n,d - n), where d = Szz_width[0]
+                const int width_zz = std::min(Szz_width[0],Sbz.bigEnd(0) - i);
+                for (int n = 1; n <= width_zz; n++) {
+                    const int dst_comp = Szz_width[0] + n;
+                    const int src_comp = Szz_width[0] - n;
+                    Szz(i,j,k,dst_comp) = Szz(i + n,j,k,src_comp);
+                }
+            });
 
 #elif AMREX_SPACEDIM == 2
+            amrex::ParallelFor( Sbx, Sby, Sbz,
+
+                [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            {
                 ignore_unused(k);
+                const amrex::IntVect iv_dst = amrex::IntVect(AMREX_D_DECL(i,j,k));
+
                 const int row_start = amrex::max(0,ncomp_xx[1] - ncomp_xx[0]);
 
                 for (int m = row_start; m < ncomp_xx[1]; ++m) {
@@ -1033,26 +1058,13 @@ void ImplicitSolver::FinishMassMatrices ()
 
                 }
 
-#endif
             },
 
                 [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
+                ignore_unused(k);
                 const amrex::IntVect iv_dst = amrex::IntVect(AMREX_D_DECL(i,j,k));
 
-#if AMREX_SPACEDIM == 1
-                const int width = std::min(Syy_width[0], Sby.bigEnd(0) - i);
-
-                // Symmetry for diagonal MM: Syy(i,d + n) = Syy(i + n,d - n),
-                // where d = Syy_width[0] is the diagonal component
-                for (int n = 1; n <= width; n++) {
-                    const int dst_comp = Syy_width[0] + n;
-                    const int src_comp = Syy_width[0] - n;
-                    Syy(iv_dst,dst_comp) = Syy(i + n,j,k,src_comp);
-                }
-
-#elif AMREX_SPACEDIM == 2
-                ignore_unused(k);
                 const int row_start = 1;
 
                 for (int m = row_start; m < ncomp_yy[1]; m++) {
@@ -1074,26 +1086,13 @@ void ImplicitSolver::FinishMassMatrices ()
                     }
                 }
 
-#endif
             },
 
                 [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
+                ignore_unused(k);
                 const amrex::IntVect iv_dst = amrex::IntVect(AMREX_D_DECL(i,j,k));
 
-#if AMREX_SPACEDIM == 1
-                const int width_zz = std::min(Szz_width[0],Sbz.bigEnd(0) - i);
-
-                // Symmetry for diagonal MM: Szz(i,d + n) = Szz(i + n,d - n),
-                // where d = Szz_width[0] is the diagonal component
-                for (int n = 1; n <= width_zz; n++) {
-                    const int dst_comp = Szz_width[0] + n;
-                    const int src_comp = Szz_width[0] - n;
-                    Szz(iv_dst,dst_comp) = Szz(i + n,j,k,src_comp);
-                }
-
-#elif AMREX_SPACEDIM == 2
-                ignore_unused(k);
                 const int row_start = std::max(0,ncomp_zz[1] - ncomp_zz[0]);
 
                 for (int m = row_start; m < ncomp_zz[1]; m++) {
@@ -1115,8 +1114,8 @@ void ImplicitSolver::FinishMassMatrices ()
                     }
                 }
 
-#endif
             });
+#endif
         }
     }
 #endif

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -955,9 +955,9 @@ void ImplicitSolver::FinishMassMatrices ()
     const int ncomp_tot_zz = AMREX_D_TERM(m_ncomp_zz[0],*m_ncomp_zz[1],*m_ncomp_zz[2]);
 #endif
 
-    amrex::GpuArray<int,3> ncomp_xx = {0,0,0};
-    amrex::GpuArray<int,3> ncomp_yy = {0,0,0};
-    amrex::GpuArray<int,3> ncomp_zz = {0,0,0};
+    amrex::GpuArray<int,3> ncomp_xx = {1,1,1};
+    amrex::GpuArray<int,3> ncomp_yy = {1,1,1};
+    amrex::GpuArray<int,3> ncomp_zz = {1,1,1};
     amrex::GpuArray<int,3> Sxx_width = {0,0,0};
     amrex::GpuArray<int,3> Syy_width = {0,0,0};
     amrex::GpuArray<int,3> Szz_width = {0,0,0};

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -800,9 +800,7 @@ void ImplicitSolver::PreRHSOp ( const amrex::Real  a_cur_time,
         m_WarpX->PushParticlesandDeposit(a_cur_time, skip_deposition, PositionPushType::Full, MomentumPushType::Full, &options);
         CumulateJ();
         if (m_use_mass_matrices_jacobian) {
-#if AMREX_SPACEDIM < 3
             FinishMassMatrices();
-#endif
             SaveE();
         }
         if (m_use_mass_matrices_pc) {
@@ -937,7 +935,6 @@ void ImplicitSolver::SetMassMatricesForPC ( const amrex::Real a_theta_dt )
 
 }
 
-#if AMREX_SPACEDIM < 3
 void ImplicitSolver::FinishMassMatrices ()
 {
     BL_PROFILE("ImplicitSolver::FinishMassMatrices()");
@@ -949,7 +946,7 @@ void ImplicitSolver::FinishMassMatrices ()
     using ablastr::fields::Direction;
     using warpx::fields::FieldType;
 
-#if AMREX_SPACEDIM == 2
+#if AMREX_SPACEDIM > 1
     const int ncomp_tot_xx = AMREX_D_TERM(m_ncomp_xx[0],*m_ncomp_xx[1],*m_ncomp_xx[2]);
     const int ncomp_tot_yy = AMREX_D_TERM(m_ncomp_yy[0],*m_ncomp_yy[1],*m_ncomp_yy[2]);
     const int ncomp_tot_zz = AMREX_D_TERM(m_ncomp_zz[0],*m_ncomp_zz[1],*m_ncomp_zz[2]);
@@ -997,31 +994,73 @@ void ImplicitSolver::FinishMassMatrices ()
             amrex::ParallelFor(
             Sbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
+                const amrex::IntVect iv_dst = amrex::IntVect(AMREX_D_DECL(i,j,k));
+
 #if AMREX_SPACEDIM == 1
-                const int idx[3] = {i, j, k};
-                const int width = std::min(Sxx_width[0],Sbx.bigEnd(0)-idx[0]);
-                // Symmetry for diagonal MM: Sxx(i,d + n) = Sxx(i+n,d - n),
-                // where d = width is the diagonal component
-                for (int n = 1; n <= width; n++) {
+                const int width = amrex::min(Sxx_width[0],Sbx.bigEnd(0)-i);
+
+                // Symmetry for diagonal MM: Sxx(i,d + n) = Sxx(i + n,d - n),
+                // where d = Sxx_width[0] is the diagonal component
+                for (int n = 1; n <= width; ++n) {
                     const int dst_comp = Sxx_width[0] + n;
                     const int src_comp = Sxx_width[0] - n;
-                    Sxx(i,j,k,dst_comp) = Sxx(i+n,j,k,src_comp);
+                    Sxx(iv_dst,dst_comp) = Sxx(i + n,j,k,src_comp);
                 }
+
 #elif AMREX_SPACEDIM == 2
-                const int row_start = std::max(0,ncomp_xx[1] - ncomp_xx[0]);
-                for (int m = row_start; m < ncomp_xx[1]; m++) {
+                ignore_unused(k);
+                const int row_start = amrex::max(0,ncomp_xx[1] - ncomp_xx[0]);
+
+                for (int m = row_start; m < ncomp_xx[1]; ++m) {
                     const int jj = m - Sxx_width[1];
-                    if (j+jj < Sbx.smallEnd(1) || j+jj > Sbx.bigEnd(1)) { continue; }
-                    // Increase width by 1 when above row with diagonal term
-                    const int above_diag_extra = (m > Sxx_width[1] ? 1:0);
-                    int width0 = std::min(m + above_diag_extra - row_start + 1, ncomp_xx[0]);
-                    for (int n = 0; n < width0; n++) {
+
+                    const int above_diag = (m > Sxx_width[1]) ? 1 : 0;
+                    const int width0 = amrex::min(m + above_diag - row_start + 1, ncomp_xx[0]);
+
+                    for (int n = 0; n < width0; ++n) {
                         const int ii = Sxx_width[0] - n;
-                        if (i+ii < Sbx.smallEnd(0) || i+ii > Sbx.bigEnd(0)) { continue; }
+
+                        const amrex::IntVect iv_src = iv_dst + amrex::IntVect(AMREX_D_DECL(ii,jj,0));
+                        if (!Sbx.contains(iv_src)) { continue; }
+
                         const int dst_comp = ncomp_xx[0]*(m + 1) - (n + 1);
                         const int src_comp = ncomp_tot_xx - 1 - dst_comp;
-                        Sxx(i,j,k,dst_comp) = Sxx(i+ii,j+jj,k,src_comp);
+
+                        Sxx(iv_dst,dst_comp) = Sxx(iv_src,src_comp);
                     }
+
+                }
+
+#elif AMREX_SPACEDIM == 3
+                const int plane_start = amrex::max(0, ncomp_xx[2] - ncomp_xx[1]);
+
+                for (int l = plane_start; l < ncomp_xx[2]; ++l) {
+                    const int kk = l - Sxx_width[2];
+
+                    const int above_diag_k = (l > Sxx_width[2]) ? 1 : 0;
+                    const int width1 = amrex::min(l + above_diag_k - plane_start + 1, ncomp_xx[1]);
+                    const int row_start = ncomp_xx[1] - width1;
+
+                    for (int m = row_start; m < ncomp_xx[1]; ++m) {
+                        const int jj = m - Sxx_width[1];
+
+                        const int above_diag_j = (m > Sxx_width[1]) ? 1 : 0;
+                        const int width0 = amrex::min(m + above_diag_j - row_start + 1, ncomp_xx[0]);
+
+                        for (int n = 0; n < width0; ++n) {
+                            const int ii = Sxx_width[0] - n;
+
+                            const amrex::IntVect iv_src = iv_dst + amrex::IntVect(AMREX_D_DECL(ii,jj,kk));
+                            if (!Sbx.contains(iv_src)) { continue; }
+
+                            const int dst_comp = ncomp_xx[0]*(m + ncomp_xx[1]*l +  1) - (n + 1);
+                            const int src_comp = ncomp_tot_xx - 1 - dst_comp;
+
+                            Sxx(iv_dst,dst_comp) = Sxx(iv_src,src_comp);
+                        }
+
+                    }
+
                 }
 #endif
             });
@@ -1030,14 +1069,13 @@ void ImplicitSolver::FinishMassMatrices ()
             Sby, [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
 #if AMREX_SPACEDIM == 1
-                const int idx[3] = {i, j, k};
-                const int width = std::min(Syy_width[0],Sby.bigEnd(0)-idx[0]);
-                // Symmetry for diagonal MM: Syy(i,d + n) = Syy(i+n,d - n),
+                const int width = std::min(Syy_width[0], Sby.bigEnd(0) - i);
+                // Symmetry for diagonal MM: Syy(i,d + n) = Syy(i + n,d - n),
                 // where d = width is the diagonal component
                 for (int n = 1; n <= width; n++) {
                     const int dst_comp = Syy_width[0] + n;
                     const int src_comp = Syy_width[0] - n;
-                    Syy(i,j,k,dst_comp) = Syy(i+n,j,k,src_comp);
+                    Syy(i,j,k,dst_comp) = Syy(i + n,j,k,src_comp);
                 }
 #elif AMREX_SPACEDIM == 2
                 const int row_start = 1;
@@ -1045,8 +1083,8 @@ void ImplicitSolver::FinishMassMatrices ()
                     const int jj = m - Syy_width[1];
                     if (j+jj < Sby.smallEnd(1) || j+jj > Sby.bigEnd(1)) { continue; }
                     // Increase width by 1 when above row with diagonal term
-                    const int above_diag_extra = (m > Syy_width[1] ? 1:0);
-                    int width0 = std::min(m + above_diag_extra - row_start + 1, ncomp_yy[0]);
+                    const int above_diag = (m > Syy_width[1]) ? 1 : 0;
+                    int width0 = std::min(m + above_diag - row_start + 1, ncomp_yy[0]);
                     for (int n = 0; n < width0; n++) {
                         const int ii = Syy_width[0] - n;
                         if (i+ii < Sby.smallEnd(0) || i+ii > Sby.bigEnd(0)) { continue; }
@@ -1062,14 +1100,13 @@ void ImplicitSolver::FinishMassMatrices ()
             Sbz, [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
 #if AMREX_SPACEDIM == 1
-                const int idx[3] = {i, j, k};
-                const int width_zz = std::min(Szz_width[0],Sbz.bigEnd(0)-idx[0]);
-                // Symmetry for diagonal MM: Szz(i,d + n) = Szz(i+n,d - n),
+                const int width_zz = std::min(Szz_width[0],Sbz.bigEnd(0) - i);
+                // Symmetry for diagonal MM: Szz(i,d + n) = Szz(i + n,d - n),
                 // where d = width is the diagonal component
                 for (int n = 1; n <= width_zz; n++) {
                     const int dst_comp = Szz_width[0] + n;
                     const int src_comp = Szz_width[0] - n;
-                    Szz(i,j,k,dst_comp) = Szz(i+n,j,k,src_comp);
+                    Szz(i,j,k,dst_comp) = Szz(i + n,j,k,src_comp);
                 }
 #elif AMREX_SPACEDIM == 2
                 const int row_start = std::max(0,ncomp_zz[1] - ncomp_zz[0]);
@@ -1077,8 +1114,8 @@ void ImplicitSolver::FinishMassMatrices ()
                     const int jj = m - Szz_width[1];
                     if (j+jj < Sbz.smallEnd(1) || j+jj > Sbz.bigEnd(1)) { continue; }
                     // Increase width by 1 when above row with diagonal term
-                    const int above_diag_extra = (m > Szz_width[1] ? 1:0);
-                    int width0 = std::min(m - row_start + above_diag_extra + 1, ncomp_zz[0]);
+                    const int above_diag = (m > Szz_width[1]) ? 1 : 0;
+                    int width0 = std::min(m - row_start + above_diag + 1, ncomp_zz[0]);
                     for (int n = 0; n < width0; n++) {
                         const int ii = Szz_width[0] - n;
                         if (i+ii < Sbz.smallEnd(0) || i+ii > Sbz.bigEnd(0)) { continue; }
@@ -1092,7 +1129,6 @@ void ImplicitSolver::FinishMassMatrices ()
         }
     }
 }
-#endif
 
 void ImplicitSolver::PrintBaseImplicitSolverParameters () const
 {

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -800,7 +800,9 @@ void ImplicitSolver::PreRHSOp ( const amrex::Real  a_cur_time,
         m_WarpX->PushParticlesandDeposit(a_cur_time, skip_deposition, PositionPushType::Full, MomentumPushType::Full, &options);
         CumulateJ();
         if (m_use_mass_matrices_jacobian) {
+#if AMREX_SPACEDIM < 3
             FinishMassMatrices();
+#endif
             SaveE();
         }
         if (m_use_mass_matrices_pc) {
@@ -935,6 +937,7 @@ void ImplicitSolver::SetMassMatricesForPC ( const amrex::Real a_theta_dt )
 
 }
 
+#if AMREX_SPACEDIM < 3
 void ImplicitSolver::FinishMassMatrices ()
 {
     BL_PROFILE("ImplicitSolver::FinishMassMatrices()");
@@ -1084,6 +1087,7 @@ void ImplicitSolver::FinishMassMatrices ()
         }
     }
 }
+#endif
 
 void ImplicitSolver::PrintBaseImplicitSolverParameters () const
 {

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -1068,60 +1068,83 @@ void ImplicitSolver::FinishMassMatrices ()
             amrex::ParallelFor(
             Sby, [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
+                const amrex::IntVect iv_dst = amrex::IntVect(AMREX_D_DECL(i,j,k));
+
 #if AMREX_SPACEDIM == 1
                 const int width = std::min(Syy_width[0], Sby.bigEnd(0) - i);
+
                 // Symmetry for diagonal MM: Syy(i,d + n) = Syy(i + n,d - n),
-                // where d = width is the diagonal component
+                // where d = Syy_width[0] is the diagonal component
                 for (int n = 1; n <= width; n++) {
                     const int dst_comp = Syy_width[0] + n;
                     const int src_comp = Syy_width[0] - n;
-                    Syy(i,j,k,dst_comp) = Syy(i + n,j,k,src_comp);
+                    Syy(iv_dst,dst_comp) = Syy(i + n,j,k,src_comp);
                 }
+
 #elif AMREX_SPACEDIM == 2
+                ignore_unused(k);
                 const int row_start = 1;
+
                 for (int m = row_start; m < ncomp_yy[1]; m++) {
                     const int jj = m - Syy_width[1];
-                    if (j+jj < Sby.smallEnd(1) || j+jj > Sby.bigEnd(1)) { continue; }
-                    // Increase width by 1 when above row with diagonal term
+
                     const int above_diag = (m > Syy_width[1]) ? 1 : 0;
-                    int width0 = std::min(m + above_diag - row_start + 1, ncomp_yy[0]);
+                    const int width0 = std::min(m + above_diag - row_start + 1, ncomp_yy[0]);
+
                     for (int n = 0; n < width0; n++) {
                         const int ii = Syy_width[0] - n;
-                        if (i+ii < Sby.smallEnd(0) || i+ii > Sby.bigEnd(0)) { continue; }
+
+                        const amrex::IntVect iv_src = iv_dst + amrex::IntVect(AMREX_D_DECL(ii,jj,0));
+                        if (!Sby.contains(iv_src)) { continue; }
+
                         const int dst_comp = ncomp_yy[0]*(m + 1) - (n + 1);
                         const int src_comp = ncomp_tot_yy - 1 - dst_comp;
-                        Syy(i,j,k,dst_comp) = Syy(i+ii,j+jj,k,src_comp);
+
+                        Syy(iv_dst,dst_comp) = Syy(iv_src,src_comp);
                     }
                 }
+
+#elif AMREX_SPACEDIM == 3
+
 #endif
             });
 
             amrex::ParallelFor(
             Sbz, [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
+                const amrex::IntVect iv_dst = amrex::IntVect(AMREX_D_DECL(i,j,k));
+
 #if AMREX_SPACEDIM == 1
                 const int width_zz = std::min(Szz_width[0],Sbz.bigEnd(0) - i);
+
                 // Symmetry for diagonal MM: Szz(i,d + n) = Szz(i + n,d - n),
-                // where d = width is the diagonal component
+                // where d = Szz_width[0] is the diagonal component
                 for (int n = 1; n <= width_zz; n++) {
                     const int dst_comp = Szz_width[0] + n;
                     const int src_comp = Szz_width[0] - n;
-                    Szz(i,j,k,dst_comp) = Szz(i + n,j,k,src_comp);
+                    Szz(iv_dst,dst_comp) = Szz(i + n,j,k,src_comp);
                 }
+
 #elif AMREX_SPACEDIM == 2
+                ignore_unused(k);
                 const int row_start = std::max(0,ncomp_zz[1] - ncomp_zz[0]);
+
                 for (int m = row_start; m < ncomp_zz[1]; m++) {
                     const int jj = m - Szz_width[1];
-                    if (j+jj < Sbz.smallEnd(1) || j+jj > Sbz.bigEnd(1)) { continue; }
-                    // Increase width by 1 when above row with diagonal term
+
                     const int above_diag = (m > Szz_width[1]) ? 1 : 0;
-                    int width0 = std::min(m - row_start + above_diag + 1, ncomp_zz[0]);
+                    const int width0 = std::min(m - row_start + above_diag + 1, ncomp_zz[0]);
+
                     for (int n = 0; n < width0; n++) {
                         const int ii = Szz_width[0] - n;
-                        if (i+ii < Sbz.smallEnd(0) || i+ii > Sbz.bigEnd(0)) { continue; }
+
+                        const amrex::IntVect iv_src = iv_dst + amrex::IntVect(AMREX_D_DECL(ii,jj,0));
+                        if (!Sbz.contains(iv_src)) { continue; }
+
                         const int dst_comp = ncomp_zz[0]*(m + 1) - (n + 1);
                         const int src_comp = ncomp_tot_zz - 1 - dst_comp;
-                        Szz(i,j,k,dst_comp) = Szz(i+ii,j+jj,k,src_comp);
+
+                        Szz(iv_dst,dst_comp) = Szz(iv_src,src_comp);
                     }
                 }
 #endif

--- a/Source/Particles/Deposition/MassMatricesDeposition.H
+++ b/Source/Particles/Deposition/MassMatricesDeposition.H
@@ -1197,19 +1197,20 @@ void doVillasenorJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::Parti
 
     if constexpr (full_mass_matrices) {
 
-    const int Ncomp_xx0 = 1 + 2*(depos_order - 1) + 2*max_crossings;
-    const int Ncomp_xz0 = 2*depos_order + 2*max_crossings;
-    const int Ncomp_zx0 = 2*depos_order + 2*max_crossings;
-    const int Ncomp_zz0 = 1 + 2*depos_order + 2*max_crossings;
-    const int Ncomp_xy0 = 2*depos_order + 2*max_crossings;
-    const int Ncomp_yx0 = 2*depos_order + 2*max_crossings;
-    const int Ncomp_yz0 = 1 + 2*depos_order + 2*max_crossings;
-    const int Ncomp_yy0 = 1 + 2*depos_order + 2*max_crossings;
-    const int Ncomp_zy0 = 1 + 2*depos_order + 2*max_crossings;
+    const int Ncomp_base = 2*depos_order + 2*max_crossings;
+    const int Ncomp_xx0 = Ncomp_base - 1;
+    const int Ncomp_xz0 = Ncomp_base;
+    const int Ncomp_zx0 = Ncomp_base;
+    const int Ncomp_zz0 = 1 + Ncomp_base;
+    const int Ncomp_xy0 = Ncomp_base;
+    const int Ncomp_yx0 = Ncomp_base;
+    const int Ncomp_yz0 = 1 + Ncomp_base;
+    const int Ncomp_yy0 = 1 + Ncomp_base;
+    const int Ncomp_zy0 = 1 + Ncomp_base;
 
-    const int width_xx1 = depos_order + max_crossings;     // (Ncomp_xx[1] - 1)/2
-    const int width_zz1 = depos_order - 1 + max_crossings; // (Ncomp_zz[1] - 1)/2
-    const int width_yy1 = depos_order + max_crossings;     // (Ncomp_yy[1] - 1)/2
+    const int width_xx1 = depos_order + max_crossings;  // (Ncomp_xx[1] - 1)/2
+    const int width_zz1 = width_xx1 - 1;                // (Ncomp_zz[1] - 1)/2
+    const int width_yy1 = width_xx1;                    // (Ncomp_yy[1] - 1)/2
 
     // Loop over segments and deposit full mass matrices
     for (int ns=0; ns<num_segments; ns++) {

--- a/Source/Particles/Deposition/MassMatricesDeposition.H
+++ b/Source/Particles/Deposition/MassMatricesDeposition.H
@@ -281,50 +281,56 @@ void doDirectJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::ParticleR
         // Deposit mass matrices
         if constexpr (full_mass_matrices) {
             for (int aa=0; aa<=depos_order; aa++){
-                //  Deposit mass matrices for X-current
-                int Nc = depos_order + aa - iz;
-                amrex::Gpu::Atomic::AddNoRet(
-                    &Sxx_arr(lo.x+l_jx+iz, 0, 0, Nc),
-                    sz_jx[iz]*sz_jx[aa]*fpxx);
-                Nc = depos_order + shift[0]*offset_xy[0] + aa - iz;
+
+                int col_base = depos_order + aa - iz;
+                int Nc;
+
+                // Reduced deposit for diagonal mass matrices
+                if (aa <= iz) {
+                    Nc = col_base;
+                    amrex::Gpu::Atomic::AddNoRet(
+                        &Sxx_arr(lo.x+l_jx+iz, 0, 0, Nc),
+                        sz_jx[iz]*sz_jx[aa]*fpxx);
+                    amrex::Gpu::Atomic::AddNoRet(
+                        &Syy_arr(lo.x+l_jy+iz, 0, 0, Nc),
+                        sz_jy[iz]*sz_jy[aa]*fpyy);
+                    amrex::Gpu::Atomic::AddNoRet(
+                        &Szz_arr(lo.x+l_jz+iz, 0, 0, Nc),
+                        sz_jz[iz]*sz_jz[aa]*fpzz);
+                }
+
+                // Deposit off-diagonal mass matrices for X-current
+                Nc = col_base + shift[0]*offset_xy[0];
                 amrex::Gpu::Atomic::AddNoRet(
                     &Sxy_arr(lo.x+l_jx+iz, 0, 0, Nc),
                     sz_jx[iz]*sz_jy[aa]*fpxy);
-                Nc = depos_order + shift[0]*offset_xz[0] + aa - iz;
+                Nc = col_base + shift[0]*offset_xz[0];
                 amrex::Gpu::Atomic::AddNoRet(
                     &Sxz_arr(lo.x+l_jx+iz, 0, 0, Nc),
                     sz_jx[iz]*sz_jz[aa]*fpxz);
 
-                //  Deposit mass matrices for Y-current
-                Nc = depos_order + shift[0]*offset_xy[0] + aa - iz;
+                // Deposit off-diagonal mass matrices for Y-current
+                Nc = col_base + shift[0]*offset_xy[0];
                 amrex::Gpu::Atomic::AddNoRet(
                     &Syx_arr(lo.x+l_jy+iz, 0, 0, Nc),
                     sz_jy[iz]*sz_jx[aa]*fpyx);
-                Nc = depos_order + aa - iz;
-                amrex::Gpu::Atomic::AddNoRet(
-                    &Syy_arr(lo.x+l_jy+iz, 0, 0, Nc),
-                    sz_jy[iz]*sz_jy[aa]*fpyy);
-                Nc = depos_order + shift[0]*offset_yz[0] + aa - iz;
+                Nc = col_base + shift[0]*offset_yz[0];
                 amrex::Gpu::Atomic::AddNoRet(
                     &Syz_arr(lo.x+l_jy+iz, 0, 0, Nc),
                     sz_jy[iz]*sz_jz[aa]*fpyz);
 
-                //  Deposit mass matrices for Z-current
-                Nc = depos_order + 1 - shift[0]*offset_xz[0] + aa - iz;
+                // Deposit off-diagonal mass matrices for Z-current
+                Nc = col_base + 1 - shift[0]*offset_xz[0];
                 amrex::Gpu::Atomic::AddNoRet(
                     &Szx_arr(lo.x+l_jz+iz, 0, 0, Nc),
                     sz_jz[iz]*sz_jx[aa]*fpzx);
-                Nc = depos_order + 1 - shift[0]*offset_yz[0] + aa - iz;
+                Nc = col_base + 1 - shift[0]*offset_yz[0];
                 amrex::Gpu::Atomic::AddNoRet(
                     &Szy_arr(lo.x+l_jz+iz, 0, 0, Nc),
                     sz_jz[iz]*sz_jy[aa]*fpzy);
-                Nc = depos_order + aa - iz;
-                amrex::Gpu::Atomic::AddNoRet(
-                    &Szz_arr(lo.x+l_jz+iz, 0, 0, Nc),
-                    sz_jz[iz]*sz_jz[aa]*fpzz);
             }
         }
-        else {  //  Deposit mass matrices for diagonal PC only
+        else { // Deposit mass matrices for diagonal PC only
             amrex::Gpu::Atomic::AddNoRet(
                 &Sxx_arr(lo.x+l_jx+iz, 0, 0, 0),
                 sz_jx[iz]*fpxx);
@@ -360,8 +366,11 @@ void doDirectJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::ParticleR
     }
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
     const int base_offset = 1 + 2*depos_order;
+
     for (int iz=0; iz<=depos_order; iz++){
+
         for (int ix=0; ix<=depos_order; ix++){
+
             const amrex::Real weight_Jx = sx_jx[ix]*sz_jx[iz];
             const amrex::Real weight_Jy = sx_jy[ix]*sz_jy[iz];
             const amrex::Real weight_Jz = sx_jz[ix]*sz_jz[iz];
@@ -375,77 +384,86 @@ void doDirectJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::ParticleR
                 &jz_arr(lo.x+j_jz+ix, lo.y+l_jz+iz, 0, 0),
                 weight_Jz*wqz);
 
-            //  Deposit mass matrices
+            // Deposit mass matrices
             if constexpr (full_mass_matrices) {
+
+                const int Ncomp0 = 1 + 2*depos_order;
+
                 for (int bb=0; bb<=depos_order; bb++){
+
+                    const int row_base = depos_order + bb - iz;
+
                     for (int aa=0; aa<=depos_order; aa++){
+                        const int col_base = depos_order + aa - ix;
                         const amrex::Real weight_Ex = sx_jx[aa]*sz_jx[bb];
                         const amrex::Real weight_Ey = sx_jy[aa]*sz_jy[bb];
                         const amrex::Real weight_Ez = sx_jz[aa]*sz_jz[bb];
 
-                        //  Deposit mass matrices for X-current
-                        int offset = base_offset;
-                        int Nc =  depos_order + aa - ix
-                               + (depos_order + bb - iz)*offset;
-                        amrex::Gpu::Atomic::AddNoRet(
-                            &Sxx_arr(lo.x+j_jx+ix, lo.y+l_jx+iz, 0, Nc),
-                            weight_Jx*weight_Ex*fpxx);
+                        int offset;
+                        int Nc;
+
+                        // Reduced deposit for diagonal mass matrices
+                        if (col_base <= Ncomp0 - row_base) {
+                            offset = base_offset;
+                            Nc = col_base + row_base*offset;
+                            amrex::Gpu::Atomic::AddNoRet(
+                                &Sxx_arr(lo.x+j_jx+ix, lo.y+l_jx+iz, 0, Nc),
+                                weight_Jx*weight_Ex*fpxx);
+                            amrex::Gpu::Atomic::AddNoRet(
+                                &Syy_arr(lo.x+j_jy+ix, lo.y+l_jy+iz, 0, Nc),
+                                weight_Jy*weight_Ey*fpyy);
+                            amrex::Gpu::Atomic::AddNoRet(
+                                &Szz_arr(lo.x+j_jz+ix, lo.y+l_jz+iz, 0, Nc),
+                                weight_Jz*weight_Ez*fpzz);
+                        }
+
+                        // Deposit off-diagonal mass matrices for X-current
                         offset = base_offset + offset_xy[0];
-                        Nc =  depos_order + 1 - shift[0]*offset_xy[0] + aa - ix
-                           + (depos_order + shift[1]*offset_xy[1] + bb - iz)*offset;
+                        Nc =  col_base + 1 - shift[0]*offset_xy[0]
+                           + (row_base + shift[1]*offset_xy[1])*offset;
                         amrex::Gpu::Atomic::AddNoRet(
                             &Sxy_arr(lo.x+j_jx+ix, lo.y+l_jx+iz, 0, Nc),
                             weight_Jx*weight_Ey*fpxy);
                         offset = base_offset + offset_xz[0];
-                        Nc =  depos_order + 1 - shift[0]*offset_xz[0] + aa - ix
-                           + (depos_order + shift[1]*offset_xz[1] + bb - iz)*offset;
+                        Nc =  col_base + 1 - shift[0]*offset_xz[0]
+                           + (row_base + shift[1]*offset_xz[1])*offset;
                         amrex::Gpu::Atomic::AddNoRet(
                             &Sxz_arr(lo.x+j_jx+ix, lo.y+l_jx+iz, 0, Nc),
                             weight_Jx*weight_Ez*fpxz);
 
-                        //  Deposit mass matrices for Y-current
-                        offset = base_offset;
-                        Nc =  depos_order + aa - ix
-                           + (depos_order + bb - iz)*offset;
-                        amrex::Gpu::Atomic::AddNoRet(
-                            &Syy_arr(lo.x+j_jy+ix, lo.y+l_jy+iz, 0, Nc),
-                            weight_Jy*weight_Ey*fpyy);
+                        // Deposit off-diagonal mass matrices for Y-current
                         offset = base_offset + offset_xy[0];
-                        Nc =  depos_order + shift[0]*offset_xy[0] + aa - ix
-                           + (depos_order + shift[1]*offset_xy[1] + bb - iz)*offset;
+                        Nc =  col_base + shift[0]*offset_xy[0]
+                           + (row_base + shift[1]*offset_xy[1])*offset;
                         amrex::Gpu::Atomic::AddNoRet(
                             &Syx_arr(lo.x+j_jy+ix, lo.y+l_jy+iz, 0, Nc),
                             weight_Jy*weight_Ex*fpyx);
                         offset = base_offset + offset_yz[0];
-                        Nc =  depos_order + shift[0]*offset_yz[0] + aa - ix
-                           + (depos_order + shift[1]*offset_yz[1] + bb - iz)*offset;
+                        Nc =  col_base + shift[0]*offset_yz[0]
+                           + (row_base + shift[1]*offset_yz[1])*offset;
                         amrex::Gpu::Atomic::AddNoRet(
                             &Syz_arr(lo.x+j_jy+ix, lo.y+l_jy+iz, 0, Nc),
                             weight_Jy*weight_Ez*fpyz);
 
-                        //  Deposit mass matrices for Z-current
-                        offset = base_offset;
-                        Nc =  depos_order + aa - ix
-                           + (depos_order + bb - iz)*offset;
-                        amrex::Gpu::Atomic::AddNoRet(
-                            &Szz_arr(lo.x+j_jz+ix, lo.y+l_jz+iz, 0, Nc),
-                            weight_Jz*weight_Ez*fpzz);
+                        // Deposit off-diagonal mass matrices for Z-current
                         offset = base_offset + offset_xz[0];
-                        Nc =  depos_order + shift[0]*offset_xz[0] + aa - ix
-                           + (depos_order + 1 - shift[1]*offset_xz[1] + bb - iz)*offset;
+                        Nc =  col_base + shift[0]*offset_xz[0]
+                           + (row_base + 1 - shift[1]*offset_xz[1])*offset;
                         amrex::Gpu::Atomic::AddNoRet(
                             &Szx_arr(lo.x+j_jz+ix, lo.y+l_jz+iz, 0, Nc),
                             weight_Jz*weight_Ex*fpzx);
                         offset = base_offset + offset_yz[0];
-                        Nc =  depos_order + shift[0]*offset_yz[0] + aa - ix
-                           + (depos_order + 1 - shift[1]*offset_yz[1] + bb - iz)*offset;
+                        Nc =  col_base + shift[0]*offset_yz[0]
+                           + (row_base + 1 - shift[1]*offset_yz[1])*offset;
                         amrex::Gpu::Atomic::AddNoRet(
                             &Szy_arr(lo.x+j_jz+ix, lo.y+l_jz+iz, 0, Nc),
                             weight_Jz*weight_Ey*fpzy);
                     }
+
                 }
+
             }
-            else {  //  Deposit mass matrices for diagonal PC only
+            else { // Deposit mass matrices for diagonal PC only
                 amrex::Gpu::Atomic::AddNoRet(
                     &Syy_arr(lo.x+j_jy+ix, lo.y+l_jy+iz, 0, 0),
                     weight_Jy*fpyy);
@@ -479,7 +497,7 @@ void doDirectJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::ParticleR
                 if constexpr (full_mass_matrices) {
                     // Should not be here. Full mass matrices not yet implemented in 3D
                 }
-                else {  //  Deposit mass matrices for diagonal PC only
+                else { // Deposit mass matrices for diagonal PC only
                     amrex::Gpu::Atomic::AddNoRet(
                         &Sxx_arr(lo.x+j_jx+ix, lo.y+k_jx+iy, lo.z+l_jx+iz, 0),
                         weight_Jx*fpxx);

--- a/Source/Particles/Deposition/MassMatricesDeposition.H
+++ b/Source/Particles/Deposition/MassMatricesDeposition.H
@@ -1328,7 +1328,7 @@ void doVillasenorJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::Parti
                         const int row_yy = depos_order - k + kE + SegShiftZ;
                         for (int iE=0; iE<=depos_order; iE++) {
                             const int col_yy = depos_order - i + iE + SegShiftX;
-                            if (col_yy > Ncomp_yy0 - 2 - row_yy) { break; } // Reduced deposit for diagonal mass matrices
+                            if (col_yy > Ncomp_yy0 - 1 - row_yy) { break; } // Reduced deposit for diagonal mass matrices
                             const int comp_yy = col_yy + Ncomp_yy0*row_yy;
                             const amrex::Real weight_E = weight_nodeX_nodeZ[ms][iE][kE];
                             amrex::Gpu::Atomic::AddNoRet( &Syy_arr(i_J, k_J, 0, comp_yy), fpyy*weight_J*weight_E);

--- a/Source/Particles/Deposition/MassMatricesDeposition.H
+++ b/Source/Particles/Deposition/MassMatricesDeposition.H
@@ -1197,12 +1197,22 @@ void doVillasenorJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::Parti
 
     if constexpr (full_mass_matrices) {
 
+    const int Ncomp_xx0 = 1 + 2*(depos_order - 1) + 2*max_crossings;
+    const int Ncomp_xz0 = 2*depos_order + 2*max_crossings;
+    const int Ncomp_zx0 = 2*depos_order + 2*max_crossings;
+    const int Ncomp_zz0 = 1 + 2*depos_order + 2*max_crossings;
+    const int Ncomp_xy0 = 2*depos_order + 2*max_crossings;
+    const int Ncomp_yx0 = 2*depos_order + 2*max_crossings;
+    const int Ncomp_yz0 = 1 + 2*depos_order + 2*max_crossings;
+    const int Ncomp_yy0 = 1 + 2*depos_order + 2*max_crossings;
+    const int Ncomp_zy0 = 1 + 2*depos_order + 2*max_crossings;
+
     // Loop over segments and deposit full mass matrices
     for (int ns=0; ns<num_segments; ns++) {
 
         // Deposit Sxx, Sxz, and Sxy for this segment
-        for (int i=0; i<=depos_order-1; i++) {
-            for (int k=0; k<=depos_order; k++) {
+        for (int i = 0; i <= depos_order - 1; i++) {
+            for (int k = 0; k <= depos_order; k++) {
                 const int i_J = lo.x + i0_cell[ns] + i;
                 const int k_J = lo.y + k0_node[ns] + k;
                 const amrex::Real weight_J = weight_cellX_nodeZ[ns][i][k];
@@ -1210,31 +1220,30 @@ void doVillasenorJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::Parti
                     const int SegShiftX = max_crossings + SegNumX[ms] - SegNumX[ns];
                     const int SegShiftZ = max_crossings + SegNumZ[ms] - SegNumZ[ns];
                     // Deposit Sxx
-                    const int Ncomp_xx0 = 1 + 2*(depos_order-1) + 2*max_crossings;
-                    for (int iE=0; iE<=depos_order-1; iE++) {
-                        for (int kE=0; kE<=depos_order; kE++) {
+                    for (int kE = 0; kE <= depos_order; kE++) {
+                        const int row_xx = depos_order - k + kE + SegShiftZ;
+                        for (int iE = 0; iE <= depos_order - 1; iE++) {
+                            const int col_xx = depos_order - 1 - i + iE + SegShiftX;
+                            if (col_xx > Ncomp_xx0 - row_xx) { break; } // Reduced deposit for diagonal mass matrices
+                            const int comp_xx = col_xx + Ncomp_xx0*row_xx;
                             const amrex::Real weight_E = weight_cellX_nodeZ[ms][iE][kE];
-                            const int comp_xx = depos_order-1 - i + iE + SegShiftX
-                                  +  Ncomp_xx0*(depos_order - k + kE + SegShiftZ);
                             amrex::Gpu::Atomic::AddNoRet(&Sxx_arr(i_J, k_J, 0, comp_xx), fpxx*weight_J*weight_E);
                         }
                     }
                     // Deposit Sxz
-                    const int Ncomp_xz0 = 2*depos_order + 2*max_crossings;
-                    for (int iE=0; iE<=depos_order; iE++) {
-                        for (int kE=0; kE<=depos_order-1; kE++) {
+                    for (int iE = 0; iE <= depos_order; iE++) {
+                        for (int kE = 0; kE <= depos_order - 1; kE++) {
                             const amrex::Real weight_E = weight_nodeX_cellZ[ms][iE][kE];
-                            const int comp_xz = depos_order-1 - i + iE + SegShiftX
+                            const int comp_xz = depos_order - 1 - i + iE + SegShiftX
                                    + Ncomp_xz0*(depos_order - k + kE + SegShiftZ);
                             amrex::Gpu::Atomic::AddNoRet(&Sxz_arr(i_J, k_J, 0, comp_xz), fpxz*weight_J*weight_E);
                         }
                     }
                     // Deposit Sxy
-                    const int Ncomp_xy0 = 2*depos_order + 2*max_crossings;
-                    for (int iE=0; iE<=depos_order; iE++) {
-                        for (int kE=0; kE<=depos_order; kE++) {
+                    for (int iE = 0; iE <= depos_order; iE++) {
+                        for (int kE = 0; kE <= depos_order; kE++) {
                             const amrex::Real weight_E = weight_nodeX_nodeZ[ms][iE][kE];
-                            const int comp_xy = depos_order-1 - i + iE + SegShiftX
+                            const int comp_xy = depos_order - 1 - i + iE + SegShiftX
                                    + Ncomp_xy0*(depos_order - k + kE + SegShiftZ);
                             amrex::Gpu::Atomic::AddNoRet(&Sxy_arr(i_J, k_J, 0, comp_xy), fpxy*weight_J*weight_E);
                         }
@@ -1254,7 +1263,6 @@ void doVillasenorJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::Parti
                     const int SegShiftX = max_crossings + SegNumX[ms] - SegNumX[ns];
                     const int SegShiftZ = max_crossings + SegNumZ[ms] - SegNumZ[ns];
                     // Deposit Szx
-                    const int Ncomp_zx0 = 2*depos_order + 2*max_crossings;
                     for (int iE=0; iE<=depos_order-1; iE++) {
                         for (int kE=0; kE<=depos_order; kE++) {
                             const amrex::Real weight_E = weight_cellX_nodeZ[ms][iE][kE];
@@ -1264,17 +1272,17 @@ void doVillasenorJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::Parti
                         }
                     }
                     // Deposit Szz
-                    const int Ncomp_zz0 = 1 + 2*depos_order + 2*max_crossings;
-                    for (int iE=0; iE<=depos_order; iE++) {
-                        for (int kE=0; kE<=depos_order-1; kE++) {
+                    for (int kE=0; kE<=depos_order-1; kE++) {
+                        const int row_zz = depos_order - 1 - k + kE + SegShiftZ;
+                        for (int iE=0; iE<=depos_order; iE++) {
+                            const int col_zz = depos_order - i + iE + SegShiftX;
+                            if (col_zz > Ncomp_zz0 - 2 - row_zz) { break; } // Reduced deposit for diagonal mass matrices
+                            const int comp_zz = col_zz + Ncomp_zz0*row_zz;
                             const amrex::Real weight_E = weight_nodeX_cellZ[ms][iE][kE];
-                            const int comp_zz = depos_order - i + iE + SegShiftX
-                                   + Ncomp_zz0*(depos_order-1 - k + kE + SegShiftZ);
                             amrex::Gpu::Atomic::AddNoRet( &Szz_arr(i_J, k_J, 0, comp_zz), fpzz*weight_J*weight_E);
                         }
                     }
                     // Deposit Szy
-                    const int Ncomp_zy0 = 1 + 2*depos_order + 2*max_crossings;
                     for (int iE=0; iE<=depos_order; iE++) {
                         for (int kE=0; kE<=depos_order; kE++) {
                             const amrex::Real weight_E = weight_nodeX_nodeZ[ms][iE][kE];
@@ -1298,7 +1306,6 @@ void doVillasenorJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::Parti
                     const int SegShiftX = max_crossings + SegNumX[ms] - SegNumX[ns];
                     const int SegShiftZ = max_crossings + SegNumZ[ms] - SegNumZ[ns];
                     // Deposit Syx
-                    const int Ncomp_yx0 = 2*depos_order + 2*max_crossings;
                     for (int iE=0; iE<=depos_order-1; iE++) {
                         for (int kE=0; kE<=depos_order; kE++) {
                             const amrex::Real weight_E = weight_cellX_nodeZ[ms][iE][kE];
@@ -1308,7 +1315,6 @@ void doVillasenorJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::Parti
                         }
                     }
                     // Deposit Syz
-                    const int Ncomp_yz0 = 1 + 2*depos_order + 2*max_crossings;
                     for (int iE=0; iE<=depos_order; iE++) {
                         for (int kE=0; kE<=depos_order-1; kE++) {
                             const amrex::Real weight_E = weight_nodeX_cellZ[ms][iE][kE];
@@ -1318,12 +1324,13 @@ void doVillasenorJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::Parti
                         }
                     }
                     // Deposit Syy
-                    const int Ncomp_yy0 = 1 + 2*depos_order + 2*max_crossings;
-                    for (int iE=0; iE<=depos_order; iE++) {
-                        for (int kE=0; kE<=depos_order; kE++) {
+                    for (int kE=0; kE<=depos_order; kE++) {
+                        const int row_yy = depos_order - k + kE + SegShiftZ;
+                        for (int iE=0; iE<=depos_order; iE++) {
+                            const int col_yy = depos_order - i + iE + SegShiftX;
+                            if (col_yy > Ncomp_yy0 - 2 - row_yy) { break; } // Reduced deposit for diagonal mass matrices
+                            const int comp_yy = col_yy + Ncomp_yy0*row_yy;
                             const amrex::Real weight_E = weight_nodeX_nodeZ[ms][iE][kE];
-                            const int comp_yy = depos_order - i + iE + SegShiftX
-                                   + Ncomp_yy0*(depos_order - k + kE + SegShiftZ);
                             amrex::Gpu::Atomic::AddNoRet( &Syy_arr(i_J, k_J, 0, comp_yy), fpyy*weight_J*weight_E);
                         }
                     }

--- a/Source/Particles/Deposition/MassMatricesDeposition.H
+++ b/Source/Particles/Deposition/MassMatricesDeposition.H
@@ -1207,6 +1207,10 @@ void doVillasenorJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::Parti
     const int Ncomp_yy0 = 1 + 2*depos_order + 2*max_crossings;
     const int Ncomp_zy0 = 1 + 2*depos_order + 2*max_crossings;
 
+    const int width_xx1 = depos_order + max_crossings;     // (Ncomp_xx[1] - 1)/2
+    const int width_zz1 = depos_order - 1 + max_crossings; // (Ncomp_zz[1] - 1)/2
+    const int width_yy1 = depos_order + max_crossings;     // (Ncomp_yy[1] - 1)/2
+
     // Loop over segments and deposit full mass matrices
     for (int ns=0; ns<num_segments; ns++) {
 
@@ -1222,9 +1226,10 @@ void doVillasenorJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::Parti
                     // Deposit Sxx
                     for (int kE = 0; kE <= depos_order; kE++) {
                         const int row_xx = depos_order - k + kE + SegShiftZ;
+                        const int above_diag = (row_xx > width_xx1) ? 1 : 0;
                         for (int iE = 0; iE <= depos_order - 1; iE++) {
                             const int col_xx = depos_order - 1 - i + iE + SegShiftX;
-                            if (col_xx > Ncomp_xx0 - row_xx) { break; } // Reduced deposit for diagonal mass matrices
+                            if (col_xx > Ncomp_xx0 - row_xx - above_diag) { break; } // Reduced deposit for diagonal mass matrices
                             const int comp_xx = col_xx + Ncomp_xx0*row_xx;
                             const amrex::Real weight_E = weight_cellX_nodeZ[ms][iE][kE];
                             amrex::Gpu::Atomic::AddNoRet(&Sxx_arr(i_J, k_J, 0, comp_xx), fpxx*weight_J*weight_E);
@@ -1274,9 +1279,10 @@ void doVillasenorJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::Parti
                     // Deposit Szz
                     for (int kE=0; kE<=depos_order-1; kE++) {
                         const int row_zz = depos_order - 1 - k + kE + SegShiftZ;
+                        const int above_diag = (row_zz > width_zz1) ? 1 : 0;
                         for (int iE=0; iE<=depos_order; iE++) {
                             const int col_zz = depos_order - i + iE + SegShiftX;
-                            if (col_zz > Ncomp_zz0 - 2 - row_zz) { break; } // Reduced deposit for diagonal mass matrices
+                            if (col_zz > Ncomp_zz0 - 2 - row_zz - above_diag) { break; } // Reduced deposit for diagonal mass matrices
                             const int comp_zz = col_zz + Ncomp_zz0*row_zz;
                             const amrex::Real weight_E = weight_nodeX_cellZ[ms][iE][kE];
                             amrex::Gpu::Atomic::AddNoRet( &Szz_arr(i_J, k_J, 0, comp_zz), fpzz*weight_J*weight_E);
@@ -1326,9 +1332,10 @@ void doVillasenorJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::Parti
                     // Deposit Syy
                     for (int kE=0; kE<=depos_order; kE++) {
                         const int row_yy = depos_order - k + kE + SegShiftZ;
+                        const int above_diag = (row_yy > width_yy1) ? 1 : 0;
                         for (int iE=0; iE<=depos_order; iE++) {
                             const int col_yy = depos_order - i + iE + SegShiftX;
-                            if (col_yy > Ncomp_yy0 - 1 - row_yy) { break; } // Reduced deposit for diagonal mass matrices
+                            if (col_yy > Ncomp_yy0 - 1 - row_yy - above_diag) { break; } // Reduced deposit for diagonal mass matrices
                             const int comp_yy = col_yy + Ncomp_yy0*row_yy;
                             const amrex::Real weight_E = weight_nodeX_nodeZ[ms][iE][kE];
                             amrex::Gpu::Atomic::AddNoRet( &Syy_arr(i_J, k_J, 0, comp_yy), fpyy*weight_J*weight_E);

--- a/Source/Particles/Deposition/MassMatricesDeposition.H
+++ b/Source/Particles/Deposition/MassMatricesDeposition.H
@@ -1529,6 +1529,9 @@ void doVillasenorJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::Parti
 
     if constexpr (full_mass_matrices) {
 
+    const int width_zz = depos_order - 1 + max_crossings;
+    const int width_yy = depos_order + max_crossings;
+
     // Loop over segments and deposit full mass matrices
     for (int ns=0; ns<num_segments; ns++) {
 
@@ -1542,8 +1545,10 @@ void doVillasenorJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::Parti
                 for (int kE=0; kE<=depos_order; kE++) {
                     const amrex::Real weight_E = weight_node[ms][kE];
                     const int comp_yy = depos_order - k + kE + SegShift;
-                    amrex::Gpu::Atomic::AddNoRet(&Sxx_arr(k_J, 0, 0, comp_yy), fpxx*weight_J*weight_E);
-                    amrex::Gpu::Atomic::AddNoRet(&Syy_arr(k_J, 0, 0, comp_yy), fpyy*weight_J*weight_E);
+                    if (comp_yy <= width_yy) { // Reduced deposit for diagonal mass matrices
+                        amrex::Gpu::Atomic::AddNoRet(&Sxx_arr(k_J, 0, 0, comp_yy), fpxx*weight_J*weight_E);
+                        amrex::Gpu::Atomic::AddNoRet(&Syy_arr(k_J, 0, 0, comp_yy), fpyy*weight_J*weight_E);
+                    }
                     amrex::Gpu::Atomic::AddNoRet(&Sxy_arr(k_J, 0, 0, comp_yy), fpxy*weight_J*weight_E);
                     amrex::Gpu::Atomic::AddNoRet(&Syx_arr(k_J, 0, 0, comp_yy), fpyx*weight_J*weight_E);
                 }
@@ -1565,8 +1570,9 @@ void doVillasenorJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::Parti
             for (int ms=0; ms<num_segments; ms++) {
                 const int SegShift = max_crossings + SegNum[ms] - SegNum[ns];
                 for (int kE=0; kE<=depos_order-1; kE++) {
+                    const int comp_zz = depos_order - 1 - k + kE + SegShift;
+                    if (comp_zz < width_zz) { break; } // Reduced deposit for diagonal mass matrices
                     const amrex::Real weight_E = weight_cell[ms][kE];
-                    const int comp_zz = depos_order-1 - k + kE + SegShift;
                     amrex::Gpu::Atomic::AddNoRet(&Szz_arr(k_J, 0, 0, comp_zz), fpzz*weight_J*weight_E);
                 }
                 for (int kE=0; kE<=depos_order; kE++) {

--- a/Source/Particles/Deposition/MassMatricesDeposition.H
+++ b/Source/Particles/Deposition/MassMatricesDeposition.H
@@ -1578,7 +1578,7 @@ void doVillasenorJandSigmaDepositionKernel ( [[maybe_unused]] const amrex::Parti
                 const int SegShift = max_crossings + SegNum[ms] - SegNum[ns];
                 for (int kE=0; kE<=depos_order-1; kE++) {
                     const int comp_zz = depos_order - 1 - k + kE + SegShift;
-                    if (comp_zz < width_zz) { break; } // Reduced deposit for diagonal mass matrices
+                    if (comp_zz > width_zz) { break; } // Reduced deposit for diagonal mass matrices
                     const amrex::Real weight_E = weight_cell[ms][kE];
                     amrex::Gpu::Atomic::AddNoRet(&Szz_arr(k_J, 0, 0, comp_zz), fpzz*weight_J*weight_E);
                 }


### PR DESCRIPTION
Mass matrix `Sij` represents a coupling between `Ji` and `Ej` on the grid (with `i,j = x,y,z`). The number of coupling coefficients depends on the square of the shape factor. When `Ji` and `Ej` live at the same location on the grid, a symmetry exists that permits reducing the deposit used to compute `Sij` by roughly one half. For a Yee grid, this symmetry only exists for the diagonal mass matrices (`Sxx`, `Syy,` `Szz`). This PR exploits this symmetry. The mass matrix components at location (i,j,k) that are not deposited in this PR are copied from their respective mapped component of the mass matrix at neighboring locations. This is done in `FinishMassMatrices()`.

[MassMatricesDiagrams_forPR6555.pdf](https://github.com/user-attachments/files/25184865/MassMatricesDiagrams_forPR6555.pdf)

- [x] Perform rigorous verification tests
- [x] clean up code and make consistent
- [x] Add helpful diagrams
- [x] do timing comparison

### Timing comparison  
2D planar pinch simulation (Villasenor deposition, shape = 2, 800 total particles per cell, 256x32 grid, 1000 steps) on **Tuolumne** a LLNL

| Branch              | Routine                                              | NCalls | Excl. Max |
|---------------------|------------------------------------------------------|--------|-----------|
| Development         | DepositCurrentAndMassMatrices()     | 3997   | 173.3     |
| This PR             | DepositCurrentAndMassMatrices()     | 3996   | 148.9     |
| This PR             | FinishMassMatrices()                                 | 3996   | 0.2494    |

Total speedup is (173.3 - (148.9 + 0.2494))/173.3 x 100 = 13.936 %. This is close to the theoretical maximum speedup of (9 - 7.5)/9*100 = 16.667. These results are from a single set of tests. I've ran the tests several times and the speedup is typically between 11% and 18%.

### What this PR does not do
This PR does not reduce the memory footprint of the mass matrices. While such a reduction is possible (see [https://doi.org/10.1016/j.cpc.2018.03.020](https://doi.org/10.1016/j.cpc.2018.03.020)), it would require substantial refactoring of how the mass matrices are constructed and used throughout the code. In practice, the mass matrix memory is only a concern for 3D simulations, and WarpX does not currently support the use of full mass matrices in 3D.