### PR TITLE
DevUtils: automate checksum reset from Azure via PR number

### DIFF
--- a/Docs/source/developers/how_to_test.rst
+++ b/Docs/source/developers/how_to_test.rst
@@ -204,30 +204,41 @@ It is possible to reset a checksum file locally by running the corresponding tes
 
        CHECKSUM_RESET=ON ctest --test-dir build -R laser_acceleration
 
-Alternatively, it is also possible to reset multiple checksum files using the output of our Azure pipelines, which can be useful for code changes that result in resetting a large numbers of checksum files.
-Here's how to do so:
+Alternatively, it is also possible to reset multiple checksum files automatically using the output of our Azure pipelines, which can be useful for code changes that result in resetting a large number of checksum files.
+Go to the directory `Tools/DevUtils <https://github.com/BLAST-WarpX/warpx/tree/development/Tools/DevUtils>`__ and run the Python script `update_benchmarks_from_azure_output.py <https://github.com/BLAST-WarpX/warpx/blob/development/Tools/DevUtils/update_benchmarks_from_azure_output.py>`__ with the ``--pr-number`` option:
 
-#. On the GitHub page of the pull request, find (one of) the pipeline(s) failing due to checksum regressions and click on "Details" (highlighted in blue).
+.. code:: bash
 
-   .. figure:: https://gist.github.com/user-attachments/assets/09db91b9-5711-4250-8b36-c52a6049e38e
+     python update_benchmarks_from_azure_output.py --pr-number 1234
 
-#. In the new page that opens up, click on "View more details on Azure pipelines" (highlighted in blue).
+This requires the `GitHub CLI <https://cli.github.com/>`__ (``gh``) to be installed and authenticated.
+The script will automatically find the failing Azure Pipelines jobs for the pull request, download their logs, and update all checksum benchmark files that did not pass the checksum analysis.
 
-   .. figure:: https://gist.github.com/user-attachments/assets/ab0c9a24-5518-4da7-890f-d79fa1c8de4c
+.. dropdown:: Legacy mode (manual log download)
 
-#. In the new page that opens up, select the group of tests for which you want to reset the checksum files (e.g., ``cartesian_3d``) and click on "View raw log".
+   If the automatic mode does not work (e.g., because ``gh`` is not available), you can also reset the checksums manually by downloading the Azure log files yourself and passing them to the script.
 
-   .. figure:: https://gist.github.com/user-attachments/assets/06c1fe27-2c13-4bd3-b6b8-8b8941b37889
+   #. On the GitHub page of the pull request, find (one of) the pipeline(s) failing due to checksum regressions and click on "Details" (highlighted in blue).
 
-#. Save the raw log as a text file on your computer (e.g., with the ``curl`` command, ``curl https://dev.azure.com/ECP-WarpX/... > raw_log.txt``).
+      .. figure:: https://gist.github.com/user-attachments/assets/09db91b9-5711-4250-8b36-c52a6049e38e
 
-#. Go to the directory `Tools/DevUtils <https://github.com/BLAST-WarpX/warpx/tree/development/Tools/DevUtils>`__ and run the Python script `update_benchmarks_from_azure_output.py <https://github.com/BLAST-WarpX/warpx/blob/development/Tools/DevUtils/update_benchmarks_from_azure_output.py>`__ passing the path of the raw log text file as a command line argument:
+   #. In the new page that opens up, click on "View more details on Azure pipelines" (highlighted in blue).
 
-   .. code:: bash
+      .. figure:: https://gist.github.com/user-attachments/assets/ab0c9a24-5518-4da7-890f-d79fa1c8de4c
 
-        python update_benchmarks_from_azure_output.py path/to/raw_log.txt
+   #. In the new page that opens up, select the group of tests for which you want to reset the checksum files (e.g., ``cartesian_3d``) and click on "View raw log".
 
-   This will update the checksum files for all the tests in the raw log that did not pass the checksum analysis.
+      .. figure:: https://gist.github.com/user-attachments/assets/06c1fe27-2c13-4bd3-b6b8-8b8941b37889
+
+   #. Save the raw log as a text file on your computer (e.g., with the ``curl`` command, ``curl https://dev.azure.com/BLAST-WarpX/... > raw_log.txt``).
+
+   #. Go to the directory `Tools/DevUtils <https://github.com/BLAST-WarpX/warpx/tree/development/Tools/DevUtils>`__ and run the Python script passing the path of the raw log text file as a command line argument:
+
+      .. code:: bash
+
+           python update_benchmarks_from_azure_output.py path/to/raw_log.txt
+
+      This will update the checksum files for all the tests in the raw log that did not pass the checksum analysis.
 
 .. _developers-testing-naming:
 

