### PR TITLE
Update profile for LUMI25.03

### DIFF
--- a/Tools/machines/lumi-csc/install_dependencies.sh
+++ b/Tools/machines/lumi-csc/install_dependencies.sh
@@ -166,7 +166,7 @@ python3 -m pip install --upgrade yt
 # install or update WarpX dependencies such as picmistandard
 python3 -m pip install --upgrade -r ${SRC_DIR}/warpx/requirements.txt
 # optional: for libEnsemble
-python3 -m pip install -r ${SRC_DIR}/warpx/Tools/LibEnsemble/requirements.txt
+#python3 -m pip install -r ${SRC_DIR}/warpx/Tools/LibEnsemble/requirements.txt
 # optional: for optimas (based on libEnsemble & ax->botorch->gpytorch->pytorch)
 #python3 -m pip install --upgrade torch --index-url https://download.pytorch.org/whl/rocm5.4.2
 #python3 -m pip install -r ${SRC_DIR}/warpx/Tools/optimas/requirements.txt

--- a/Tools/machines/lumi-csc/install_dependencies.sh
+++ b/Tools/machines/lumi-csc/install_dependencies.sh
@@ -168,5 +168,6 @@ python3 -m pip install --upgrade -r ${SRC_DIR}/warpx/requirements.txt
 # optional: for libEnsemble
 #python3 -m pip install -r ${SRC_DIR}/warpx/Tools/LibEnsemble/requirements.txt
 # optional: for optimas (based on libEnsemble & ax->botorch->gpytorch->pytorch)
+python3 -m pip install -r ${SRC_DIR}/warpx/Tools/optimas/requirements.txt
 #python3 -m pip install --upgrade torch --index-url https://download.pytorch.org/whl/rocm5.4.2
 #python3 -m pip install -r ${SRC_DIR}/warpx/Tools/optimas/requirements.txt

--- a/Tools/machines/lumi-csc/install_dependencies.sh
+++ b/Tools/machines/lumi-csc/install_dependencies.sh
@@ -165,8 +165,6 @@ python3 -m pip install --upgrade matplotlib
 python3 -m pip install --upgrade yt
 # install or update WarpX dependencies such as picmistandard
 python3 -m pip install --upgrade -r ${SRC_DIR}/warpx/requirements.txt
-# optional: for libEnsemble
-#python3 -m pip install -r ${SRC_DIR}/warpx/Tools/LibEnsemble/requirements.txt
 # optional: for optimas (based on libEnsemble & ax->botorch->gpytorch->pytorch)
 python3 -m pip install -r ${SRC_DIR}/warpx/Tools/optimas/requirements.txt
 #python3 -m pip install --upgrade torch --index-url https://download.pytorch.org/whl/rocm5.4.2

--- a/Tools/machines/lumi-csc/lumi_warpx.profile.example
+++ b/Tools/machines/lumi-csc/lumi_warpx.profile.example
@@ -2,9 +2,9 @@
 #export proj="project_..."
 
 # required dependencies
-module load LUMI/24.03  partition/G
-module load rocm/6.0.3
-module load buildtools/24.03
+module load LUMI/25.03  partition/G
+module load rocm/6.3.4
+module load buildtools/25.03
 
 # optional: just an additional text editor
 module load nano
@@ -17,8 +17,7 @@ export LD_LIBRARY_PATH=${SW_DIR}/blaspp-2024.05.31/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=${SW_DIR}/lapackpp-2024.05.31/lib64:$LD_LIBRARY_PATH
 
 # optional: for QED lookup table generation support
-module load Boost/1.82.0-cpeCray-23.09
-
+module load Boost/1.88.0-cpeCray-25.03
 # optional: for openPMD support
 export CMAKE_PREFIX_PATH=${SW_DIR}/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=${SW_DIR}/hdf5-1.14.1.2:$CMAKE_PREFIX_PATH

--- a/Tools/machines/lumi-csc/lumi_warpx.profile.example
+++ b/Tools/machines/lumi-csc/lumi_warpx.profile.example
@@ -18,6 +18,7 @@ export LD_LIBRARY_PATH=${SW_DIR}/lapackpp-2024.05.31/lib64:$LD_LIBRARY_PATH
 
 # optional: for QED lookup table generation support
 module load Boost/1.88.0-cpeCray-25.03
+
 # optional: for openPMD support
 export CMAKE_PREFIX_PATH=${SW_DIR}/c-blosc-1.21.1:$CMAKE_PREFIX_PATH
 export CMAKE_PREFIX_PATH=${SW_DIR}/hdf5-1.14.1.2:$CMAKE_PREFIX_PATH


### PR DESCRIPTION
Since LUMI has upgraded to version 25.03 as the default stack, this PR updates the instructions for compiling and running WarpX on LUMI accordingly, amending all loaded modules to their latest compatible versions.