### PR TITLE
Replace missing Summit postprocessing documentation

### DIFF
--- a/Docs/source/install/hpc/crusher.rst
+++ b/Docs/source/install/hpc/crusher.rst
@@ -178,7 +178,7 @@ Post-Processing
 
 For post-processing, most users use Python via OLCFs's `Jupyter service <https://jupyter.olcf.ornl.gov>`__ (`Docs <https://docs.olcf.ornl.gov/services_and_applications/jupyter/index.html>`__).
 
-Please follow the same guidance as for :ref:`OLCF Summit post-processing <post-processing-summit>`.
+Please follow the same guidance as for :ref:`OLCF Frontier post-processing <post-processing-frontier>`.
 
 .. _known-crusher-issues:
 

--- a/Docs/source/install/hpc/frontier.rst
+++ b/Docs/source/install/hpc/frontier.rst
@@ -178,7 +178,22 @@ Post-Processing
 
 For post-processing, most users use Python via OLCFs's `Jupyter service <https://jupyter.olcf.ornl.gov>`__ (`Docs <https://docs.olcf.ornl.gov/services_and_applications/jupyter/index.html>`__).
 
-Please follow the same guidance as for :ref:`OLCF Summit post-processing <post-processing-summit>`.
+We usually just install our software on-the-fly on Frontier.
+When starting up a post-processing session, run this in your first cells:
+
+.. note::
+
+   The following software packages are installed only into a temporary directory.
+
+.. code-block:: bash
+
+   # work-around for OLCFHELP-4242
+   !jupyter serverextension enable --py --sys-prefix dask_labextension
+
+   # next Jupyter cell: the software you want
+   !mamba install --quiet -c conda-forge -y openpmd-api openpmd-viewer ipympl ipywidgets fast-histogram yt
+
+   # restart notebook
 
 .. _known-frontier-issues:
 


### PR DESCRIPTION
The Summit post-processing documentation was removed in https://github.com/BLAST-WarpX/warpx/pull/6528. However, it was still being referenced in other parts of the documentation, leading to:
```
WARNING: undefined label: 'post-processing-summit'
```

This PR copies the post-processing documentation that was removed in https://github.com/BLAST-WarpX/warpx/pull/6528 into the current Frontier documentation, and fixes the corresponding references.