--- a/Docs/source/developers/how_to_test.rst
+++ b/Docs/source/developers/how_to_test.rst
@@ -214,32 +214,6 @@ Go to the directory `Tools/DevUtils <https://github.com/BLAST-WarpX/warpx/tree/d
 This requires the `GitHub CLI <https://cli.github.com/>`__ (``gh``) to be installed and authenticated.
 The script will automatically find the failing Azure Pipelines jobs for the pull request, download their logs, and update all checksum benchmark files that did not pass the checksum analysis.
 
-.. dropdown:: Legacy mode (manual log download)
-
-   If the automatic mode does not work (e.g., because ``gh`` is not available), you can also reset the checksums manually by downloading the Azure log files yourself and passing them to the script.
-
-   #. On the GitHub page of the pull request, find (one of) the pipeline(s) failing due to checksum regressions and click on "Details" (highlighted in blue).
-
-      .. figure:: https://gist.github.com/user-attachments/assets/09db91b9-5711-4250-8b36-c52a6049e38e
-
-   #. In the new page that opens up, click on "View more details on Azure pipelines" (highlighted in blue).
-
-      .. figure:: https://gist.github.com/user-attachments/assets/ab0c9a24-5518-4da7-890f-d79fa1c8de4c
-
-   #. In the new page that opens up, select the group of tests for which you want to reset the checksum files (e.g., ``cartesian_3d``) and click on "View raw log".
-
-      .. figure:: https://gist.github.com/user-attachments/assets/06c1fe27-2c13-4bd3-b6b8-8b8941b37889
-
-   #. Save the raw log as a text file on your computer (e.g., with the ``curl`` command, ``curl https://dev.azure.com/BLAST-WarpX/... > raw_log.txt``).
-
-   #. Go to the directory `Tools/DevUtils <https://github.com/BLAST-WarpX/warpx/tree/development/Tools/DevUtils>`__ and run the Python script passing the path of the raw log text file as a command line argument:
-
-      .. code:: bash
-
-           python update_benchmarks_from_azure_output.py path/to/raw_log.txt
-
-      This will update the checksum files for all the tests in the raw log that did not pass the checksum analysis.
-
 .. _developers-testing-naming:
 
 Naming conventions for automated tests

--- a/Tools/DevUtils/update_benchmarks_from_azure_output.py
+++ b/Tools/DevUtils/update_benchmarks_from_azure_output.py
@@ -4,50 +4,291 @@
 #
 # License: BSD-3-Clause-LBNL
 
+"""
+This Python script updates the Azure benchmarks automatically.
+
+It can be run in two ways:
+
+1. Automatic mode (recommended): pass a GitHub PR number, and the script
+   fetches the failing Azure Pipelines logs automatically.
+
+       python update_benchmarks_from_azure_output.py --pr-number 1234
+
+   The ``gh`` CLI must be installed and authenticated (available via conda base).
+
+2. Legacy mode: pass a raw Azure log text file downloaded manually.
+
+       python update_benchmarks_from_azure_output.py path/to/raw_log.txt
+"""
+
+import argparse
 import json
+import os
 import re
+import subprocess
 import sys
+import urllib.request
 
-"""
-This Python script updates the Azure benchmarks automatically using a raw
-Azure output text file that is passed as command line argument of the script.
-"""
-
-# read path to Azure output text file
-azure_output = sys.argv[1]
+# path of all checksums benchmark files, relative to this script
+benchmark_path = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "../../Regression/Checksum/benchmarks_json/",
+)
 
 # string to identify failing tests that require a checksums reset
-new_checksums = "New checksums"
-failing_test = ""
+new_checksums_marker = "New checksums"
 
-# path of all checksums benchmark files
-benchmark_path = "../../Regression/Checksum/benchmarks_json/"
 
