### PR TITLE
check fusion energy on init.

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.H
@@ -39,6 +39,10 @@ namespace BinaryCollisionUtils{
     NuclearFusionType get_nuclear_fusion_type (const std::string& collision_name,
                                                MultiParticleContainer const * mypc);
 
+    void CheckFusionEnergy (const NuclearFusionType fusion_type,
+                            const amrex::ParticleReal mass_before,
+                            const amrex::ParticleReal mass_after);
+
     CollisionType get_collision_type (const std::string& collision_name,
                                       MultiParticleContainer const * mypc);
 

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
@@ -14,6 +14,8 @@
 #include <AMReX_Vector.H>
 
 #include <string>
+#include <sstream>
+#include <limits>
 
 #include "Utils/TextMsg.H"
 
@@ -101,14 +103,22 @@ namespace BinaryCollisionUtils{
     NuclearFusionType get_nuclear_fusion_type (const std::string& collision_name,
                                                MultiParticleContainer const * const mypc)
     {
+        using namespace amrex::literals;
+
         const amrex::ParmParse pp_collision_name(collision_name);
         amrex::Vector<std::string> species_names;
         pp_collision_name.getarr("species", species_names);
         auto& species1 = mypc->GetParticleContainerFromName(species_names[0]);
         auto& species2 = mypc->GetParticleContainerFromName(species_names[1]);
+
+        // Compute the total mass before and after collision to check the fusion energy
+        const amrex::ParticleReal mass_before = species1.getMass() + species2.getMass();
+        amrex::ParticleReal mass_after = 0.0_prt;
+
         amrex::Vector<std::string> product_species_name;
         pp_collision_name.getarr("product_species", product_species_name);
 
+        NuclearFusionType fusion_type = NuclearFusionType::Undefined;
         if ((species1.AmIA<PhysicalSpecies::hydrogen2>() && species2.AmIA<PhysicalSpecies::hydrogen3>())
             ||
             (species1.AmIA<PhysicalSpecies::hydrogen3>() && species2.AmIA<PhysicalSpecies::hydrogen2>())
@@ -119,12 +129,13 @@ namespace BinaryCollisionUtils{
                 "ERROR: Deuterium-tritium fusion must contain exactly two product species");
             auto& product_species1 = mypc->GetParticleContainerFromName(product_species_name[0]);
             auto& product_species2 = mypc->GetParticleContainerFromName(product_species_name[1]);
+            mass_after = product_species1.getMass() + product_species2.getMass();
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 (product_species1.AmIA<PhysicalSpecies::helium4>() && product_species2.AmIA<PhysicalSpecies::neutron>())
                 ||
                 (product_species1.AmIA<PhysicalSpecies::neutron>() && product_species2.AmIA<PhysicalSpecies::helium4>()),
                 "ERROR: Product species of deuterium-tritium fusion must be of type neutron and helium4");
-            return NuclearFusionType::DeuteriumTritiumToNeutronHelium;
+            fusion_type = NuclearFusionType::DeuteriumTritiumToNeutronHelium;
         }
         else if (species1.AmIA<PhysicalSpecies::hydrogen2>() && species2.AmIA<PhysicalSpecies::hydrogen2>())
         {
@@ -133,14 +144,15 @@ namespace BinaryCollisionUtils{
                 "ERROR: Deuterium-deuterium fusion must contain exactly two product species");
             auto& product_species1 = mypc->GetParticleContainerFromName(product_species_name[0]);
             auto& product_species2 = mypc->GetParticleContainerFromName(product_species_name[1]);
+            mass_after = product_species1.getMass() + product_species2.getMass();
             if (
                 (product_species1.AmIA<PhysicalSpecies::helium3>() && product_species2.AmIA<PhysicalSpecies::neutron>())
                 ||(product_species1.AmIA<PhysicalSpecies::neutron>() && product_species2.AmIA<PhysicalSpecies::helium3>())){
-                return NuclearFusionType::DeuteriumDeuteriumToNeutronHelium;
+                fusion_type = NuclearFusionType::DeuteriumDeuteriumToNeutronHelium;
             } else if (
                 (product_species1.AmIA<PhysicalSpecies::hydrogen3>() && product_species2.AmIA<PhysicalSpecies::proton>())
                 ||(product_species1.AmIA<PhysicalSpecies::proton>() && product_species2.AmIA<PhysicalSpecies::hydrogen3>())){
-                return NuclearFusionType::DeuteriumDeuteriumToProtonTritium;
+                fusion_type = NuclearFusionType::DeuteriumDeuteriumToProtonTritium;
             } else {
                 WARPX_ABORT_WITH_MESSAGE("ERROR: Product species of deuterium-deuterium fusion must be of type helium3 and neutron, or tritium/hydrogen3 and proton/hydrogen1");
             }
@@ -155,12 +167,13 @@ namespace BinaryCollisionUtils{
                 "ERROR: Deuterium-helium fusion must contain exactly two product species");
             auto& product_species1 = mypc->GetParticleContainerFromName(product_species_name[0]);
             auto& product_species2 = mypc->GetParticleContainerFromName(product_species_name[1]);
+            mass_after = product_species1.getMass() + product_species2.getMass();
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 (product_species1.AmIA<PhysicalSpecies::helium4>() && product_species2.AmIA<PhysicalSpecies::proton>())
                 ||
                 (product_species1.AmIA<PhysicalSpecies::proton>() && product_species2.AmIA<PhysicalSpecies::helium4>()),
                 "ERROR: Product species of deuterium-helium fusion must be of type proton/hydrogen1 and alpha/helium4");
-            return NuclearFusionType::DeuteriumHeliumToProtonHelium;
+            fusion_type = NuclearFusionType::DeuteriumHeliumToProtonHelium;
         }
         else if ((species1.AmIA<PhysicalSpecies::proton>() && species2.AmIA<PhysicalSpecies::boron11>())
             ||
@@ -171,15 +184,72 @@ namespace BinaryCollisionUtils{
                 product_species_name.size() == 1,
                 "ERROR: Proton-boron must contain exactly one product species");
             auto& product_species = mypc->GetParticleContainerFromName(product_species_name[0]);
+            mass_after = 3.0_prt*product_species.getMass();
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 product_species.AmIA<PhysicalSpecies::helium4>(),
                 "ERROR: Product species of proton-boron fusion must be of type helium4");
-            return NuclearFusionType::ProtonBoronToAlphas;
+            fusion_type = NuclearFusionType::ProtonBoronToAlphas;
         }
