### PR TITLE
Embedded Boundary Particle Condition enhancement to support reflecting

### DIFF
--- a/PR_NOTES.md
+++ b/PR_NOTES.md
@@ -13,29 +13,42 @@ crosses the EB surface.
 Three files form the critical path:
 
 1. `ParticleBoundaryProcess.H` — only `Absorb` and `NoOp` functors existed;
-   no `Reflect` functor.
+   no reflection capability.
 2. `MultiParticleContainer.cpp:1130` — `ScrapeParticlesAtEB()` hard-codes
    `ParticleBoundaryProcess::Absorb()` for every species.
 3. `WarpXEvolve.cpp:690-696` — domain BCs are applied first
    (`ApplyBoundaryConditions`), then EB scraping unconditionally absorbs.
 
 The scraper template in `ParticleScraper.H` was *already* designed for pluggable
-functors — it just never had a Reflect implementation.
+functors — it just never had a reflection implementation.
 
 ## Changes in This Branch
 
-### 1. Specular Reflect functor (`ParticleBoundaryProcess.H`)
+### 1. Bisection-based specular reflection (`ParticleScraper.H`)
 
-Added `ParticleBoundaryProcess::Reflect` that performs:
-- **Position reflection**: `x_new = x − 2·φ·n̂` (mirrors particle across EB surface)
-- **Velocity reflection**: `v_new = v − 2(v·n̂)n̂` (reverses normal component)
+Added `reflectParticlesAtEB()`, a new function template that handles curved EB
+surfaces correctly using the same bisection algorithm as
+`ParticleBoundaryBuffer::FindEmbeddedBoundaryIntersection`. For each particle
+that crosses into the EB (`phi < 0`):
 
-Handles all dimension variants: 3D, XZ, RZ (with cylindrical ↔ Cartesian velocity
-projection), and 1D_Z.
+1. **Bisect** along the particle trajectory (using `amrex::bisect` + `UpdatePosition`)
+   to find the exact contact point where `phi = 0`.
+2. **Compute normal** at the contact point (not at the penetrated position).
+3. **Reflect velocity** specularly: `v_new = v − 2(v·n̂)n̂`.
+4. **Advance** from the contact point with reflected velocity for the remaining
+   fraction of the timestep.
+
+This replaces the earlier `ParticleBoundaryProcess::Reflect` functor which used
+the simpler approximation `x_new = x − 2·φ·n̂`. That formula is only exact for
+planar surfaces; for curved EBs (the primary use case) it accumulates error
+proportional to the surface curvature.
+
+Handles all dimension variants: 3D, XZ, RZ (with cylindrical → Cartesian normal
+conversion), and 1D_Z.
 
 ### 2. Scraper interface extended (`ParticleScraper.H`)
 
-The functor call was changed from:
+The functor call in `scrapeParticlesAtEB` was changed from:
 ```cpp
 f(ptd, ip, pos, normal, engine);
 ```