-with open(azure_output, "r") as f:
-    # find length of Azure prefix to be removed from each line,
-    # first line of Azure output starts with "##[section]Starting:"
-    first_line = f.readline()
-    prefix_length = first_line.find("#")
-    # loop over lines
-    for line in f:
-        # remove Azure prefix from line
+def _detect_prefix_length(first_line):
+    """Return the length of the Azure timestamp prefix on a log line.
+
+    Azure raw logs have lines like:
+        2024-01-01T00:00:00.0000000Z ##[section]Starting: ...
+    The prefix is everything before the first '#'.  If no '#' is found,
+    assume there is no prefix (length 0).
+    """
+    idx = first_line.find("#")
+    return idx if idx >= 0 else 0
+
+
+def update_benchmarks_from_log_text(log_text):
+    """Parse Azure log text and update checksum JSON files for failing tests.
+
+    Returns a list of JSON filenames that were updated.
+    """
+    lines = log_text.splitlines()
+    if not lines:
+        return []
+
+    prefix_length = _detect_prefix_length(lines[0])
+
+    failing_test = ""
+    json_file_string = ""
+    updated = []
+
+    for line in lines:
+        # remove Azure timestamp prefix
         line = line[prefix_length:]
+
         if failing_test == "":
             # no failing test found yet
-            if re.search(new_checksums, line):
-                # failing test found, set failing test name
+            if re.search(new_checksums_marker, line):
+                # found a failing test – extract its name
                 failing_test = line[line.find("test_") : line.find(".json")]
                 json_file_string = ""
         else:
-            # extract and dump new checksums of failing test
-            json_file_string += line
-            if line.startswith("}"):  # end of new checksums
+            # accumulate JSON lines for the failing test
+            json_file_string += line + "\n"
+            if line.startswith("}"):  # end of new checksums block
                 json_file = json.loads(json_file_string)
                 json_filename = failing_test + ".json"
-                json_filepath = benchmark_path + json_filename
+                json_filepath = os.path.join(benchmark_path, json_filename)
                 print(f"\nDumping new checksums file {json_filename}:")
                 print(json_file_string)
                 with open(json_filepath, "w") as json_f:
                     json.dump(json_file, json_f, indent=2)
-                # reset to empty string to continue search of failing tests
+                updated.append(json_filename)
+                # reset to continue searching for more failing tests
                 failing_test = ""