-        WARPX_ABORT_WITH_MESSAGE("Binary nuclear fusion not implemented between species " +
-                        species_names[0] + " of type " + species1.getSpeciesTypeName() +
-                        " and species " + species_names[1] + " of type " +
-                        species2.getSpeciesTypeName());
-        return NuclearFusionType::Undefined;
+        else {
+            WARPX_ABORT_WITH_MESSAGE("Binary nuclear fusion not implemented between species " +
+                            species_names[0] + " of type " + species1.getSpeciesTypeName() +
+                            " and species " + species_names[1] + " of type " +
+                            species2.getSpeciesTypeName());
+        }
+
+        CheckFusionEnergy(fusion_type, mass_before, mass_after);
+
+        return fusion_type;
+    }
+
+    void CheckFusionEnergy (const NuclearFusionType fusion_type,
+                            const amrex::ParticleReal mass_before,
+                            const amrex::ParticleReal mass_after)
+    {
+        // Compute the fusion energy
+        amrex::ParticleReal fusion_energy = (mass_before - mass_after)*PhysConst::c2;
+
+        // Verify that the fusion energy is close to what is exected
+        std::ostringstream error_msg;
+        amrex::ParticleReal expected_fusion_energy = 0.0_prt;
+        amrex::ParticleReal energy_error = std::numeric_limits<amrex::ParticleReal>::max();
+        const amrex::ParticleReal energy_tolerance = PhysConst::m_e * PhysConst::c2;
+        if (fusion_type == NuclearFusionType::DeuteriumTritiumToNeutronHelium) {
+            expected_fusion_energy = 17.58929696e6_prt * PhysConst::q_e;
+            energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
+            error_msg << "Fusion energy mismatch in D + T -> He4 + n\n";
+        }
+        if (fusion_type == NuclearFusionType::DeuteriumDeuteriumToProtonTritium) {
+            expected_fusion_energy = 4.032653948e6_prt * PhysConst::q_e;
+            energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
+            error_msg << "Fusion energy mismatch in D + D -> T + p\n";
+        }
+        if (fusion_type == NuclearFusionType::DeuteriumDeuteriumToNeutronHelium) {
+            expected_fusion_energy = 3.26891111e6_prt * PhysConst::q_e;
+            energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
+            error_msg << "Fusion energy mismatch in D + D -> He3 + n\n";
+        }
+        if (fusion_type == NuclearFusionType::DeuteriumHeliumToProtonHelium) {
+            expected_fusion_energy = 18.35303980e6_prt * PhysConst::q_e;
+            energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
+            error_msg << "Fusion energy mismatch in D + He3 -> He3 + p\n";
+        }
+        if (fusion_type == NuclearFusionType::ProtonBoronToAlphas) {
+            expected_fusion_energy = 8.68212502e6_prt * PhysConst::q_e;
+            energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
+            error_msg << "Fusion energy mismatch in p + B11 -> 3 He4\n";
+        }
+
+        error_msg << "  energy error [eV]           = " << energy_error / PhysConst::q_e << "\n"
+                  << "  energy tolerance [eV]       = " << energy_tolerance / PhysConst::q_e << "\n"
+                  << "  expected fusion energy [eV] = " << expected_fusion_energy / PhysConst::q_e << "\n"
+                  << "  computed fusion energy [eV] = " << fusion_energy / PhysConst::q_e<< "\n"
+                  << "Check that species masses are set correctly.";
+
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+            energy_error < energy_tolerance,
+            error_msg.str()
+        );
+
     }
 }

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
@@ -15,7 +15,6 @@
 
 #include <string>
 #include <sstream>
