### PR TITLE
Doc: Perlmutter GCC Downgrade

### DIFF
--- a/Tools/machines/perlmutter-nersc/perlmutter_gpu_warpx.profile.example
+++ b/Tools/machines/perlmutter-nersc/perlmutter_gpu_warpx.profile.example
@@ -12,6 +12,7 @@ module load craype
 module load craype-x86-milan
 module load craype-accel-nvidia80
 module load cudatoolkit
+module load gcc-native/13.2  # default gcc-native/14 breaks pybind11 builds with NVCC 12.9.41
 module load cmake/3.30.2
 
 # missing modules installed here


### PR DESCRIPTION
After the last upgrade, Perlmutter (NERSC) ships CUDA 12.9.0 with NVCC 12.9.41. The default compiler was updated to GCC 14.3.0.

Compiling WarpX for CUDA breaks the pyAMReX / pybind11 builds, so we downgrade to GCC 13.2 instead.