### PR TITLE
Make checksum for `test_3d_linear_compton_bunch_laser` less brittle

### DIFF
--- a/Examples/Tests/linear_compton/inputs_test_3d_linear_compton_bunch_laser
+++ b/Examples/Tests/linear_compton/inputs_test_3d_linear_compton_bunch_laser
@@ -21,7 +21,7 @@ my_constants.sigma_kn_max = 6.65e-29 # Maximum value of Klein-Nishina cross-sect
 my_constants.v_rel = 2 *clight
 my_constants.probability_target_value = 0.05
 my_constants.dt =  probability_target_value / (sigma_kn_max * dens * v_rel )
-my_constants.N_step = floor(T / dt)
+my_constants.N_step = floor(T / dt) + 1
 # space
 my_constants.Lz = 8 * bunch_sigma_z
 my_constants.zmin = -0.5*Lz

--- a/Regression/Checksum/benchmarks_json/test_3d_linear_compton_bunch_laser.json
+++ b/Regression/Checksum/benchmarks_json/test_3d_linear_compton_bunch_laser.json
@@ -24,10 +24,10 @@
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 0.0,
-    "particle_position_x": 7.810529085905394e-06,
-    "particle_position_y": 3.0588244214844662e-06,
-    "particle_position_z": 3.953021420882662e-06,
-    "particle_weight": 9398496240601504.0
+    "particle_position_x": 0.0,
+    "particle_position_y": 0.0,
+    "particle_position_z": 0.0,
+    "particle_weight": 0.0
   },
   "photon2": {
     "particle_momentum_x": 0.0,


### PR DESCRIPTION
The test `test_3d_linear_compton_bunch_laser` involves a photon bunch passing through the simulation box, as seen in these images from different timesteps:
<img width="778" height="708" alt="Screenshot 2026-02-09 at 11 53 59 AM" src="https://github.com/user-attachments/assets/18c6171f-f59e-440a-81fb-aa58f251cd3a" />
<img width="808" height="702" alt="Screenshot 2026-02-09 at 11 54 14 AM" src="https://github.com/user-attachments/assets/d7238745-c99b-4eb3-88b7-318786f00662" />
<img width="836" height="724" alt="Screenshot 2026-02-09 at 11 54 35 AM" src="https://github.com/user-attachments/assets/5ca9ee0a-f33c-4fb5-ba65-8b56a9ac66aa" />

The end of the simulation correspond **closely** to the time at which the photon bunch has exited the simulation box. 

However, because of this, there is sometimes still one or two photons in the box at the very last timestep. It seems that this happens randomly (depending on the seed) and is related to the fact that the particles injected with flux injection are emitted with random delays **within one timestep**. For this reason, the very last few photons of the bunch can be emitted with just the right random delays for them to still be in the simulation box at the last timestep. (This is confirmed by the current value of the sum of photon weights in the checksum: `Benchmark: [photon1,particle_weight] 9.398496240601504e+15` which, after verification, turns out to be the weight of a **single photon macroparticle**.)

For this reason, the checksum is very brittle: small unrelated changes in the code (e.g. drawing new random numbers in another part of the code) can change the random delay with which the photons are emitted, and thus can change whether there are still photons in the simulation box at the end of the simulation.

This PR avoids this issue by taking one more timestep, to make sure that the simulation box is completely cleared of photons at the time when the checksum is computed.