-#include <limits>
 
 #include "Utils/TextMsg.H"
 
@@ -210,39 +209,35 @@ namespace BinaryCollisionUtils{
         amrex::ParticleReal fusion_energy = (mass_before - mass_after)*PhysConst::c2;
 
         // The expected fusion energies are computed using fully ionized species mass
-        // computed as M = A*m_u - Z*m_e, with A the atomic mass numbers found in
+        // computed as M = A*m_u - Z*m_e, with the atomic mass numbers A found in
         // SpeciesPhysicalProperties.cpp
 
-        // Verify that the fusion energy is close to what is exected
+        // Verify that the fusion energy is close to what is expected
         std::ostringstream error_msg;
         amrex::ParticleReal expected_fusion_energy = 0.0_prt;
-        amrex::ParticleReal energy_error = std::numeric_limits<amrex::ParticleReal>::max();
         const amrex::ParticleReal energy_rel_tol = 0.01_prt;
         if (fusion_type == NuclearFusionType::DeuteriumTritiumToNeutronHelium) {
             expected_fusion_energy = 17.58929696e6_prt * PhysConst::q_e;
-            energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
             error_msg << "Fusion energy mismatch in D + T -> He4 + n\n";
         }
         if (fusion_type == NuclearFusionType::DeuteriumDeuteriumToProtonTritium) {
             expected_fusion_energy = 4.032653948e6_prt * PhysConst::q_e;
-            energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
             error_msg << "Fusion energy mismatch in D + D -> T + p\n";
         }
         if (fusion_type == NuclearFusionType::DeuteriumDeuteriumToNeutronHelium) {
             expected_fusion_energy = 3.26891111e6_prt * PhysConst::q_e;
-            energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
             error_msg << "Fusion energy mismatch in D + D -> He3 + n\n";
         }
         if (fusion_type == NuclearFusionType::DeuteriumHeliumToProtonHelium) {
             expected_fusion_energy = 18.35303980e6_prt * PhysConst::q_e;
-            energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
             error_msg << "Fusion energy mismatch in D + He3 -> He3 + p\n";
         }
         if (fusion_type == NuclearFusionType::ProtonBoronToAlphas) {
             expected_fusion_energy = 8.68212502e6_prt * PhysConst::q_e;
-            energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
             error_msg << "Fusion energy mismatch in p + B11 -> 3 He4\n";
         }
+
+        amrex::ParticleReal energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
 
         error_msg << "  energy error [eV]           = " << energy_error / PhysConst::q_e << "\n"
                   << "  energy tolerance (rel.)     = " << energy_rel_tol << "\n"

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
@@ -208,14 +208,12 @@ namespace BinaryCollisionUtils{
         // Compute the fusion energy
         amrex::ParticleReal fusion_energy = (mass_before - mass_after)*PhysConst::c2;
 
+        // Verify that the fusion energy is close to what is expected.
         // The expected fusion energies are computed using fully ionized species mass
         // computed as M = A*m_u - Z*m_e, with the atomic mass numbers A found in
         // SpeciesPhysicalProperties.cpp
-
-        // Verify that the fusion energy is close to what is expected
         std::ostringstream error_msg;
         amrex::ParticleReal expected_fusion_energy = 0.0_prt;
-        const amrex::ParticleReal energy_rel_tol = 0.01_prt;
         if (fusion_type == NuclearFusionType::DeuteriumTritiumToNeutronHelium) {
             expected_fusion_energy = 17.58929696e6_prt * PhysConst::q_e;
             error_msg << "Fusion energy mismatch in D + T -> He4 + n\n";
@@ -237,7 +235,8 @@ namespace BinaryCollisionUtils{
             error_msg << "Fusion energy mismatch in p + B11 -> 3 He4\n";
         }
 
-        amrex::ParticleReal energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
+        const amrex::ParticleReal energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
+        const amrex::ParticleReal energy_rel_tol = 0.01_prt;
 
         error_msg << "  energy error [eV]           = " << energy_error / PhysConst::q_e << "\n"
                   << "  energy tolerance (rel.)     = " << energy_rel_tol << "\n"

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
@@ -245,13 +245,13 @@ namespace BinaryCollisionUtils{
         }
 
         error_msg << "  energy error [eV]           = " << energy_error / PhysConst::q_e << "\n"
-                  << "  energy rel tolerance        = " << energy_rel_tolerance << "\n"
+                  << "  energy tolerance (rel.)     = " << energy_rel_tol << "\n"
                   << "  expected fusion energy [eV] = " << expected_fusion_energy / PhysConst::q_e << "\n"
                   << "  computed fusion energy [eV] = " << fusion_energy / PhysConst::q_e<< "\n"
                   << "Check that species masses are set correctly.";
 
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            energy_error < energy_rel_tolerance*expected_fusion_energy,
+            energy_error < energy_rel_tol*expected_fusion_energy,
             error_msg.str()
         );
 

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollisionUtils.cpp
@@ -209,11 +209,15 @@ namespace BinaryCollisionUtils{
         // Compute the fusion energy
         amrex::ParticleReal fusion_energy = (mass_before - mass_after)*PhysConst::c2;
 
+        // The expected fusion energies are computed using fully ionized species mass
+        // computed as M = A*m_u - Z*m_e, with A the atomic mass numbers found in
+        // SpeciesPhysicalProperties.cpp
+
         // Verify that the fusion energy is close to what is exected
         std::ostringstream error_msg;
         amrex::ParticleReal expected_fusion_energy = 0.0_prt;
         amrex::ParticleReal energy_error = std::numeric_limits<amrex::ParticleReal>::max();
-        const amrex::ParticleReal energy_tolerance = PhysConst::m_e * PhysConst::c2;
+        const amrex::ParticleReal energy_rel_tol = 0.01_prt;
         if (fusion_type == NuclearFusionType::DeuteriumTritiumToNeutronHelium) {
             expected_fusion_energy = 17.58929696e6_prt * PhysConst::q_e;
             energy_error = amrex::Math::abs(fusion_energy - expected_fusion_energy);
@@ -241,13 +245,13 @@ namespace BinaryCollisionUtils{
         }
 
         error_msg << "  energy error [eV]           = " << energy_error / PhysConst::q_e << "\n"
-                  << "  energy tolerance [eV]       = " << energy_tolerance / PhysConst::q_e << "\n"
+                  << "  energy rel tolerance        = " << energy_rel_tolerance << "\n"
                   << "  expected fusion energy [eV] = " << expected_fusion_energy / PhysConst::q_e << "\n"
                   << "  computed fusion energy [eV] = " << fusion_energy / PhysConst::q_e<< "\n"
                   << "Check that species masses are set correctly.";
 
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            energy_error < energy_tolerance,
+            energy_error < energy_rel_tolerance*expected_fusion_energy,
             error_msg.str()
         );
 


### PR DESCRIPTION
PR #6518 replaced the hard-wired fusion energy for two-product fusion reactions with a direct calculation based on the mass of the reactant and product species. Since the user has the ability to set the mass of any species (even when using a specific `species_type`), it is a good idea to check that the fusion energy computed based on the mass difference is close to the expected value for a given fusion reaction. This PR adds this check using a 1% relative tolerance.

When all species are ions with mass computed as M = A*m_u - Z*m_e with the atomic mass numbers A given in SpeciesPhysicalProperties.cpp, this results in the following reaction energies:
```
D + T   => He4 + n: Q = 17.58929696 MeV
D + D   => T + p:   Q = 4.032653948 MeV
D + D   => He3 + n: Q = 3.26891111 MeV
D + He3 => He4 + p: Q = 18.35303980 MeV
p + B11 => 3He4:    Q = 8.68212502 MeV
```
This PR is a partial replacement to PR https://github.com/BLAST-WarpX/warpx/pull/6519