### PR TITLE
Docs: update instructions to compile/use WarpX on Adastra (CINES)

### DIFF
--- a/Tools/machines/adastra-cines/adastra_warpx.profile.example
+++ b/Tools/machines/adastra-cines/adastra_warpx.profile.example
@@ -7,13 +7,13 @@ export SW_DIR=${WORKDIR}/sw/
 
 # required dependencies
 module purge
-module load cpe/24.07
+module load cpe/25.09
 module load craype-accel-amd-gfx90a craype-x86-trento
-module load PrgEnv-cray
+module load rocm/6.4.3
+module load PrgEnv-amd
+module load cray-mpich/9.0.1
 module load develop
-module load CCE-GPU-4.0.0
-module load amd-mixed/6.2.1
-module load cmake/3.27.9
+module load cmake/4.0.3
 
 # optional: faster builds
 module load ninja
@@ -25,13 +25,13 @@ export LD_LIBRARY_PATH=${SW_DIR}/adastra/gpu/blaspp-2024.05.31/lib64:$LD_LIBRARY
 export LD_LIBRARY_PATH=${SW_DIR}/adastra/gpu/lapackpp-2024.05.31/lib64:$LD_LIBRARY_PATH
 
 # optional: for QED lookup table generation support
-module load boost/1.86.0-mpi
+export CMAKE_PREFIX_PATH=${SW_DIR}/adastra/gpu/boost-1.88.0:${CMAKE_PREFIX_PATH}
+export LD_LIBRARY_PATH=${SW_DIR}/adastra/gpu/boost-1.88.0/lib:${LD_LIBRARY_PATH}
 
 # optional: for openPMD support
 module load cray-hdf5-parallel
-export CMAKE_PREFIX_PATH=${SW_DIR}/adastra/gpu/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=${SW_DIR}/adastra/gpu/c-blosc-2.23.0:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=${SW_DIR}/adastra/gpu/adios2-2.10.2:$CMAKE_PREFIX_PATH
-
 export PATH=${SW_DIR}/adastra/gpu/adios2-2.10.2/bin:${PATH}
 
 # optional: for Python bindings or libEnsemble
@@ -65,4 +65,4 @@ export AMREX_AMD_ARCH=gfx90a
 # compiler environment hints
 export CC=$(which cc)
 export CXX=$(which CC)
-export FC=$(which amdflang)
+export FC=$(which ftn)

--- a/Tools/machines/adastra-cines/install_dependencies.sh
+++ b/Tools/machines/adastra-cines/install_dependencies.sh
@@ -34,6 +34,9 @@ python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 # General extra dependencies ##################################################
 #
 
+# define how many threads are used for compilation
+PARALLEL=16
+
 # BLAS++ (for PSATD+RZ)
 if [ -d ${SRC_DIR}/blaspp ]
 then
@@ -45,8 +48,8 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/blaspp.git ${SRC_DIR}/blaspp
 fi
 rm -rf ${SRC_DIR}/blaspp-adastra-gpu-build
-CXX=$(which CC) cmake -S ${SRC_DIR}/blaspp -B ${SRC_DIR}/blaspp-adastra-gpu-build -Duse_openmp=OFF -Dgpu_backend=hip -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
-cmake --build ${SRC_DIR}/blaspp-adastra-gpu-build --target install --parallel 16
+cmake -S ${SRC_DIR}/blaspp -B ${SRC_DIR}/blaspp-adastra-gpu-build -Duse_openmp=OFF -Dgpu_backend=hip -DGPU_TARGETS=gfx90a  -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
+cmake --build ${SRC_DIR}/blaspp-adastra-gpu-build --target install --parallel ${PARALLEL}
 rm -rf ${SRC_DIR}/blaspp-adastra-gpu-build
 
 # LAPACK++ (for PSATD+RZ)
@@ -60,37 +63,35 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/lapackpp.git ${SRC_DIR}/lapackpp
 fi
 rm -rf ${SRC_DIR}/lapackpp-adastra-gpu-build
-CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S ${SRC_DIR}/lapackpp -B ${SRC_DIR}/lapackpp-adastra-gpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
-cmake --build ${SRC_DIR}/lapackpp-adastra-gpu-build --target install --parallel 16
+cmake -S ${SRC_DIR}/lapackpp -B ${SRC_DIR}/lapackpp-adastra-gpu-build -DGPU_TARGETS=gfx90a  -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
+cmake --build ${SRC_DIR}/lapackpp-adastra-gpu-build --target install --parallel ${PARALLEL}
 rm -rf ${SRC_DIR}/lapackpp-adastra-gpu-build
 
