### PR TITLE
 Fix: Resolved issue-6579: Python WarpX Finalize Does Not Work for Sequential Simulations

### DIFF
--- a/Python/pywarpx/Bucket.py
+++ b/Python/pywarpx/Bucket.py
@@ -56,6 +56,15 @@ class Bucket(object):
                 self.argvattrs[vname] == value
             ), Exception(errmsg)
 
+    def clear(self):
+        """Reset all parameter attributes, returning the bucket to an empty state.
+
+        This is used when finalizing a simulation so that a subsequent
+        simulation started in the same interpreter does not inherit stale
+        parameter values from the previous run.
+        """
+        self.argvattrs.clear()
+
     def attrlist(self):
         "Concatenate the attributes into a string"
         result = []

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -169,17 +169,84 @@ class LibWarpX:
     def finalize(self, finalize_mpi=1):
         """
         Call finalize for WarpX and AMReX. Registered to run at program exit.
+
+        After this call the simulation state is fully torn down and a new
+        simulation may be started in the same Python process by calling
+        :meth:`initialize` again.
         """
-        # TODO: simplify, part of pyAMReX already
-        if self.initialized:
-            del self.warpx
-            # The call to warpx_finalize causes a crash - don't know why
-            # self.libwarpx_so.warpx_finalize()
-            self.libwarpx_so.amrex_finalize()
+        if not self.initialized:
+            return
 
-            from pywarpx import callbacks
+        # Clear Python callbacks first, while everything is still alive.
+        from pywarpx import callbacks
 
-            callbacks.clear_all()
+        callbacks.clear_all()
+
+        # Destroy the WarpX C++ singleton (frees all simulation data).
+        self.libwarpx_so.finalize()
+
+        # Drop the Python reference to the (now-destroyed) C++ object.
+        del self.warpx
+
+        # Shut down AMReX.
+        self.libwarpx_so.amrex_finalize()
+
+        self.initialized = False
+
+        # Reset all module-level parameter state so that a fresh simulation
+        # can be configured without inheriting values from the previous run.
+        self._reset_global_state()
+
+    def _reset_global_state(self):
+        """Reset module-level Bucket instances and lists to their initial state.
+
+        This is necessary because the pywarpx parameter objects are module-level
+        singletons.  Without resetting them, a second simulation started in the
+        same interpreter would inherit stale parameters from the first run.
+        """
+        from .Algo import algo
+        from .Amr import amr
+        from .Amrex import amrex
+        from .Boundary import boundary
+        from .Collisions import collisions, collisions_list
+        from .Constants import my_constants
+        from .Diagnostics import diagnostics, reduced_diagnostics
+        from .EB2 import eb2
+        from .Geometry import geometry
+        from .HybridPICModel import external_vector_potential, hybridpicmodel
+        from .Interpolation import interpolation
+        from .Lasers import lasers, lasers_list
+        from .Particles import particles, particles_list
+        from .PSATD import psatd
+        from .WarpX import warpx
+
+        # Clear all Bucket parameter state.
+        for bucket in [
+            warpx, algo, amr, amrex, boundary, collisions,
+            my_constants, diagnostics, reduced_diagnostics, eb2,
+            geometry, hybridpicmodel, external_vector_potential,
+            interpolation, lasers, psatd,
+        ]:
+            bucket.clear()
+
+        # Restore default attributes that other code may expect to exist.
+        particles.clear()
+        particles.species_names = []
+        particles.rigid_injected_species = []
+
+        lasers.names = []
+
+        # Clear accumulated species, laser, and collision lists.
+        particles_list.clear()
+        lasers_list.clear()
+        collisions_list.clear()
+
+        # Clear diagnostic registries.
+        diagnostics._diagnostics_dict.clear()
+        reduced_diagnostics._diagnostics_dict.clear()
+
+        # Clear the dynamic bucket dictionary.
+        warpx._bucket_dict.clear()
 
 
 libwarpx = LibWarpX()

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -222,10 +222,22 @@ class LibWarpX:
 
         # Clear all Bucket parameter state.
         for bucket in [
-            warpx, algo, amr, amrex, boundary, collisions,
-            my_constants, diagnostics, reduced_diagnostics, eb2,
-            geometry, hybridpicmodel, external_vector_potential,
-            interpolation, lasers, psatd,
+            warpx,
+            algo,
+            amr,
+            amrex,
+            boundary,
+            collisions,
+            my_constants,
+            diagnostics,
+            reduced_diagnostics,
+            eb2,
+            geometry,
+            hybridpicmodel,
+            external_vector_potential,
+            interpolation,
+            lasers,
+            psatd,
         ]:
             bucket.clear()
 

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -3522,6 +3522,7 @@ class Simulation(picmistandard.PICMI_Simulation):
     def finalize(self):
         if self.warpx_initialized:
             self.warpx_initialized = False
+            self.inputs_initialized = False
             pywarpx.warpx.finalize()
 
     @property


### PR DESCRIPTION
# Fix: Python WarpX Finalize Does Not Work for Sequential Simulations

Closes #6579

## Problem

Running multiple WarpX simulations sequentially in the same Python interpreter caused segfaults and MPI communicator duplication errors after the first simulation. The issue was reported with this reproducer:

```python
from pywarpx import warpx

for i in range(3):
    sim = warpx
    sim.load_inputs_file("Examples/Physics_applications/laser_acceleration/inputs_base_2d")
    sim.step()
    sim.finalize()
```

## Root Causes

1. **`WarpX::Finalize()` was never called** — The C++ WarpX singleton was never destroyed between runs. The old code had `self.libwarpx_so.warpx_finalize()` commented out with a note saying "causes a crash," but the crash was actually caused by the wrong teardown ordering.

2. **`LibWarpX.initialized` was never reset to `False`** — After the first finalize, the flag stayed `True`, so the second `amrex_init()` call happened while AMReX was still active → MPI communicator duplication error.

3. **Callbacks were cleared *after* `amrex_finalize()`** — The cleanup ordering was backwards.

4. **Module-level Python state leaked across runs** — All `Bucket` parameter objects and species/laser/collision lists are module-level singletons that accumulated stale data from previous simulations.

5. **PICMI `inputs_initialized` wasn't reset** — Preventing proper re-initialization of subsequent simulations.

## Solution

Rewrote `LibWarpX.finalize()` with the correct teardown order:
1. Clear Python callbacks (while C++ objects are still alive)
2. Call `WarpX::Finalize()` via `self.libwarpx_so.finalize()` to destroy the C++ singleton
3. Drop the Python wrapper reference (`del self.warpx`)
4. Call `amrex_finalize()` to shut down AMReX
5. Set `self.initialized = False`
6. Reset all module-level Bucket/list state via new `_reset_global_state()` helper

## Changes Made

- **`Python/pywarpx/Bucket.py`**: Added `clear()` method to reset a Bucket's parameter dictionary to empty state
- **`Python/pywarpx/_libwarpx.py`**: Rewrote `finalize()` with proper teardown ordering and added `_reset_global_state()` to clean up all module-level state
- **`Python/pywarpx/picmi.py`**: Reset `inputs_initialized` in `Simulation.finalize()` so subsequent simulations properly re-initialize

## Testing

- Verified the reproducer script from #6579 now runs successfully
- No lint errors introduced
- All three code paths covered: direct `warpx` API, `load_inputs_file()`, and PICMI `Simulation`

## Notes

This fix enables sequential simulations in the same Python interpreter, matching the behavior of AMReX, pyAMReX, and ImpactX. Each `finalize()` call now fully tears down the C++ simulation, shuts down AMReX, and resets all Python-side state, allowing the next `initialize()` to start fresh.
