### PR TITLE
Improve performance of hybrid-PIC algorithm

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -518,16 +518,52 @@ void HybridPICModel::BfieldEvolveRK (
     );
 
     // The Bfield is now given by:
-    // B_new = B_old + 0.5 * dt * K0 + 0.5 * dt * [-curl x E(B_old + 0.5 * dt * K1)]
-    //       = B_old + 0.5 * dt * K0 + 0.5 * dt * K1
-    for (int ii = 0; ii < 3; ii++)
-    {
-        // Subtract 0.5 * dt * K0 from the Bfield for each direction, to get
-        // B_new = B_old + 0.5 * dt * K1.
-        MultiFab::Subtract(*Bfield[lev][ii], K[ii], 0, 0, 1, ng);
-        // Extract 0.5 * dt * K1 for each direction into index 1 of K.
-        MultiFab::LinComb(
-            K[ii], 1._rt, *Bfield[lev][ii], 0, -1._rt, B_old[ii], 0, 1, 1, ng
+    //   B_new = B_old + 0.5 * dt * K0 + 0.5 * dt * [-curl x E(B_old + 0.5 * dt * K1)]
+    //         = B_old + 0.5 * dt * K0 + 0.5 * dt * K1
+    //
+    // Subtract 0.5 * dt * K0 from the Bfield to get
+    //   B_new = B_old + 0.5 * dt * K1.
+    // Extract 0.5 * dt * K1 and write into index 1 of K.
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for ( MFIter mfi(*Bfield[lev][0], TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
+
+        // Extract field data for this grid/tile
+        Array4<Real> const &Bx = Bfield[lev][0]->array(mfi);
+        Array4<Real> const &By = Bfield[lev][1]->array(mfi);
+        Array4<Real> const &Bz = Bfield[lev][2]->array(mfi);
+        Array4<Real> const &Kx = K[0].array(mfi);
+        Array4<Real> const &Ky = K[1].array(mfi);
+        Array4<Real> const &Kz = K[2].array(mfi);
+        Array4<Real const> const &Bx_old = B_old[0].const_array(mfi);
+        Array4<Real const> const &By_old = B_old[1].const_array(mfi);
+        Array4<Real const> const &Bz_old = B_old[2].const_array(mfi);
+
+        // Extract tileboxes for which to loop
+        Box const& tjx  = mfi.tilebox(Bfield[lev][0]->ixType().toIntVect(), ng);
+        Box const& tjy  = mfi.tilebox(Bfield[lev][1]->ixType().toIntVect(), ng);
+        Box const& tjz  = mfi.tilebox(Bfield[lev][2]->ixType().toIntVect(), ng);
+
+        amrex::ParallelFor(tjx, tjy, tjz,
+            // x calculation
+            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+                Bx(i, j, k) -= Kx(i, j, k, 0);
+                Kx(i, j, k, 1) = Bx(i, j, k) - Bx_old(i, j, k);
+            },
+
+            // y calculation
+            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+                By(i, j, k) -= Ky(i, j, k, 0);
+                Ky(i, j, k, 1) = By(i, j, k) - By_old(i, j, k);
+            },
+
+            // z calculation
+            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+                Bz(i, j, k) -= Kz(i, j, k, 0);
+                Kz(i, j, k, 1) = Bz(i, j, k) - Bz_old(i, j, k);
+            }
         );
     }
 
@@ -554,18 +590,17 @@ void HybridPICModel::BfieldEvolveRK (
     );
 
     // The Bfield is now given by:
-    // B_new = B_old + dt * K2 + 0.5 * dt * [-curl x E(B_old + dt * K2)]
-    //       = B_old + dt * K2 + 0.5 * dt * K3
-    //
-    // index 0 of K = 0.5 * dt * K0
-    // index 1 of K = 0.5 * dt * K1
+    //   B_new = B_old + dt * K2 + 0.5 * dt * [-curl x E(B_old + dt * K2)]
+    //         = B_old + dt * K2 + 0.5 * dt * K3
+    // and
+    //   index 0 of K = 0.5 * dt * K0
+    //   index 1 of K = 0.5 * dt * K1
     //
     // We calculate:
-    //     K = 0.5 * dt * K0 + dt * K1 + dt * K2 + 0.5 * dt * K3
+    //   K = 0.5 * dt * K0 + dt * K1 + dt * K2 + 0.5 * dt * K3
     // then update B with the Runge-Kutta sum:
-    //     B = B_old + 1/3 * K
+    //   B = B_old + 1/3 * K
 
