### PR TITLE
Fill guard cells for EB update MFs

### DIFF
--- a/Source/EmbeddedBoundary/EmbeddedBoundaryInit.H
+++ b/Source/EmbeddedBoundary/EmbeddedBoundaryInit.H
@@ -59,7 +59,8 @@ namespace warpx::embedded_boundary
     void MarkUpdateCellsStairCase (
         std::array< std::unique_ptr<amrex::iMultiFab>,3> & eb_update,
         ablastr::fields::VectorField const & field,
-        amrex::EBFArrayBoxFactory const & eb_fact );
+        amrex::EBFArrayBoxFactory const & eb_fact,
+        const amrex::Periodicity& periodicity );
 
     /** \brief Set a flag to indicate on which grid points the E field
      *  should be updated, depending on their position relative to the embedded boundary.

--- a/Source/EmbeddedBoundary/EmbeddedBoundaryInit.cpp
+++ b/Source/EmbeddedBoundary/EmbeddedBoundaryInit.cpp
@@ -125,7 +125,8 @@ void
 web::MarkUpdateCellsStairCase (
     std::array< std::unique_ptr<amrex::iMultiFab>,3> & eb_update,
     ablastr::fields::VectorField const& field,
-    amrex::EBFArrayBoxFactory const & eb_fact )
+    amrex::EBFArrayBoxFactory const & eb_fact,
+    const amrex::Periodicity& periodicity )
 {
 
     using ablastr::fields::Direction;
@@ -212,7 +213,8 @@ web::MarkUpdateCellsStairCase (
             }
 
         }
-
+        // Populate guard cells
+        eb_update[idim]->FillBoundary(periodicity);
     }
 
 }

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -1612,12 +1612,12 @@ void WarpX::InitializeEBGridData (int lev)
                 warpx::embedded_boundary::MarkUpdateCellsStairCase(
                     m_eb_update_E[lev],
                     m_fields.get_alldirs(FieldType::Efield_fp, lev),
-                    eb_fact );
+                    eb_fact, Geom(lev).periodicity() );
                 // Mark on which grid points B should be updated (stair-case approximation)
                 warpx::embedded_boundary::MarkUpdateCellsStairCase(
                     m_eb_update_B[lev],
                     m_fields.get_alldirs(FieldType::Bfield_fp, lev),
-                    eb_fact );
+                    eb_fact, Geom(lev).periodicity() );
             }
 
         }


### PR DESCRIPTION
This PR is in preparation for #6571.

The MFs that specify whether a given cell edge / face / node is covered by the embedded boundary is updated to have valid values in the guard cells. This is needed for the follow up PR since in the hybrid-PIC solver we aim to reduce parallel communication by calculating the plasma current in guard cells as well (and therefore need to know whether those locations are covered by the embedded boundary). This was not needed before since only internal cells were updated during the calculation of the plasma current ($\nabla \times B$) and a `FillBoundary` call was used to obtain the appropriate values in the guard cells.