+
+    return updated
+
+
+# ---------------------------------------------------------------------------
+# Automatic mode: fetch logs from Azure via GitHub PR number
+# ---------------------------------------------------------------------------
+
+
+def get_azure_build_info(pr_number, repo):
+    """Use ``gh`` to find the Azure Pipelines build URL for a PR.
+
+    Returns (org, project, build_id).
+    """
+    print(f"Fetching CI checks for PR #{pr_number} on {repo} ...")
+    result = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "checks",
+            str(pr_number),
+            "--repo",
+            repo,
+            "--json",
+            "name,state,link",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"Error running 'gh pr checks': {result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    checks = json.loads(result.stdout)
+
+    # Find the top-level BLAST-WarpX.CI check that links to the Azure build
+    azure_url = None
+    for check in checks:
+        details_url = check.get("link", "")
+        if check["name"] == "BLAST-WarpX.CI" and "dev.azure.com" in details_url:
+            azure_url = details_url
+            break
+
+    if azure_url is None:
+        print(
+            "Could not find an Azure Pipelines build URL in the PR checks.\n"
+            "Make sure the CI has run and that 'BLAST-WarpX.CI' appears in the checks.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Parse https://dev.azure.com/{org}/{project}/_build/results?buildId={id}
+    m = re.match(
+        r"https://dev\.azure\.com/([^/]+)/([^/]+)/_build/results\?buildId=(\d+)",
+        azure_url,
+    )
+    if not m:
+        print(f"Could not parse Azure build URL: {azure_url}", file=sys.stderr)
+        sys.exit(1)
+
+    org, project, build_id = m.group(1), m.group(2), m.group(3)
+    print(f"Found Azure build: org={org}, buildId={build_id}")
+    return org, project, build_id
+
+
+def get_failing_test_log_ids(org, project, build_id):
+    """Query the Azure DevOps build timeline and return log IDs for failing Test tasks.
+
+    Returns a list of (log_id, job_name) tuples.
+    """
+    url = (
+        f"https://dev.azure.com/{org}/{project}"
+        f"/_apis/build/builds/{build_id}/timeline?api-version=7.1"
+    )
+    print("Fetching build timeline from Azure ...")
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req) as resp:
+        timeline = json.loads(resp.read().decode())
+
+    records = timeline.get("records", [])
+
+    # Build a map from record id → name for parent look-ups
+    id_to_name = {r["id"]: r.get("name", "unknown") for r in records}
+
+    failing = []
+    for record in records:
+        if (
+            record.get("type") == "Task"
+            and record.get("name") == "Test"
+            and record.get("result") == "failed"
+            and record.get("log")
+        ):
+            log_id = record["log"]["id"]
+            parent_name = id_to_name.get(record.get("parentId", ""), "unknown")
+            print(f"  Failing Test task in job '{parent_name}', log ID: {log_id}")
+            failing.append((log_id, parent_name))
+
+    if not failing:
+        print("No failing Test tasks found in the Azure build timeline.")
+
+    return failing
+
+
+def download_azure_log(org, project, build_id, log_id):
+    """Download a raw log from Azure DevOps and return it as a string."""
+    url = (
+        f"https://dev.azure.com/{org}/{project}"
+        f"/_apis/build/builds/{build_id}/logs/{log_id}?api-version=7.1"
+    )
+    req = urllib.request.Request(url, headers={"Accept": "text/plain"})
+    with urllib.request.urlopen(req) as resp:
+        return resp.read().decode("utf-8", errors="replace")
+
+
+def process_pr(pr_number, repo):
+    """Fetch Azure logs for a PR and update all failing checksum benchmarks."""
+    org, project, build_id = get_azure_build_info(pr_number, repo)
+    failing_log_ids = get_failing_test_log_ids(org, project, build_id)
+
+    if not failing_log_ids:
+        print("No failing tests to update.")
+        return
+
+    all_updated = []
+    for log_id, job_name in failing_log_ids:
+        print(f"\nDownloading log for job '{job_name}' (log ID: {log_id}) ...")
+        log_text = download_azure_log(org, project, build_id, log_id)
+        updated = update_benchmarks_from_log_text(log_text)
+        all_updated.extend(updated)
+
+    if all_updated:
+        print(f"\nSuccessfully updated {len(all_updated)} checksum file(s):")
+        for f in all_updated:
+            print(f"  {f}")
+    else:
+        print("\nNo checksum files needed updating.")
+
+
+# ---------------------------------------------------------------------------
+# Legacy mode: process a downloaded Azure log file
+# ---------------------------------------------------------------------------
+
+
+def process_file(azure_output):
+    """Parse a manually downloaded Azure log file and update checksum benchmarks."""
+    with open(azure_output, "r") as f:
+        log_text = f.read()
+    update_benchmarks_from_log_text(log_text)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Update WarpX checksum benchmarks from Azure Pipelines output. "
+            "Either provide a GitHub PR number (automatic mode) or a path to "
+            "a raw Azure log file (legacy mode)."
+        )
+    )
+    parser.add_argument(
+        "--pr-number",
+        type=int,
+        metavar="PR",
+        help=(
+            "GitHub PR number. The script will automatically fetch the failing "
+            "Azure Pipelines logs and update the checksum benchmark files. "
+            "Requires the 'gh' CLI to be installed and authenticated."
+        ),
+    )
+    parser.add_argument(
+        "--repo",
+        default="BLAST-WarpX/warpx",
+        metavar="OWNER/REPO",
+        help="GitHub repository (default: BLAST-WarpX/warpx).",
+    )
+    parser.add_argument(
+        "azure_output",
+        nargs="?",
+        metavar="LOG_FILE",
+        help="Path to a raw Azure log text file (legacy mode).",
+    )
+
+    args = parser.parse_args()
+
+    if args.pr_number is not None and args.azure_output is not None:
+        parser.error("Provide either --pr-number or a log file path, not both.")
+
+    if args.pr_number is not None:
+        process_pr(args.pr_number, args.repo)
+    elif args.azure_output is not None:
+        process_file(args.azure_output)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/DevUtils/update_benchmarks_from_azure_output.py
+++ b/Tools/DevUtils/update_benchmarks_from_azure_output.py
@@ -5,20 +5,15 @@
 # License: BSD-3-Clause-LBNL
 
 """
-This Python script updates the Azure benchmarks automatically.
+This Python script updates the Azure benchmarks automatically using a GitHub
+PR number.  It fetches the failing Azure Pipelines logs and updates the
+checksum benchmark JSON files.
 
-It can be run in two ways:
+Usage::
 
-1. Automatic mode (recommended): pass a GitHub PR number, and the script
-   fetches the failing Azure Pipelines logs automatically.
+    python update_benchmarks_from_azure_output.py --pr-number 1234
 
-       python update_benchmarks_from_azure_output.py --pr-number 1234
-
-   The ``gh`` CLI must be installed and authenticated (available via conda base).
-
-2. Legacy mode: pass a raw Azure log text file downloaded manually.
-
-       python update_benchmarks_from_azure_output.py path/to/raw_log.txt
+The ``gh`` CLI must be installed and authenticated.
 """
 
 import argparse