-    // Loop through the grids, and over the tiles within each grid
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
@@ -588,26 +623,22 @@ void HybridPICModel::BfieldEvolveRK (
         Box const& tjz  = mfi.tilebox(Bfield[lev][2]->ixType().toIntVect(), ng);
 
         amrex::ParallelFor(tjx, tjy, tjz,
-
             // Bx calculation
             [=] AMREX_GPU_DEVICE (int i, int j, int k){
-
                 Kx(i, j, k, 0) += Bx(i, j, k) - Bx_old(i, j, k) + 2.0 * Kx(i, j, k, 1);
-                Bx(i, j, k) = Bx_old(i, j, k) + 1.0/3.0 * Kx(i, j, k, 0);
+                Bx(i, j, k) = Bx_old(i, j, k) + Kx(i, j, k, 0) / 3.0;
             },
 
             // By calculation
             [=] AMREX_GPU_DEVICE (int i, int j, int k){
-
                 Ky(i, j, k, 0) += By(i, j, k) - By_old(i, j, k) + 2.0 * Ky(i, j, k, 1);
-                By(i, j, k) = By_old(i, j, k) + 1.0/3.0 * Ky(i, j, k, 0);
+                By(i, j, k) = By_old(i, j, k) + Ky(i, j, k, 0) / 3.0;
             },
 
             // Bz calculation
             [=] AMREX_GPU_DEVICE (int i, int j, int k){
-
                 Kz(i, j, k, 0) += Bz(i, j, k) - Bz_old(i, j, k) + 2.0 * Kz(i, j, k, 1);
-                Bz(i, j, k) = Bz_old(i, j, k) + 1.0/3.0 * Kz(i, j, k, 0);
+                Bz(i, j, k) = Bz_old(i, j, k) + Kz(i, j, k, 0) / 3.0;
             }
         );
     }

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -662,6 +662,10 @@ void HybridPICModel::FieldPush (
     CalculatePlasmaCurrent(Bfield, eb_update_E);
     // Calculate the E-field from Ohm's law
     HybridPICSolveE(Efield, Jfield, Bfield, rhofield, eb_update_E, true);
+    // Call FillBoundary if a collocated grid is used
+    if (Bz_IndexType[0] == Ez_IndexType[0]) {
+        warpx.FillBoundaryE(ng, nodal_sync);
+    }
 
     // Push forward the B-field using Faraday's law
     warpx.EvolveB(dt, subcycling_half, t_old);

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -492,7 +492,6 @@ void HybridPICModel::BfieldEvolveRK (
             Bfield[lev][ii]->boxArray(), Bfield[lev][ii]->DistributionMap(), 2,
             Bfield[lev][ii]->nGrowVect()
         );
-        K[ii].setVal(0.0);
     }
 
     // The Runge-Kutta scheme begins here.
@@ -557,24 +556,59 @@ void HybridPICModel::BfieldEvolveRK (
     // The Bfield is now given by:
     // B_new = B_old + dt * K2 + 0.5 * dt * [-curl x E(B_old + dt * K2)]
     //       = B_old + dt * K2 + 0.5 * dt * K3
-    for (int ii = 0; ii < 3; ii++)
-    {
-        // Subtract B_old from the Bfield for each direction, to get
-        // B = dt * K2 + 0.5 * dt * K3.
-        MultiFab::Subtract(*Bfield[lev][ii], B_old[ii], 0, 0, 1, ng);
+    //
+    // index 0 of K = 0.5 * dt * K0
+    // index 1 of K = 0.5 * dt * K1
+    //
+    // We calculate:
+    //     K = 0.5 * dt * K0 + dt * K1 + dt * K2 + 0.5 * dt * K3
+    // then update B with the Runge-Kutta sum:
+    //     B = B_old + 1/3 * K
 
-        // Add dt * K2 + 0.5 * dt * K3 to index 0 of K (= 0.5 * dt * K0).
-        MultiFab::Add(K[ii], *Bfield[lev][ii], 0, 0, 1, ng);
+    // Loop through the grids, and over the tiles within each grid
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for ( MFIter mfi(*Bfield[lev][0], TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
 
-        // Add 2 * 0.5 * dt * K1 to index 0 of K.
-        MultiFab::LinComb(
-            K[ii], 1.0, K[ii], 0, 2.0, K[ii], 1, 0, 1, ng
-        );
+        // Extract field data for this grid/tile
+        Array4<Real> const &Bx = Bfield[lev][0]->array(mfi);
+        Array4<Real> const &By = Bfield[lev][1]->array(mfi);
+        Array4<Real> const &Bz = Bfield[lev][2]->array(mfi);
+        Array4<Real> const &Kx = K[0].array(mfi);
+        Array4<Real> const &Ky = K[1].array(mfi);
+        Array4<Real> const &Kz = K[2].array(mfi);
+        Array4<Real const> const &Bx_old = B_old[0].const_array(mfi);
+        Array4<Real const> const &By_old = B_old[1].const_array(mfi);
+        Array4<Real const> const &Bz_old = B_old[2].const_array(mfi);
 
-        // Overwrite the Bfield with the Runge-Kutta sum:
-        // B_new = B_old + 1/3 * dt * (0.5 * K0 + K1 + K2 + 0.5 * K3).
-        MultiFab::LinComb(
-            *Bfield[lev][ii], 1.0, B_old[ii], 0, 1.0/3.0, K[ii], 0, 0, 1, ng
+        // Extract tileboxes for which to loop
+        Box const& tjx  = mfi.tilebox(Bfield[lev][0]->ixType().toIntVect(), ng);
+        Box const& tjy  = mfi.tilebox(Bfield[lev][1]->ixType().toIntVect(), ng);
+        Box const& tjz  = mfi.tilebox(Bfield[lev][2]->ixType().toIntVect(), ng);
+
+        amrex::ParallelFor(tjx, tjy, tjz,
+
+            // Bx calculation
+            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+
+                Kx(i, j, k, 0) += Bx(i, j, k) - Bx_old(i, j, k) + 2.0 * Kx(i, j, k, 1);
+                Bx(i, j, k) = Bx_old(i, j, k) + 1.0/3.0 * Kx(i, j, k, 0);
+            },
+
+            // By calculation
+            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+
+                Ky(i, j, k, 0) += By(i, j, k) - By_old(i, j, k) + 2.0 * Ky(i, j, k, 1);
+                By(i, j, k) = By_old(i, j, k) + 1.0/3.0 * Ky(i, j, k, 0);
+            },
+
+            // Bz calculation
+            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+
+                Kz(i, j, k, 0) += Bz(i, j, k) - Bz_old(i, j, k) + 2.0 * Kz(i, j, k, 1);
+                Bz(i, j, k) = Bz_old(i, j, k) + 1.0/3.0 * Kz(i, j, k, 0);
+            }
         );
     }
 }