@@ -44,9 +57,8 @@ to:
 f(ptd, ip, pos, normal, phi_value, engine);
 ```
 
-`phi_value` (the signed distance, negative inside the EB) is needed so the
-functor can compute the correct reflected position. `NoOp` and `Absorb` accept
-and ignore it.
+`phi_value` (the signed distance, negative inside the EB) is passed to the
+functor for use by future BCs. `NoOp` and `Absorb` accept and ignore it.
 
 ### 3. User-facing configuration
 
@@ -61,14 +73,22 @@ Parsed in `MakeWarpX()` via `query_enum_sloppy`, stored as
 A low-priority warning is emitted when the parameter is unspecified, so existing
 users are informed of the default absorbing behavior.
 
-### 4. Functor dispatch (`MultiParticleContainer::ScrapeParticlesAtEB`)
+### 4. Dispatch (`MultiParticleContainer::ScrapeParticlesAtEB`)
 
 Branches on `WarpX::eb_particle_boundary`:
-- `Reflecting` → `ParticleBoundaryProcess::Reflect()`
-- anything else → `ParticleBoundaryProcess::Absorb()`
+- `Reflecting` → `reflectParticlesAtEB()` (per-level, with dt and mass)
+- anything else → `scrapeParticlesAtEB()` with `ParticleBoundaryProcess::Absorb()`
 
 Injection/reposition call sites (`AddParticles.cpp`, `WarpXParticleContainer.cpp`)
 remain `Absorb` — particles created inside the EB should be removed.
+
+### Why reflection is not a functor
+
+Unlike `Absorb` which only needs the particle ID, specular reflection on curved
+surfaces requires trajectory data (`dt`, `mass`) and the signed distance array
+(`phi`) for bisection — data not available in the functor interface. The
+reflection logic therefore lives directly in `reflectParticlesAtEB()` rather than
+as a functor passed to `scrapeParticlesAtEB()`.
 
 ## Functor Interface — Extensibility Assessment
 
@@ -85,14 +105,14 @@ void operator()(PData& ptd, int i,
 
 | BC Type | What it does | Why the interface is sufficient |
 |---------|-------------|-------------------------------|
-| **Diffuse reflect** | Re-emit with cosine-weighted random direction from surface | `normal` + `engine` generate the random direction; `phi_value` repositions the particle |
-| **Thermal** | Rethermalize velocity at wall temperature | `uth` stored as functor struct member; `normal` orients half-Maxwellian; `engine` samples it; `phi_value` repositions |
+| **Diffuse reflect** | Re-emit with cosine-weighted random direction from surface | `normal` + `engine` generate the random direction; bisection handles position |
+| **Thermal** | Rethermalize velocity at wall temperature | `uth` stored as functor struct member; `normal` orients half-Maxwellian; `engine` samples it |
 | **Stochastic absorb/reflect** | Velocity-dependent reflection probability | Reflection model parser stored as functor member; velocity read from `ptd`; `engine` for random draw |
 | **Accommodation coefficient** | Partial thermalization (mix of specular + diffuse) | `alpha`, `uth` as struct members; everything else available |
 
-Per-BC configuration data belongs on the **functor struct** (e.g., `Thermal{uth=...}`),
-not in the scraper call. The scraper arguments are geometry data; the functor carries
-physics parameters. This separation is clean.
+Note: BCs involving position correction (diffuse, thermal) would also benefit
+from the bisection approach to find the true contact point, similar to what
+`reflectParticlesAtEB` does.
 
 ### Not sufficient for
 
@@ -104,21 +124,13 @@ physics parameters. This separation is clean.
 These would need a different design (likely a post-scrape particle injection step),
 regardless of what data the scraper passes.
 
-### One optional future improvement
-
-`phi_value` approximates the penetration distance at the end of the timestep.
-For more precise intersection timing (needed if a BC depends on exact collision
-energy), the scraper could additionally pass a `dt_fraction` from bisection — the
-`ParticleBoundaryBuffer` already computes this. Not needed for the BCs above, but
-noted for completeness.
-
 ## Files Changed
 
-| File | Lines | Summary |
-|------|-------|---------|
-| `Source/EmbeddedBoundary/ParticleBoundaryProcess.H` | +90 | `Reflect` functor; updated `NoOp`/`Absorb` signatures for `phi_value` |
-| `Source/EmbeddedBoundary/ParticleScraper.H` | +1 −1 | Pass `phi_value` to functor |
-| `Source/Particles/MultiParticleContainer.cpp` | +10 −2 | Dispatch on `WarpX::eb_particle_boundary` |
-| `Source/WarpX.H` | +6 | New `eb_particle_boundary` static member |
-| `Source/WarpX.cpp` | +22 | Parse `warpx.eb_particle_boundary_condition` with validation and warning |
-| `Python/pywarpx/picmi.py` | +17 | `particle_boundary_condition` param on `EmbeddedBoundary` |
+| File | Summary |
+|------|---------|
+| `Source/EmbeddedBoundary/ParticleBoundaryProcess.H` | Updated `NoOp`/`Absorb` signatures for `phi_value`; removed old `Reflect` functor |
+| `Source/EmbeddedBoundary/ParticleScraper.H` | Pass `phi_value` to functor; new `reflectParticlesAtEB()` with bisection |
+| `Source/Particles/MultiParticleContainer.cpp` | Dispatch on `WarpX::eb_particle_boundary` |
+| `Source/WarpX.H` | New `eb_particle_boundary` static member |
+| `Source/WarpX.cpp` | Parse `warpx.eb_particle_boundary_condition` with validation and warning |
+| `Python/pywarpx/picmi.py` | `particle_boundary_condition` param on `EmbeddedBoundary` |

--- a/PR_NOTES.md
+++ b/PR_NOTES.md
@@ -1,0 +1,124 @@
+# EB Particle Boundary Condition — Design Notes for PR
+
+## Problem (Issue #6566)
+
+Embedded boundary particle scraping unconditionally absorbs all particles via a
+hard-coded `ParticleBoundaryProcess::Absorb()` functor. Users setting reflecting
+particle BCs on the domain walls observe particle loss when an EB is present,
+because the EB scraper overrides the domain BC and destroys every particle that
+crosses the EB surface.
+
+## Root Cause
+
+Three files form the critical path:
+
+1. `ParticleBoundaryProcess.H` — only `Absorb` and `NoOp` functors existed;
+   no `Reflect` functor.
+2. `MultiParticleContainer.cpp:1130` — `ScrapeParticlesAtEB()` hard-codes
+   `ParticleBoundaryProcess::Absorb()` for every species.
+3. `WarpXEvolve.cpp:690-696` — domain BCs are applied first
+   (`ApplyBoundaryConditions`), then EB scraping unconditionally absorbs.
+
+The scraper template in `ParticleScraper.H` was *already* designed for pluggable
+functors — it just never had a Reflect implementation.
+
+## Changes in This Branch
+
+### 1. Specular Reflect functor (`ParticleBoundaryProcess.H`)
+
+Added `ParticleBoundaryProcess::Reflect` that performs:
+- **Position reflection**: `x_new = x − 2·φ·n̂` (mirrors particle across EB surface)
+- **Velocity reflection**: `v_new = v − 2(v·n̂)n̂` (reverses normal component)
+
+Handles all dimension variants: 3D, XZ, RZ (with cylindrical ↔ Cartesian velocity
+projection), and 1D_Z.
+
+### 2. Scraper interface extended (`ParticleScraper.H`)
+
+The functor call was changed from:
+```cpp
+f(ptd, ip, pos, normal, engine);
+```
+to:
+```cpp
+f(ptd, ip, pos, normal, phi_value, engine);
+```
+
+`phi_value` (the signed distance, negative inside the EB) is needed so the
+functor can compute the correct reflected position. `NoOp` and `Absorb` accept
+and ignore it.
+
+### 3. User-facing configuration
+
+| Interface | Parameter | Values |
+|-----------|-----------|--------|
+| PICMI Python | `picmi.EmbeddedBoundary(..., particle_boundary_condition='Reflecting')` | `'Absorbing'` (default), `'Reflecting'` |
+| Classic input | `warpx.eb_particle_boundary_condition = Reflecting` | `Absorbing` (default), `Reflecting` |
+
+Parsed in `MakeWarpX()` via `query_enum_sloppy`, stored as
+`WarpX::eb_particle_boundary` (`ParticleBoundaryType` enum).
+
+A low-priority warning is emitted when the parameter is unspecified, so existing
+users are informed of the default absorbing behavior.
+
+### 4. Functor dispatch (`MultiParticleContainer::ScrapeParticlesAtEB`)
+
+Branches on `WarpX::eb_particle_boundary`:
+- `Reflecting` → `ParticleBoundaryProcess::Reflect()`
+- anything else → `ParticleBoundaryProcess::Absorb()`
+
+Injection/reposition call sites (`AddParticles.cpp`, `WarpXParticleContainer.cpp`)
+remain `Absorb` — particles created inside the EB should be removed.
+
+## Functor Interface — Extensibility Assessment
+
+The current scraper-to-functor interface is:
+
+```cpp
+void operator()(PData& ptd, int i,
+                const RealVect& pos, const RealVect& normal,
+                amrex::Real phi_value,
+                RandomEngine const& engine)
+```
+
+### Sufficient for these future BCs
+
+| BC Type | What it does | Why the interface is sufficient |
+|---------|-------------|-------------------------------|
+| **Diffuse reflect** | Re-emit with cosine-weighted random direction from surface | `normal` + `engine` generate the random direction; `phi_value` repositions the particle |
+| **Thermal** | Rethermalize velocity at wall temperature | `uth` stored as functor struct member; `normal` orients half-Maxwellian; `engine` samples it; `phi_value` repositions |
+| **Stochastic absorb/reflect** | Velocity-dependent reflection probability | Reflection model parser stored as functor member; velocity read from `ptd`; `engine` for random draw |
+| **Accommodation coefficient** | Partial thermalization (mix of specular + diffuse) | `alpha`, `uth` as struct members; everything else available |
+
+Per-BC configuration data belongs on the **functor struct** (e.g., `Thermal{uth=...}`),
+not in the scraper call. The scraper arguments are geometry data; the functor carries
+physics parameters. This separation is clean.
+
+### Not sufficient for
+
+| BC Type | Why |
+|---------|-----|
+| **Secondary electron emission** | Functor modifies one particle in-place; cannot create new particles. Would need a two-phase approach: (1) flag & record collision data, (2) create new particles in a separate pass. |
+| **Sputtering / surface chemistry** | Same architectural limitation — requires particle creation. |
+
+These would need a different design (likely a post-scrape particle injection step),
+regardless of what data the scraper passes.
+
+### One optional future improvement
+
+`phi_value` approximates the penetration distance at the end of the timestep.
+For more precise intersection timing (needed if a BC depends on exact collision
+energy), the scraper could additionally pass a `dt_fraction` from bisection — the
+`ParticleBoundaryBuffer` already computes this. Not needed for the BCs above, but
+noted for completeness.
+
+## Files Changed
+
+| File | Lines | Summary |
+|------|-------|---------|
+| `Source/EmbeddedBoundary/ParticleBoundaryProcess.H` | +90 | `Reflect` functor; updated `NoOp`/`Absorb` signatures for `phi_value` |
+| `Source/EmbeddedBoundary/ParticleScraper.H` | +1 −1 | Pass `phi_value` to functor |
+| `Source/Particles/MultiParticleContainer.cpp` | +10 −2 | Dispatch on `WarpX::eb_particle_boundary` |
+| `Source/WarpX.H` | +6 | New `eb_particle_boundary` static member |
+| `Source/WarpX.cpp` | +22 | Parse `warpx.eb_particle_boundary_condition` with validation and warning |
+| `Python/pywarpx/picmi.py` | +17 | `particle_boundary_condition` param on `EmbeddedBoundary` |

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2915,6 +2915,11 @@ class EmbeddedBoundary(picmistandard.base._ClassWithInit):
         Whether to cover cells with multiple cuts.
         (If False, this will raise an error if some cells have multiple cuts)
 
+    particle_boundary_condition: string, default='Absorbing'
+        Boundary condition for particles at the embedded boundary surface.
+        Supported values: 'Absorbing' (particles removed on contact)
+        or 'Reflecting' (specular reflection).
+
     Parameters used in the analytic expressions should be given as additional keyword arguments.
 
     """
@@ -2928,6 +2933,7 @@ class EmbeddedBoundary(picmistandard.base._ClassWithInit):
         stl_reverse_normal=False,
         potential=None,
         cover_multiple_cuts=None,
+        particle_boundary_condition=None,
         **kw,
     ):
         assert stl_file is None or implicit_function is None, Exception(
@@ -2955,6 +2961,12 @@ class EmbeddedBoundary(picmistandard.base._ClassWithInit):
         self.potential = potential
 
         self.cover_multiple_cuts = cover_multiple_cuts
+
+        if particle_boundary_condition is not None:
+            assert particle_boundary_condition in ("Absorbing", "Reflecting"), (
+                "particle_boundary_condition must be 'Absorbing' or 'Reflecting'"
+            )
+        self.particle_boundary_condition = particle_boundary_condition
 
         # Handle keyword arguments used in expressions
         self.user_defined_kw = {}
@@ -2995,6 +3007,11 @@ class EmbeddedBoundary(picmistandard.base._ClassWithInit):
                 self.potential, self.mangle_dict
             )
             pywarpx.warpx.__setattr__("eb_potential(x,y,z,t)", expression)
+
+        if self.particle_boundary_condition is not None:
+            pywarpx.warpx.eb_particle_boundary_condition = (
+                self.particle_boundary_condition
+            )
 
 
 class PlasmaLens(picmistandard.base._ClassWithInit):

--- a/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
+++ b/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
@@ -7,10 +7,14 @@
 #ifndef WARPX_PARTICLEBOUNDARYPROCESS_H_
 #define WARPX_PARTICLEBOUNDARYPROCESS_H_
 
+#include "Particles/WarpXParticleContainer.H"
+
 #include <AMReX_Particle.H>
 #include <AMReX_REAL.H>
 #include <AMReX_RealVect.H>
 #include <AMReX_Random.H>
+
+#include <cmath>
 
 
 namespace ParticleBoundaryProcess {
@@ -20,6 +24,7 @@ struct NoOp {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void operator() (const PData& /*ptd*/, int /*i*/,
                      const amrex::RealVect& /*pos*/, const amrex::RealVect& /*normal*/,
+                     amrex::Real /*phi_value*/,
                      amrex::RandomEngine const& /*engine*/) const noexcept
     {}
 };
@@ -29,11 +34,94 @@ struct Absorb {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void operator() (PData& ptd, int i,
                      const amrex::RealVect& /*pos*/, const amrex::RealVect& /*normal*/,
+                     amrex::Real /*phi_value*/,
                      amrex::RandomEngine const& /*engine*/) const noexcept
     {
         amrex::ParticleIDWrapper{ptd.m_idcpu[i]}.make_invalid();
     }
 };
+
+/**
+ * \brief Reflect particles off embedded boundary surfaces.
+ *
+ *  Specular reflection: the position is mirrored across the EB surface
+ *  using the signed distance (phi_value), and the velocity component
+ *  normal to the surface is reversed.
+ */
+struct Reflect {
+    template <typename PData>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void operator() (PData& ptd, int i,
+                     const amrex::RealVect& /*pos*/, const amrex::RealVect& normal,
+                     amrex::Real phi_value,
+                     amrex::RandomEngine const& /*engine*/) const noexcept
+    {
+        // --- Reflect position across EB surface ---
+        // phi_value < 0 inside EB. The reflected position is
+        // x_new = x - 2 * phi * n  (moves particle to the mirror point outside).
+#if defined(WARPX_DIM_3D)
+        ptd.m_rdata[PIdx::x][i] -= amrex::ParticleReal(2.0 * phi_value * normal[0]);
+        ptd.m_rdata[PIdx::y][i] -= amrex::ParticleReal(2.0 * phi_value * normal[1]);
+        ptd.m_rdata[PIdx::z][i] -= amrex::ParticleReal(2.0 * phi_value * normal[2]);
+#elif defined(WARPX_DIM_XZ)
+        ptd.m_rdata[PIdx::x][i] -= amrex::ParticleReal(2.0 * phi_value * normal[0]);
+        ptd.m_rdata[PIdx::z][i] -= amrex::ParticleReal(2.0 * phi_value * normal[1]);
+#elif defined(WARPX_DIM_RZ)
+        ptd.m_rdata[PIdx::x][i] -= amrex::ParticleReal(2.0 * phi_value * normal[0]);
+        ptd.m_rdata[PIdx::z][i] -= amrex::ParticleReal(2.0 * phi_value * normal[1]);
+#elif defined(WARPX_DIM_1D_Z)
+        ptd.m_rdata[PIdx::z][i] -= amrex::ParticleReal(2.0 * phi_value * normal[0]);
+#endif
+
+        // --- Reflect velocity: v_new = v - 2*(v . n_hat)*n_hat ---
+#if defined(WARPX_DIM_3D)
+        amrex::ParticleReal const v_dot_n =
+            ptd.m_rdata[PIdx::ux][i] * amrex::ParticleReal(normal[0]) +
+            ptd.m_rdata[PIdx::uy][i] * amrex::ParticleReal(normal[1]) +
+            ptd.m_rdata[PIdx::uz][i] * amrex::ParticleReal(normal[2]);
+        ptd.m_rdata[PIdx::ux][i] -= amrex::ParticleReal(2.0) * v_dot_n * amrex::ParticleReal(normal[0]);
+        ptd.m_rdata[PIdx::uy][i] -= amrex::ParticleReal(2.0) * v_dot_n * amrex::ParticleReal(normal[1]);
+        ptd.m_rdata[PIdx::uz][i] -= amrex::ParticleReal(2.0) * v_dot_n * amrex::ParticleReal(normal[2]);
+
+#elif defined(WARPX_DIM_XZ)
+        // normal is (n_x, n_z). uy is out-of-plane, unaffected.
+        amrex::ParticleReal const v_dot_n =
+            ptd.m_rdata[PIdx::ux][i] * amrex::ParticleReal(normal[0]) +
+            ptd.m_rdata[PIdx::uz][i] * amrex::ParticleReal(normal[1]);
+        ptd.m_rdata[PIdx::ux][i] -= amrex::ParticleReal(2.0) * v_dot_n * amrex::ParticleReal(normal[0]);
+        ptd.m_rdata[PIdx::uz][i] -= amrex::ParticleReal(2.0) * v_dot_n * amrex::ParticleReal(normal[1]);
+
+#elif defined(WARPX_DIM_RZ)
+        // normal is (n_r, n_z). Velocity is Cartesian (ux, uy, uz).
+        // Project velocity to cylindrical (v_r, v_theta, v_z), reflect
+        // the (v_r, v_z) components, then project back.
+        amrex::ParticleReal const theta_i = ptd.m_rdata[PIdx::theta][i];
+        amrex::ParticleReal const cos_t = std::cos(theta_i);
+        amrex::ParticleReal const sin_t = std::sin(theta_i);
+
+        amrex::ParticleReal v_r =  ptd.m_rdata[PIdx::ux][i]*cos_t + ptd.m_rdata[PIdx::uy][i]*sin_t;
+        amrex::ParticleReal v_t = -ptd.m_rdata[PIdx::ux][i]*sin_t + ptd.m_rdata[PIdx::uy][i]*cos_t;
+        amrex::ParticleReal v_z =  ptd.m_rdata[PIdx::uz][i];
+
+        amrex::ParticleReal const v_dot_n =
+            v_r * amrex::ParticleReal(normal[0]) +
+            v_z * amrex::ParticleReal(normal[1]);
+        v_r -= amrex::ParticleReal(2.0) * v_dot_n * amrex::ParticleReal(normal[0]);
+        v_z -= amrex::ParticleReal(2.0) * v_dot_n * amrex::ParticleReal(normal[1]);
+
+        // Back to Cartesian
+        ptd.m_rdata[PIdx::ux][i] = v_r*cos_t - v_t*sin_t;
+        ptd.m_rdata[PIdx::uy][i] = v_r*sin_t + v_t*cos_t;
+        ptd.m_rdata[PIdx::uz][i] = v_z;
+
+#elif defined(WARPX_DIM_1D_Z)
+        amrex::ParticleReal const v_dot_n =
+            ptd.m_rdata[PIdx::uz][i] * amrex::ParticleReal(normal[0]);
+        ptd.m_rdata[PIdx::uz][i] -= amrex::ParticleReal(2.0) * v_dot_n * amrex::ParticleReal(normal[0]);
+#endif
+    }
+};
+
 }
 
 #endif //WARPX_PARTICLEBOUNDARYPROCESS_H_

--- a/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
+++ b/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
@@ -14,8 +14,6 @@
 #include <AMReX_RealVect.H>
 #include <AMReX_Random.H>
 
-#include <cmath>
-
 
 namespace ParticleBoundaryProcess {
 
@@ -38,87 +36,6 @@ struct Absorb {
                      amrex::RandomEngine const& /*engine*/) const noexcept
     {
         amrex::ParticleIDWrapper{ptd.m_idcpu[i]}.make_invalid();
-    }
-};
-
-/**
- * \brief Reflect particles off embedded boundary surfaces.
- *
- *  Specular reflection: the position is mirrored across the EB surface
- *  using the signed distance (phi_value), and the velocity component
- *  normal to the surface is reversed.
- */
-struct Reflect {
-    template <typename PData>
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    void operator() (PData& ptd, int i,
-                     const amrex::RealVect& /*pos*/, const amrex::RealVect& normal,
-                     amrex::Real phi_value,
-                     amrex::RandomEngine const& /*engine*/) const noexcept
-    {
-        // --- Reflect position across EB surface ---
-        // phi_value < 0 inside EB. The reflected position is
-        // x_new = x - 2 * phi * n  (moves particle to the mirror point outside).
-#if defined(WARPX_DIM_3D)
-        ptd.m_rdata[PIdx::x][i] -= amrex::ParticleReal(2.0 * phi_value * normal[0]);
-        ptd.m_rdata[PIdx::y][i] -= amrex::ParticleReal(2.0 * phi_value * normal[1]);
-        ptd.m_rdata[PIdx::z][i] -= amrex::ParticleReal(2.0 * phi_value * normal[2]);
-#elif defined(WARPX_DIM_XZ)
-        ptd.m_rdata[PIdx::x][i] -= amrex::ParticleReal(2.0 * phi_value * normal[0]);
-        ptd.m_rdata[PIdx::z][i] -= amrex::ParticleReal(2.0 * phi_value * normal[1]);
-#elif defined(WARPX_DIM_RZ)
-        ptd.m_rdata[PIdx::x][i] -= amrex::ParticleReal(2.0 * phi_value * normal[0]);
-        ptd.m_rdata[PIdx::z][i] -= amrex::ParticleReal(2.0 * phi_value * normal[1]);
-#elif defined(WARPX_DIM_1D_Z)
-        ptd.m_rdata[PIdx::z][i] -= amrex::ParticleReal(2.0 * phi_value * normal[0]);
-#endif
-
-        // --- Reflect velocity: v_new = v - 2*(v . n_hat)*n_hat ---
-#if defined(WARPX_DIM_3D)
-        amrex::ParticleReal const v_dot_n =
-            ptd.m_rdata[PIdx::ux][i] * amrex::ParticleReal(normal[0]) +
-            ptd.m_rdata[PIdx::uy][i] * amrex::ParticleReal(normal[1]) +
-            ptd.m_rdata[PIdx::uz][i] * amrex::ParticleReal(normal[2]);
-        ptd.m_rdata[PIdx::ux][i] -= amrex::ParticleReal(2.0) * v_dot_n * amrex::ParticleReal(normal[0]);
-        ptd.m_rdata[PIdx::uy][i] -= amrex::ParticleReal(2.0) * v_dot_n * amrex::ParticleReal(normal[1]);
-        ptd.m_rdata[PIdx::uz][i] -= amrex::ParticleReal(2.0) * v_dot_n * amrex::ParticleReal(normal[2]);
-
-#elif defined(WARPX_DIM_XZ)
-        // normal is (n_x, n_z). uy is out-of-plane, unaffected.
-        amrex::ParticleReal const v_dot_n =
-            ptd.m_rdata[PIdx::ux][i] * amrex::ParticleReal(normal[0]) +
-            ptd.m_rdata[PIdx::uz][i] * amrex::ParticleReal(normal[1]);
-        ptd.m_rdata[PIdx::ux][i] -= amrex::ParticleReal(2.0) * v_dot_n * amrex::ParticleReal(normal[0]);
-        ptd.m_rdata[PIdx::uz][i] -= amrex::ParticleReal(2.0) * v_dot_n * amrex::ParticleReal(normal[1]);
-
-#elif defined(WARPX_DIM_RZ)
-        // normal is (n_r, n_z). Velocity is Cartesian (ux, uy, uz).
-        // Project velocity to cylindrical (v_r, v_theta, v_z), reflect
-        // the (v_r, v_z) components, then project back.
-        amrex::ParticleReal const theta_i = ptd.m_rdata[PIdx::theta][i];
-        amrex::ParticleReal const cos_t = std::cos(theta_i);
-        amrex::ParticleReal const sin_t = std::sin(theta_i);
-
-        amrex::ParticleReal v_r =  ptd.m_rdata[PIdx::ux][i]*cos_t + ptd.m_rdata[PIdx::uy][i]*sin_t;
-        amrex::ParticleReal v_t = -ptd.m_rdata[PIdx::ux][i]*sin_t + ptd.m_rdata[PIdx::uy][i]*cos_t;
-        amrex::ParticleReal v_z =  ptd.m_rdata[PIdx::uz][i];
-
-        amrex::ParticleReal const v_dot_n =
-            v_r * amrex::ParticleReal(normal[0]) +
-            v_z * amrex::ParticleReal(normal[1]);
-        v_r -= amrex::ParticleReal(2.0) * v_dot_n * amrex::ParticleReal(normal[0]);
-        v_z -= amrex::ParticleReal(2.0) * v_dot_n * amrex::ParticleReal(normal[1]);
-
-        // Back to Cartesian
-        ptd.m_rdata[PIdx::ux][i] = v_r*cos_t - v_t*sin_t;
-        ptd.m_rdata[PIdx::uy][i] = v_r*sin_t + v_t*cos_t;
-        ptd.m_rdata[PIdx::uz][i] = v_z;
-
-#elif defined(WARPX_DIM_1D_Z)
-        amrex::ParticleReal const v_dot_n =
-            ptd.m_rdata[PIdx::uz][i] * amrex::ParticleReal(normal[0]);
-        ptd.m_rdata[PIdx::uz][i] -= amrex::ParticleReal(2.0) * v_dot_n * amrex::ParticleReal(normal[0]);
-#endif
     }
 };
 

--- a/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
+++ b/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
@@ -56,12 +56,6 @@ struct Reflect {
                      amrex::Real phi_value,
                      amrex::RandomEngine const& /*engine*/) const noexcept
     {
-        if (i == 0) {
-            printf("[ParticleBoundaryProcess::Reflect] EB reflection active  "
-                   "phi=%e  normal=(%e, %e)\n",
-                   phi_value, double(normal[0]), double(normal[1]));
-        }
-
         // --- Reflect position across EB surface ---
         // phi_value < 0 inside EB. The reflected position is
         // x_new = x - 2 * phi * n  (moves particle to the mirror point outside).

--- a/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
+++ b/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
@@ -56,6 +56,12 @@ struct Reflect {
                      amrex::Real phi_value,
                      amrex::RandomEngine const& /*engine*/) const noexcept
     {
+        if (i == 0) {
+            printf("[ParticleBoundaryProcess::Reflect] EB reflection active  "
+                   "phi=%e  normal=(%e, %e)\n",
+                   phi_value, double(normal[0]), double(normal[1]));
+        }
+
         // --- Reflect position across EB surface ---
         // phi_value < 0 inside EB. The reflected position is
         // x_new = x - 2 * phi * n  (moves particle to the mirror point outside).

--- a/Source/EmbeddedBoundary/ParticleScraper.H
+++ b/Source/EmbeddedBoundary/ParticleScraper.H
@@ -9,11 +9,13 @@
 
 #include "EmbeddedBoundary/DistanceToEB.H"
 #include "Particles/Pusher/GetAndSetPosition.H"
+#include "Particles/Pusher/UpdatePosition.H"
 
 
 #include <ablastr/particles/NodalFieldGather.H>
 
 #include <AMReX.H>
+#include <AMReX_Algorithm.H>
 #include <AMReX_MultiFab.H>
 #include <AMReX_Particle.H>
 #include <AMReX_RandomEngine.H>
@@ -214,6 +216,172 @@ scrapeParticlesAtEB (PC& pc, ablastr::fields::MultiLevelScalarField const& dista
                 }
             });
         }
+    }
+}
+
+/**
+ * \brief Reflect particles off embedded boundary walls using bisection.
+ *
+ *  For each particle that has crossed into the EB (phi < 0), this function:
+ *  1. Bisects along the particle trajectory to find the contact point on
+ *     the EB surface (where phi = 0).
+ *  2. Computes the surface normal at the exact contact point.
+ *  3. Performs specular velocity reflection: v_new = v - 2*(v . n)*n.
+ *  4. Advances the particle from the contact point with the reflected
+ *     velocity for the remaining fraction of the timestep.
+ *
+ *  This handles curved EB surfaces correctly, unlike the simpler phi-based
+ *  approximation (x_new = x - 2*phi*n) which is only exact for planar
+ *  surfaces. The bisection approach follows the same algorithm used in
+ *  ParticleBoundaryBuffer::FindEmbeddedBoundaryIntersection.
+ *
+ * \tparam PC a type of amrex ParticleContainer
+ *
+ * \param pc the particle container to reflect.
+ * \param distance_to_eb MultiFabs storing the signed distance function.
+ * \param lev the mesh refinement level to work on.
+ * \param dt the timestep size at this level.
+ * \param mass the particle mass for this species.
+ */
+template <class PC, std::enable_if_t<amrex::IsParticleContainer<PC>::value, int> foo = 0>
+void
+reflectParticlesAtEB (PC& pc, ablastr::fields::MultiLevelScalarField const& distance_to_eb,
+                      int lev, amrex::Real dt, amrex::ParticleReal mass)
+{
+    BL_PROFILE("reflectParticlesAtEB");
+
+    const auto plo = pc.Geom(lev).ProbLoArray();
+    const auto dxi = pc.Geom(lev).InvCellSizeArray();
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for(WarpXParIter pti(pc, lev); pti.isValid(); ++pti)
+    {
+        const auto getPosition = GetParticlePosition<PIdx>(pti);
+        auto setPosition = SetParticlePosition<PIdx>(pti);
+        auto& tile = pti.GetParticleTile();
+        auto ptd = tile.getParticleTileData();
+        const auto np = tile.numParticles();
+        auto phi = (*distance_to_eb[lev])[pti].array();
+
+        amrex::ParallelForRNG( np,
+        [=] AMREX_GPU_DEVICE (const int ip, amrex::RandomEngine const& engine) noexcept
+        {
+            amrex::ignore_unused(engine);
+
+            if (!amrex::ParticleIDWrapper{ptd.m_idcpu[ip]}.is_valid()) { return; }
+
+            amrex::ParticleReal xp, yp, zp;
+            getPosition(ip, xp, yp, zp);
+
+            int i, j, k;
+            amrex::Real W[AMREX_SPACEDIM][2];
+            ablastr::particles::compute_weights<amrex::IndexType::NODE>(
+                xp, yp, zp, plo, dxi, i, j, k, W);
+            amrex::Real const phi_value =
+                ablastr::particles::interp_field_nodal(i, j, k, W, phi);
+
+            if (phi_value < 0.0)
+            {
+                amrex::ParticleReal ux = ptd.m_rdata[PIdx::ux][ip];
+                amrex::ParticleReal uy = ptd.m_rdata[PIdx::uy][ip];
+                amrex::ParticleReal uz = ptd.m_rdata[PIdx::uz][ip];
+
+                // Step 1: Bisect along trajectory to find the fraction of dt
+                // to walk backward from end-of-step to reach the EB surface.
+                amrex::Real const dt_fraction = amrex::bisect(0.0, 1.0,
+                    [=] (amrex::Real dt_frac) {
+                        int bi, bj, bk;
+                        amrex::Real bW[AMREX_SPACEDIM][2];
+                        amrex::ParticleReal x_temp = xp, y_temp = yp, z_temp = zp;
+                        UpdatePosition(x_temp, y_temp, z_temp,
+                                       ux, uy, uz, -dt_frac * dt, mass);
+                        ablastr::particles::compute_weights<amrex::IndexType::NODE>(
+                            x_temp, y_temp, z_temp, plo, dxi, bi, bj, bk, bW);
+                        return ablastr::particles::interp_field_nodal(
+                            bi, bj, bk, bW, phi);
+                    });
+
+                // Step 2: Move to contact point on the EB surface
+                amrex::ParticleReal x_c = xp, y_c = yp, z_c = zp;
+                UpdatePosition(x_c, y_c, z_c, ux, uy, uz,
+                               -dt_fraction * dt, mass);
+
+                // Step 3: Compute normal at the contact point
+                int ci, cj, ck;
+                amrex::Real cW[AMREX_SPACEDIM][2];
+                ablastr::particles::compute_weights<amrex::IndexType::NODE>(
+                    x_c, y_c, z_c, plo, dxi, ci, cj, ck, cW);
+                int cci, ccj, cck;
+                amrex::Real ccW[AMREX_SPACEDIM][2];
+                ablastr::particles::compute_weights<amrex::IndexType::CELL>(
+                    x_c, y_c, z_c, plo, dxi, cci, ccj, cck, ccW);
+                amrex::RealVect normal = DistanceToEB::interp_normal(
+                    ci, cj, ck, cW, cci, ccj, cck, ccW, phi, dxi);
+                DistanceToEB::normalize(normal);
+
+                // Step 4: Specular velocity reflection  v = v - 2(v.n)n
+                // Normal is in reduced-dimension coordinates;
+                // velocity is always 3D Cartesian.
+#if defined(WARPX_DIM_3D)
+                amrex::ParticleReal const v_dot_n =
+                    ux * amrex::ParticleReal(normal[0]) +
+                    uy * amrex::ParticleReal(normal[1]) +
+                    uz * amrex::ParticleReal(normal[2]);
+                ux -= amrex::ParticleReal(2.0) * v_dot_n
+                    * amrex::ParticleReal(normal[0]);
+                uy -= amrex::ParticleReal(2.0) * v_dot_n
+                    * amrex::ParticleReal(normal[1]);
+                uz -= amrex::ParticleReal(2.0) * v_dot_n
+                    * amrex::ParticleReal(normal[2]);
+#elif defined(WARPX_DIM_XZ)
+                // normal is (n_x, n_z). uy is out-of-plane, unaffected.
+                amrex::ParticleReal const v_dot_n =
+                    ux * amrex::ParticleReal(normal[0]) +
+                    uz * amrex::ParticleReal(normal[1]);
+                ux -= amrex::ParticleReal(2.0) * v_dot_n
+                    * amrex::ParticleReal(normal[0]);
+                uz -= amrex::ParticleReal(2.0) * v_dot_n
+                    * amrex::ParticleReal(normal[1]);
+#elif defined(WARPX_DIM_RZ)
+                // normal is (n_r, n_z). Convert to 3D Cartesian using
+                // the particle theta at the contact point.
+                amrex::ParticleReal const theta_c = std::atan2(y_c, x_c);
+                amrex::ParticleReal const cos_tc = std::cos(theta_c);
+                amrex::ParticleReal const sin_tc = std::sin(theta_c);
+                amrex::ParticleReal const n3d_x =
+                    amrex::ParticleReal(normal[0]) * cos_tc;
+                amrex::ParticleReal const n3d_y =
+                    amrex::ParticleReal(normal[0]) * sin_tc;
+                amrex::ParticleReal const n3d_z =
+                    amrex::ParticleReal(normal[1]);
+                amrex::ParticleReal const v_dot_n =
+                    ux * n3d_x + uy * n3d_y + uz * n3d_z;
+                ux -= amrex::ParticleReal(2.0) * v_dot_n * n3d_x;
+                uy -= amrex::ParticleReal(2.0) * v_dot_n * n3d_y;
+                uz -= amrex::ParticleReal(2.0) * v_dot_n * n3d_z;
+#elif defined(WARPX_DIM_1D_Z)
+                amrex::ParticleReal const v_dot_n =
+                    uz * amrex::ParticleReal(normal[0]);
+                uz -= amrex::ParticleReal(2.0) * v_dot_n
+                    * amrex::ParticleReal(normal[0]);
+#endif
+
+                // Step 5: Store reflected velocity
+                ptd.m_rdata[PIdx::ux][ip] = ux;
+                ptd.m_rdata[PIdx::uy][ip] = uy;
+                ptd.m_rdata[PIdx::uz][ip] = uz;
+
+                // Step 6: Advance from contact point with reflected velocity
+                // for the remaining fraction of the timestep
+                amrex::ParticleReal x_new = x_c, y_new = y_c, z_new = z_c;
+                UpdatePosition(x_new, y_new, z_new, ux, uy, uz,
+                               dt_fraction * dt, mass);
+
+                // Step 7: Write final position back to particle
+                setPosition(ip, x_new, y_new, z_new);
+            }
+        });
     }
 }
 

--- a/Source/EmbeddedBoundary/ParticleScraper.H
+++ b/Source/EmbeddedBoundary/ParticleScraper.H
@@ -209,7 +209,7 @@ scrapeParticlesAtEB (PC& pc, ablastr::fields::MultiLevelScalarField const& dista
 #elif (defined WARPX_DIM_1D_Z)
                     pos[0] = zp;
 #endif
-                    f(ptd, ip, pos, normal, engine);
+                    f(ptd, ip, pos, normal, phi_value, engine);
 
                 }
             });

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -1127,7 +1127,7 @@ void MultiParticleContainer::ScrapeParticlesAtEB (
     ablastr::fields::MultiLevelScalarField const& distance_to_eb)
 {
     for (auto& pc : allcontainers) {
-        scrapeParticlesAtEB(*pc, distance_to_eb, ParticleBoundaryProcess::Absorb());
+        scrapeParticlesAtEB(*pc, distance_to_eb, ParticleBoundaryProcess::Reflect());
     }
 }
 

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -1126,8 +1126,14 @@ void MultiParticleContainer::CheckIonizationProductSpecies()
 void MultiParticleContainer::ScrapeParticlesAtEB (
     ablastr::fields::MultiLevelScalarField const& distance_to_eb)
 {
-    for (auto& pc : allcontainers) {
-        scrapeParticlesAtEB(*pc, distance_to_eb, ParticleBoundaryProcess::Reflect());
+    if (WarpX::eb_particle_boundary == ParticleBoundaryType::Reflecting) {
+        for (auto& pc : allcontainers) {
+            scrapeParticlesAtEB(*pc, distance_to_eb, ParticleBoundaryProcess::Reflect());
+        }
+    } else {
+        for (auto& pc : allcontainers) {
+            scrapeParticlesAtEB(*pc, distance_to_eb, ParticleBoundaryProcess::Absorb());
+        }
     }
 }
 

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -1127,8 +1127,13 @@ void MultiParticleContainer::ScrapeParticlesAtEB (
     ablastr::fields::MultiLevelScalarField const& distance_to_eb)
 {
     if (WarpX::eb_particle_boundary == ParticleBoundaryType::Reflecting) {
+        auto& warpx = WarpX::GetInstance();
         for (auto& pc : allcontainers) {
-            scrapeParticlesAtEB(*pc, distance_to_eb, ParticleBoundaryProcess::Reflect());
+            amrex::ParticleReal const mass = pc->getMass();
+            for (int lev = 0; lev <= pc->finestLevel(); ++lev) {
+                amrex::Real const dt_lev = warpx.getdt(lev);
+                reflectParticlesAtEB(*pc, distance_to_eb, lev, dt_lev, mass);
+            }
         }
     } else {
         for (auto& pc : allcontainers) {

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -215,6 +215,12 @@ public:
      */
     static inline amrex::Array<ParticleBoundaryType,AMREX_SPACEDIM> particle_boundary_hi;
 
+    /** Particle boundary condition at embedded boundaries.
+     *  Only Absorbing and Reflecting are supported.
+     *  Default is Absorbing for backward compatibility.
+     */
+    static inline ParticleBoundaryType eb_particle_boundary = ParticleBoundaryType::Absorbing;
+
     //! Integers that correspond to the time dependency of J (constant, linear)
     //! and rho (linear, quadratic) for the PSATD algorithm
     static inline auto time_dependency_J = TimeDependencyJ::Default;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -290,6 +290,28 @@ void WarpX::MakeWarpX ()
     std::tie(particle_boundary_lo, particle_boundary_hi) =
         warpx::particles::parse_particle_boundaries(is_field_boundary_periodic);
 
+    // Parse embedded boundary particle boundary condition
+    if (EB::enabled()) {
+        amrex::ParmParse const pp_warpx("warpx");
+        if (pp_warpx.contains("eb_particle_boundary_condition")) {
+            pp_warpx.query_enum_sloppy(
+                "eb_particle_boundary_condition", eb_particle_boundary, "-_");
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                eb_particle_boundary == ParticleBoundaryType::Absorbing ||
+                eb_particle_boundary == ParticleBoundaryType::Reflecting,
+                "warpx.eb_particle_boundary_condition must be Absorbing or Reflecting");
+        } else {
+            eb_particle_boundary = ParticleBoundaryType::Absorbing;
+            ablastr::warn_manager::WMRecordWarning(
+                "EmbeddedBoundary",
+                "warpx.eb_particle_boundary_condition is not specified. "
+                "Defaulting to Absorbing. Particles that cross the embedded "
+                "boundary surface will be removed. Set to Reflecting to "
+                "reflect particles instead.",
+                ablastr::warn_manager::WarnPriority::low);
+        }
+    }
+
     CheckGriddingForRZSpectral();
 
     m_instance = new WarpX();


### PR DESCRIPTION
# EB Particle Boundary Condition

## Problem (Issue #6566)

Embedded boundary particle scraping unconditionally absorbs all particles via a
hard-coded `ParticleBoundaryProcess::Absorb()` functor. Users setting reflecting
particle BCs on the domain walls observe particle loss when an EB is present,
because the EB scraper overrides the domain BC and destroys every particle that
crosses the EB surface.

## Root Cause

Three files form the critical path:

1. `ParticleBoundaryProcess.H` — only `Absorb` and `NoOp` functors existed;
   no `Reflect` functor.
2. `MultiParticleContainer.cpp:1130` — `ScrapeParticlesAtEB()` hard-codes
   `ParticleBoundaryProcess::Absorb()` for every species.
3. `WarpXEvolve.cpp:690-696` — domain BCs are applied first
   (`ApplyBoundaryConditions`), then EB scraping unconditionally absorbs.

The scraper template in `ParticleScraper.H` was *already* designed for pluggable
functors — it just never had a Reflect implementation.

## Changes in This Branch

### 1. Specular Reflect functor (`ParticleBoundaryProcess.H`)

Added `ParticleBoundaryProcess::Reflect` that performs:
- **Position reflection**: `x_new = x − 2·φ·n̂` (mirrors particle across EB surface)
- **Velocity reflection**: `v_new = v − 2(v·n̂)n̂` (reverses normal component)

Handles all dimension variants: 3D, XZ, RZ (with cylindrical ↔ Cartesian velocity
projection), and 1D_Z.

### 2. Scraper interface extended (`ParticleScraper.H`)

The functor call was changed from:
```cpp
f(ptd, ip, pos, normal, engine);
```
to:
```cpp
f(ptd, ip, pos, normal, phi_value, engine);
```

`phi_value` (the signed distance, negative inside the EB) is needed so the
functor can compute the correct reflected position. `NoOp` and `Absorb` accept
and ignore it.

### 3. User-facing configuration

| Interface | Parameter | Values |
|-----------|-----------|--------|
| PICMI Python | `picmi.EmbeddedBoundary(..., particle_boundary_condition='Reflecting')` | `'Absorbing'` (default), `'Reflecting'` |
| Classic input | `warpx.eb_particle_boundary_condition = Reflecting` | `Absorbing` (default), `Reflecting` |

Parsed in `MakeWarpX()` via `query_enum_sloppy`, stored as
`WarpX::eb_particle_boundary` (`ParticleBoundaryType` enum).

A low-priority warning is emitted when the parameter is unspecified, so existing
users are informed of the default absorbing behavior.

### 4. Functor dispatch (`MultiParticleContainer::ScrapeParticlesAtEB`)

Branches on `WarpX::eb_particle_boundary`:
- `Reflecting` → `ParticleBoundaryProcess::Reflect()`
- anything else → `ParticleBoundaryProcess::Absorb()`

Injection/reposition call sites (`AddParticles.cpp`, `WarpXParticleContainer.cpp`)
remain `Absorb` — particles created inside the EB should be removed.

## Functor Interface — Extensibility Assessment

The current scraper-to-functor interface is:

```cpp
void operator()(PData& ptd, int i,
                const RealVect& pos, const RealVect& normal,
                amrex::Real phi_value,
                RandomEngine const& engine)