@@ -92,11 +87,6 @@ def update_benchmarks_from_log_text(log_text):
                 failing_test = ""
 
     return updated
-
-
-# ---------------------------------------------------------------------------
-# Automatic mode: fetch logs from Azure via GitHub PR number
-# ---------------------------------------------------------------------------
 
 
 def get_azure_build_info(pr_number, repo):
@@ -204,9 +194,35 @@ def download_azure_log(org, project, build_id, log_id):
         return resp.read().decode("utf-8", errors="replace")
 
 
-def process_pr(pr_number, repo):
-    """Fetch Azure logs for a PR and update all failing checksum benchmarks."""
-    org, project, build_id = get_azure_build_info(pr_number, repo)
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Update WarpX checksum benchmarks from Azure Pipelines output. "
+            "Fetches failing test logs for the given GitHub PR number and "
+            "updates the benchmark JSON files automatically."
+        )
+    )
+    parser.add_argument(
+        "--pr-number",
+        type=int,
+        required=True,
+        metavar="PR",
+        help=(
+            "GitHub PR number. The script will automatically fetch the failing "
+            "Azure Pipelines logs and update the checksum benchmark files. "
+            "Requires the 'gh' CLI to be installed and authenticated."
+        ),
+    )
+    parser.add_argument(
+        "--repo",
+        default="BLAST-WarpX/warpx",
+        metavar="OWNER/REPO",
+        help="GitHub repository (default: BLAST-WarpX/warpx).",
+    )
+
+    args = parser.parse_args()
+
+    org, project, build_id = get_azure_build_info(args.pr_number, args.repo)
     failing_log_ids = get_failing_test_log_ids(org, project, build_id)
 
     if not failing_log_ids:
@@ -226,68 +242,6 @@ def process_pr(pr_number, repo):
             print(f"  {f}")
     else:
         print("\nNo checksum files needed updating.")
-
-
-# ---------------------------------------------------------------------------
-# Legacy mode: process a downloaded Azure log file
-# ---------------------------------------------------------------------------
-
-
-def process_file(azure_output):
-    """Parse a manually downloaded Azure log file and update checksum benchmarks."""
-    with open(azure_output, "r") as f:
-        log_text = f.read()
-    update_benchmarks_from_log_text(log_text)
-
-
-# ---------------------------------------------------------------------------
-# Entry point
-# ---------------------------------------------------------------------------
-
-
-def main():
-    parser = argparse.ArgumentParser(
-        description=(
-            "Update WarpX checksum benchmarks from Azure Pipelines output. "
-            "Either provide a GitHub PR number (automatic mode) or a path to "
-            "a raw Azure log file (legacy mode)."
-        )
-    )
-    parser.add_argument(
-        "--pr-number",
-        type=int,
-        metavar="PR",
-        help=(
-            "GitHub PR number. The script will automatically fetch the failing "
-            "Azure Pipelines logs and update the checksum benchmark files. "
-            "Requires the 'gh' CLI to be installed and authenticated."
-        ),
-    )
-    parser.add_argument(
-        "--repo",
-        default="BLAST-WarpX/warpx",
-        metavar="OWNER/REPO",
-        help="GitHub repository (default: BLAST-WarpX/warpx).",
-    )
-    parser.add_argument(
-        "azure_output",
-        nargs="?",
-        metavar="LOG_FILE",
-        help="Path to a raw Azure log text file (legacy mode).",
-    )
-
-    args = parser.parse_args()
-
-    if args.pr_number is not None and args.azure_output is not None:
-        parser.error("Provide either --pr-number or a log file path, not both.")
-
-    if args.pr_number is not None:
-        process_pr(args.pr_number, args.repo)
-    elif args.azure_output is not None:
-        process_file(args.azure_output)
-    else:
-        parser.print_help()
-        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/Tools/DevUtils/update_benchmarks_from_azure_output.py
+++ b/Tools/DevUtils/update_benchmarks_from_azure_output.py
@@ -100,9 +100,7 @@ def check_gh_available():
         )
         sys.exit(1)
 
