### PR TITLE
Take into account relativistic velocity in particle reflection test

### DIFF
--- a/Examples/Tests/particle_boundary_interaction/analysis.py
+++ b/Examples/Tests/particle_boundary_interaction/analysis.py
@@ -23,9 +23,10 @@ it = ts.iterations
 x, y, z = ts.get_particle(["x", "y", "z"], species="electrons", iteration=it[-1])
 
 # Analytical results calculated
-x_analytic = 0.03532
+
+x_analytic = 0.03308
 y_analytic = 0.00000
-z_analytic = -0.20531
+z_analytic = -0.20299
 
 print("NUMERICAL coordinates of the point of contact:")
 print(f"x={x[0]:5.5f}, y={y[0]:5.5f}, z={z[0]:5.5f}")

--- a/Examples/Tests/particle_boundary_interaction/analysis.py
+++ b/Examples/Tests/particle_boundary_interaction/analysis.py
@@ -25,7 +25,7 @@ x, y, z = ts.get_particle(["x", "y", "z"], species="electrons", iteration=it[-1]
 # Analytical results calculated
 
 x_analytic = 0.03307855709632465
-y_analytic = 0.
+y_analytic = 0.0
 z_analytic = -0.2029948949556386
 
 print("NUMERICAL coordinates of the point of contact:")

--- a/Examples/Tests/particle_boundary_interaction/analysis.py
+++ b/Examples/Tests/particle_boundary_interaction/analysis.py
@@ -24,9 +24,9 @@ x, y, z = ts.get_particle(["x", "y", "z"], species="electrons", iteration=it[-1]
 
 # Analytical results calculated
 
-x_analytic = 0.03308
-y_analytic = 0.00000
-z_analytic = -0.20299
+x_analytic = 0.03307855709632465
+y_analytic = 0.
+z_analytic = -0.2029948949556386
 
 print("NUMERICAL coordinates of the point of contact:")
 print(f"x={x[0]:5.5f}, y={y[0]:5.5f}, z={z[0]:5.5f}")

--- a/Examples/Tests/particle_boundary_interaction/inputs_test_rz_particle_boundary_interaction_picmi.py
+++ b/Examples/Tests/particle_boundary_interaction/inputs_test_rz_particle_boundary_interaction_picmi.py
@@ -3,6 +3,9 @@
 # --- This input is a simple case of reflection
 # --- of one electron on the surface of a sphere.
 
+import numpy as np
+import scipy.constants as scc
+
 from pywarpx import callbacks, particle_containers, picmi
 from pywarpx.LoadThirdParty import load_cupy
 
@@ -173,10 +176,16 @@ def mirror_reflection():
     uy_reflect = to_numpy(uy_reflect)
     uz_reflect = to_numpy(uz_reflect)
 
+    inv_c2 = 1.0 / (scc.c**2)
+    inv_gamma = 1.0 / np.sqrt(
+        1.0 + (ux_reflect**2 + uy_reflect**2 + uz_reflect**2) * inv_c2
+    )
+    dt_remaining = dt - delta_t
+
     electrons.add_particles(
-        x=x + (dt - delta_t) * ux_reflect,
-        y=y + (dt - delta_t) * uy_reflect,
-        z=z + (dt - delta_t) * uz_reflect,
+        x=x + dt_remaining * ux_reflect * inv_gamma,
+        y=y + dt_remaining * uy_reflect * inv_gamma,
+        z=z + dt_remaining * uz_reflect * inv_gamma,
         ux=ux_reflect,
         uy=uy_reflect,
         uz=uz_reflect,

--- a/Regression/Checksum/benchmarks_json/test_rz_particle_boundary_interaction_picmi.json
+++ b/Regression/Checksum/benchmarks_json/test_rz_particle_boundary_interaction_picmi.json
@@ -1,18 +1,18 @@
 {
-  "lev=0": {
-    "Er": 1.328767988208224e-06,
-    "Ez": 1.7917377388960658e-06,
-    "phi": 3.398392905405859e-07,
-    "rho": 7.811529217958713e-16,
-    "rho_electrons": 7.811529217958713e-16
-  },
   "electrons": {
-    "particle_position_x": 0.03532003602713797,
-    "particle_position_y": 0.0,
-    "particle_position_z": 0.20531131195378569,
     "particle_momentum_x": 7.082238793052739e-21,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 7.319015182182129e-21,
+    "particle_position_x": 0.03307855709632465,
+    "particle_position_y": 0.0,
+    "particle_position_z": 0.2029948949556386,
     "particle_weight": 1.0
+  },
+  "lev=0": {
+    "Er": 1.1856495561793996e-06,
+    "Ez": 1.5857370046432742e-06,
+    "phi": 2.9706925974206054e-07,
+    "rho": 8.111193584817117e-16,
+    "rho_electrons": 8.111193584817117e-16
   }
 }


### PR DESCRIPTION
The particle reflection test uses a callback to treat the reflection of particles on embedded boundaries. However, in computing the particle motion, it was neglecting the fact that the particle might be relativistic (which is the case in this test), i.e. it was using:
```
 x_new = x_contact + ux * dt_remaining 
 ```
instead of
```
x_new = x_contact + ux/gamma * dt_remaining
```
This PR implements the latter formula.