-# c-blosc (I/O compression, for OpenPMD)
-if [ -d ${SRC_DIR}/c-blosc ]
+# c-blosc2 (I/O compression, for OpenPMD)
+if [ -d ${SRC_DIR}/c-blosc2 ]
 then
   # git repository is already there
   :
 else
-  git clone -b v1.21.1 https://github.com/Blosc/c-blosc.git ${SRC_DIR}/c-blosc
+  git clone -b v2.23.0 https://github.com/Blosc/c-blosc2.git ${SRC_DIR}/c-blosc2
 fi
-rm -rf ${SRC_DIR}/c-blosc-ad-build
-cmake -S ${SRC_DIR}/c-blosc -B ${SRC_DIR}/c-blosc-ad-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/c-blosc-1.21.1
-cmake --build ${SRC_DIR}/c-blosc-ad-build --target install --parallel 16
-rm -rf ${SRC_DIR}/c-blosc-ad-build
+rm -rf ${SRC_DIR}/c-blosc2-ad-build
+cmake -S ${SRC_DIR}/c-blosc2 -B ${SRC_DIR}/c-blosc2-ad-build -DBUILD_TESTS=OFF -DBUILD_EXAMPLES=OFF  -DBUILD_FUZZERS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/c-blosc-2.23.0
+cmake --build ${SRC_DIR}/c-blosc2-ad-build --target install --parallel ${PARALLEL}
+rm -rf ${SRC_DIR}/c-blosc2-ad-build
 
-# ADIOS2 v. 2.10.2 (for OpenPMD)
-if [ -d ${SRC_DIR}/adios2 ]
+# c-blosc2 (I/O compression, for OpenPMD)
+if [ -d ${SRC_DIR}/c-blosc2 ]
 then
-  cd ${SRC_DIR}/adios2
-  git fetch --prune
-  git checkout v2.10.2
-  cd -
+  # git repository is already there
+  :
 else
-  git clone -b v2.10.2 https://github.com/ornladios/ADIOS2.git ${SRC_DIR}/adios2
+  git clone -b v2.23.0 https://github.com/Blosc/c-blosc2.git ${SRC_DIR}/c-blosc2
 fi
-rm -rf ${SRC_DIR}/adios2-ad-build
-cmake -S ${SRC_DIR}/adios2 -B ${SRC_DIR}/adios2-ad-build -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.10.2
-cmake --build ${SRC_DIR}/adios2-ad-build --target install -j 16
-rm -rf ${SRC_DIR}/adios2-ad-build
+rm -rf ${SRC_DIR}/c-blosc2-ad-build
+cmake -S ${SRC_DIR}/c-blosc2 -B ${SRC_DIR}/c-blosc2-ad-build -DBUILD_TESTS=OFF -DBUILD_EXAMPLES=OFF  -DBUILD_FUZZERS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/c-blosc-2.23.0
+cmake --build ${SRC_DIR}/c-blosc2-ad-build --target install --parallel ${PARALLEL}
+rm -rf ${SRC_DIR}/c-blosc2-ad-build
 
 
 # Python ######################################################################

--- a/Tools/machines/adastra-cines/install_dependencies.sh
+++ b/Tools/machines/adastra-cines/install_dependencies.sh
@@ -67,6 +67,17 @@ cmake -S ${SRC_DIR}/lapackpp -B ${SRC_DIR}/lapackpp-adastra-gpu-build -DGPU_TARG
 cmake --build ${SRC_DIR}/lapackpp-adastra-gpu-build --target install --parallel ${PARALLEL}
 rm -rf ${SRC_DIR}/lapackpp-adastra-gpu-build
 
+# Boost (QED tables)
+rm -rf ${SRC_DIR}/boost-temp
+mkdir -p ${SRC_DIR}/boost-temp
+curl -Lo ${SRC_DIR}/boost-temp/boost.tar.gz https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.gz
+tar -xzf ${SRC_DIR}/boost-temp/boost.tar.gz -C ${SRC_DIR}/boost-temp
+cd ${SRC_DIR}/boost-temp/boost_1_88_0
+./bootstrap.sh -with-libraries=math  --prefix=${SW_DIR}/boost-1.88.0
+./b2 --with-math cxxflags="-std=c++17" install -j ${PARALLEL}
+cd -
+rm -rf ${SRC_DIR}/boost-temp
+
 # c-blosc2 (I/O compression, for OpenPMD)
 if [ -d ${SRC_DIR}/c-blosc2 ]
 then

