### PR TITLE
C++20

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -144,13 +144,13 @@ jobs:
         cmake-easyinstall --prefix=/usr/local           \
           git+https://github.com/icl-utk-edu/blaspp.git \
           -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache) \
-          -DCMAKE_CXX_STANDARD=17                       \
+          -DCMAKE_CXX_STANDARD=20                       \
           -Duse_openmp=OFF -Dbuild_tests=OFF -DCMAKE_VERBOSE_MAKEFILE=ON
         # LAPACK++
         cmake-easyinstall --prefix=/usr/local             \
           git+https://github.com/icl-utk-edu/lapackpp.git \
           -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache)   \
-          -DCMAKE_CXX_STANDARD=17                         \
+          -DCMAKE_CXX_STANDARD=20                         \
           -Duse_cmake_find_lapack=ON -Dbuild_tests=OFF -DCMAKE_VERBOSE_MAKEFILE=ON
       fi
       # Remove system copy of Matplotlib to avoid conflict

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@ Checks: '
         -bugprone-implicit-widening-of-multiplication-result,
         -bugprone-misplaced-widening-cast,
         -bugprone-unchecked-optional-access,
+        -bugprone-unused-local-non-trivial-variable,
     cert-*,
         -cert-err58-cpp,
     clang-analyzer-*,
@@ -36,10 +37,18 @@ Checks: '
         -modernize-avoid-c-arrays,
         -modernize-return-braced-init-list,
         -modernize-use-trailing-return-type,
+        -modernize-use-constraints,
+        -modernize-use-designated-initializers,
+        -modernize-use-std-numbers,
+        -modernize-use-ranges,
+        -modernize-use-integer-sign-comparison,
+        -modernize-use-starts-ends-with,
     mpi-*,
     performance-*,
+        -performance-enum-size,
     portability-*,
     readability-*,
+        -readability-avoid-nested-conditional-operator,
         -readability-convert-member-functions-to-static,
         -readability-else-after-return,
         -readability-function-cognitive-complexity,
@@ -48,7 +57,12 @@ Checks: '
         -readability-isolate-declaration,
         -readability-magic-numbers,
         -readability-named-parameter,
-        -readability-uppercase-literal-suffix
+        -readability-uppercase-literal-suffix,
+        -readability-redundant-casting,
+        -readability-container-contains,
+        -readability-redundant-inline-specifier,
+        -readability-redundant-member-init,
+        -readability-reference-to-constructed-temporary
     '
 
 CheckOptions:
@@ -64,3 +78,20 @@ CheckOptions:
   value:        "false"
 
 HeaderFilterRegex: 'Source[a-z_A-Z0-9\/]+\.H$'
+
+# TODO Modernize this after switching to C++20:
+# -modernize-use-constraints
+# -modernize-use-designated-initializers
+# -modernize-use-std-numbers
+# -modernize-use-ranges
+# -modernize-use-integer-sign-comparison
+# -modernize-use-starts-ends-with
+# -readability-container-contains
+
+# TODO Consider enabling the following checks:
+# -bugprone-unused-local-non-trivial-variable
+# -performance-enum-size
+# -readability-container-contains
+# -readability-redundant-inline-specifier
+# -readability-redundant-member-init
+# -readability-reference-to-constructed-temporary

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -32,7 +32,7 @@ jobs:
     - name: install dependencies
       if: ${{ needs.check_changes.outputs.has_non_docs_changes == 'true' }}
       run: |
-        .github/workflows/dependencies/clang.sh 17
+        .github/workflows/dependencies/clang.sh 18
     - name: set up cache
       if: ${{ needs.check_changes.outputs.has_non_docs_changes == 'true' }}
       uses: actions/cache@v4
@@ -50,8 +50,8 @@ jobs:
         export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
         export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
-        export CXX=$(which clang++-17)
-        export CC=$(which clang-17)
+        export CXX=$(which clang++-18)
+        export CC=$(which clang-18)
 
         ##### FOR DEBUG ONLY: CLEAR CACHE ######################
         # clearing the cache forces running clang-tidy on all
@@ -74,7 +74,7 @@ jobs:
         cmake --build build_clang_tidy -j 4
         ${{github.workspace}}/.github/workflows/source/makeMakefileForClangTidy.py --input ${{github.workspace}}/ccache.log.txt
         make -j4 --keep-going -f clang-tidy-ccache-misses.mak \
-            CLANG_TIDY=clang-tidy-17 \
+            CLANG_TIDY=clang-tidy-18 \
             CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
         ccache -s
         du -hs ~/.cache/ccache

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -43,7 +43,7 @@ jobs:
         python-version: '3.x'
     - name: install dependencies
       run: |
-        .github/workflows/dependencies/nvcc.sh 11.7
+        .github/workflows/dependencies/nvcc.sh 12.2
     - name: CCache Cache
       uses: actions/cache@v4
       with:
@@ -128,7 +128,7 @@ jobs:
     - uses: actions/checkout@v6
     - name: install dependencies
       run: |
-        .github/workflows/dependencies/nvcc.sh 11.7
+        .github/workflows/dependencies/nvcc.sh 12.2
     - name: CCache Cache
       uses: actions/cache@v4
       with:

--- a/.github/workflows/dependencies/nvcc.sh
+++ b/.github/workflows/dependencies/nvcc.sh
@@ -30,16 +30,9 @@ sudo apt-get install -y \
 $(dirname "$0")/ccache.sh
 
 # parse version number from command line argument
-VERSION_DOTTED=${1:-11.7}
-VERSION_DASHED=${VERSION_DOTTED/./-}  # replace first occurence of "." with "-"
-
-# installation instructions from https://developer.nvidia.com/cuda-11-7-0-download-archive
-# (Linux, x86_64, Ubuntu, 22.04, deb (local))
-wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-ubuntu2204.pin
-sudo mv cuda-ubuntu2204.pin /etc/apt/preferences.d/cuda-repository-pin-600
-wget https://developer.download.nvidia.com/compute/cuda/${VERSION_DOTTED}.0/local_installers/cuda-repo-ubuntu2204-${VERSION_DASHED}-local_${VERSION_DOTTED}.0-515.43.04-1_amd64.deb
-sudo dpkg -i cuda-repo-ubuntu2204-${VERSION_DASHED}-local_${VERSION_DOTTED}.0-515.43.04-1_amd64.deb
-sudo cp /var/cuda-repo-ubuntu2204-${VERSION_DASHED}-local/cuda-*-keyring.gpg /usr/share/keyrings/
+VERSION_DOTTED=${1-12.0} && VERSION_DASHED=$(sed 's/\./-/' <<< $VERSION_DOTTED)
+curl -O https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
+sudo dpkg -i cuda-keyring_1.0-1_all.deb
 
 sudo apt-get update
 sudo apt-get install -y          \