-    result = subprocess.run(
-        ["gh", "auth", "status"], capture_output=True, text=True
-    )
+    result = subprocess.run(["gh", "auth", "status"], capture_output=True, text=True)
     if result.returncode != 0:
         print(
             "Error: 'gh' is not authenticated.\n"

--- a/Tools/DevUtils/update_benchmarks_from_azure_output.py
+++ b/Tools/DevUtils/update_benchmarks_from_azure_output.py
@@ -95,7 +95,7 @@ def check_gh_available():
     if shutil.which("gh") is None:
         print(
             "Error: the 'gh' CLI is not installed or not on PATH.\n"
-            "Install it from https://cli.github.com/ and re-run this script.",
+            "Install it from https://cli.github.com/ or with `conda`, and re-run this script.",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/Tools/DevUtils/update_benchmarks_from_azure_output.py
+++ b/Tools/DevUtils/update_benchmarks_from_azure_output.py
@@ -20,6 +20,7 @@ import argparse
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import urllib.request
@@ -89,6 +90,29 @@ def update_benchmarks_from_log_text(log_text):
     return updated
 
 
+def check_gh_available():
+    """Verify that ``gh`` is installed and authenticated; exit with a helpful message if not."""
+    if shutil.which("gh") is None:
+        print(
+            "Error: the 'gh' CLI is not installed or not on PATH.\n"
+            "Install it from https://cli.github.com/ and re-run this script.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    result = subprocess.run(
+        ["gh", "auth", "status"], capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        print(
+            "Error: 'gh' is not authenticated.\n"
+            "Run 'gh auth login' to authenticate, then re-run this script.\n"
+            f"Details: {result.stderr.strip()}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
 def get_azure_build_info(pr_number, repo):
     """Use ``gh`` to find the Azure Pipelines build URL for a PR.
 
@@ -119,7 +143,9 @@ def get_azure_build_info(pr_number, repo):
     azure_url = None
     for check in checks:
         details_url = check.get("link", "")
-        if check["name"] == "BLAST-WarpX.CI" and "dev.azure.com" in details_url:
+        if check["name"] == "BLAST-WarpX.CI" and details_url.startswith(
+            "https://dev.azure.com/"
+        ):
             azure_url = details_url
             break
 
@@ -222,6 +248,7 @@ def main():
 
     args = parser.parse_args()
 
+    check_gh_available()
     org, project, build_id = get_azure_build_info(args.pr_number, args.repo)
     failing_log_ids = get_failing_test_log_ids(org, project, build_id)
 


### PR DESCRIPTION
## Summary

- Replaces the manual Azure log download workflow with a single command
- `update_benchmarks_from_azure_output.py` now accepts `--pr-number PR` and handles everything automatically: it uses the `gh` CLI to find the Azure Pipelines build for the PR, queries the Azure DevOps REST API for failing Test task log IDs, downloads each log, and updates all failing benchmark JSON files
- Updates `Docs/source/developers/how_to_test.rst` accordingly ; removes screenshots that were showing how to manually download the logs.

🤖 Code and PR description generated with Cursor.

## Usage

```bash
cd Tools/DevUtils
python update_benchmarks_from_azure_output.py --pr-number 1234
```

Requires the [`gh` CLI](https://cli.github.com/) to be installed and authenticated.

## Test plan

- [x] Tested with `--pr-number 6518` (PR with failing fusion checksum tests): correctly identified 3 failing jobs, downloaded logs, and updated 6 benchmark JSON files
- [x] Tested with `--pr-number 6619` (PR with all passing tests): correctly reported nothing to update