### PR TITLE
reduce expanded fusion collision type checking.

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.H
@@ -42,6 +42,10 @@ namespace BinaryCollisionUtils{
     CollisionType get_collision_type (const std::string& collision_name,
                                       MultiParticleContainer const * mypc);
 
+    bool is_two_product_fusion_type (const CollisionType collision_type);
+
+    bool is_two_product_fusion_type (const NuclearFusionType fusion_type);
+
     CollisionType nuclear_fusion_type_to_collision_type (NuclearFusionType fusion_type);
 
     /**

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.H
@@ -42,11 +42,54 @@ namespace BinaryCollisionUtils{
     CollisionType get_collision_type (const std::string& collision_name,
                                       MultiParticleContainer const * mypc);
 
-    bool is_two_product_fusion_type (const CollisionType collision_type);
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    CollisionType nuclear_fusion_type_to_collision_type (NuclearFusionType fusion_type)
+    {
+        CollisionType collision_type = CollisionType::Undefined;
+        if (fusion_type == NuclearFusionType::DeuteriumTritiumToNeutronHelium) {
+            collision_type = CollisionType::DeuteriumTritiumToNeutronHeliumFusion;
+        }
+        else if (fusion_type == NuclearFusionType::DeuteriumDeuteriumToProtonTritium) {
+            collision_type = CollisionType::DeuteriumDeuteriumToProtonTritiumFusion;
+        }
+        else if (fusion_type == NuclearFusionType::DeuteriumDeuteriumToNeutronHelium) {
+            collision_type = CollisionType::DeuteriumDeuteriumToNeutronHeliumFusion;
+        }
+        else if (fusion_type == NuclearFusionType::DeuteriumHeliumToProtonHelium) {
+            collision_type = CollisionType::DeuteriumHeliumToProtonHeliumFusion;
+        }
+        else if (fusion_type == NuclearFusionType::ProtonBoronToAlphas) {
+            collision_type = CollisionType::ProtonBoronToAlphasFusion;
+        }
+        else {
+            AMREX_IF_ON_HOST((
+                WARPX_ABORT_WITH_MESSAGE("Invalid nuclear fusion type");
+            ))
+        }
+        return collision_type;
+    }
 
-    bool is_two_product_fusion_type (const NuclearFusionType fusion_type);
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    bool is_two_product_fusion_type (const CollisionType collision_type)
+    {
+        if ((collision_type == CollisionType::DeuteriumTritiumToNeutronHeliumFusion) ||
+            (collision_type == CollisionType::DeuteriumDeuteriumToProtonTritiumFusion) ||
+            (collision_type == CollisionType::DeuteriumDeuteriumToNeutronHeliumFusion) ||
+            (collision_type == CollisionType::DeuteriumHeliumToProtonHeliumFusion))
+        {
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
 
-    CollisionType nuclear_fusion_type_to_collision_type (NuclearFusionType fusion_type);
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    bool is_two_product_fusion_type (const NuclearFusionType fusion_type)
+    {
+        CollisionType collision_type = nuclear_fusion_type_to_collision_type(fusion_type);
+        return is_two_product_fusion_type(collision_type);
+    }
 
     /**
      * \brief Return (relativistic) collision energy, collision speed and

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
@@ -182,45 +182,4 @@ namespace BinaryCollisionUtils{
                         species2.getSpeciesTypeName());
         return NuclearFusionType::Undefined;
     }
-
-    CollisionType nuclear_fusion_type_to_collision_type (const NuclearFusionType fusion_type)
-    {
-        if (fusion_type == NuclearFusionType::DeuteriumTritiumToNeutronHelium) {
-            return CollisionType::DeuteriumTritiumToNeutronHeliumFusion;
-        }
-        if (fusion_type == NuclearFusionType::DeuteriumDeuteriumToProtonTritium) {
-            return CollisionType::DeuteriumDeuteriumToProtonTritiumFusion;
-        }
-        if (fusion_type == NuclearFusionType::DeuteriumDeuteriumToNeutronHelium) {
-            return CollisionType::DeuteriumDeuteriumToNeutronHeliumFusion;
-        }
-        if (fusion_type == NuclearFusionType::DeuteriumHeliumToProtonHelium) {
-            return CollisionType::DeuteriumHeliumToProtonHeliumFusion;
-        }
-        if (fusion_type == NuclearFusionType::ProtonBoronToAlphas) {
-            return CollisionType::ProtonBoronToAlphasFusion;
-        }
-        WARPX_ABORT_WITH_MESSAGE("Invalid nuclear fusion type");
-        return CollisionType::Undefined;
-    }
-
-    bool is_two_product_fusion_type (const CollisionType collision_type)
-    {
-        if ((collision_type == CollisionType::DeuteriumTritiumToNeutronHeliumFusion) ||
-            (collision_type == CollisionType::DeuteriumDeuteriumToProtonTritiumFusion) ||
-            (collision_type == CollisionType::DeuteriumDeuteriumToNeutronHeliumFusion) ||
-            (collision_type == CollisionType::DeuteriumHeliumToProtonHeliumFusion))
-        {
-            return true;
-        }
-        else {
-            return false;
-        }
-    }
-
-    bool is_two_product_fusion_type (const NuclearFusionType fusion_type)
-    {
-        CollisionType collision_type = nuclear_fusion_type_to_collision_type(fusion_type);
-        return is_two_product_fusion_type(collision_type);
-    }
 }

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
@@ -203,4 +203,24 @@ namespace BinaryCollisionUtils{
         WARPX_ABORT_WITH_MESSAGE("Invalid nuclear fusion type");
         return CollisionType::Undefined;
     }
+
+    bool is_two_product_fusion_type (const CollisionType collision_type)
+    {
+        if ((collision_type == CollisionType::DeuteriumTritiumToNeutronHeliumFusion) ||
+            (collision_type == CollisionType::DeuteriumDeuteriumToProtonTritiumFusion) ||
+            (collision_type == CollisionType::DeuteriumDeuteriumToNeutronHeliumFusion) ||
+            (collision_type == CollisionType::DeuteriumHeliumToProtonHeliumFusion))
+        {
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
+
+    bool is_two_product_fusion_type (const NuclearFusionType fusion_type)
+    {
+        CollisionType collision_type = nuclear_fusion_type_to_collision_type(fusion_type);
+        return is_two_product_fusion_type(collision_type);
+    }
 }

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/SingleNuclearFusionEvent.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/SingleNuclearFusionEvent.H
@@ -83,9 +83,7 @@ void SingleNuclearFusionEvent (const amrex::ParticleReal& u1x, const amrex::Part
     {
         fusion_cross_section = ProtonBoronFusionCrossSection(E_coll);
     }
-    else if ((fusion_type == NuclearFusionType::DeuteriumTritiumToNeutronHelium)
-          || (fusion_type == NuclearFusionType::DeuteriumDeuteriumToProtonTritium)
-          || (fusion_type == NuclearFusionType::DeuteriumDeuteriumToNeutronHelium))
+    else if (BinaryCollisionUtils::is_two_product_fusion_type(fusion_type))
     {
         fusion_cross_section = BoschHaleFusionCrossSection(E_coll, fusion_type, m1, m2);
     }

--- a/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
@@ -206,9 +206,7 @@ public:
                                                         p_pair_indices_1[i], p_pair_indices_2[i],
                                                         product_start_index, m1, m2, engine);
                 }
-                else if ((t_collision_type == CollisionType::DeuteriumTritiumToNeutronHeliumFusion)
-                      || (t_collision_type == CollisionType::DeuteriumDeuteriumToProtonTritiumFusion)
-                      || (t_collision_type == CollisionType::DeuteriumDeuteriumToNeutronHeliumFusion))
+                else if (BinaryCollisionUtils::is_two_product_fusion_type(t_collision_type))
                 {
                     const amrex::ParticleReal mass_before = m1 + m2;
                     const amrex::ParticleReal mass_after = products_mass_data[0] + products_mass_data[1];

--- a/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.cpp
@@ -34,11 +34,9 @@ ParticleCreationFunc::ParticleCreationFunc (const std::string& collision_name,
         m_num_products_device.push_back(3);
 #endif
     }
-    else if ((m_collision_type == CollisionType::DeuteriumTritiumToNeutronHeliumFusion)
-             || (m_collision_type == CollisionType::DeuteriumDeuteriumToProtonTritiumFusion)
-             || (m_collision_type == CollisionType::DeuteriumDeuteriumToNeutronHeliumFusion)
-             || (m_collision_type == CollisionType::LinearBreitWheeler)
-             || (m_collision_type == CollisionType::LinearCompton))
+    else if ((BinaryCollisionUtils::is_two_product_fusion_type(m_collision_type))
+        || (m_collision_type == CollisionType::LinearBreitWheeler)
+        || (m_collision_type == CollisionType::LinearCompton))
     {
         m_num_product_species = 2;
         m_num_products_host.push_back(1);


### PR DESCRIPTION
This PR reduced the use of expanded logical conditions checking for a two-product fusion type. This should fix a bug since the D + He3 => He4 + p reaction was missing in three separate places.

For example, the following lines of code appear in several places in the code:
```
if ((t_collision_type == CollisionType::DeuteriumTritiumToNeutronHeliumFusion) ||
    (t_collision_type == CollisionType::DeuteriumDeuteriumToProtonTritiumFusion) ||
    (t_collision_type == CollisionType::DeuteriumDeuteriumToNeutronHeliumFusion))
{
    DoSomethingForTwoProductFusionType();
}
```

The issue is that these code blocks fail to capture the fact that there is a fourth two-product fusion type:
`CollisionType::DeuteriumHeliumToProtonHeliumFusion`. To minimize the chance of errors, the above is replaced with 
```
if (BinaryCollisionUtils::is_two_product_fusion_type(t_collision_type))
{
    DoSomethingForTwoProductFusionType();
}
```

This PR is a partial replacement to PR #6519 