--- a/.github/workflows/dependencies/nvcc.sh
+++ b/.github/workflows/dependencies/nvcc.sh
@@ -30,9 +30,16 @@ sudo apt-get install -y \
 $(dirname "$0")/ccache.sh
 
 # parse version number from command line argument
-VERSION_DOTTED=${1-12.0} && VERSION_DASHED=$(sed 's/\./-/' <<< $VERSION_DOTTED)
-curl -O https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.0-1_all.deb
-sudo dpkg -i cuda-keyring_1.0-1_all.deb
+VERSION_DOTTED=${1:-12.2}
+VERSION_DASHED=${VERSION_DOTTED/./-}  # replace first occurence of "." with "-"
+
+# installation instructions from https://developer.nvidia.com/cuda-12-2-0-download-archive
+# (Linux, x86_64, Ubuntu, 22.04, deb (local))
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-ubuntu2204.pin
+sudo mv cuda-ubuntu2204.pin /etc/apt/preferences.d/cuda-repository-pin-600
+wget https://developer.download.nvidia.com/compute/cuda/${VERSION_DOTTED}.0/local_installers/cuda-repo-ubuntu2204-${VERSION_DASHED}-local_${VERSION_DOTTED}.0-535.54.03-1_amd64.deb
+sudo dpkg -i cuda-repo-ubuntu2204-${VERSION_DASHED}-local_${VERSION_DOTTED}.0-535.54.03-1_amd64.deb
+sudo cp /var/cuda-repo-ubuntu2204-${VERSION_DASHED}-local/cuda-*-keyring.gpg /usr/share/keyrings/
 
 sudo apt-get update
 sudo apt-get install -y          \

--- a/.github/workflows/insitu.yml
+++ b/.github/workflows/insitu.yml
@@ -17,33 +17,6 @@ jobs:
     name: Analyze
     uses: ./.github/workflows/check_changes.yml
 
-  sensei:
-    name: SENSEI
-    runs-on: ubuntu-24.04
-    needs: check_changes
-    if: ${{ github.event.pull_request.draft == false && needs.check_changes.outputs.has_non_docs_changes == 'true' }}
-    env:
-      CXX: clang++
-      CC: clang
-      CXXFLAGS: "-Werror -Wshadow -Woverloaded-virtual -Wunreachable-code -Wno-error=pass-failed"
-      CMAKE_GENERATOR: Ninja
-      CMAKE_PREFIX_PATH: /root/install/sensei/v4.0.0/lib64/cmake
-      OMP_NUM_THREADS: 1
-    container:
-      image: senseiinsitu/ci:fedora35-amrex-20220613
-    steps:
-    - uses: actions/checkout@v4
-    - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v2
-    - name: Configure
-      run: |
-        cmake -S . -B build     \
-          -DWarpX_SENSEI=ON     \
-          -DWarpX_COMPUTE=NOACC
-    - name: Build
-      run: |
-        cmake --build build -j 4
-
   ascent:
     name: Ascent
     runs-on: ubuntu-24.04

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,7 +18,7 @@ jobs:
     uses: ./.github/workflows/check_changes.yml
 
   build_win_msvc:
-    name: MSVC C++17 w/o MPI
+    name: MSVC C++20 w/o MPI
     runs-on: windows-latest
     # disabled due to issues in #5230
     if: 0
@@ -72,7 +72,7 @@ jobs:
 #  --diagformat=openpmd
 
   build_win_clang:
-    name: Clang C++17 w/ OMP w/o MPI
+    name: Clang C++20 w/ OMP w/o MPI
     runs-on: windows-2022
     needs: check_changes
     if: ${{ github.event.pull_request.draft == false && needs.check_changes.outputs.has_non_docs_changes == 'true' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,9 @@ endif()
 
 # C++ Standard in Superbuilds #################################################
 #
-# This is the easiest way to push up a C++17 requirement for AMReX, PICSAR and
+# This is the easiest way to push up a C++20 requirement for AMReX, PICSAR and
 # openPMD-api until they increase their requirement.
-set_cxx17_superbuild()
+set_cxx20_superbuild()
 
 
 # CCache Support ##############################################################
@@ -221,11 +221,11 @@ include(CTest)
 # Old GCCs: std::filesystem as a separate library
 try_compile(CXX_HAS_STD_FS "${WarpX_BINARY_DIR}/temp"
     "${WarpX_SOURCE_DIR}/cmake/has_filesystem.cpp"
-    CMAKE_FLAGS -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON
+    CMAKE_FLAGS -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_STANDARD_REQUIRED=ON
 )
 try_compile(CXX_HAS_STD_FS_WITH_LINK "${WarpX_BINARY_DIR}/temp"
     "${WarpX_SOURCE_DIR}/cmake/has_filesystem.cpp"
-    CMAKE_FLAGS -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON
+    CMAKE_FLAGS -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_STANDARD_REQUIRED=ON
     LINK_LIBRARIES stdc++fs
 )
 
@@ -304,7 +304,7 @@ foreach(D IN LISTS WarpX_DIMS)
         if(CXX_HAS_STD_FS_WITH_LINK)
             target_link_libraries(ablastr_${SD} PUBLIC stdc++fs)
         else()
-            message(FATAL_ERROR "Your compiler does not support C++17 "
+            message(FATAL_ERROR "Your compiler does not support C++20 "
                     "<filesystem> Please use a newer C++ compiler.")
         endif()
     endif()
@@ -574,14 +574,14 @@ foreach(D IN LISTS WarpX_DIMS)
     endif()
 endforeach()
 
-# C++ properties: at least a C++17 capable compiler is needed
+# C++ properties: at least a C++20 capable compiler is needed
 if(WarpX_COMPUTE STREQUAL CUDA)
     # AMReX helper function: propagate CUDA specific target & source properties
     foreach(warpx_tgt IN LISTS _ALL_TARGETS)
         setup_target_for_cuda_compilation(${warpx_tgt})
     endforeach()
     foreach(warpx_tgt IN LISTS _ALL_TARGETS)
-        target_compile_features(${warpx_tgt} PUBLIC cuda_std_17)
+        target_compile_features(${warpx_tgt} PUBLIC cuda_std_20)
     endforeach()
     set_target_properties(${_ALL_TARGETS} PROPERTIES
         CUDA_EXTENSIONS OFF
@@ -589,13 +589,7 @@ if(WarpX_COMPUTE STREQUAL CUDA)
     )
 else()
     foreach(warpx_tgt IN LISTS _ALL_TARGETS)
-        if(WarpX_SIMD)
-            # vir::cvt
-            # https://github.com/mattkretz/vir-simd/issues/45
-            target_compile_features(${warpx_tgt} PUBLIC cxx_std_20)
-        else()
-            target_compile_features(${warpx_tgt} PUBLIC cxx_std_17)
-        endif()
+        target_compile_features(${warpx_tgt} PUBLIC cxx_std_20)
     endforeach()
     set_target_properties(${_ALL_TARGETS} PROPERTIES
         CXX_EXTENSIONS OFF

--- a/Docs/source/developers/faq.rst
+++ b/Docs/source/developers/faq.rst
@@ -29,8 +29,8 @@ Do you worry about using ``size_t`` vs. ``uint`` vs. ``int`` for indexing things
 Close to but not necessarily ``uint``, `depends on the platform <https://en.cppreference.com/w/cpp/language/types>`__.
 For "hot" inner loops, you want to use ``int`` instead of an unsigned integer type. Why? Because ``int`` has no handling for overflows (it is intentional, undefined behavior in C++), which allows compilers to vectorize easier, because they don't need to check for an overflow every time one reaches the control/condition section of the loop.
 
-C++20 will also add support for `ssize <https://en.cppreference.com/w/cpp/iterator/size>`__ (signed size), but we currently require C++17 for builds.
-Thus, sometimes you need to ``static_cast<int>(...)``.
+C++20 also adds support for `ssize <https://en.cppreference.com/w/cpp/iterator/size>`__ (signed size).
+Alternatively, sometimes you need to ``static_cast<int>(...)``.
 
 
 What does ``std::make_unique`` do?

--- a/Docs/source/developers/how_to_run_clang_tidy.rst
+++ b/Docs/source/developers/how_to_run_clang_tidy.rst
@@ -36,7 +36,7 @@ Few optional environment variables can be set to tune the behavior of the script
 
 * ``CLANG``, ``CLANGXX``, and ``CLANGTIDY``: set the version of the compiler and the linter.
 
-For continuous integration we currently use clang version 17.0.6 and it is recommended to use this version locally as well.
+For continuous integration we currently use clang version 18 and it is recommended to use this version locally as well.
 A newer version may find issues not currently covered by CI tests (checks are opt-in), while older versions may not find all the issues.
 
 Here's an example of how to run the script after setting the appropriate environment variables:
@@ -44,8 +44,8 @@ Here's an example of how to run the script after setting the appropriate environ
 .. code-block:: bash
 
    export WARPX_TOOLS_LINTER_PARALLEL=12
-   export CLANG=clang-17
-   export CLANGXX=clang++-17
-   export CLANGTIDY=clang-tidy-17
+   export CLANG=clang-18
+   export CLANGXX=clang++-18
+   export CLANGTIDY=clang-tidy-18
 
    ./Tools/Linter/runClangTidy.sh

--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -6,7 +6,7 @@ List of Dependencies
 WarpX depends on the following popular third party software.
 Please see installation instructions below.
 
-- a mature `C++17 <https://en.wikipedia.org/wiki/C%2B%2B17>`__ compiler, e.g., GCC 9.1+, Clang 7, NVCC 11.0, MSVC 19.15 or newer
+- a mature `C++20 <https://en.wikipedia.org/wiki/C%2B%2B17>`__ compiler, e.g., GCC 12+, Clang 14, NVCC 12.4, MSVC 19.39 or newer
 - `CMake 3.24.0+ <https://cmake.org>`__
 - `Git 2.18+ <https://git-scm.com>`__
 - `AMReX <https://amrex-codes.github.io>`__: we automatically download and compile a copy of AMReX

--- a/Docs/source/install/hpc/lawrencium.rst
+++ b/Docs/source/install/hpc/lawrencium.rst
@@ -60,13 +60,13 @@ And since Lawrencium does not yet provide a module for them, install ADIOS2, BLA
    # BLAS++ (for PSATD+RZ)
    git clone https://github.com/icl-utk-edu/blaspp.git src/blaspp
    rm -rf src/blaspp-v100-build
-   cmake -S src/blaspp -B src/blaspp-v100-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=$HOME/sw/v100/blaspp-master
+   cmake -S src/blaspp -B src/blaspp-v100-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=20 -DCMAKE_INSTALL_PREFIX=$HOME/sw/v100/blaspp-master
    cmake --build src/blaspp-v100-build --target install --parallel 12
 
    # LAPACK++ (for PSATD+RZ)
    git clone https://github.com/icl-utk-edu/lapackpp.git src/lapackpp
    rm -rf src/lapackpp-v100-build
-   cmake -S src/lapackpp -B src/lapackpp-v100-build -DCMAKE_CXX_STANDARD=17 -Dgpu_backend=cuda -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=$HOME/sw/v100/lapackpp-master -Duse_cmake_find_lapack=ON -DBLAS_LIBRARIES=${LAPACK_DIR}/lib/libblas.a -DLAPACK_LIBRARIES=${LAPACK_DIR}/lib/liblapack.a
+   cmake -S src/lapackpp -B src/lapackpp-v100-build -DCMAKE_CXX_STANDARD=20 -Dgpu_backend=cuda -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=$HOME/sw/v100/lapackpp-master -Duse_cmake_find_lapack=ON -DBLAS_LIBRARIES=${LAPACK_DIR}/lib/libblas.a -DLAPACK_LIBRARIES=${LAPACK_DIR}/lib/liblapack.a
    cmake --build src/lapackpp-v100-build --target install --parallel 12
 
 Optionally, download and install Python packages for :ref:`PICMI <usage-picmi>` or dynamic ensemble optimizations (`libEnsemble <https://libensemble.readthedocs.io/en/main/>`__):

--- a/Docs/source/install/hpc/ookami.rst
+++ b/Docs/source/install/hpc/ookami.rst
@@ -101,7 +101,7 @@ We compiled with the Fujitsu Compiler (Clang) with the following build string:
       -DCMAKE_CXX_COMPILER=$(which mpiFCC)          \
       -DCMAKE_CXX_COMPILER_ID="Clang"               \
       -DCMAKE_CXX_COMPILER_VERSION=12.0             \
-      -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="14"    \
+      -DCMAKE_CXX_STANDARD_COMPUTED_DEFAULT="20"    \
       -DCMAKE_CXX_FLAGS="-Nclang"                   \
       -DAMReX_DIFFERENT_COMPILER=ON                 \
       -DAMReX_MPI_THREAD_MULTIPLE=FALSE             \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Supported Platforms](https://img.shields.io/badge/platforms-linux%20|%20osx%20|%20win-blue)](https://warpx.readthedocs.io/en/latest/install/users.html)
 [![GitHub commits since last release](https://img.shields.io/github/commits-since/BLAST-WarpX/warpx/latest/development.svg)](https://github.com/BLAST-WarpX/warpx/compare/development)
 [![HPSF](https://img.shields.io/badge/hosted%20by-HPSF-orange)](https://hpsf.io)
-[![Language: C++17](https://img.shields.io/badge/language-C%2B%2B17-orange.svg)](https://isocpp.org/)
+[![Language: C++20](https://img.shields.io/badge/language-C%2B%2B20-orange.svg)](https://isocpp.org/)
 [![Language: Python](https://img.shields.io/badge/language-Python-orange.svg)](https://python.org/)  
 [![License WarpX](https://img.shields.io/badge/license-BSD--3--Clause--LBNL-blue.svg)](https://spdx.org/licenses/BSD-3-Clause-LBNL.html)
 [![DOI (source)](https://img.shields.io/badge/DOI%20(source)-10.5281/zenodo.4571577-blue.svg)](https://doi.org/10.5281/zenodo.4571577)

--- a/Source/Make.WarpX
+++ b/Source/Make.WarpX
@@ -7,7 +7,7 @@ USE_PARTICLES = TRUE
 USE_RPATH     = TRUE
 USE_GPU_RDC   = FALSE
 BL_NO_FORT    = TRUE
-CXXSTD        = c++17
+CXXSTD        = c++20
 
 # required for AMReX async I/O
 MPI_THREAD_MULTIPLE = TRUE

--- a/Tools/Linter/runClangTidy.sh
+++ b/Tools/Linter/runClangTidy.sh
@@ -55,13 +55,13 @@ ${CTIDY} --version
 echo
 echo "This can be overridden by setting the environment"
 echo "variables CLANG, CLANGXX, and CLANGTIDY e.g.: "
-echo "$ export CLANG=clang-17"
-echo "$ export CLANGXX=clang++-17"
-echo "$ export CLANGTIDY=clang-tidy-17"
+echo "$ export CLANG=clang-18"
+echo "$ export CLANGXX=clang++-18"
+echo "$ export CLANGTIDY=clang-tidy-18"
 echo "$ ./Tools/Linter/runClangTidy.sh"
 echo
 echo "******************************************************"
-echo "* Warning: clang v17 is currently used in CI tests.  *"
+echo "* Warning: clang v18 is currently used in CI tests.  *"
 echo "* It is therefore recommended to use this version.   *"
 echo "* Otherwise, a newer version may find issues not     *"
 echo "* currently covered by CI tests while older versions *"

--- a/Tools/QedTablesUtils/CMakeLists.txt
+++ b/Tools/QedTablesUtils/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(WarpX::qed_table_generator ALIAS qed_table_generator)
 
 target_link_libraries(qed_table_generator PRIVATE PXRMP_QED)
 
-target_compile_features(qed_table_generator PUBLIC cxx_std_17)
+target_compile_features(qed_table_generator PUBLIC cxx_std_20)
 set_target_properties(qed_table_generator PROPERTIES CXX_EXTENSIONS OFF)
 
 
@@ -31,5 +31,5 @@ add_executable(WarpX::qed_table_reader ALIAS qed_table_reader)
 
 target_link_libraries(qed_table_reader PRIVATE PXRMP_QED)
 
-target_compile_features(qed_table_reader PUBLIC cxx_std_17)
+target_compile_features(qed_table_reader PUBLIC cxx_std_20)
 set_target_properties(qed_table_reader PROPERTIES CXX_EXTENSIONS OFF)

--- a/Tools/machines/adastra-cines/install_dependencies.sh
+++ b/Tools/machines/adastra-cines/install_dependencies.sh
@@ -45,7 +45,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/blaspp.git ${SRC_DIR}/blaspp
 fi
 rm -rf ${SRC_DIR}/blaspp-adastra-gpu-build
-CXX=$(which CC) cmake -S ${SRC_DIR}/blaspp -B ${SRC_DIR}/blaspp-adastra-gpu-build -Duse_openmp=OFF -Dgpu_backend=hip -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
+CXX=$(which CC) cmake -S ${SRC_DIR}/blaspp -B ${SRC_DIR}/blaspp-adastra-gpu-build -Duse_openmp=OFF -Dgpu_backend=hip -DCMAKE_CXX_STANDARD=20 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
 cmake --build ${SRC_DIR}/blaspp-adastra-gpu-build --target install --parallel 16
 rm -rf ${SRC_DIR}/blaspp-adastra-gpu-build
 
@@ -60,7 +60,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/lapackpp.git ${SRC_DIR}/lapackpp
 fi
 rm -rf ${SRC_DIR}/lapackpp-adastra-gpu-build
-CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S ${SRC_DIR}/lapackpp -B ${SRC_DIR}/lapackpp-adastra-gpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
+CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S ${SRC_DIR}/lapackpp -B ${SRC_DIR}/lapackpp-adastra-gpu-build -DCMAKE_CXX_STANDARD=20 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
 cmake --build ${SRC_DIR}/lapackpp-adastra-gpu-build --target install --parallel 16
 rm -rf ${SRC_DIR}/lapackpp-adastra-gpu-build
 

--- a/Tools/machines/aurora-alcf/install_dependencies.sh
+++ b/Tools/machines/aurora-alcf/install_dependencies.sh
@@ -41,7 +41,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/blaspp.git $HOME/src/blaspp
 fi
 rm -rf $HOME/src/blaspp-aurora-gpu-build
-CXX=icpx CXXFLAGS="-qmkl" cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-aurora-gpu-build -Duse_openmp=OFF -Dgpu_backend=sycl -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31 -DCMAKE_EXE_LINKER_FLAGS="-qmkl"
+CXX=icpx CXXFLAGS="-qmkl" cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-aurora-gpu-build -Duse_openmp=OFF -Dgpu_backend=sycl -DCMAKE_CXX_STANDARD=20 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31 -DCMAKE_EXE_LINKER_FLAGS="-qmkl"
 cmake --build $HOME/src/blaspp-aurora-gpu-build --target install --parallel 16
 rm -rf $HOME/src/blaspp-aurora-gpu-build
 
@@ -56,7 +56,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/lapackpp.git $HOME/src/lapackpp
 fi
 rm -rf $HOME/src/lapackpp-aurora-gpu-build
-CXX=icpx CXXFLAGS="-DLAPACK_FORTRAN_ADD_ -qmkl" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-aurora-gpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31 -DCMAKE_EXE_LINKER_FLAGS="-qmkl"
+CXX=icpx CXXFLAGS="-DLAPACK_FORTRAN_ADD_ -qmkl" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-aurora-gpu-build -DCMAKE_CXX_STANDARD=20 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31 -DCMAKE_EXE_LINKER_FLAGS="-qmkl"
 cmake --build $HOME/src/lapackpp-aurora-gpu-build --target install --parallel 16
 rm -rf $HOME/src/lapackpp-aurora-gpu-build
 

--- a/Tools/machines/crusher-olcf/install_dependencies.sh
+++ b/Tools/machines/crusher-olcf/install_dependencies.sh
@@ -55,7 +55,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/blaspp.git $HOME/src/blaspp
 fi
 rm -rf $HOME/src/blaspp-crusher-gpu-build
-CXX=$(which CC) cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-crusher-gpu-build -Duse_openmp=OFF -Dgpu_backend=hip -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
+CXX=$(which CC) cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-crusher-gpu-build -Duse_openmp=OFF -Dgpu_backend=hip -DCMAKE_CXX_STANDARD=20 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
 cmake --build $HOME/src/blaspp-crusher-gpu-build --target install --parallel 16
 rm -rf $HOME/src/blaspp-crusher-gpu-build
 
@@ -70,7 +70,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/lapackpp.git $HOME/src/lapackpp
 fi
 rm -rf $HOME/src/lapackpp-crusher-gpu-build
-CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-crusher-gpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
+CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-crusher-gpu-build -DCMAKE_CXX_STANDARD=20 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
 cmake --build $HOME/src/lapackpp-crusher-gpu-build --target install --parallel 16
 rm -rf $HOME/src/lapackpp-crusher-gpu-build
 

--- a/Tools/machines/dane-llnl/install_dependencies.sh
+++ b/Tools/machines/dane-llnl/install_dependencies.sh
@@ -76,7 +76,7 @@ then
 else
   git clone -b v2024.10.26 https://github.com/icl-utk-edu/blaspp.git ${WARPX_SW_DIR}/src/blaspp
 fi
-cmake -S ${WARPX_SW_DIR}/src/blaspp -B ${build_dir}/blaspp-dane-build -Duse_openmp=ON -Duse_cmake_find_blas=ON -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${WARPX_SW_DIR}/install/blaspp-2024.10.26
+cmake -S ${WARPX_SW_DIR}/src/blaspp -B ${build_dir}/blaspp-dane-build -Duse_openmp=ON -Duse_cmake_find_blas=ON -DCMAKE_CXX_STANDARD=20 -DCMAKE_INSTALL_PREFIX=${WARPX_SW_DIR}/install/blaspp-2024.10.26
 cmake --build ${build_dir}/blaspp-dane-build --target install --parallel 6
 
 # LAPACK++ (for PSATD+RZ)
@@ -89,7 +89,7 @@ then
 else
   git clone -b v2024.10.26 https://github.com/icl-utk-edu/lapackpp.git ${WARPX_SW_DIR}/src/lapackpp
 fi
-CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S ${WARPX_SW_DIR}/src/lapackpp -B ${build_dir}/lapackpp-dane-build -Duse_cmake_find_lapack=ON -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${WARPX_SW_DIR}/install/lapackpp-2024.10.26
+CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S ${WARPX_SW_DIR}/src/lapackpp -B ${build_dir}/lapackpp-dane-build -Duse_cmake_find_lapack=ON -DCMAKE_CXX_STANDARD=20 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${WARPX_SW_DIR}/install/lapackpp-2024.10.26
 cmake --build ${build_dir}/lapackpp-dane-build --target install --parallel 6
 
 

--- a/Tools/machines/frontier-olcf/install_dependencies.sh
+++ b/Tools/machines/frontier-olcf/install_dependencies.sh
@@ -55,7 +55,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/blaspp.git $HOME/src/blaspp
 fi
 rm -rf $HOME/src/blaspp-frontier-gpu-build
-CXX=$(which CC) cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-frontier-gpu-build -Duse_openmp=OFF -Dgpu_backend=hip -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
+CXX=$(which CC) cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-frontier-gpu-build -Duse_openmp=OFF -Dgpu_backend=hip -DCMAKE_CXX_STANDARD=20 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
 cmake --build $HOME/src/blaspp-frontier-gpu-build --target install --parallel 16
 rm -rf $HOME/src/blaspp-frontier-gpu-build
 
@@ -70,7 +70,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/lapackpp.git $HOME/src/lapackpp
 fi
 rm -rf $HOME/src/lapackpp-frontier-gpu-build
-CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-frontier-gpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
+CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-frontier-gpu-build -DCMAKE_CXX_STANDARD=20 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
 cmake --build $HOME/src/lapackpp-frontier-gpu-build --target install --parallel 16
 rm -rf $HOME/src/lapackpp-frontier-gpu-build
 

--- a/Tools/machines/greatlakes-umich/install_v100_dependencies.sh
+++ b/Tools/machines/greatlakes-umich/install_v100_dependencies.sh
@@ -86,7 +86,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/blaspp.git $HOME/src/blaspp
 fi
 rm -rf $HOME/src/blaspp-v100-build
-cmake -S $HOME/src/blaspp -B ${build_dir}/blaspp-v100-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
+cmake -S $HOME/src/blaspp -B ${build_dir}/blaspp-v100-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=20 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
 cmake --build ${build_dir}/blaspp-v100-build --target install --parallel 8
 rm -rf ${build_dir}/blaspp-v100-build
 
@@ -101,7 +101,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/lapackpp.git $HOME/src/lapackpp
 fi
 rm -rf $HOME/src/lapackpp-v100-build
-CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B ${build_dir}/lapackpp-v100-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
+CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B ${build_dir}/lapackpp-v100-build -DCMAKE_CXX_STANDARD=20 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
 cmake --build ${build_dir}/lapackpp-v100-build --target install --parallel 8
 rm -rf ${build_dir}/lapackpp-v100-build
 

--- a/Tools/machines/hpc3-uci/install_gpu_dependencies.sh
+++ b/Tools/machines/hpc3-uci/install_gpu_dependencies.sh
@@ -85,7 +85,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/blaspp.git $HOME/src/blaspp
 fi
 rm -rf $HOME/src/blaspp-pm-gpu-build
-cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-pm-gpu-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
+cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-pm-gpu-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=20 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
 cmake --build $HOME/src/blaspp-pm-gpu-build --target install --parallel 8
 rm -rf $HOME/src/blaspp-pm-gpu-build
 
@@ -100,7 +100,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/lapackpp.git $HOME/src/lapackpp
 fi
 rm -rf $HOME/src/lapackpp-pm-gpu-build
-CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-pm-gpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
+CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-pm-gpu-build -DCMAKE_CXX_STANDARD=20 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
 cmake --build $HOME/src/lapackpp-pm-gpu-build --target install --parallel 8
 rm -rf $HOME/src/lapackpp-pm-gpu-build
 

--- a/Tools/machines/leonardo-cineca/install_gpu_dependencies.sh
+++ b/Tools/machines/leonardo-cineca/install_gpu_dependencies.sh
@@ -53,7 +53,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/blaspp.git $HOME/src/blaspp
 fi
 rm -rf $HOME/src/blaspp-gpu-build
-CXX=$(which g++) cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-gpu-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
+CXX=$(which g++) cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-gpu-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=20 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
 cmake --build $HOME/src/blaspp-gpu-build --target install --parallel 16
 rm -rf $HOME/src/blaspp-gpu-build
 
@@ -69,7 +69,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/lapackpp.git $HOME/src/lapackpp
 fi
 rm -rf $HOME/src/lapackpp-gpu-build
-CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-gpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
+CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-gpu-build -DCMAKE_CXX_STANDARD=20 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
 cmake --build $HOME/src/lapackpp-gpu-build --target install --parallel 16
 rm -rf $HOME/src/lapackpp-gpu-build
 

--- a/Tools/machines/lonestar6-tacc/install_a100_dependencies.sh
+++ b/Tools/machines/lonestar6-tacc/install_a100_dependencies.sh
@@ -77,7 +77,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/blaspp.git $HOME/src/blaspp
 fi
 rm -rf $HOME/src/blaspp-a100-build
-cmake -S $HOME/src/blaspp -B ${build_dir}/blaspp-a100-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
+cmake -S $HOME/src/blaspp -B ${build_dir}/blaspp-a100-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=20 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
 cmake --build ${build_dir}/blaspp-a100-build --target install --parallel 16
 rm -rf ${build_dir}/blaspp-a100-build
 
@@ -92,7 +92,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/lapackpp.git $HOME/src/lapackpp
 fi
 rm -rf $HOME/src/lapackpp-a100-build
-CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B ${build_dir}/lapackpp-a100-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
+CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B ${build_dir}/lapackpp-a100-build -DCMAKE_CXX_STANDARD=20 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
 cmake --build ${build_dir}/lapackpp-a100-build --target install --parallel 16
 rm -rf ${build_dir}/lapackpp-a100-build
 

--- a/Tools/machines/lumi-csc/install_dependencies.sh
+++ b/Tools/machines/lumi-csc/install_dependencies.sh
@@ -54,7 +54,7 @@ cmake -S ${SRC_DIR}/blaspp                   \
       -B ${build_dir}/blaspp-lumi-gpu-build  \
       -Duse_openmp=OFF                       \
       -Dgpu_backend=hip                      \
-      -DCMAKE_CXX_STANDARD=17                \
+      -DCMAKE_CXX_STANDARD=20                \
       -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
 cmake --build ${build_dir}/blaspp-lumi-gpu-build --target install --parallel 16
 rm -rf ${build_dir}/blaspp-lumi-gpu-build
@@ -73,7 +73,7 @@ rm -rf ${build_dir}/lapackpp-lumi-gpu-build
 CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" \
 cmake -S ${SRC_DIR}/lapackpp                     \
       -B ${build_dir}/lapackpp-lumi-gpu-build    \
-      -DCMAKE_CXX_STANDARD=17                    \
+      -DCMAKE_CXX_STANDARD=20                    \
       -Dbuild_tests=OFF                          \
       -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON     \
       -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31

--- a/Tools/machines/perlmutter-nersc/container/gpu/mpi/Containerfile
+++ b/Tools/machines/perlmutter-nersc/container/gpu/mpi/Containerfile
@@ -172,7 +172,7 @@ RUN git clone                  \
        -B /tmp/blaspp-build    \
        -Duse_openmp=OFF        \
        -Dgpu_backend=cuda      \
-       -DCMAKE_CXX_STANDARD=17 \
+       -DCMAKE_CXX_STANDARD=20 \
        -DCMAKE_INSTALL_PREFIX=/opt/warpx                         \
        -DBLAS_LIBRARIES=/usr/lib/x86_64-linux-gnu/libblas.so     \
        -DLAPACK_LIBRARIES=/usr/lib/x86_64-linux-gnu/liblapack.so \
@@ -189,7 +189,7 @@ RUN git clone                     \
                                && \
     cmake -S /tmp/lapackpp        \
       -B /tmp/lapackpp-build      \
-      -DCMAKE_CXX_STANDARD=17     \
+      -DCMAKE_CXX_STANDARD=20     \
       -Dbuild_tests=OFF           \
       -DCMAKE_INSTALL_PREFIX=/opt/warpx \
       -DLAPACK_LIBRARIES=/usr/lib/x86_64-linux-gnu/liblapack.so \

--- a/Tools/machines/perlmutter-nersc/container/gpu/nompi/Containerfile
+++ b/Tools/machines/perlmutter-nersc/container/gpu/nompi/Containerfile
@@ -142,7 +142,7 @@ RUN git clone                  \
        -B /tmp/blaspp-build    \
        -Duse_openmp=OFF        \
        -Dgpu_backend=cuda      \
-       -DCMAKE_CXX_STANDARD=17 \
+       -DCMAKE_CXX_STANDARD=20 \
        -DCMAKE_INSTALL_PREFIX=/opt/warpx                         \
        -DBLAS_LIBRARIES=/usr/lib/x86_64-linux-gnu/libblas.so     \
        -DLAPACK_LIBRARIES=/usr/lib/x86_64-linux-gnu/liblapack.so \
@@ -159,7 +159,7 @@ RUN git clone                     \
                                && \
     cmake -S /tmp/lapackpp        \
       -B /tmp/lapackpp-build      \
-      -DCMAKE_CXX_STANDARD=17     \
+      -DCMAKE_CXX_STANDARD=20     \
       -Dbuild_tests=OFF           \
       -DCMAKE_INSTALL_PREFIX=/opt/warpx \
       -DLAPACK_LIBRARIES=/usr/lib/x86_64-linux-gnu/liblapack.so \

--- a/Tools/machines/perlmutter-nersc/install_cpu_dependencies.sh
+++ b/Tools/machines/perlmutter-nersc/install_cpu_dependencies.sh
@@ -63,7 +63,7 @@ curl -Lo $HOME/src/boost-temp/boost.tar.gz https://archives.boost.io/release/1.8
 tar -xzf $HOME/src/boost-temp/boost.tar.gz -C $HOME/src/boost-temp
 cd $HOME/src/boost-temp/boost_1_82_0
 ./bootstrap.sh --with-libraries=math --prefix=${SW_DIR}/boost-1.82.0
-./b2 cxxflags="-std=c++17" install -j ${PARALLEL}
+./b2 cxxflags="-std=c++20" install -j ${PARALLEL}
 cd -
 rm -rf $HOME/src/boost-temp
 
@@ -108,7 +108,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/blaspp.git $HOME/src/blaspp
 fi
 rm -rf $HOME/src/blaspp-pm-cpu-build
-CXX=$(which CC) cmake -S $HOME/src/blaspp -B ${build_dir}/blaspp-pm-cpu-build -Duse_openmp=ON -Dgpu_backend=OFF -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
+CXX=$(which CC) cmake -S $HOME/src/blaspp -B ${build_dir}/blaspp-pm-cpu-build -Duse_openmp=ON -Dgpu_backend=OFF -DCMAKE_CXX_STANDARD=20 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
 cmake --build ${build_dir}/blaspp-pm-cpu-build --target install --parallel ${PARALLEL}
 rm -rf ${build_dir}/blaspp-pm-cpu-build
 
@@ -123,7 +123,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/lapackpp.git $HOME/src/lapackpp
 fi
 rm -rf $HOME/src/lapackpp-pm-cpu-build
-CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B ${build_dir}/lapackpp-pm-cpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
+CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B ${build_dir}/lapackpp-pm-cpu-build -DCMAKE_CXX_STANDARD=20 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
 cmake --build ${build_dir}/lapackpp-pm-cpu-build --target install --parallel ${PARALLEL}
 rm -rf ${build_dir}/lapackpp-pm-cpu-build
 

--- a/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
+++ b/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
@@ -63,7 +63,7 @@ curl -Lo $HOME/src/boost-temp/boost.tar.gz https://archives.boost.io/release/1.8
 tar -xzf $HOME/src/boost-temp/boost.tar.gz -C $HOME/src/boost-temp
 cd $HOME/src/boost-temp/boost_1_82_0
 ./bootstrap.sh --with-libraries=math --prefix=${SW_DIR}/boost-1.82.0
-./b2 cxxflags="-std=c++17" install -j ${PARALLEL}
+./b2 cxxflags="-std=c++20" install -j ${PARALLEL}
 cd -
 rm -rf $HOME/src/boost-temp
 
@@ -108,7 +108,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/blaspp.git $HOME/src/blaspp
 fi
 rm -rf $HOME/src/blaspp-pm-gpu-build
-CXX=$(which CC) cmake -S $HOME/src/blaspp -B ${build_dir}/blaspp-pm-gpu-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
+CXX=$(which CC) cmake -S $HOME/src/blaspp -B ${build_dir}/blaspp-pm-gpu-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=20 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
 cmake --build ${build_dir}/blaspp-pm-gpu-build --target install --parallel ${PARALLEL}
 rm -rf ${build_dir}/blaspp-pm-gpu-build
 
@@ -123,7 +123,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/lapackpp.git $HOME/src/lapackpp
 fi
 rm -rf $HOME/src/lapackpp-pm-gpu-build
-CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B ${build_dir}/lapackpp-pm-gpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
+CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B ${build_dir}/lapackpp-pm-gpu-build -DCMAKE_CXX_STANDARD=20 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
 cmake --build ${build_dir}/lapackpp-pm-gpu-build --target install --parallel ${PARALLEL}
 rm -rf ${build_dir}/lapackpp-pm-gpu-build
 

--- a/Tools/machines/pitzer-osc/install_cpu_dependencies.sh
+++ b/Tools/machines/pitzer-osc/install_cpu_dependencies.sh
@@ -60,7 +60,7 @@ CXX=$(which CC) cmake -S ${SRC_DIR}/blaspp \
   -B ${build_dir}/blaspp-pitzer-cpu-build \
   -Duse_openmp=ON \
   -Dgpu_backend=OFF \
-  -DCMAKE_CXX_STANDARD=17 \
+  -DCMAKE_CXX_STANDARD=20 \
   -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
 cmake --build ${build_dir}/blaspp-pitzer-cpu-build --target install --parallel 16
 rm -rf ${build_dir}/blaspp-pitzer-cpu-build
@@ -77,7 +77,7 @@ fi
 rm -rf ${build_dir}/lapackpp-pitzer-cpu-build
 CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S ${SRC_DIR}/lapackpp \
   -B ${build_dir}/lapackpp-pitzer-cpu-build \
-  -DCMAKE_CXX_STANDARD=17 \
+  -DCMAKE_CXX_STANDARD=20 \
   -Dbuild_tests=OFF \
   -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON \
   -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31

--- a/Tools/machines/pitzer-osc/install_v100_dependencies.sh
+++ b/Tools/machines/pitzer-osc/install_v100_dependencies.sh
@@ -60,7 +60,7 @@ CXX=$(which CC) cmake -S ${SRC_DIR}/blaspp \
   -B ${build_dir}/blaspp-pitzer-v100-build \
   -Duse_openmp=ON \
   -Dgpu_backend=cuda \
-  -DCMAKE_CXX_STANDARD=17 \
+  -DCMAKE_CXX_STANDARD=20 \
   -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
 cmake --build ${build_dir}/blaspp-pitzer-v100-build --target install --parallel 16
 rm -rf ${build_dir}/blaspp-pitzer-v100-build
@@ -77,7 +77,7 @@ fi
 rm -rf ${build_dir}/lapackpp-pitzer-v100-build
 CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S ${SRC_DIR}/lapackpp \
   -B ${build_dir}/lapackpp-pitzer-v100-build \
-  -DCMAKE_CXX_STANDARD=17 \
+  -DCMAKE_CXX_STANDARD=20 \
   -Dbuild_tests=OFF \
   -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON \
   -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31

--- a/Tools/machines/polaris-alcf/install_gpu_dependencies.sh
+++ b/Tools/machines/polaris-alcf/install_gpu_dependencies.sh
@@ -71,7 +71,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/blaspp.git $HOME/src/blaspp
 fi
 rm -rf $HOME/src/blaspp-pm-gpu-build
-CXX=$(which CC) cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-pm-gpu-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
+CXX=$(which CC) cmake -S $HOME/src/blaspp -B $HOME/src/blaspp-pm-gpu-build -Duse_openmp=OFF -Dgpu_backend=cuda -DCMAKE_CXX_STANDARD=20 -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
 cmake --build $HOME/src/blaspp-pm-gpu-build --target install --parallel 16
 rm -rf $HOME/src/blaspp-pm-gpu-build
 
@@ -86,7 +86,7 @@ else
   git clone -b v2024.05.31 https://github.com/icl-utk-edu/lapackpp.git $HOME/src/lapackpp
 fi
 rm -rf $HOME/src/lapackpp-pm-gpu-build
-CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-pm-gpu-build -DCMAKE_CXX_STANDARD=17 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
+CXX=$(which CC) CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S $HOME/src/lapackpp -B $HOME/src/lapackpp-pm-gpu-build -DCMAKE_CXX_STANDARD=20 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${SW_DIR}/lapackpp-2024.05.31
 cmake --build $HOME/src/lapackpp-pm-gpu-build --target install --parallel 16
 rm -rf $HOME/src/lapackpp-pm-gpu-build
 

--- a/Tools/machines/tuolumne-llnl/install_cpu_dependencies.sh
+++ b/Tools/machines/tuolumne-llnl/install_cpu_dependencies.sh
@@ -137,7 +137,7 @@ cmake \
     -Duse_openmp=ON                           \
     -Dgpu_backend=OFF                         \
     -DBUILD_SHARED_LIBS=OFF                   \
-    -DCMAKE_CXX_STANDARD=17                   \
+    -DCMAKE_CXX_STANDARD=20                   \
     -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
 cmake \
     --build ${build_dir}/blaspp-tuolumne-cpu-build \
@@ -159,7 +159,7 @@ cmake \
     --fresh                                     \
     -S ${SRC_DIR}/lapackpp                      \
     -B ${build_dir}/lapackpp-tuolumne-cpu-build \
-    -DCMAKE_CXX_STANDARD=17                     \
+    -DCMAKE_CXX_STANDARD=20                     \
     -Dgpu_backend=OFF                           \
     -Dbuild_tests=OFF                           \
     -DBUILD_SHARED_LIBS=OFF                     \

--- a/Tools/machines/tuolumne-llnl/install_mi300a_dependencies.sh
+++ b/Tools/machines/tuolumne-llnl/install_mi300a_dependencies.sh
@@ -137,7 +137,7 @@ cmake \
     -Duse_openmp=OFF                          \
     -Dgpu_backend=hip                         \
     -DBUILD_SHARED_LIBS=OFF                   \
-    -DCMAKE_CXX_STANDARD=17                   \
+    -DCMAKE_CXX_STANDARD=20                   \
     -DCMAKE_INSTALL_PREFIX=${SW_DIR}/blaspp-2024.05.31
 cmake \
     --build ${build_dir}/blaspp-tuolumne-mi300a-build \
@@ -159,7 +159,7 @@ cmake \
     --fresh                                     \
     -S ${SRC_DIR}/lapackpp                      \
     -B ${build_dir}/lapackpp-tuolumne-mi300a-build \
-    -DCMAKE_CXX_STANDARD=17                     \
+    -DCMAKE_CXX_STANDARD=20                     \
     -Dgpu_backend=hip                           \
     -Dbuild_tests=OFF                           \
     -DBUILD_SHARED_LIBS=OFF                     \

--- a/cmake/WarpXFunctions.cmake
+++ b/cmake/WarpXFunctions.cmake
@@ -1,11 +1,11 @@
-# Set C++17 for the whole build if not otherwise requested
+# Set C++20 for the whole build if not otherwise requested
 #
-# This is the easiest way to push up a C++17 requirement for AMReX, PICSAR and
+# This is the easiest way to push up a C++20 requirement for AMReX, PICSAR and
 # openPMD-api until they increase their requirement.
 #
-macro(set_cxx17_superbuild)
+macro(set_cxx20_superbuild)
     if(NOT DEFINED CMAKE_CXX_STANDARD)
-        set(CMAKE_CXX_STANDARD 17)
+        set(CMAKE_CXX_STANDARD 20)
     endif()
     if(NOT DEFINED CMAKE_CXX_EXTENSIONS)
         set(CMAKE_CXX_EXTENSIONS OFF)
@@ -15,7 +15,7 @@ macro(set_cxx17_superbuild)
     endif()
 
     if(NOT DEFINED CMAKE_CUDA_STANDARD)
-        set(CMAKE_CUDA_STANDARD 17)
+        set(CMAKE_CUDA_STANDARD 20)
     endif()
     if(NOT DEFINED CMAKE_CUDA_EXTENSIONS)
         set(CMAKE_CUDA_EXTENSIONS OFF)


### PR DESCRIPTION
Switch to C++20. AMReX is making the switch soon (https://github.com/AMReX-Codes/amrex/issues/4840) and is preparing CI in https://github.com/AMReX-Codes/amrex/pull/4976 so we can also generally pull up the requirements.

- [x] wait for 26.03 release
- [x] patch [toml11](https://github.com/ToruNiina/toml11/pull/295) / use clang 14+ (for CI, we can do https://github.com/openPMD/openPMD-api/pull/1874 )
- [x] merge for the 26.05 release cycle