### PR TITLE
Hybrid PIC: change definition of number of substeps

### DIFF
--- a/Examples/Tests/ohm_solver_cylinder_compression/inputs_test_3d_ohm_solver_cylinder_compression_picmi.py
+++ b/Examples/Tests/ohm_solver_cylinder_compression/inputs_test_3d_ohm_solver_cylinder_compression_picmi.py
@@ -60,7 +60,7 @@ class PlasmaCylinderCompression(object):
     NPPC = 50
 
     # Number of substeps used to update B
-    substeps = 30
+    substeps = 60
 
     def Bz(self, r):
         return np.sqrt(

--- a/Examples/Tests/ohm_solver_cylinder_compression/inputs_test_rz_ohm_solver_cylinder_compression_picmi.py
+++ b/Examples/Tests/ohm_solver_cylinder_compression/inputs_test_rz_ohm_solver_cylinder_compression_picmi.py
@@ -58,7 +58,7 @@ class PlasmaCylinderCompression(object):
     NPPC = 100
 
     # Number of substeps used to update B
-    substeps = 30
+    substeps = 60
 
     def Bz(self, r):
         return np.sqrt(

--- a/Examples/Tests/ohm_solver_em_modes/inputs_test_1d_ohm_solver_em_modes_picmi.py
+++ b/Examples/Tests/ohm_solver_em_modes/inputs_test_1d_ohm_solver_em_modes_picmi.py
@@ -56,7 +56,7 @@ class EMModes(object):
     # Plasma resistivity - used to dampen the mode excitation
     eta = [[1e-7, 1e-7], [1e-7, 1e-5], [1e-7, 1e-4]]
     # Number of substeps used to update B
-    substeps = 20
+    substeps = 40
 
     def __init__(self, test, dim, B_dir, verbose):
         """Get input parameters for the specific case desired."""

--- a/Examples/Tests/ohm_solver_em_modes/inputs_test_rz_ohm_solver_em_modes_picmi.py
+++ b/Examples/Tests/ohm_solver_em_modes/inputs_test_rz_ohm_solver_em_modes_picmi.py
@@ -54,7 +54,7 @@ class CylindricalNormalModes(object):
     # Plasma resistivity - used to dampen the mode excitation
     eta = 5e-4
     # Number of substeps used to update B
-    substeps = 20
+    substeps = 40
 
     def __init__(self, test, verbose):
         """Get input parameters for the specific case desired."""

--- a/Examples/Tests/ohm_solver_ion_Landau_damping/inputs_test_2d_ohm_solver_landau_damping_picmi.py
+++ b/Examples/Tests/ohm_solver_ion_Landau_damping/inputs_test_2d_ohm_solver_landau_damping_picmi.py
@@ -54,7 +54,7 @@ class IonLandauDamping(object):
     # Plasma resistivity - used to dampen the mode excitation
     eta = 1e-7
     # Number of substeps used to update B
-    substeps = 10
+    substeps = 20
 
     def __init__(self, test, dim, m, T_ratio, verbose):
         """Get input parameters for the specific case desired."""

--- a/Examples/Tests/ohm_solver_ion_beam_instability/inputs_test_1d_ohm_solver_ion_beam_picmi.py
+++ b/Examples/Tests/ohm_solver_ion_beam_instability/inputs_test_1d_ohm_solver_ion_beam_picmi.py
@@ -52,7 +52,7 @@ class HybridPICBeamInstability(object):
     # Plasma resistivity - used to dampen the mode excitation
     eta = 1e-7
     # Number of substeps used to update B
-    substeps = 10
+    substeps = 20
 
     # Beam parameters
     n_beam = [0.02, 0.1]

--- a/Examples/Tests/ohm_solver_magnetic_reconnection/inputs_test_2d_ohm_solver_magnetic_reconnection_picmi.py
+++ b/Examples/Tests/ohm_solver_magnetic_reconnection/inputs_test_2d_ohm_solver_magnetic_reconnection_picmi.py
@@ -61,7 +61,7 @@ class ForceFreeSheetReconnection(object):
     # Plasma resistivity - used to dampen the mode excitation
     eta = 6e-3  # normalized resistivity
     # Number of substeps used to update B
-    substeps = 20
+    substeps = 40
 
     def __init__(self, test, verbose):
         self.test = test

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -32,8 +32,12 @@ void HybridPICModel::ReadParameters ()
     const ParmParse pp_hybrid("hybrid_pic_model");
 
     // The B-field update is subcycled to improve stability - the number
-    // of sub steps can be specified by the user (defaults to 50).
+    // of sub steps can be specified by the user.
     utils::parser::queryWithParser(pp_hybrid, "substeps", m_substeps);
+    if (m_substeps % 2 != 0) {
+        Abort("hybrid_pic_model.substeps must be divisible by 2. "
+              "The value " + std::to_string(m_substeps) + " is not valid.");
+    }
 
     utils::parser::queryWithParser(pp_hybrid, "holmstrom_vacuum_region", m_holmstrom_vacuum_region);
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -11,6 +11,7 @@
 #include "HybridPICModel.H"
 
 #include <ablastr/utils/Communication.H>
+#include <ablastr/warn_manager/WarnManager.H>
 
 #include "EmbeddedBoundary/Enabled.H"
 #include "Python/callbacks.H"
@@ -35,8 +36,13 @@ void HybridPICModel::ReadParameters ()
     // of sub steps can be specified by the user.
     utils::parser::queryWithParser(pp_hybrid, "substeps", m_substeps);
     if (m_substeps % 2 != 0) {
-        Abort("hybrid_pic_model.substeps must be divisible by 2. "
-              "The value " + std::to_string(m_substeps) + " is not valid.");
+        ablastr::warn_manager::WMRecordWarning(
+            "HybridPIC",
+            "hybrid_pic_model.substeps must be divisible by 2. "
+            "The value " + std::to_string(m_substeps) + " is not valid. "
+            "Automatically adjusting to " + std::to_string(m_substeps + 1) + ".",
+            ablastr::warn_manager::WarnPriority::medium);
+        m_substeps += 1;
     }
 
     utils::parser::queryWithParser(pp_hybrid, "holmstrom_vacuum_region", m_holmstrom_vacuum_region);

--- a/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
@@ -98,14 +98,15 @@ void WarpX::HybridPICEvolveFields ()
     // Push the B field from t=n to t=n+1/2 using the current and density
     // at t=n, while updating the E field along with B using the electron
     // momentum equation
-    for (int sub_step = 0; sub_step < sub_steps; sub_step++)
+    const int sub_steps_per_half = sub_steps / 2;
+    for (int sub_step = 0; sub_step < sub_steps_per_half; sub_step++)
     {
         m_hybrid_pic_model->BfieldEvolveRK(
             m_fields.get_mr_levels_alldirs(FieldType::Bfield_fp, finest_level),
             m_fields.get_mr_levels_alldirs(FieldType::Efield_fp, finest_level),
             current_fp_temp, rho_fp_temp,
             m_eb_update_E,
-            0.5_rt/sub_steps*dt[0],
+            dt[0]/sub_steps,
             SubcyclingHalf::FirstHalf, guard_cells.ng_FieldSolver,
             WarpX::sync_nodal_points
         );
@@ -131,7 +132,7 @@ void WarpX::HybridPICEvolveFields ()
     }
 
     // Now push the B field from t=n+1/2 to t=n+1 using the n+1/2 quantities
-    for (int sub_step = 0; sub_step < sub_steps; sub_step++)
+    for (int sub_step = 0; sub_step < sub_steps_per_half; sub_step++)
     {
         m_hybrid_pic_model->BfieldEvolveRK(
             m_fields.get_mr_levels_alldirs(FieldType::Bfield_fp, finest_level),
@@ -139,7 +140,7 @@ void WarpX::HybridPICEvolveFields ()
             m_fields.get_mr_levels_alldirs(FieldType::current_fp, finest_level),
             rho_fp_temp,
             m_eb_update_E,
-            0.5_rt/sub_steps*dt[0],
+            dt[0]/sub_steps,
             SubcyclingHalf::SecondHalf, guard_cells.ng_FieldSolver,
             WarpX::sync_nodal_points
         );


### PR DESCRIPTION
The new definition matches the user intuition more closely: if the user sets `substeps=10`, then there will be 10 field updates (each using the RK4 algorithm) each using $\Delta t/10$ within one timestep.

(As opposed to the current behavior: 20 field updates with $\Delta t/20$.)