```

### Sufficient for these future BCs

| BC Type | What it does | Why the interface is sufficient |
|---------|-------------|-------------------------------|
| **Diffuse reflect** | Re-emit with cosine-weighted random direction from surface | `normal` + `engine` generate the random direction; `phi_value` repositions the particle |
| **Thermal** | Rethermalize velocity at wall temperature | `uth` stored as functor struct member; `normal` orients half-Maxwellian; `engine` samples it; `phi_value` repositions |
| **Stochastic absorb/reflect** | Velocity-dependent reflection probability | Reflection model parser stored as functor member; velocity read from `ptd`; `engine` for random draw |
| **Accommodation coefficient** | Partial thermalization (mix of specular + diffuse) | `alpha`, `uth` as struct members; everything else available |

Per-BC configuration data belongs on the **functor struct** (e.g., `Thermal{uth=...}`),
not in the scraper call. The scraper arguments are geometry data; the functor carries
physics parameters. This separation is clean.

### Not sufficient for

| BC Type | Why |
|---------|-----|
| **Secondary electron emission** | Functor modifies one particle in-place; cannot create new particles. Would need a two-phase approach: (1) flag & record collision data, (2) create new particles in a separate pass. |
| **Sputtering / surface chemistry** | Same architectural limitation — requires particle creation. |

These would need a different design (likely a post-scrape particle injection step),
regardless of what data the scraper passes.

### One optional future improvement

`phi_value` approximates the penetration distance at the end of the timestep.
For more precise intersection timing (needed if a BC depends on exact collision
energy), the scraper could additionally pass a `dt_fraction` from bisection — the
`ParticleBoundaryBuffer` already computes this. Not needed for the BCs above, but
noted for completeness.

## Files Changed

| File | Lines | Summary |
|------|-------|---------|
| `Source/EmbeddedBoundary/ParticleBoundaryProcess.H` | +90 | `Reflect` functor; updated `NoOp`/`Absorb` signatures for `phi_value` |
| `Source/EmbeddedBoundary/ParticleScraper.H` | +1 −1 | Pass `phi_value` to functor |
| `Source/Particles/MultiParticleContainer.cpp` | +10 −2 | Dispatch on `WarpX::eb_particle_boundary` |
| `Source/WarpX.H` | +6 | New `eb_particle_boundary` static member |
| `Source/WarpX.cpp` | +22 | Parse `warpx.eb_particle_boundary_condition` with validation and warning |
| `Python/pywarpx/picmi.py` | +17 | `particle_boundary_condition` param on `EmbeddedBoundary` |