@@ -597,7 +631,6 @@ void HybridPICModel::FieldPush (
     CalculatePlasmaCurrent(Bfield, eb_update_E);
     // Calculate the E-field from Ohm's law
     HybridPICSolveE(Efield, Jfield, Bfield, rhofield, eb_update_E, true);
-    warpx.FillBoundaryE(ng, nodal_sync);
 
     // Push forward the B-field using Faraday's law
     warpx.EvolveB(dt, subcycling_half, t_old);

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -662,10 +662,7 @@ void HybridPICModel::FieldPush (
     CalculatePlasmaCurrent(Bfield, eb_update_E);
     // Calculate the E-field from Ohm's law
     HybridPICSolveE(Efield, Jfield, Bfield, rhofield, eb_update_E, true);
-    // Call FillBoundary if a collocated grid is used
-    if (Bz_IndexType[0] == Ez_IndexType[0]) {
-        warpx.FillBoundaryE(ng, nodal_sync);
-    }
+    warpx.FillBoundaryE(ng, nodal_sync);
 
     // Push forward the B-field using Faraday's law
     warpx.EvolveB(dt, subcycling_half, t_old);

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICSolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICSolveE.cpp
@@ -87,11 +87,6 @@ void FiniteDifferenceSolver::CalculateCurrentAmpereCylindrical (
     // for the profiler
     amrex::LayoutData<amrex::Real>* cost = WarpX::getCosts(lev);
 
-    // reset Jfield
-    Jfield[0]->setVal(0);
-    Jfield[1]->setVal(0);
-    Jfield[2]->setVal(0);
-
     // Loop through the grids, and over the tiles within each grid
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
@@ -277,11 +272,6 @@ void FiniteDifferenceSolver::CalculateCurrentAmpereSpherical (
     // for the profiler
     amrex::LayoutData<amrex::Real>* cost = WarpX::getCosts(lev);
 
-    // reset Jfield
-    Jfield[0]->setVal(0);
-    Jfield[1]->setVal(0);
-    Jfield[2]->setVal(0);
-
     // Loop through the grids, and over the tiles within each grid
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
@@ -378,11 +368,6 @@ void FiniteDifferenceSolver::CalculateCurrentAmpereCartesian (
 {
     // for the profiler
     amrex::LayoutData<amrex::Real>* cost = WarpX::getCosts(lev);
-
-    // reset Jfield
-    Jfield[0]->setVal(0);
-    Jfield[1]->setVal(0);
-    Jfield[2]->setVal(0);
 
     // Loop through the grids, and over the tiles within each grid
 #ifdef AMREX_USE_OMP


### PR DESCRIPTION
A couple changes have been made to improve performance of the hybrid-PIC algorithm (focussed on the field solver).
1. GPU kernels were merged in the update of the B-field from Runge-Kutta sums.
2. ~~The `FillBoundary` call for the E-field used to update the B-field has been removed since local tests showed this did not affect results.~~ -> moved to #6575 
3. Unnecessary `setVal(0)` calls were removed for MFs that are fully overwritten anyway.

A quick test on a single V100 GPU (with only 1 tile in the simulation) showed performance improvement of ~20% due to the kernel merging.
A larger test on 8 A100 GPUs (on Polaris) also showed ~20% performance improvement, going from ~3.37 steps/second before this PR to ~4.06 steps/second with this PR.