### PR TITLE
Fail RTD doc on warning

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,6 +14,7 @@ build:
 
 sphinx:
   configuration: Docs/source/conf.py
+  fail_on_warning: true
 
 conda:
   environment: Docs/conda.yml

--- a/Docs/source/theory/intro.rst
+++ b/Docs/source/theory/intro.rst
@@ -3,7 +3,7 @@
 Overview
 ========
 
-.. _theory-pi:
+.. _theory-pic:
 
 WarpX simulates the **self-consistent** evolution of **particle species** (e.g., electrons, ions, etc.) in the presence of **electric and magnetic fields**.
 In this context, *self-consistent* indicates that the particle dynamics are influenced by the fields, while the fields themselves evolve in response to the particles' changing charge and current densities.

--- a/Docs/source/theory/intro.rst
+++ b/Docs/source/theory/intro.rst
@@ -3,7 +3,7 @@
 Overview
 ========
 
-.. _theory-pic:
+.. _theory-pi:
 
 WarpX simulates the **self-consistent** evolution of **particle species** (e.g., electrons, ions, etc.) in the presence of **electric and magnetic fields**.
 In this context, *self-consistent* indicates that the particle dynamics are influenced by the fields, while the fields themselves evolve in response to the particles' changing charge and current densities.


### PR DESCRIPTION
Follow-up to https://github.com/BLAST-WarpX/warpx/pull/6560: as suggested by @lucafedeli88, it would be good to check for warnings from the documentation in CI