### PR TITLE
Blended Pusher For Large Timestep Dynamics in Magnetic Fields

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -301,6 +301,9 @@ class Species(picmistandard.PICMI_Species):
         self.resampling_algorithm_target_weight = kw.pop(
             "warpx_resampling_algorithm_target_weight", None
         )
+        self.warpx_resampling_algorithm_target_ratio = kw.pop(
+            "warpx_resampling_algorithm_target_ratio", None
+        )
         self.resampling_algorithm_velocity_grid_type = kw.pop(
             "warpx_resampling_algorithm_velocity_grid_type", None
         )
@@ -2071,40 +2074,19 @@ class ElectrostaticSolver(picmistandard.PICMI_ElectrostaticSolver):
     """
     See `Input Parameters <https://warpx.readthedocs.io/en/latest/usage/parameters.html>`__ for more information.
 
-    The standard PICMI parameters `required_precision` and `maximum_iterations` control the
-    MLMG Poisson solver convergence for the labframe electrostatic solvers. When `warpx_magnetostatic=True`,
-    these parameters are used as defaults for the magnetostatic solver but can be overridden
-    with the explicit `warpx_magnetostatic_*` parameters.
-
     Parameters
     ----------
     warpx_relativistic: bool, default=False
         Whether to use the relativistic solver or lab frame solver
 
     warpx_absolute_tolerance: float, default=0.
-        Absolute tolerance on the labframe electrostatic solver
+        Absolute tolerance on the lab frame solver
 
     warpx_self_fields_verbosity: integer, default=2
-        Level of verbosity for the labframe electrostatic solver
+        Level of verbosity for the lab frame solver
 
     warpx_magnetostatic: bool, default=False
-        Whether to also solve for self-consistent magnetic fields from currents.
-
-    warpx_magnetostatic_required_precision: float, optional
-        Relative precision for the magnetostatic solver. If not specified,
-        defaults to the value of `required_precision`.
-
-    warpx_magnetostatic_absolute_tolerance: float, optional
-        Absolute tolerance for the magnetostatic solver. If not specified,
-        defaults to the value of `warpx_absolute_tolerance`.
-
-    warpx_magnetostatic_max_iters: integer, optional
-        Maximum iterations for the magnetostatic solver. If not specified,
-        defaults to the value of `maximum_iterations`.
-
-    warpx_magnetostatic_verbosity: integer, optional
-        Verbosity level for the magnetostatic solver. If not specified,
-        defaults to the value of `warpx_self_fields_verbosity`.
+        Whether to use the magnetostatic solver
 
     warpx_effective_potential: bool, default=False
         Whether to use the effective potential Poisson solver (EP-PIC)
@@ -2116,7 +2098,8 @@ class ElectrostaticSolver(picmistandard.PICMI_ElectrostaticSolver):
     warpx_effective_potential_time_filter_param: float, default=0.1
         Time filtering parameter used to filter sigma in the effective
         potential scheme. sigma is updated using:
-        sigma^n = warpx_effective_potential_time_filter_param * sigma^n + (1 - warpx_effective_potential_time_filter_param) * sigma^n-1
+        sigma^n = warpx_effective_potential_time_filter_param * sigma^n
+                  + (1 - warpx_effective_potential_time_filter_param) * sigma^n-1
 
     warpx_effective_potential_density_floor: float, default=0
         If given, this value will be used as the minimum density during the
@@ -2138,15 +2121,6 @@ class ElectrostaticSolver(picmistandard.PICMI_ElectrostaticSolver):
         self.absolute_tolerance = kw.pop("warpx_absolute_tolerance", None)
         self.self_fields_verbosity = kw.pop("warpx_self_fields_verbosity", None)
         self.magnetostatic = kw.pop("warpx_magnetostatic", False)
-        # Explicit magnetostatic solver parameters (override self_fields_* defaults)
-        self.magnetostatic_required_precision = kw.pop(
-            "warpx_magnetostatic_required_precision", None
-        )
-        self.magnetostatic_absolute_tolerance = kw.pop(
-            "warpx_magnetostatic_absolute_tolerance", None
-        )
-        self.magnetostatic_max_iters = kw.pop("warpx_magnetostatic_max_iters", None)
-        self.magnetostatic_verbosity = kw.pop("warpx_magnetostatic_verbosity", None)
         self.effective_potential = kw.pop("warpx_effective_potential", False)
         self.effective_potential_factor = kw.pop(
             "warpx_effective_potential_factor", None
@@ -2165,6 +2139,9 @@ class ElectrostaticSolver(picmistandard.PICMI_ElectrostaticSolver):
         # Open BC means FieldBoundaryType::Open for electrostatic sims, rather than perfectly-matched layer
         BC_map["open"] = "open"
 
+        # Open BC means FieldBoundaryType::Open for electrostatic sims, rather than perfectly-matched layer
+        BC_map['open'] = 'open'
+        
         self.grid.grid_initialize_inputs()
 
         # set adaptive timestepping parameters
@@ -2194,22 +2171,13 @@ class ElectrostaticSolver(picmistandard.PICMI_ElectrostaticSolver):
             pywarpx.warpx.self_fields_absolute_tolerance = self.absolute_tolerance
             pywarpx.warpx.self_fields_max_iters = self.maximum_iterations
             pywarpx.warpx.self_fields_verbosity = self.self_fields_verbosity
-            # Explicit magnetostatic solver parameters (if provided)
-            pywarpx.warpx.magnetostatic_solver_required_precision = (
-                self.magnetostatic_required_precision
-            )
-            pywarpx.warpx.magnetostatic_solver_absolute_tolerance = (
-                self.magnetostatic_absolute_tolerance
-            )
-            pywarpx.warpx.magnetostatic_solver_max_iters = self.magnetostatic_max_iters
-            pywarpx.warpx.magnetostatic_solver_verbosity = self.magnetostatic_verbosity
             pywarpx.boundary.potential_lo_x = self.grid.potential_xmin
             pywarpx.boundary.potential_lo_y = self.grid.potential_ymin
             pywarpx.boundary.potential_lo_z = self.grid.potential_zmin
             pywarpx.boundary.potential_hi_x = self.grid.potential_xmax
             pywarpx.boundary.potential_hi_y = self.grid.potential_ymax
             pywarpx.boundary.potential_hi_z = self.grid.potential_zmax
-
+            
         pywarpx.warpx.poisson_solver = self.method
 
 
@@ -2707,6 +2675,72 @@ class AnalyticAppliedField(picmistandard.PICMI_AnalyticAppliedField):
                 )
 
 
+class AnalyticGradBAppliedField(picmistandard.PICMI_AnalyticAppliedField):
+    def init(self, kw):
+        # Reuse the same constant-mangling machinery
+        self.mangle_dict = None
+
+    def applied_field_initialize_inputs(self):
+        # lower/upper_bound not used by WarpX
+
+        if self.mangle_dict is None:
+            self.mangle_dict = pywarpx.my_constants.add_keywords(self.user_defined_kw)
+
+        # If any gradB component is set, enable the parser mode
+        if (self.Bx_expression is not None
+            or self.By_expression is not None
+            or self.Bz_expression is not None):
+
+            # This string MUST match what you used in MultiParticleContainer
+            pywarpx.particles.gradB_ext_particle_init_style = (
+                "parse_gradb_ext_particle_function"
+            )
+
+            for sdir, expression in zip(
+                ["x", "y", "z"],
+                [self.Bx_expression, self.By_expression, self.Bz_expression],
+            ):
+                if expression is None:
+                    continue
+                expression = pywarpx.my_constants.mangle_expression(
+                    expression, self.mangle_dict
+                )
+                # Name here must match your C++ Store_parserString key, e.g.
+                # "gradBx_external_particle_function(x,y,z,t)" or similar.
+                pywarpx.particles.__setattr__(
+                    f"gradB{sdir}_external_particle_function(x,y,z,t)", expression
+                )
+
+class AnalyticKappaAppliedField(picmistandard.PICMI_AnalyticAppliedField):
+    def init(self, kw):
+        self.mangle_dict = None
+
+    def applied_field_initialize_inputs(self):
+        if self.mangle_dict is None:
+            self.mangle_dict = pywarpx.my_constants.add_keywords(self.user_defined_kw)
+
+        # For kappa, you might choose to name the PICMI-side components x,y,z
+        if (self.Bx_expression is not None
+            or self.By_expression is not None
+            or self.Bz_expression is not None):
+
+            pywarpx.particles.kappa_ext_particle_init_style = (
+                "parse_kappa_ext_particle_function"
+            )
+
+            for comp, expression in zip(
+                ["x", "y", "z"],
+                [self.Bx_expression, self.By_expression, self.Bz_expression],
+            ):
+                if expression is None:
+                    continue
+                expression = pywarpx.my_constants.mangle_expression(
+                    expression, self.mangle_dict
+                )
+                pywarpx.particles.__setattr__(
+                    f"kappa{comp}_external_particle_function(x,y,z,t)", expression
+                )
+
 class Mirror(picmistandard.PICMI_Mirror):
     def applied_field_initialize_inputs(self):
         try:
@@ -2826,6 +2860,7 @@ class MCCCollisions(picmistandard.base._ClassWithInit):
         background_mass=None,
         max_background_density=None,
         ndt=None,
+        electron_species=None,
         **kw,
     ):
         self.name = name
@@ -2836,6 +2871,7 @@ class MCCCollisions(picmistandard.base._ClassWithInit):
         self.scattering_processes = scattering_processes
         self.max_background_density = max_background_density
         self.ndt = ndt
+        self.electron_species = electron_species
 
         self.handle_init(kw)
 
@@ -2858,6 +2894,8 @@ class MCCCollisions(picmistandard.base._ClassWithInit):
         collision.background_mass = self.background_mass
         collision.max_background_density = self.max_background_density
         collision.ndt = self.ndt
+        if self.electron_species is not None:
+            collision.electron_species = self.electron_species.name
 
         collision.scattering_processes = self.scattering_processes.keys()
         for process, kw in self.scattering_processes.items():

--- a/Source/Particles/Gather/GetExternalFields.H
+++ b/Source/Particles/Gather/GetExternalFields.H
@@ -22,6 +22,8 @@
 struct GetExternalEBField
 {
     enum ExternalFieldInitType { None, Parser, RepeatedPlasmaLens, Unknown };
+    enum class ExternalGradBInitType { None, Parser, FromGrid, Unknown }; // Used for blended pusher
+    enum class ExternalKappaInitType { None, Parser, FromGrid, Unknown }; // Used for curvature drift in blended pusher
 
     GetExternalEBField () = default;
 
@@ -29,6 +31,8 @@ struct GetExternalEBField
 
     ExternalFieldInitType m_Etype;
     ExternalFieldInitType m_Btype;
+    ExternalGradBInitType m_gradBtype = ExternalGradBInitType::None; // new member for blended pusher
+    ExternalKappaInitType m_kappatype = ExternalKappaInitType::None; // new member for blended pusher
 
     amrex::ParticleReal m_gamma_boost;
     amrex::ParticleReal m_uz_boost;
@@ -39,6 +43,16 @@ struct GetExternalEBField
     amrex::ParserExecutor<4> m_Bxfield_partparser;
     amrex::ParserExecutor<4> m_Byfield_partparser;
     amrex::ParserExecutor<4> m_Bzfield_partparser;
+
+    //new parsers for blended pusher - gradB
+    amrex::ParserExecutor<4> m_gradBxfield_partparser;
+    amrex::ParserExecutor<4> m_gradByfield_partparser;
+    amrex::ParserExecutor<4> m_gradBzfield_partparser;
+
+    //new parsers for blended pusher - kappa
+    amrex::ParserExecutor<4> m_kappaxfield_partparser;
+    amrex::ParserExecutor<4> m_kappayfield_partparser;
+    amrex::ParserExecutor<4> m_kappazfield_partparser;
 
     GetParticlePosition<PIdx> m_get_position;
     amrex::Real m_time;
@@ -57,7 +71,10 @@ struct GetExternalEBField
     LatticeElementFinderDevice d_lattice_element_finder;
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    bool isNoOp () const { return (m_Etype == None && m_Btype == None && !d_lattice_element_finder.m_initialized); }
+    bool isNoOp () const { return (m_Etype == None && m_Btype == None 
+        && m_gradBtype == ExternalGradBInitType::None
+        && m_kappatype == ExternalKappaInitType::None
+        && !d_lattice_element_finder.m_initialized); }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void operator () (long i,
@@ -66,7 +83,13 @@ struct GetExternalEBField
                       amrex::ParticleReal& field_Ez,
                       amrex::ParticleReal& field_Bx,
                       amrex::ParticleReal& field_By,
-                      amrex::ParticleReal& field_Bz) const noexcept
+                      amrex::ParticleReal& field_Bz,
+                      amrex::ParticleReal& gradBx,
+                      amrex::ParticleReal& gradBy,
+                      amrex::ParticleReal& gradBz,
+                      amrex::ParticleReal& kappax,
+                      amrex::ParticleReal& kappay,
+                      amrex::ParticleReal& kappaz) const noexcept
     {
         using namespace amrex::literals;
 
@@ -75,7 +98,9 @@ struct GetExternalEBField
                                         field_Bx, field_By, field_Bz);
         }
 
-        if (m_Etype == None && m_Btype == None) { return; }
+        if (m_Etype == None && m_Btype == None &&  
+            m_gradBtype == ExternalGradBInitType::None 
+            && m_kappatype == ExternalKappaInitType::None) { return; }
 
         amrex::ParticleReal Ex = 0._prt;
         amrex::ParticleReal Ey = 0._prt;
@@ -83,6 +108,15 @@ struct GetExternalEBField
         amrex::ParticleReal Bx = 0._prt;
         amrex::ParticleReal By = 0._prt;
         amrex::ParticleReal Bz = 0._prt;
+
+
+        gradBx = 0._prt;
+        gradBy = 0._prt;
+        gradBz = 0._prt;
+
+        kappax = 0._prt;
+        kappay = 0._prt;
+        kappaz = 0._prt;
 
         constexpr amrex::ParticleReal inv_c2 = 1._prt/(PhysConst::c*PhysConst::c);
 
@@ -112,6 +146,37 @@ struct GetExternalEBField
             Bx = m_Bxfield_partparser((amrex::ParticleReal) x, (amrex::ParticleReal) y, (amrex::ParticleReal) z, lab_time);
             By = m_Byfield_partparser((amrex::ParticleReal) x, (amrex::ParticleReal) y, (amrex::ParticleReal) z, lab_time);
             Bz = m_Bzfield_partparser((amrex::ParticleReal) x, (amrex::ParticleReal) y, (amrex::ParticleReal) z, lab_time);
+        }
+
+        //
+        if (m_gradBtype == ExternalGradBInitType::Parser)
+        {
+            amrex::ParticleReal x, y, z;
+            m_get_position(i, x, y, z);
+            amrex::Real lab_time = m_time;
+            if (m_gamma_boost > 1._prt) {
+                lab_time = m_gamma_boost*m_time + m_uz_boost*z*inv_c2;
+                z = m_gamma_boost*z + m_uz_boost*m_time;
+            }
+            // gradB fields used for blended pusher - these are passed back by reference
+            gradBx = m_gradBxfield_partparser((amrex::ParticleReal) x, (amrex::ParticleReal) y, (amrex::ParticleReal) z, lab_time);
+            gradBy = m_gradByfield_partparser((amrex::ParticleReal) x, (amrex::ParticleReal) y, (amrex::ParticleReal) z, lab_time);
+            gradBz = m_gradBzfield_partparser((amrex::ParticleReal) x, (amrex::ParticleReal) y, (amrex::ParticleReal) z, lab_time);
+        }
+
+        if (m_kappatype == ExternalKappaInitType::Parser)
+        {
+            amrex::ParticleReal x, y, z;
+            m_get_position(i, x, y, z);
+            amrex::Real lab_time = m_time;
+            if (m_gamma_boost > 1._prt) {
+                lab_time = m_gamma_boost*m_time + m_uz_boost*z*inv_c2;
+                z = m_gamma_boost*z + m_uz_boost*m_time;
+            }
+            // kappa uses for curvature drift in blended pusher - these are passed back by reference
+            kappax = m_kappaxfield_partparser((amrex::ParticleReal) x, (amrex::ParticleReal) y, (amrex::ParticleReal) z, lab_time);
+            kappay = m_kappayfield_partparser((amrex::ParticleReal) x, (amrex::ParticleReal) y, (amrex::ParticleReal) z, lab_time);
+            kappaz = m_kappazfield_partparser((amrex::ParticleReal) x, (amrex::ParticleReal) y, (amrex::ParticleReal) z, lab_time);
         }
 
         if (m_Etype == RepeatedPlasmaLens ||

--- a/Source/Particles/Gather/GetExternalFields.cpp
+++ b/Source/Particles/Gather/GetExternalFields.cpp
@@ -43,7 +43,9 @@ GetExternalEBField::GetExternalEBField (const WarpXParIter& a_pti, long a_offset
     if (mypc.m_E_ext_particle_s == "parse_e_ext_particle_function" ||
         mypc.m_B_ext_particle_s == "parse_b_ext_particle_function" ||
         mypc.m_E_ext_particle_s == "repeated_plasma_lens" ||
-        mypc.m_B_ext_particle_s == "repeated_plasma_lens")
+        mypc.m_B_ext_particle_s == "repeated_plasma_lens" ||
+        mypc.m_gradB_ext_particle_s == "parse_gradb_ext_particle_function" ||
+        mypc.m_kappa_ext_particle_s == "parse_kappa_ext_particle_function")
     {
         m_time = warpx.gett_new(a_pti.GetLevel());
         m_get_position = GetParticlePosition<PIdx>(a_pti, a_offset);
@@ -64,6 +66,25 @@ GetExternalEBField::GetExternalEBField (const WarpXParIter& a_pti, long a_offset
         m_Byfield_partparser = mypc.m_By_particle_parser->compile<4>();
         m_Bzfield_partparser = mypc.m_Bz_particle_parser->compile<4>();
     }
+
+    //new parsers for blended pusher - gradB
+    if (mypc.m_gradB_ext_particle_s == "parse_gradb_ext_particle_function")
+    {
+        m_gradBtype = ExternalGradBInitType::Parser;
+        m_gradBxfield_partparser = mypc.m_gradBx_particle_parser->compile<4>();
+        m_gradByfield_partparser = mypc.m_gradBy_particle_parser->compile<4>();
+        m_gradBzfield_partparser = mypc.m_gradBz_particle_parser->compile<4>();
+    }
+
+    //new parsers for blended pusher - kappa
+    if (mypc.m_kappa_ext_particle_s == "parse_kappa_ext_particle_function")
+    {
+        m_kappatype = ExternalKappaInitType::Parser;
+        m_kappaxfield_partparser = mypc.m_kappax_particle_parser->compile<4>();
+        m_kappayfield_partparser = mypc.m_kappay_particle_parser->compile<4>();
+        m_kappazfield_partparser = mypc.m_kappaz_particle_parser->compile<4>();
+    }
+
 
     if (mypc.m_E_ext_particle_s == "repeated_plasma_lens" ||
         mypc.m_B_ext_particle_s == "repeated_plasma_lens")

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -332,10 +332,20 @@ public:
 
     std::string m_B_ext_particle_s = "none";
     std::string m_E_ext_particle_s = "none";
+    std::string m_gradB_ext_particle_s = "none";   // used for Blended pusher
+    std::string m_kappa_ext_particle_s = "none";   // used for Blended pusher
     // Parser for B_external on the particle
     std::unique_ptr<amrex::Parser> m_Bx_particle_parser;
     std::unique_ptr<amrex::Parser> m_By_particle_parser;
     std::unique_ptr<amrex::Parser> m_Bz_particle_parser;
+    // Parser for gradB_external on the particle - used for Blended pusher
+    std::unique_ptr<amrex::Parser> m_gradBx_particle_parser;
+    std::unique_ptr<amrex::Parser> m_gradBy_particle_parser;
+    std::unique_ptr<amrex::Parser> m_gradBz_particle_parser;
+    // Parser for kappa_external on the particle - used for Blended pusher
+    std::unique_ptr<amrex::Parser> m_kappax_particle_parser;
+    std::unique_ptr<amrex::Parser> m_kappay_particle_parser;
+    std::unique_ptr<amrex::Parser> m_kappaz_particle_parser;
     // Parser for E_external on the particle
     std::unique_ptr<amrex::Parser> m_Ex_particle_parser;
     std::unique_ptr<amrex::Parser> m_Ey_particle_parser;

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -148,6 +148,19 @@ MultiParticleContainer::ReadParameters ()
                        m_E_ext_particle_s.begin(),
                        ::tolower);
 
+        // query gradB and kappa init styles for blended pusher
+        pp_particles.query("gradB_ext_particle_init_style", m_gradB_ext_particle_s);
+        std::transform(m_gradB_ext_particle_s.begin(),
+               m_gradB_ext_particle_s.end(),
+               m_gradB_ext_particle_s.begin(),
+               ::tolower);
+               
+        pp_particles.query("kappa_ext_particle_init_style", m_kappa_ext_particle_s);
+        std::transform(m_kappa_ext_particle_s.begin(),
+               m_kappa_ext_particle_s.end(),
+               m_kappa_ext_particle_s.begin(),
+               ::tolower);
+
         // if the input string for B_ext_particle_s is
         // "parse_b_ext_particle_function" then the mathematical expression
         // for the Bx_, By_, Bz_external_particle_function(x,y,z)
@@ -174,6 +187,64 @@ MultiParticleContainer::ReadParameters ()
                utils::parser::makeParser(str_By_ext_particle_function,{"x","y","z","t"}));
            m_Bz_particle_parser = std::make_unique<amrex::Parser>(
                utils::parser::makeParser(str_Bz_ext_particle_function,{"x","y","z","t"}));
+
+        }
+
+        // if the input string for gradB_ext_particle_s is
+        // "parse_gradB_ext_particle_function" then the mathematical expression
+        // for the gradBx_, gradBy_, gradBz_external_particle_function(x,y,z)
+        // must be provided in the input file.
+        if (m_gradB_ext_particle_s == "parse_gradb_ext_particle_function") {
+           // store the mathematical expression as string
+           std::string str_gradBx_ext_particle_function;
+           std::string str_gradBy_ext_particle_function;
+           std::string str_gradBz_ext_particle_function;
+           utils::parser::Store_parserString(
+                pp_particles, "gradBx_external_particle_function(x,y,z,t)",
+                str_gradBx_ext_particle_function);
+           utils::parser::Store_parserString(
+                pp_particles, "gradBy_external_particle_function(x,y,z,t)",
+                str_gradBy_ext_particle_function);
+           utils::parser::Store_parserString(
+                pp_particles, "gradBz_external_particle_function(x,y,z,t)",
+                str_gradBz_ext_particle_function);
+
+           // Parser for gradB_external on the particle
+           m_gradBx_particle_parser = std::make_unique<amrex::Parser>(
+               utils::parser::makeParser(str_gradBx_ext_particle_function,{"x","y","z","t"}));
+           m_gradBy_particle_parser = std::make_unique<amrex::Parser>(
+               utils::parser::makeParser(str_gradBy_ext_particle_function,{"x","y","z","t"}));
+           m_gradBz_particle_parser = std::make_unique<amrex::Parser>(
+               utils::parser::makeParser(str_gradBz_ext_particle_function,{"x","y","z","t"}));
+
+        }
+
+        // if the input string for kappa_ext_particle_s is
+        // "parse_kappa_ext_particle_function" then the mathematical expression
+        // for the kappax_, kappay_, kappaz_external_particle_function(x,y,z)
+        // must be provided in the input file.
+        if (m_kappa_ext_particle_s == "parse_kappa_ext_particle_function") {
+           // store the mathematical expression as string
+           std::string str_kappax_ext_particle_function;
+           std::string str_kappay_ext_particle_function;
+           std::string str_kappaz_ext_particle_function;
+           utils::parser::Store_parserString(
+                pp_particles, "kappax_external_particle_function(x,y,z,t)",
+                str_kappax_ext_particle_function);
+           utils::parser::Store_parserString(
+                pp_particles, "kappay_external_particle_function(x,y,z,t)",
+                str_kappay_ext_particle_function);
+           utils::parser::Store_parserString(
+                pp_particles, "kappaz_external_particle_function(x,y,z,t)",
+                str_kappaz_ext_particle_function);
+
+           // Parser for kappa_external on the particle
+           m_kappax_particle_parser = std::make_unique<amrex::Parser>(
+               utils::parser::makeParser(str_kappax_ext_particle_function,{"x","y","z","t"}));
+           m_kappay_particle_parser = std::make_unique<amrex::Parser>(
+               utils::parser::makeParser(str_kappay_ext_particle_function,{"x","y","z","t"}));
+           m_kappaz_particle_parser = std::make_unique<amrex::Parser>(
+               utils::parser::makeParser(str_kappaz_ext_particle_function,{"x","y","z","t"}));
 
         }
 

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -212,7 +212,14 @@ PhotonParticleContainer::PushPX (WarpXParIter& pti,
 
             [[maybe_unused]] const auto& getExternalEB_tmp = getExternalEB; // workaround for nvcc
             if constexpr (exteb_control == has_exteb) {
-                getExternalEB(i, Exp, Eyp, Ezp, Bxp, Byp, Bzp);
+                // getExternalEB(i, Exp, Eyp, Ezp, Bxp, Byp, Bzp);
+
+                // NEW: extra outputs for blended pusher
+                [[maybe_unused]] amrex::ParticleReal gradBx = 0._prt, gradBy = 0._prt, gradBz = 0._prt;
+                [[maybe_unused]] amrex::ParticleReal kappax = 0._prt, kappay = 0._prt, kappaz = 0._prt;
+
+                getExternalEB(i, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+                    gradBx, gradBy, gradBz, kappax, kappay, kappaz);
             }
 
 #ifdef WARPX_QED

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -512,6 +512,10 @@ protected:
     /* Vector of user-defined parser for initializing user-defined real attributes */
     amrex::Vector< std::unique_ptr<amrex::Parser> > m_user_real_attrib_parser;
 
+// declared for blended pusher
+    private:
+    int m_mu_gc_comp    = -1;
+    int m_alpha_gc_comp = -1;
 };
 
 #endif

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -26,11 +26,15 @@
 #include "Particles/Pusher/CopyParticleAttribs.H"
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/Pusher/PushSelector.H"
+#include "Particles/Pusher/UpdateMomentumBlended.H"
 #include "Particles/Pusher/UpdateMomentumBoris.H"
 #include "Particles/Pusher/UpdateMomentumBorisWithRadiationReaction.H"
 #include "Particles/Pusher/UpdateMomentumHigueraCary.H"
 #include "Particles/Pusher/UpdateMomentumVay.H"
 #include "Particles/Pusher/UpdatePosition.H"
+#include "Particles/Pusher/UpdatePositionBlended.H"
+#include "Particles/Pusher/ComputeBlendedAlpha.H"
+#include "Particles/Pusher/ComputeBlendedMu.H"
 #include "Particles/SpeciesPhysicalProperties.H"
 #include "Particles/WarpXParticleContainer.H"
 #include "Utils/Parser/ParserUtils.H"
@@ -324,6 +328,11 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
       amrex::Abort("Saving previous particle positions not yet implemented in RZ");
 #endif
     }
+
+    // Blended solver requires mu and alpha components
+    AddRealComp("mu_gc");
+    AddRealComp("alpha_p_gc");
+    AddRealComp("alpha_x_gc");
 
     // Read reflection models for absorbing boundaries; defaults to a zero
     pp_species_name.query("reflection_model_xlo(E)", m_boundary_conditions.reflection_model_xlo_str);
@@ -1166,6 +1175,16 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
             ParticleReal* const AMREX_RESTRICT uy = attribs[PIdx::uy].dataPtr();
             ParticleReal* const AMREX_RESTRICT uz = attribs[PIdx::uz].dataPtr();
 
+            // Allocate these pointers if we’re using the blended pusher
+            ParticleReal* AMREX_RESTRICT mu_gc    = nullptr;
+            ParticleReal* AMREX_RESTRICT alpha_p_gc = nullptr;
+
+            if (np > 0) {
+                // Get mu and alpha_p
+                mu_gc    = pti.GetAttribs("mu_gc").dataPtr();
+                alpha_p_gc = pti.GetAttribs("alpha_p_gc").dataPtr();
+            }
+
             int* AMREX_RESTRICT ion_lev = nullptr;
             if (do_field_ionization) {
                 ion_lev = pti.GetiAttribs("ionizationLevel").dataPtr();
@@ -1198,6 +1217,13 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
                 amrex::ParticleReal Byp = By_external_particle;
                 amrex::ParticleReal Bzp = Bz_external_particle;
 
+                amrex::ParticleReal gradBx = 0._prt;
+                amrex::ParticleReal gradBy = 0._prt;
+                amrex::ParticleReal gradBz = 0._prt;
+                amrex::ParticleReal kappax = 0._prt;
+                amrex::ParticleReal kappay = 0._prt;
+                amrex::ParticleReal kappaz = 0._prt;
+
                 if (!t_do_not_gather){
                     // first gather E and B to the particle positions
                     doGatherShapeN(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
@@ -1210,8 +1236,15 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
                 // Externally applied E and B-field in Cartesian co-ordinates
                 [[maybe_unused]] const auto& getExternalEB_tmp = getExternalEB;
                 if constexpr (exteb_control == has_exteb) {
-                    getExternalEB(ip, Exp, Eyp, Ezp, Bxp, Byp, Bzp);
+                    getExternalEB(ip, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+                                  gradBx, gradBy, gradBz,
+                                  kappax, kappay, kappaz);
                 }
+
+                // --- blended-specific alpha/mu ---
+                ParticleReal alpha_p_loc = 1._prt;
+                ParticleReal alpha_x_loc = 1._prt;
+                ParticleReal mu_loc    = 0._prt;
 
                 if (do_crr) {
                     amrex::ParticleReal qp = q;
@@ -1237,6 +1270,26 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
                     UpdateMomentumHigueraCary( ux[ip], uy[ip], uz[ip],
                                                Exp, Eyp, Ezp, Bxp,
                                                Byp, Bzp, qp, mass, dt);
+                } else if (pusher_algo == ParticlePusherAlgo::Blended) {
+                    amrex::ParticleReal qp = q;
+                    if (ion_lev){ qp *= ion_lev[ip]; }
+
+                    //update mu for blended pusher
+                    ComputeBlendedMu( mu_gc[ip],Bxp, Byp, Bzp,
+                                      ux[ip], uy[ip], uz[ip], mass);
+
+                    // update alpha for blended momentum push
+                    ComputeBlendedAlpha( alpha_p_gc[ip], Bxp, Byp, Bzp,
+                                         qp, mass, dt);
+
+                    alpha_p_loc = alpha_p_gc[ip];
+                    mu_loc    = mu_gc[ip];
+
+                    UpdateMomentumBlended( ux[ip], uy[ip], uz[ip],
+                                               Exp, Eyp, Ezp, Bxp,
+                                               Byp, Bzp, qp, mass, dt,
+                                               gradBx, gradBy, gradBz,
+                                               alpha_p_loc, mu_loc);
                 } else {
                     amrex::Abort("Unknown particle pusher");
                 }
@@ -1338,6 +1391,18 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
     ParticleReal* const AMREX_RESTRICT uy = attribs[PIdx::uy].dataPtr() + offset;
     ParticleReal* const AMREX_RESTRICT uz = attribs[PIdx::uz].dataPtr() + offset;
 
+
+    // Allocate these pointers if we’re using the blended pusher
+    ParticleReal* AMREX_RESTRICT mu_gc    = nullptr;
+    ParticleReal* AMREX_RESTRICT alpha_p_gc = nullptr;
+    ParticleReal* AMREX_RESTRICT alpha_x_gc = nullptr;
+
+    if (WarpX::particle_pusher_algo == ParticlePusherAlgo::Blended) {
+        mu_gc    = pti.GetAttribs("mu_gc").dataPtr() + offset;
+        alpha_p_gc = pti.GetAttribs("alpha_p_gc").dataPtr() + offset;
+        alpha_x_gc = pti.GetAttribs("alpha_x_gc").dataPtr() + offset;
+    }
+
     CopyParticleAttribs copyAttribs;
     if (copy_particle_attribs) {
         copyAttribs = CopyParticleAttribs(*this, pti, offset);
@@ -1427,6 +1492,13 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
         amrex::ParticleReal Byp = By_external_particle;
         amrex::ParticleReal Bzp = Bz_external_particle;
 
+        amrex::ParticleReal gradBx = 0._prt;
+        amrex::ParticleReal gradBy = 0._prt;
+        amrex::ParticleReal gradBz = 0._prt;
+        amrex::ParticleReal kappax = 0._prt;
+        amrex::ParticleReal kappay = 0._prt;
+        amrex::ParticleReal kappaz = 0._prt;
+
         if (gather_fields) {
             // first gather E and B to the particle positions
             doGatherShapeN(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
@@ -1438,7 +1510,8 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
 
         [[maybe_unused]] const auto& getExternalEB_tmp = getExternalEB;
         if constexpr (exteb_control == has_exteb) {
-            getExternalEB(ip, Exp, Eyp, Ezp, Bxp, Byp, Bzp);
+            getExternalEB(ip, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+                          gradBx, gradBy, gradBz, kappax, kappay, kappaz);
         }
 
         scaleFields(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp);
@@ -1448,17 +1521,39 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
             copyAttribs(ip);
         }
 
+        // --- blended-specific alpha/mu ---
+        ParticleReal alpha_p_loc = 1._prt;
+        ParticleReal alpha_x_loc = 1._prt;
+        ParticleReal mu_loc    = 0._prt;
+
+        if (pusher_algo == ParticlePusherAlgo::Blended) {
+            amrex::ParticleReal qp = q;
+            if (ion_lev) { qp *= ion_lev[ip]; }
+
+            //update alpha and mu for blended pusher
+            ComputeBlendedMu( mu_gc[ip],Bxp, Byp, Bzp,
+                                ux[ip], uy[ip], uz[ip], mass);
+
+            ComputeBlendedAlpha( alpha_p_gc[ip], Bxp, Byp, Bzp,
+                                qp, mass, dt);
+
+            alpha_p_loc = alpha_p_gc[ip];
+            mu_loc    = mu_gc[ip];
+        }
+
 #ifdef WARPX_QED
         if (momentum_push_type != MomentumPushType::None) {
             if (!do_sync) {
                 doParticleMomentumPush<0>(ux[ip], uy[ip], uz[ip],
                                           Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+                                          gradBx, gradBy, gradBz,
                                           ion_lev ? ion_lev[ip] : 1,
                                           mass, q, pusher_algo, do_crr,
-                                          t_chi_max,
+                                          alpha_p_loc,mu_loc,t_chi_max,
                                           dt);
             } else {
                 if constexpr (qed_control == has_qed) {
+                    //Blended pusher not implemented for QED with quantum sync
                     doParticleMomentumPush<1>(ux[ip], uy[ip], uz[ip],
                                               Exp, Eyp, Ezp, Bxp, Byp, Bzp,
                                               ion_lev ? ion_lev[ip] : 1,
@@ -1472,8 +1567,10 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
         if (momentum_push_type != MomentumPushType::None) {
             doParticleMomentumPush<0>(ux[ip], uy[ip], uz[ip],
                                       Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+                                      gradBx, gradBy, gradBz,
                                       ion_lev ? ion_lev[ip] : 1,
                                       mass, q, pusher_algo, do_crr,
+                                      alpha_p_loc,mu_loc,
                                       dt);
         }
 #endif
@@ -1482,7 +1579,23 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
         if (position_push_type == PositionPushType::FirstHalf || position_push_type == PositionPushType::SecondHalf) {
             position_dt *= 0.5_rt;
         }
-        UpdatePosition(xp, yp, zp, ux[ip], uy[ip], uz[ip], position_dt, mass);
+        
+        if (pusher_algo == ParticlePusherAlgo::Blended) {
+            amrex::ParticleReal qp = q;
+            if (ion_lev) { qp *= ion_lev[ip]; }
+
+            ComputeBlendedAlpha( alpha_x_gc[ip], Bxp, Byp, Bzp,
+                                         qp, mass, position_dt);
+            alpha_x_loc = alpha_x_gc[ip];
+
+            UpdatePositionBlended(xp, yp, zp, ux[ip], uy[ip], uz[ip],
+                              Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+                              gradBx, gradBy, gradBz,
+                              kappax, kappay, kappaz,
+                              position_dt, mass, qp, alpha_x_loc, mu_loc);
+        } else {
+            UpdatePosition(xp, yp, zp, ux[ip], uy[ip], uz[ip], position_dt, mass);
+        }
         setPosition(ip, xp, yp, zp);
 
 #ifdef WARPX_QED

--- a/Source/Particles/Pusher/ComputeBlendedAlpha.H
+++ b/Source/Particles/Pusher/ComputeBlendedAlpha.H
@@ -1,0 +1,33 @@
+/* Copyright 2025 Nathan Cook
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+ // Source/Particles/Pusher/ComputeBlendedAlpha.H
+#ifndef WARPX_PARTICLES_PUSHER_COMPUTEBLENDEDALPHA_H_
+#define WARPX_PARTICLES_PUSHER_COMPUTEBLENDEDALPHA_H_
+
+#include <AMReX_REAL.H>
+#include <cmath>
+
+
+/** \brief Compute the blending coefficient alpha for the 
+ *         Blended particle pusher given the values of
+ *         magntic field at the particle location `Bx`, `By`, `Bz` */
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void ComputeBlendedAlpha(
+    amrex::ParticleReal& alpha_gc,
+    const amrex::ParticleReal Bx, const amrex::ParticleReal By, const amrex::ParticleReal Bz,
+    const amrex::ParticleReal q, const amrex::ParticleReal m, const amrex::Real dt )
+{
+    const amrex::ParticleReal B2 = Bx*Bx + By*By + Bz*Bz;
+    const amrex::ParticleReal Bmag = std::sqrt(B2);
+    const amrex::ParticleReal omega_c = std::abs(q)*Bmag/m;
+
+    alpha_gc = 1._prt/std::sqrt(1._prt + (0.5_prt*omega_c*dt)*(0.5_prt*omega_c*dt));
+
+}
+
+#endif

--- a/Source/Particles/Pusher/ComputeBlendedMu.H
+++ b/Source/Particles/Pusher/ComputeBlendedMu.H
@@ -1,0 +1,52 @@
+/* Copyright 2025 Nathan Cook
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+ // Source/Particles/Pusher/ComputeBlendedMu.H
+#ifndef WARPX_PARTICLES_PUSHER_COMPUTEBLENDEDMU_H_
+#define WARPX_PARTICLES_PUSHER_COMPUTEBLENDEDMU_H_
+
+#include <AMReX_REAL.H>
+#include <cmath>
+
+
+/** \brief Compute the magnetic moment mu of a particle for the
+ *         Blended particle pusher given particle momenta and the values of
+ *         magntic field at the particle location `Bx`, `By`, `Bz` */
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void ComputeBlendedMu(
+    amrex::ParticleReal& mu_gc,
+    const amrex::ParticleReal Bx, const amrex::ParticleReal By, const amrex::ParticleReal Bz,
+    const amrex::ParticleReal ux, const amrex::ParticleReal uy, const amrex::ParticleReal uz,
+    const amrex::ParticleReal m)
+{
+
+    const amrex::ParticleReal B2   = Bx*Bx + By*By + Bz*Bz;
+    // Limit B2 to threshold value B2min to avoid division by zero
+    constexpr amrex::ParticleReal B2min  = 1e-24_prt;     // Tesla
+    const amrex::ParticleReal invB = 1._prt / std::sqrt(amrex::max(B2, B2min));
+
+    const amrex::ParticleReal bx = Bx * invB;
+    const amrex::ParticleReal by = By * invB;
+    const amrex::ParticleReal bz = Bz * invB;
+
+    const amrex::ParticleReal u_par = ux*bx + uy*by + uz*bz;
+
+    const amrex::ParticleReal upar_x = u_par * bx;
+    const amrex::ParticleReal upar_y = u_par * by;
+    const amrex::ParticleReal upar_z = u_par * bz;
+
+    const amrex::ParticleReal uperp_x = ux - upar_x;
+    const amrex::ParticleReal uperp_y = uy - upar_y;
+    const amrex::ParticleReal uperp_z = uz - upar_z;
+
+    const amrex::ParticleReal uperp2 =
+        uperp_x*uperp_x + uperp_y*uperp_y + uperp_z*uperp_z;
+
+    mu_gc = 0.5_prt * m * uperp2 * invB;
+}
+
+#endif

--- a/Source/Particles/Pusher/ImplicitPushPX.cpp
+++ b/Source/Particles/Pusher/ImplicitPushPX.cpp
@@ -177,7 +177,15 @@ namespace {
             // Externally applied E and B-field in Cartesian co-ordinates
             [[maybe_unused]] const auto& getExternalEB_tmp = getExternalEB;
             if constexpr (exteb_control == has_exteb) {
-                getExternalEB(ip, Exp, Eyp, Ezp, Bxp, Byp, Bzp);
+                // getExternalEB(ip, Exp, Eyp, Ezp, Bxp, Byp, Bzp);
+
+                // NEW: extra outputs for blended pusher
+                [[maybe_unused]] amrex::ParticleReal gradBx = 0._prt, gradBy = 0._prt, gradBz = 0._prt;
+                [[maybe_unused]] amrex::ParticleReal kappax = 0._prt, kappay = 0._prt, kappaz = 0._prt;
+
+                getExternalEB(ip, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+                    gradBx, gradBy, gradBz, kappax, kappay, kappaz);
+
             }
 
             // The momentum push starts with the velocity at the start of the step

--- a/Source/Particles/Pusher/PushSelector.H
+++ b/Source/Particles/Pusher/PushSelector.H
@@ -12,6 +12,7 @@
 #include "Particles/Pusher/UpdateMomentumBorisWithRadiationReaction.H"
 #include "Particles/Pusher/UpdateMomentumHigueraCary.H"
 #include "Particles/Pusher/UpdateMomentumVay.H"
+#include "Particles/Pusher/UpdateMomentumBlended.H"
 #include "Particles/WarpXParticleContainer.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 
@@ -29,10 +30,11 @@
  * \param ion_lev                   Ionization level of this particle (0 if ionization not on)
  * \param m                         Mass of this species.
  * \param a_q                       Charge of this species.
- * \param pusher_algo               0: Boris, 1: Vay, 2: HigueraCary
+ * \param pusher_algo               0: Boris, 1: Vay, 2: HigueraCary, 3: Blended
  * \param do_crr                    Whether to do the classical radiation reaction
  * \param t_chi_max                 Cutoff chi for QSR
  * \param dt                        Time step size
+ * \param gradBx, gradBy, gradBz    Magnetic field gradient (dB/dx,dB/dy,dB/dz) on particles - only used for Blended pusher.
  */
 
 template <int do_sync>
@@ -46,11 +48,16 @@ void doParticleMomentumPush(amrex::ParticleReal& ux,
                             const amrex::ParticleReal Bx,
                             const amrex::ParticleReal By,
                             const amrex::ParticleReal Bz,
+                            const amrex::ParticleReal gradBx,
+                            const amrex::ParticleReal gradBy,
+                            const amrex::ParticleReal gradBz,
                             const int ion_lev,
                             const amrex::ParticleReal m,
                             const amrex::ParticleReal a_q,
                             const ParticlePusherAlgo pusher_algo,
                             const int do_crr,
+                            const amrex::ParticleReal alpha_gc,
+                            const amrex::ParticleReal mu_gc,
 #ifdef WARPX_QED
                             const amrex::Real t_chi_max,
 #endif
@@ -58,6 +65,12 @@ void doParticleMomentumPush(amrex::ParticleReal& ux,
 {
     amrex::ParticleReal qp = a_q;
     qp *= ion_lev;
+
+    // Blended pusher not supported with QED / radiation reaction
+    if (do_crr && pusher_algo == ParticlePusherAlgo::Blended) {
+        amrex::Abort("Blended particle pusher is not supported with QED / "
+                     "radiation reaction (do_crr=1).");
+    }
 
     if (do_crr) {
 #ifdef WARPX_QED
@@ -95,10 +108,64 @@ void doParticleMomentumPush(amrex::ParticleReal& ux,
     } else if (pusher_algo == ParticlePusherAlgo::HigueraCary) {
         UpdateMomentumHigueraCary( ux, uy, uz,
                                    Ex, Ey, Ez, Bx,
-                                   By, Bz, qp, m, dt);
-    } //else {
+                                   By, Bz, qp, m, dt);    
+    } else if (pusher_algo == ParticlePusherAlgo::Blended) {
+        UpdateMomentumBlended( ux, uy, uz,
+                               Ex, Ey, Ez, Bx,
+                               By, Bz, qp, m, dt,
+                               gradBx, gradBy, gradBz,
+                               alpha_gc, mu_gc);
+    }     
+    //else {
 //        amrex::Abort("Unknown particle pusher");
 //    }
 }
+
+
+
+// --------------------------------------------------------------------
+// Preserve the old interface with a wrapper that sets gradBx=gradBy=gradBz=0, alpha_gc=1, mu_gc=0
+// --------------------------------------------------------------------
+template <int do_sync>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+void doParticleMomentumPush(
+    amrex::ParticleReal& ux,
+    amrex::ParticleReal& uy,
+    amrex::ParticleReal& uz,
+    const amrex::ParticleReal Ex,
+    const amrex::ParticleReal Ey,
+    const amrex::ParticleReal Ez,
+    const amrex::ParticleReal Bx,
+    const amrex::ParticleReal By,
+    const amrex::ParticleReal Bz,
+    const int ion_lev,
+    const amrex::ParticleReal m,
+    const amrex::ParticleReal a_q,
+    const ParticlePusherAlgo pusher_algo,
+    const int do_crr,
+#ifdef WARPX_QED
+    const amrex::Real t_chi_max,
+#endif
+    const amrex::Real dt)
+{
+    // Forward with dBdx=dBdy=dBdz=0
+    // and with alpha_gc=1 and mu_gc=0
+    doParticleMomentumPush<do_sync>(
+        ux, uy, uz,
+        Ex, Ey, Ez,
+        Bx, By, Bz,
+        0._prt, 0._prt, 0._prt,
+        ion_lev,
+        m,
+        a_q,
+        pusher_algo,
+        do_crr,
+        1._prt, 0._prt,
+#ifdef WARPX_QED
+        t_chi_max,
+#endif
+        dt);
+}
+
 
 #endif // WARPX_PARTICLES_PUSHER_SELECTOR_H_

--- a/Source/Particles/Pusher/UpdateMomentumBlended.H
+++ b/Source/Particles/Pusher/UpdateMomentumBlended.H
@@ -1,0 +1,95 @@
+/* Copyright 2019 David Grote, Maxence Thevenet, Remi Lehe
+ * Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef WARPX_PARTICLES_PUSHER_UPDATEMOMENTUM_BLENDED_H_
+#define WARPX_PARTICLES_PUSHER_UPDATEMOMENTUM_BLENDED_H_
+
+#include <AMReX_REAL.H>
+#include "Utils/WarpXConst.H"
+
+/** \brief Update the particle's momentum over a timestep,
+ *    given the value of its momenta `ux`, `uy`, `uz` 
+ *    fields Ex, Ey, Ez, Bx, By, Bz, gradients gradBx, gradBy, gradBz 
+ *    and pre-computed alpha/mu */
+
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void UpdateMomentumBlended(
+    amrex::ParticleReal& ux, amrex::ParticleReal& uy, amrex::ParticleReal& uz,
+    const amrex::ParticleReal Ex, const amrex::ParticleReal Ey, const amrex::ParticleReal Ez,
+    const amrex::ParticleReal Bx, const amrex::ParticleReal By, const amrex::ParticleReal Bz,
+    const amrex::ParticleReal q, const amrex::ParticleReal m, const amrex::Real dt,
+    const amrex::ParticleReal gradBx, const amrex::ParticleReal gradBy, const amrex::ParticleReal gradBz,
+    const amrex::ParticleReal alpha_gc, const amrex::ParticleReal mu_gc)
+{
+    using namespace amrex::literals;
+
+    const amrex::ParticleReal econst = 0.5_prt*q*dt/m;
+    
+    // First half-push for E
+    ux += econst*Ex;
+    uy += econst*Ey;
+    uz += econst*Ez;
+
+    // Compute temporary gamma factor and |B|
+    constexpr amrex::ParticleReal inv_c2 = 1._prt/(PhysConst::c*PhysConst::c);
+    const amrex::ParticleReal inv_gamma = 1._prt/std::sqrt(1._prt + (ux*ux + uy*uy + uz*uz)*inv_c2);
+    const amrex::ParticleReal Bmag = std::sqrt(Bx*Bx + By*By + Bz*Bz);
+
+    // Limit Bmin to avoid division by zero
+    constexpr amrex::ParticleReal Bmin  = 1e-12_prt;     // Tesla
+    const amrex::Real invB = 1.0_prt / amrex::max(Bmag, Bmin);
+
+    const amrex::ParticleReal bx = Bx*invB;
+    const amrex::ParticleReal by = By*invB;
+    const amrex::ParticleReal bz = Bz*invB;
+
+    //compute parallel and perpendicular momenta
+    const amrex::ParticleReal u_dot_b = ux*bx + uy*by + uz*bz;
+    const amrex::ParticleReal upar_x  = u_dot_b * bx;
+    const amrex::ParticleReal upar_y  = u_dot_b * by;
+    const amrex::ParticleReal upar_z  = u_dot_b * bz;
+
+    const amrex::ParticleReal uperp_x = ux - upar_x;
+    const amrex::ParticleReal uperp_y = uy - upar_y;
+    const amrex::ParticleReal uperp_z = uz - upar_z;
+
+    // Magnetic rotation
+    // - Compute temporary variables
+    const amrex::ParticleReal tx = econst*inv_gamma*Bx;
+    const amrex::ParticleReal ty = econst*inv_gamma*By;
+    const amrex::ParticleReal tz = econst*inv_gamma*Bz;
+    const amrex::ParticleReal tsqi = 2._prt/(1._prt + tx*tx + ty*ty + tz*tz);
+    const amrex::ParticleReal sx = tx*tsqi;
+    const amrex::ParticleReal sy = ty*tsqi;
+    const amrex::ParticleReal sz = tz*tsqi;
+    const amrex::ParticleReal ux_p = ux + uy*tz - uz*ty;
+    const amrex::ParticleReal uy_p = uy + uz*tx - ux*tz;
+    const amrex::ParticleReal uz_p = uz + ux*ty - uy*tx;
+    // - Update momentum
+    ux += uy_p*sz - uz_p*sy;
+    uy += uz_p*sx - ux_p*sz;
+    uz += ux_p*sy - uy_p*sx;
+    // Second half-push for E
+    ux += econst*Ex;
+    uy += econst*Ey;
+    uz += econst*Ez;
+
+    // Mirror force correction to momentum
+    const amrex::ParticleReal bdotGradB = bx*gradBx + by*gradBy + bz*gradBz;
+    const amrex::ParticleReal coeff = -1._prt*(mu_gc/m) * bdotGradB * dt;
+
+    const amrex::ParticleReal dux = bx*coeff;
+    const amrex::ParticleReal duy = by*coeff;
+    const amrex::ParticleReal duz = bz*coeff;
+
+    ux += (1._prt - alpha_gc)*dux;
+    uy += (1._prt - alpha_gc)*duy;
+    uz += (1._prt - alpha_gc)*duz;
+
+}
+
+#endif // WARPX_PARTICLES_PUSHER_UPDATEMOMENTUM_BLENDED_H_

--- a/Source/Particles/Pusher/UpdatePositionBlended.H
+++ b/Source/Particles/Pusher/UpdatePositionBlended.H
@@ -1,0 +1,163 @@
+/* Copyright 2019 David Grote, Maxence Thevenet, Remi Lehe
+ * Weiqun Zhang
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef WARPX_PARTICLES_PUSHER_UPDATEPOSITIONBLENDED_H_
+#define WARPX_PARTICLES_PUSHER_UPDATEPOSITIONBLENDED_H_
+
+#include "Utils/WarpXConst.H"
+
+#include <AMReX.H>
+//#include <AMReX_FArrayBox.H>
+#include <AMReX_REAL.H>
+
+
+/** \brief Push the particle position over one time step,
+ *         given the value of its momenta `ux`, `uy`, `uz`,
+ *         magnetic field components, `Bx`, `By`, `Bz`,
+ *         and magnetic field gradients `gradBx`, `gradBy`, `gradBz`,
+ *         using the Blended position update, including estimated drifts (gradB, ExB, curvature)
+ */
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void UpdatePositionBlended ( amrex::ParticleReal& x, amrex::ParticleReal& y, amrex::ParticleReal& z,
+                     const amrex::ParticleReal ux, const amrex::ParticleReal uy, const amrex::ParticleReal uz,
+                     const amrex::ParticleReal Ex, const amrex::ParticleReal Ey, const amrex::ParticleReal Ez,
+                     const amrex::ParticleReal Bx, const amrex::ParticleReal By, const amrex::ParticleReal Bz,
+                     const amrex::ParticleReal gradBx, const amrex::ParticleReal gradBy, const amrex::ParticleReal gradBz,
+                     const amrex::ParticleReal kappax, const amrex::ParticleReal kappay, const amrex::ParticleReal kappaz,
+                     const amrex::Real dt,
+                     amrex::ParticleReal const m, const amrex::ParticleReal q,
+                     const amrex::ParticleReal alpha_gc, const amrex::ParticleReal mu_gc)
+
+{
+    using namespace amrex::literals;
+
+    // Compute blending coefficient alpha
+    // const amrex::ParticleReal alpha = ComputeBlendedAlpha(Bx, By, Bz, q, m, dt);
+
+    amrex::ParticleReal const u2 = ux*ux + uy*uy + uz*uz;
+
+    // massive particles
+    if (m > 0.0_rt) {
+        
+        constexpr amrex::ParticleReal inv_c2 = 1._prt/(PhysConst::c*PhysConst::c);
+        const amrex::ParticleReal inv_gamma = 1._prt/std::sqrt(1._prt + u2*inv_c2);
+
+        // Compute |B|
+        const amrex::ParticleReal Bmag = std::sqrt(Bx*Bx + By*By + Bz*Bz);
+
+        // Limit Bmag to threshold value Bmin to avoid division by zero
+        constexpr amrex::ParticleReal Bmin  = 1e-12_prt;     // Tesla
+        const amrex::Real invB = 1.0_prt / amrex::max(Bmag, Bmin);
+
+        // If B is below threshold, fall back to standard x += v dt
+        // otherwise do standard blended position update with drifts
+        if (Bmag <= Bmin) {
+
+#if !defined(WARPX_DIM_1D_Z)
+            x += ux * inv_gamma * dt;
+#endif
+#if defined(WARPX_DIM_3D) || defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+            // Particles pushed in 3D even in 1D cylindrical, 1D spherical, and 2D cylindrical geometry
+            y += uy * inv_gamma * dt;
+#endif
+#if !defined(WARPX_DIM_RCYLINDER)
+            z += uz * inv_gamma * dt;
+#endif
+            return;
+        }
+
+        //define unit vector components
+        const amrex::ParticleReal bx = Bx * invB;
+        const amrex::ParticleReal by = By * invB;
+        const amrex::ParticleReal bz = Bz * invB;
+
+        //compute parallel and perpendicular momenta
+        const amrex::ParticleReal u_dot_b = ux*bx + uy*by + uz*bz;
+        const amrex::ParticleReal upar_x  = u_dot_b * bx;
+        const amrex::ParticleReal upar_y  = u_dot_b * by;
+        const amrex::ParticleReal upar_z  = u_dot_b * bz;
+
+        const amrex::ParticleReal uperp_x = ux - upar_x;
+        const amrex::ParticleReal uperp_y = uy - upar_y;
+        const amrex::ParticleReal uperp_z = uz - upar_z;
+
+        // E×B drift: v_E = (c E × B) / B^2
+        const amrex::ParticleReal ExB_x = Ey*Bz - Ez*By;
+        const amrex::ParticleReal ExB_y = Ez*Bx - Ex*Bz;
+        const amrex::ParticleReal ExB_z = Ex*By - Ey*Bx;
+
+        const amrex::ParticleReal vE_x =  ExB_x * invB * invB;
+        const amrex::ParticleReal vE_y =  ExB_y * invB * invB;
+        const amrex::ParticleReal vE_z =  ExB_z * invB * invB;
+
+        // Grad-B drift: v_gradB = (mu / (q B)) (B × ∇B) / B^2
+        const amrex::ParticleReal bXgradB_x = By*gradBz - Bz*gradBy;
+        const amrex::ParticleReal bXgradB_y = Bz*gradBx - Bx*gradBz;
+        const amrex::ParticleReal bXgradB_z = Bx*gradBy - By*gradBx;
+
+        const amrex::ParticleReal vgradB_x = (mu_gc * invB * invB / q) * bXgradB_x;
+        const amrex::ParticleReal vgradB_y = (mu_gc * invB * invB / q) * bXgradB_y;
+        const amrex::ParticleReal vgradB_z = (mu_gc * invB * invB / q) * bXgradB_z;
+
+
+        // Curvature drift: v_c = (γ^2 v_par^2)/((q/m) * Bmag) * (b × kappa)
+        const amrex::ParticleReal bXkx = by*kappaz - bz*kappay;
+        const amrex::ParticleReal bXky = bz*kappax - bx*kappaz;
+        const amrex::ParticleReal bXkz = bx*kappay - by*kappax;
+
+        const amrex::ParticleReal coeff = m*(upar_x*upar_x + upar_y*upar_y + upar_z*upar_z) * invB / q;
+
+        // vcurv_x = (m * (inv_gamma*upar_x)*(inv_gamma*upar_x)  * invB / q * bXkx;
+        const amrex::ParticleReal vcurv_x = coeff * bXkx;
+        const amrex::ParticleReal vcurv_y = coeff * bXky;
+        const amrex::ParticleReal vcurv_z = coeff * bXkz;
+
+        // net drift velocity
+        const amrex::ParticleReal vx_drift = vE_x + vgradB_x + vcurv_x;
+        const amrex::ParticleReal vy_drift = vE_y + vgradB_y + vcurv_y;
+        const amrex::ParticleReal vz_drift = vE_z + vgradB_z + vcurv_z;
+
+        // Update positions over one time step
+        // Blended update blends perpendicular and drift motion via alpha
+#if !defined(WARPX_DIM_1D_Z)
+            x += upar_x * inv_gamma * dt 
+            + alpha_gc * uperp_x * inv_gamma * dt 
+            + (1._prt - alpha_gc) * vx_drift * dt;
+#endif
+#if defined(WARPX_DIM_3D) || defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+            // Particles pushed in 3D even in 1D cylindrical, 1D spherical, and 2D cylindrical geometry
+            y += upar_y * inv_gamma * dt 
+            + alpha_gc * uperp_y * inv_gamma * dt 
+            + (1._prt - alpha_gc) * vy_drift * dt;
+#endif
+#if !defined(WARPX_DIM_RCYLINDER)
+            z += upar_z * inv_gamma * dt 
+            + alpha_gc * uperp_z * inv_gamma * dt 
+            + (1._prt - alpha_gc) * vz_drift * dt;
+#endif
+    }
+    // massless particles (photons)
+    else {
+        if (u2 > 0._prt) {
+            amrex::ParticleReal const c_over_unorm = PhysConst::c/std::sqrt(u2);
+
+            // Update positions over one time step
+#if !defined(WARPX_DIM_1D_Z)
+            x += ux * c_over_unorm * dt;
+#endif
+#if defined(WARPX_DIM_3D) || defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+            // Particles pushed in 3D even in 1D cylindrical, 1D spherical, and 2D cylindrical geometry
+            y += uy * c_over_unorm * dt;
+#endif
+#if !defined(WARPX_DIM_RCYLINDER)
+            z += uz * c_over_unorm * dt;
+#endif
+        }
+    }
+}
+
+#endif // WARPX_PARTICLES_PUSHER_UPDATEPOSITIONBLENDED_H_

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -17,6 +17,7 @@
 #include "Pusher/UpdateMomentumBorisWithRadiationReaction.H"
 #include "Pusher/UpdateMomentumHigueraCary.H"
 #include "Pusher/UpdateMomentumVay.H"
+#include "Particles/Pusher/UpdateMomentumBlended.H"
 #include "RigidInjectedParticleContainer.H"
 #include "Utils/Parser/ParserUtils.H"
 #include "Utils/WarpXAlgorithmSelection.H"
@@ -380,6 +381,13 @@ RigidInjectedParticleContainer::PushP (int lev, Real dt,
             amrex::ParticleReal* const AMREX_RESTRICT uypp = attribs[PIdx::uy].dataPtr();
             amrex::ParticleReal* const AMREX_RESTRICT uzpp = attribs[PIdx::uz].dataPtr();
 
+            //grab alpha and mu for blended pusher
+            int const mu_gc_comp    = GetRealCompIndex("mu_gc");
+            int const alpha_gc_comp = GetRealCompIndex("alpha_gc");
+
+            ParticleReal* const AMREX_RESTRICT alpha_gc = attribs[alpha_gc_comp].dataPtr();
+            ParticleReal* const AMREX_RESTRICT mu_gc = attribs[mu_gc_comp].dataPtr();
+
             int* AMREX_RESTRICT ion_lev = nullptr;
             if (do_field_ionization) {
                 ion_lev = pti.GetiAttribs("ionizationLevel").dataPtr();
@@ -429,9 +437,17 @@ RigidInjectedParticleContainer::PushP (int lev, Real dt,
                                dinv, xyzmin, lo, n_rz_azimuthal_modes,
                                nox, galerkin_interpolation);
 
+                // NEW: extra outputs for blended pusher
+                [[maybe_unused]] amrex::ParticleReal gradBx = 0._prt, gradBy = 0._prt, gradBz = 0._prt;
+                [[maybe_unused]] amrex::ParticleReal kappax = 0._prt, kappay = 0._prt, kappaz = 0._prt;
+
                 [[maybe_unused]] const auto& getExternalEB_tmp = getExternalEB;
                 if constexpr (exteb_control == has_exteb) {
-                    getExternalEB(ip, Exp, Eyp, Ezp, Bxp, Byp, Bzp);
+                    // getExternalEB(ip, Exp, Eyp, Ezp, Bxp, Byp, Bzp);
+
+                    getExternalEB(ip, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+                        gradBx, gradBy, gradBz, kappax, kappay, kappaz);
+
                 }
 
                 amrex::ParticleReal qp = q;
@@ -453,6 +469,12 @@ RigidInjectedParticleContainer::PushP (int lev, Real dt,
                     UpdateMomentumHigueraCary( uxpp[ip], uypp[ip], uzpp[ip],
                                                Exp, Eyp, Ezp, Bxp,
                                                Byp, Bzp, qp, mass, dt);
+                } else if (pusher_algo == ParticlePusherAlgo::Blended) {
+                    UpdateMomentumBlended( uxpp[ip], uypp[ip], uzpp[ip],
+                                               Exp, Eyp, Ezp, Bxp,
+                                               Byp, Bzp, qp, mass, dt,
+                                               gradBx, gradBy, gradBz,
+                                               alpha_gc[ip], mu_gc[ip]);
                 } else {
                     amrex::Abort("Unknown particle pusher");
                 }

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -75,7 +75,9 @@ AMREX_ENUM(ParticlePusherAlgo,
            Boris,
            Vay,
            HigueraCary,
+           Blended,
            higuera = HigueraCary,
+           blended = Blended,
            Default = Boris);
 
 AMREX_ENUM(CurrentDepositionAlgo,

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -183,7 +183,7 @@ public:
     static inline auto charge_deposition_algo = ChargeDepositionAlgo::Default;
     //! Integer that corresponds to the field gathering algorithm (energy-conserving, momentum-conserving)
     static inline auto field_gathering_algo = GatheringAlgo::Default;
-    //! Integer that corresponds to the particle push algorithm (Boris, Vay, Higuera-Cary)
+    //! Integer that corresponds to the particle push algorithm (Boris, Vay, Higuera-Cary, Blended)
     static inline auto particle_pusher_algo = ParticlePusherAlgo::Default;
     //! Integer that corresponds to the type of Maxwell solver (Yee, CKC, PSATD, ECT)
     static inline auto electromagnetic_solver_id = ElectromagneticSolverAlgo::Default;
@@ -798,8 +798,6 @@ public:
 
     // Magnetostatic Solver Interface
     MagnetostaticSolver::VectorPoissonBoundaryHandler m_vector_poisson_boundary_handler;
-    amrex::Real magnetostatic_solver_required_precision = amrex::Real(1.e-11);
-    amrex::Real magnetostatic_solver_absolute_tolerance = amrex::Real(0.0);
     int magnetostatic_solver_max_iters = 200;
     int magnetostatic_solver_verbosity = 2;
     void ComputeMagnetostaticField ();


### PR DESCRIPTION
This PR implements a blended push update for tracking particles in magnetic fields for timesteps large relative to the species gyrofrequency. The algorithm follows the explicit update described in [Cohen et al. (2005)](https://pubs.aip.org/aip/pop/article-abstract/12/5/056708/1016556/Simulating-electron-clouds-in-heavy-ion?redirectedFrom=fulltext) and more recently in [Lau et al (2020)](doi.org/10.1063/5.0012439).

The algorithm is designed to be used with an analytically specified external magnetic field, including the gradient and curvature vector components using the string-parser capabilities provided by WarpX/AMReX. Both flat-file and PICMI-based specifications are permitted. The algorithm does not include modifications to the Poisson equation that incorporate polarization densities for large electron and ion charge densities.