--- a/Tools/machines/adastra-cines/install_dependencies.sh
+++ b/Tools/machines/adastra-cines/install_dependencies.sh
@@ -80,18 +80,20 @@ cmake -S ${SRC_DIR}/c-blosc2 -B ${SRC_DIR}/c-blosc2-ad-build -DBUILD_TESTS=OFF -
 cmake --build ${SRC_DIR}/c-blosc2-ad-build --target install --parallel ${PARALLEL}
 rm -rf ${SRC_DIR}/c-blosc2-ad-build
 
-# c-blosc2 (I/O compression, for OpenPMD)
-if [ -d ${SRC_DIR}/c-blosc2 ]
+# ADIOS2 v. 2.10.2 (for OpenPMD)
+if [ -d ${SRC_DIR}/adios2 ]
 then
-  # git repository is already there
-  :
+  cd ${SRC_DIR}/adios2
+  git fetch --prune
+  git checkout v2.10.2
+  cd -
 else
-  git clone -b v2.23.0 https://github.com/Blosc/c-blosc2.git ${SRC_DIR}/c-blosc2
+  git clone -b v2.10.2 https://github.com/ornladios/ADIOS2.git ${SRC_DIR}/adios2
 fi
-rm -rf ${SRC_DIR}/c-blosc2-ad-build
-cmake -S ${SRC_DIR}/c-blosc2 -B ${SRC_DIR}/c-blosc2-ad-build -DBUILD_TESTS=OFF -DBUILD_EXAMPLES=OFF  -DBUILD_FUZZERS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/c-blosc-2.23.0
-cmake --build ${SRC_DIR}/c-blosc2-ad-build --target install --parallel ${PARALLEL}
-rm -rf ${SRC_DIR}/c-blosc2-ad-build
+rm -rf ${SRC_DIR}/adios2-ad-build
+cmake -S ${SRC_DIR}/adios2 -B ${SRC_DIR}/adios2-ad-build -DADIOS2_USE_Blosc2=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${SW_DIR}/adios2-2.10.2
+cmake --build ${SRC_DIR}/adios2-ad-build --target install -j ${PARALLEL}
+rm -rf ${SRC_DIR}/adios2-ad-build
 
 
 # Python ######################################################################

--- a/Tools/machines/adastra-cines/submit.sh
+++ b/Tools/machines/adastra-cines/submit.sh
@@ -10,42 +10,19 @@
 module purge
 
 # A CrayPE environment version
-module load cpe/24.07
+module load cpe/25.09
 # An architecture
 module load craype-accel-amd-gfx90a craype-x86-trento
 # A compiler to target the architecture
-module load PrgEnv-cray
-# Some architecture related libraries and tools
-module load develop
-module load CCE-GPU-4.0.0
-# AMD related libraries
-module load rocm/6.1.2
-module load amd-mixed/6.1.2
-# note
-# cray-mpich versions 8.1.28 and 8.1.30 have known issues
-# that cause node memory increase over time which leads
-# to slowdown and out-of-memory crashes.
-module load cray-mpich/8.1.26
+module load rocm/6.4.3
+module load PrgEnv-amd
+# The MPI library
+module load cray-mpich/9.0.1
 
 date
 module list
 
 export MPICH_GPU_SUPPORT_ENABLED=1
-
-# note
-# this environment setting is currently needed to work-around a
-# known issue with Libfabric
-#export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
-# or, less invasive:
-export FI_MR_CACHE_MONITOR=memhooks  # alternative cache monitor
-
-# note
-# On machines with similar architectures (Frontier, OLCF) these settings
-# seem to prevent the following issue:
-# OLCFDEV-1597: OFI Poll Failed UNDELIVERABLE Errors
-# https://docs.olcf.ornl.gov/systems/frontier_user_guide.html#olcfdev-1597-ofi-poll-failed-undeliverable-errors
-export MPICH_SMP_SINGLE_COPY_MODE=NONE
-export FI_CXI_RX_MATCH_MODE=software
 
 # note
 # this environment setting is needed to avoid that rocFFT writes a cache in


### PR DESCRIPTION
This PR updates the instructions to compile and use WarpX on the Adastra supercomputer (CINES, France).

The main changes are the following:

- AMD compiler instead of Cray compiler is used by default for performance reasons
- mpich v9.0.1 , cpe v25.09, and rocm v6.4.3 are now used
- boost is installed manually from source (the version available on Adastra is not compatible with the aforementioned modules)
- blosc v2.23 instead of blosc v1.21.1 is used for compatibility reasons with ADIOS2 v2.10.2
- workarounds in the submission script have been mostly eliminated, since they do not seem to be necessary

