### PR TITLE
[WIP] Add pressure tensor and heat flux diagnostics

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3093,8 +3093,11 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
 
 * ``<diag_name>.fields_to_plot`` (list of `strings`, optional)
     Fields written to output.
-    Possible scalar fields: ``part_per_cell`` ``rho`` ``phi`` ``F`` ``part_per_grid`` ``proc_num`` ``divE`` ``divB`` ``eb_covered`` ``rho_<species_name>`` and ``T_<species_name>``, where ``<species_name>`` must match the name of one of the available particle species.
+    Possible scalar fields: ``part_per_cell`` ``rho`` ``phi`` ``F`` ``part_per_grid`` ``proc_num`` ``divE`` ``divB`` ``eb_covered`` ``rho_<species_name>``, ``T_<species_name>``, ``P_<species_name>``, and ``Q_<species_name>``, where ``<species_name>`` must match the name of one of the available particle species.
     ``T_<species_name>`` is the temperature in eV.
+    ``P_<species_name>`` is the pressure tensor, output as 6 components (``Pxx``, ``Pxy``, ``Pxz``, ``Pyy``, ``Pyz``, ``Pzz``) in Pa.
+    The trace ``(Pxx + Pyy + Pzz) / 3`` equals ``n * k_B * T`` where ``n`` is the number density and ``T`` is the scalar temperature.
+    ``Q_<species_name>`` is the heat flux vector, output as 3 components (``Qx``, ``Qy``, ``Qz``) in W/m^2.
     ``eb_covered`` is a number between 0 and 1 that indicates the fraction of the cell that is covered by the embedded boundary.
     Note that ``phi`` will only be written out when ``do_electrostatic==labframe``.
     Also, note that for ``<diag_name>.diag_type = BackTransformed``, the only scalar field currently supported is ``rho``.

--- a/Examples/Tests/collision/inputs_test_3d_collision_xyz
+++ b/Examples/Tests/collision/inputs_test_3d_collision_xyz
@@ -76,7 +76,7 @@ collision3.ndt = 10
 diagnostics.diags_names = diag1 diag_parser_filter diag_uniform_filter diag_random_filter
 diag1.intervals = 10
 diag1.diag_type = Full
-diag1.fields_to_plot = Ex Ey Ez Bx By Bz T_electron T_ion
+diag1.fields_to_plot = Ex Ey Ez Bx By Bz T_electron T_ion Q_electron Q_ion
 
 ## diag_parser_filter is a diag used to test the particle filter function.
 diag_parser_filter.intervals = 150:150:

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -3764,6 +3764,12 @@ class FieldDiagnostic(picmistandard.PICMI_FieldDiagnostic, WarpXDiagnosticBase):
                 elif dataname.startswith("T_"):
                     # Adds T_species diagnostic
                     fields_to_plot.add(dataname)
+                elif dataname.startswith("P_"):
+                    # Adds P_species pressure tensor diagnostic (6 components)
+                    fields_to_plot.add(dataname)
+                elif dataname.startswith("Q_"):
+                    # Adds Q_species heat flux diagnostic (3 components)
+                    fields_to_plot.add(dataname)
                 elif any([dataname.startswith(tstr) for tstr in T_fields_list]):
                     fields_to_plot.add(dataname)
                 elif dataname == "dive":

--- a/Source/Diagnostics/ComputeDiagFunctors/CMakeLists.txt
+++ b/Source/Diagnostics/ComputeDiagFunctors/CMakeLists.txt
@@ -15,7 +15,9 @@ foreach(D IN LISTS WarpX_DIMS)
         BackTransformFunctor.cpp
         BackTransformParticleFunctor.cpp
         ParticleReductionFunctor.cpp
+        HeatFluxFunctor.cpp
         PhiFunctor.cpp
+        PressureTensorFunctor.cpp
         TemperatureFunctor.cpp
     )
 endforeach()

--- a/Source/Diagnostics/ComputeDiagFunctors/HeatFluxFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/HeatFluxFunctor.H
@@ -1,0 +1,42 @@
+#ifndef WARPX_HEATFLUXFUNCTOR_H_
+#define WARPX_HEATFLUXFUNCTOR_H_
+
+#include "ComputeDiagFunctor.H"
+
+#include <AMReX_BaseFwd.H>
+
+/**
+ * \brief Functor to calculate per-cell heat flux vector from particle data.
+ *
+ * Computes the 3 components of the heat flux vector
+ * Q_i = (n * mass / 2) * <|u - <u>|^2 * (u_i - <u_i>)>  [W/m^2]
+ * where u = gamma*v is the 4-velocity, n is the number density,
+ * and the average is weighted over macro-particles in each cell.
+ *
+ * Output components (in order): Qx, Qy, Qz
+ */
+class HeatFluxFunctor final : public ComputeDiagFunctor
+{
+public:
+    /** \brief Constructor
+     * \param[in] lev level of multifab
+     * \param[in] crse_ratio for interpolating field values from simulation MultiFabs
+                  to the output diagnostic MultiFab mf_dst
+     * \param[in] ispec index of the species over which to calculate the heat flux
+     * \param[in] ncomp Number of components (must be 3 for the heat flux vector)
+     */
+    HeatFluxFunctor(int lev, amrex::IntVect crse_ratio, int ispec, int ncomp=3);
+
+    /** \brief Compute the heat flux in each grid cell.
+     *
+     * \param[out] mf_dst output MultiFab where the result is written
+     * \param[in] dcomp first component of mf_dst in which cell-centered
+     *            data is stored
+     */
+    void operator()(amrex::MultiFab& mf_dst, int dcomp, int /*i_buffer=0*/) const override;
+private:
+    int m_lev; /**< level on which mf_src is defined */
+    int m_ispec; /**< index of species to average over */
+};
+
+#endif // WARPX_HEATFLUXFUNCTOR_H_

--- a/Source/Diagnostics/ComputeDiagFunctors/HeatFluxFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/HeatFluxFunctor.cpp
@@ -1,0 +1,38 @@
+#include "HeatFluxFunctor.H"
+
+#include "Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor.H"
+#include "Particles/MultiParticleContainer.H"
+#include "Particles/WarpXParticleContainer.H"
+#include "WarpX.H"
+
+#include <ablastr/coarsen/sample.H>
+
+#include <AMReX_BLassert.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_REAL.H>
+
+HeatFluxFunctor::HeatFluxFunctor (const int lev,
+        const amrex::IntVect crse_ratio, const int ispec, const int ncomp)
+    : ComputeDiagFunctor(ncomp, crse_ratio), m_lev(lev), m_ispec(ispec)
+{
+    // Heat flux has 3 components: Qx, Qy, Qz
+    AMREX_ALWAYS_ASSERT(ncomp == 3);
+}
+
+void
+HeatFluxFunctor::operator() (amrex::MultiFab& mf_dst, const int dcomp, const int /*i_buffer*/) const
+{
+    auto& warpx = WarpX::GetInstance();
+
+    auto& pc = warpx.GetPartContainer().GetParticleContainer(m_ispec);
+    amrex::Real const mass = pc.getMass();
+
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(mass > 0.,
+        "The heat flux diagnostic can not be calculated for a massless species.");
+
+    std::unique_ptr<amrex::MultiFab> heatflux = pc.GetAverageNGPHeatFlux(m_lev);
+
+    // Coarsen and interpolate all 3 components from heatflux to the output diagnostic MultiFab.
+    ablastr::coarsen::sample::Coarsen(mf_dst, *heatflux, dcomp, 0, nComp(), 0, m_crse_ratio);
+}

--- a/Source/Diagnostics/ComputeDiagFunctors/PressureTensorFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/PressureTensorFunctor.H
@@ -1,0 +1,42 @@
+#ifndef WARPX_PRESSURETENSORFUNCTOR_H_
+#define WARPX_PRESSURETENSORFUNCTOR_H_
+
+#include "ComputeDiagFunctor.H"
+
+#include <AMReX_BaseFwd.H>
+
+/**
+ * \brief Functor to calculate per-cell pressure tensor from particle data.
+ *
+ * Computes the 6 independent components of the symmetric pressure tensor
+ * P_ij = n * mass * <(u_i - <u_i>)(u_j - <u_j>)>  [Pa]
+ * where u = gamma*v is the 4-velocity, n is the number density,
+ * and the average is weighted over macro-particles in each cell.
+ *
+ * Output components (in order): Pxx, Pxy, Pxz, Pyy, Pyz, Pzz
+ */
+class PressureTensorFunctor final : public ComputeDiagFunctor
+{
+public:
+    /** \brief Constructor
+     * \param[in] lev level of multifab
+     * \param[in] crse_ratio for interpolating field values from simulation MultiFabs
+                  to the output diagnostic MultiFab mf_dst
+     * \param[in] ispec index of the species over which to calculate the pressure tensor
+     * \param[in] ncomp Number of components (must be 6 for the symmetric tensor)
+     */
+    PressureTensorFunctor(int lev, amrex::IntVect crse_ratio, int ispec, int ncomp=6);
+
+    /** \brief Compute the pressure tensor in each grid cell.
+     *
+     * \param[out] mf_dst output MultiFab where the result is written
+     * \param[in] dcomp first component of mf_dst in which cell-centered
+     *            data is stored
+     */
+    void operator()(amrex::MultiFab& mf_dst, int dcomp, int /*i_buffer=0*/) const override;
+private:
+    int m_lev; /**< level on which mf_src is defined */
+    int m_ispec; /**< index of species to average over */
+};
+
+#endif // WARPX_PRESSURETENSORFUNCTOR_H_

--- a/Source/Diagnostics/ComputeDiagFunctors/PressureTensorFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/PressureTensorFunctor.cpp
@@ -1,0 +1,39 @@
+
+#include "PressureTensorFunctor.H"
+
+#include "Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor.H"
+#include "Particles/MultiParticleContainer.H"
+#include "Particles/WarpXParticleContainer.H"
+#include "WarpX.H"
+
+#include <ablastr/coarsen/sample.H>
+
+#include <AMReX_BLassert.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_REAL.H>
+
+PressureTensorFunctor::PressureTensorFunctor (const int lev,
+        const amrex::IntVect crse_ratio, const int ispec, const int ncomp)
+    : ComputeDiagFunctor(ncomp, crse_ratio), m_lev(lev), m_ispec(ispec)
+{
+    // Pressure tensor has 6 independent components: xx, xy, xz, yy, yz, zz
+    AMREX_ALWAYS_ASSERT(ncomp == 6);
+}
+
+void
+PressureTensorFunctor::operator() (amrex::MultiFab& mf_dst, const int dcomp, const int /*i_buffer*/) const
+{
+    auto& warpx = WarpX::GetInstance();
+
+    auto& pc = warpx.GetPartContainer().GetParticleContainer(m_ispec);
+    amrex::Real const mass = pc.getMass();
+
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(mass > 0.,
+        "The pressure tensor diagnostic can not be calculated for a massless species.");
+
+    std::unique_ptr<amrex::MultiFab> ptensor = pc.GetAverageNGPPressureTensor(m_lev);
+
+    // Coarsen and interpolate all 6 components from ptensor to the output diagnostic MultiFab.
+    ablastr::coarsen::sample::Coarsen(mf_dst, *ptensor, dcomp, 0, nComp(), 0, m_crse_ratio);
+}

--- a/Source/Diagnostics/Diagnostics.H
+++ b/Source/Diagnostics/Diagnostics.H
@@ -326,6 +326,10 @@ protected:
     amrex::Vector<int> m_rho_per_species_index;
     /** Array of species indices that dump temperature per species */
     amrex::Vector<int> m_T_per_species_index;
+    /** Array of species indices that dump pressure tensor per species */
+    amrex::Vector<int> m_P_per_species_index;
+    /** Array of species indices that dump heat flux per species */
+    amrex::Vector<int> m_Q_per_species_index;
     /** Vector of particle buffer vectors for each snapshot */
     amrex::Vector< amrex::Vector<std::unique_ptr<PinnedMemoryParticleContainer> > > m_particles_buffer;
     /** Vector of pointers to functors to compute particle output per species*/

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -203,7 +203,58 @@ Diagnostics::BaseReadParameters ()
         m_varnames_fields.clear();
     }
 
-    m_varnames = m_varnames_fields;
+    // Expand multi-component diagnostic entries in m_varnames.
+    // m_varnames_fields retains single entries (one functor slot per diagnostic),
+    // while m_varnames expands them into individual component names.
+    // Also validate species names and store species indices.
+    {
+        amrex::Vector<std::string> expanded_varnames;
+        for (const auto& f : m_varnames_fields) {
+            if (f.rfind("P_", 0) == 0) {
+                // Pressure tensor: 6 components (Pxx, Pxy, Pxz, Pyy, Pyz, Pzz)
+                const std::string sp = f.substr(2);
+                bool species_name_is_wrong = true;
+                for (int i = 0, n = int(m_all_species_names.size()); i < n; i++) {
+                    if (sp == m_all_species_names[i]) {
+                        m_P_per_species_index.push_back(i);
+                        species_name_is_wrong = false;
+                    }
+                }
+                WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                    !species_name_is_wrong,
+                    "Input error: string " + f + " in " + m_diag_name
+                    + ".fields_to_plot does not match any species"
+                );
+                expanded_varnames.push_back("Pxx_" + sp);
+                expanded_varnames.push_back("Pxy_" + sp);
+                expanded_varnames.push_back("Pxz_" + sp);
+                expanded_varnames.push_back("Pyy_" + sp);
+                expanded_varnames.push_back("Pyz_" + sp);
+                expanded_varnames.push_back("Pzz_" + sp);
+            } else if (f.rfind("Q_", 0) == 0) {
+                // Heat flux: 3 components (Qx, Qy, Qz)
+                const std::string sp = f.substr(2);
+                bool species_name_is_wrong = true;
+                for (int i = 0, n = int(m_all_species_names.size()); i < n; i++) {
+                    if (sp == m_all_species_names[i]) {
+                        m_Q_per_species_index.push_back(i);
+                        species_name_is_wrong = false;
+                    }
+                }
+                WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                    !species_name_is_wrong,
+                    "Input error: string " + f + " in " + m_diag_name
+                    + ".fields_to_plot does not match any species"
+                );
+                expanded_varnames.push_back("Qx_" + sp);
+                expanded_varnames.push_back("Qy_" + sp);
+                expanded_varnames.push_back("Qz_" + sp);
+            } else {
+                expanded_varnames.push_back(f);
+            }
+        }
+        m_varnames = expanded_varnames;
+    }
     // Generate names of averaged particle fields and append to m_varnames
     for (const auto& fname : m_pfield_varnames) {
         for (const auto& sname : m_pfield_species) {

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -10,6 +10,8 @@
 #include "ComputeDiagFunctors/PartPerGridFunctor.H"
 #include "ComputeDiagFunctors/ParticleReductionFunctor.H"
 #include "ComputeDiagFunctors/PhiFunctor.H"
+#include "ComputeDiagFunctors/HeatFluxFunctor.H"
+#include "ComputeDiagFunctors/PressureTensorFunctor.H"
 #include "ComputeDiagFunctors/ProcessNumberFunctor.H"
 #include "ComputeDiagFunctors/TemperatureFunctor.H"
 #include "ComputeDiagFunctors/RhoFunctor.H"
@@ -386,6 +388,10 @@ FullDiagnostics::InitializeFieldFunctorsRZopenPMD (int lev)
     int i = 0;
     // Species index to loop over species that dump temperature per species
     int i_T_species = 0;
+    // Species index to loop over species that dump pressure tensor per species
+    int i_P_species = 0;
+    // Species index to loop over species that dump heat flux per species
+    int i_Q_species = 0;
     const int ncomp = ncomp_multimodefab;
     // This function is called multiple times, for different values of `lev`
     // but the `varnames` need only be updated once.
@@ -483,6 +489,31 @@ FullDiagnostics::InitializeFieldFunctorsRZopenPMD (int lev)
                 AddRZModesToOutputNames(std::string("T_") + m_all_species_names[m_T_per_species_index[i_T_species]], ncomp);
             }
             i_T_species++;
+        } else if ( m_varnames_fields[comp].rfind("P_", 0) == 0 ){
+            // Initialize pressure tensor functor to dump 6-component tensor per species
+            const std::string species_name = m_all_species_names[m_P_per_species_index[i_P_species]];
+            m_all_field_functors[lev][comp] = std::make_unique<PressureTensorFunctor>(lev, m_crse_ratio, m_P_per_species_index[i_P_species], 6);
+            if (update_varnames) {
+                // Pressure tensor is particle-based (no RZ modes); push 6 component names directly
+                m_varnames.push_back("Pxx_" + species_name);
+                m_varnames.push_back("Pxy_" + species_name);
+                m_varnames.push_back("Pxz_" + species_name);
+                m_varnames.push_back("Pyy_" + species_name);
+                m_varnames.push_back("Pyz_" + species_name);
+                m_varnames.push_back("Pzz_" + species_name);
+            }
+            i_P_species++;
+        } else if ( m_varnames_fields[comp].rfind("Q_", 0) == 0 ){
+            // Initialize heat flux functor to dump 3-component vector per species
+            const std::string species_name = m_all_species_names[m_Q_per_species_index[i_Q_species]];
+            m_all_field_functors[lev][comp] = std::make_unique<HeatFluxFunctor>(lev, m_crse_ratio, m_Q_per_species_index[i_Q_species], 3);
+            if (update_varnames) {
+                // Heat flux is particle-based (no RZ modes); push 3 component names directly
+                m_varnames.push_back("Qx_" + species_name);
+                m_varnames.push_back("Qy_" + species_name);
+                m_varnames.push_back("Qz_" + species_name);
+            }
+            i_Q_species++;
         } else if ( m_varnames_fields[comp] == "F" ){
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::F_fp, lev), lev, m_crse_ratio,
                                                         false, ncomp);
@@ -838,6 +869,12 @@ FullDiagnostics::InitializeFieldFunctors (int lev)
     // Species index to loop over species that dump temperature per species
     int i_T_species = 0;
 
+    // Species index to loop over species that dump pressure tensor per species
+    int i_P_species = 0;
+
+    // Species index to loop over species that dump heat flux per species
+    int i_Q_species = 0;
+
     const auto nvar = static_cast<int>(m_varnames_fields.size());
     const auto nspec = static_cast<int>(m_pfield_species.size());
     const auto ntot = static_cast<int>(nvar + m_pfield_varnames.size() * nspec);
@@ -858,22 +895,25 @@ FullDiagnostics::InitializeFieldFunctors (int lev)
 
     m_all_field_functors[lev].resize(ntot);
     // Fill vector of functors for all components except individual cylindrical modes.
+    // Note: matching uses m_varnames_fields[comp] (not m_varnames[comp]) because
+    // multi-component diagnostics like pressure tensor expand m_varnames but not
+    // m_varnames_fields, so the indices may differ.
     for (int comp=0; comp<nvar; comp++){
         for (int idir=0; idir < 3; idir++) {
-            if        ( m_varnames[comp] == "E"+field_names[idir] ){
+            if        ( m_varnames_fields[comp] == "E"+field_names[idir] ){
                 m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Efield_aux, Direction{idir}, lev), lev, m_crse_ratio);
-            } else if ( m_varnames[comp] == "B"+field_names[idir] ){
+            } else if ( m_varnames_fields[comp] == "B"+field_names[idir] ){
                 m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Bfield_aux, Direction{idir}, lev), lev, m_crse_ratio);
-            } else if ( m_varnames[comp] == "j"+field_names[idir] ){
+            } else if ( m_varnames_fields[comp] == "j"+field_names[idir] ){
                 m_all_field_functors[lev][comp] = std::make_unique<JFunctor>(idir, lev, m_crse_ratio, true, deposit_current);
                 deposit_current = false;
-            } else if ( m_varnames[comp] == "j"+field_names[idir]+"_displacement" ) {
+            } else if ( m_varnames_fields[comp] == "j"+field_names[idir]+"_displacement" ) {
                     m_all_field_functors[lev][comp] = std::make_unique<JdispFunctor>(idir, lev, m_crse_ratio, true);
-            } else if ( m_varnames[comp] == "A"+field_names[idir] ){
+            } else if ( m_varnames_fields[comp] == "A"+field_names[idir] ){
                 m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::vector_potential_fp_nodal, Direction{idir}, lev), lev, m_crse_ratio);
-            } else if ( m_varnames[comp].rfind("T"+field_names[idir]+"_", 0) == 0 ){
+            } else if ( m_varnames_fields[comp].rfind("T"+field_names[idir]+"_", 0) == 0 ){
                 // Remove component to get string to lookup in field register.
-                std::string T_arr_str = std::string(m_varnames[comp]);
+                std::string T_arr_str = std::string(m_varnames_fields[comp]);
                 T_arr_str.erase(T_arr_str.begin() + 1);
                 m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(T_arr_str, Direction{idir}, lev), lev, m_crse_ratio);
             }
@@ -881,39 +921,47 @@ FullDiagnostics::InitializeFieldFunctors (int lev)
         // Check if comp was found above
         if (m_all_field_functors[lev][comp]) {continue;}
 
-        if ( m_varnames[comp] == "rho" ){
+        if ( m_varnames_fields[comp] == "rho" ){
             // Initialize rho functor to dump total rho
             m_all_field_functors[lev][comp] = std::make_unique<RhoFunctor>(lev, m_crse_ratio, true);
-        } else if ( m_varnames[comp].rfind("rho_", 0) == 0 ){
+        } else if ( m_varnames_fields[comp].rfind("rho_", 0) == 0 ){
             // Initialize rho functor to dump rho per species
             m_all_field_functors[lev][comp] = std::make_unique<RhoFunctor>(lev, m_crse_ratio, true, m_rho_per_species_index[i]);
             i++;
-        } else if ( m_varnames[comp].rfind("T_", 0) == 0 ){
+        } else if ( m_varnames_fields[comp].rfind("T_", 0) == 0 ){
             // Initialize temperature functor to dump temperature per species
             m_all_field_functors[lev][comp] = std::make_unique<TemperatureFunctor>(lev, m_crse_ratio, m_T_per_species_index[i_T_species]);
             i_T_species++;
-        } else if ( m_varnames[comp] == "F" ){
+        } else if ( m_varnames_fields[comp].rfind("P_", 0) == 0 ){
+            // Initialize pressure tensor functor to dump 6-component tensor per species
+            m_all_field_functors[lev][comp] = std::make_unique<PressureTensorFunctor>(lev, m_crse_ratio, m_P_per_species_index[i_P_species], 6);
+            i_P_species++;
+        } else if ( m_varnames_fields[comp].rfind("Q_", 0) == 0 ){
+            // Initialize heat flux functor to dump 3-component vector per species
+            m_all_field_functors[lev][comp] = std::make_unique<HeatFluxFunctor>(lev, m_crse_ratio, m_Q_per_species_index[i_Q_species], 3);
+            i_Q_species++;
+        } else if ( m_varnames_fields[comp] == "F" ){
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::F_fp, lev), lev, m_crse_ratio);
-        } else if ( m_varnames[comp] == "G" ){
+        } else if ( m_varnames_fields[comp] == "G" ){
             m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::G_fp, lev), lev, m_crse_ratio);
-        } else if ( m_varnames[comp] == "phi" ){
+        } else if ( m_varnames_fields[comp] == "phi" ){
             m_all_field_functors[lev][comp] = std::make_unique<PhiFunctor>(lev, m_crse_ratio);
-        } else if ( m_varnames[comp] == "part_per_cell" ){
+        } else if ( m_varnames_fields[comp] == "part_per_cell" ){
             m_all_field_functors[lev][comp] = std::make_unique<PartPerCellFunctor>(nullptr, lev, m_crse_ratio);
-        } else if ( m_varnames[comp] == "part_per_grid" ){
+        } else if ( m_varnames_fields[comp] == "part_per_grid" ){
             m_all_field_functors[lev][comp] = std::make_unique<PartPerGridFunctor>(nullptr, lev, m_crse_ratio);
-        } else if ( m_varnames[comp] == "proc_num" ){
+        } else if ( m_varnames_fields[comp] == "proc_num" ){
             m_all_field_functors[lev][comp] = std::make_unique<ProcessNumberFunctor>(nullptr, lev, m_crse_ratio);
-        } else if ( m_varnames[comp] == "divB" ){
+        } else if ( m_varnames_fields[comp] == "divB" ){
             m_all_field_functors[lev][comp] = std::make_unique<DivBFunctor>(warpx.m_fields.get_alldirs(FieldType::Bfield_aux, lev), lev, m_crse_ratio);
-        } else if ( m_varnames[comp] == "divE" ){
+        } else if ( m_varnames_fields[comp] == "divE" ){
             m_all_field_functors[lev][comp] = std::make_unique<DivEFunctor>(warpx.m_fields.get_alldirs(FieldType::Efield_aux, lev), lev, m_crse_ratio);
-        } else if ( m_varnames[comp] == "eb_covered" ){
+        } else if ( m_varnames_fields[comp] == "eb_covered" ){
             m_all_field_functors[lev][comp] = std::make_unique<EBCoveredFunctor>(lev, m_crse_ratio);
         } else {
             WARPX_ABORT_WITH_MESSAGE(
-                "Error on component " + m_varnames[comp] + ": "
-                + m_varnames[comp] + " is not a known field output type for this geometry");
+                "Error on component " + m_varnames_fields[comp] + ": "
+                + m_varnames_fields[comp] + " is not a known field output type for this geometry");
         }
     }
     // Add functors for average particle data for each species

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -370,6 +370,12 @@ public:
     void DepositTotalNGPTemperature (amrex::MultiFab* temperature, const int lev);
     std::unique_ptr<amrex::MultiFab> GetAverageNGPTemperature (int lev);
 
+    void DepositNGPPressureTensor (amrex::MultiFab* ptensor, const int lev);
+    std::unique_ptr<amrex::MultiFab> GetAverageNGPPressureTensor (int lev);
+
+    void DepositNGPHeatFlux (amrex::MultiFab* heatflux, const int lev);
+    std::unique_ptr<amrex::MultiFab> GetAverageNGPHeatFlux (int lev);
+
     void DepositNumberDensity (amrex::MultiFab* number_density, const int lev);
     std::unique_ptr<amrex::MultiFab> GetNumberDensity (int lev);
 

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2033,6 +2033,268 @@ WarpXParticleContainer::GetAverageNGPTemperature (int lev)
     return temperature;
 }
 
+void
+WarpXParticleContainer::DepositNGPPressureTensor (amrex::MultiFab* ptensor, const int lev)
+{
+
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_mass > 0.,
+        "The pressure tensor can not be calculated for a massless species.");
+
+    // Temporary cell-centered, multi-component MultiFab for storing particle sums
+    // comp 0: sum(w), comp 1: sum(w*ux), comp 2: sum(w*uy), comp 3: sum(w*uz)
+    int const sum_comps = 4;
+    amrex::MultiFab sum_mf(ptensor->boxArray(), ptensor->DistributionMap(), sum_comps, ptensor->nGrowVect());
+    sum_mf.setVal(0., 0, sum_comps, sum_mf.nGrowVect());
+
+    // Pass 1: Calculate the average velocity <u> per cell
+    ParticleToMesh(*this, sum_mf, lev,
+            [=] AMREX_GPU_DEVICE (const WarpXParticleContainer::SuperParticleType& p,
+                amrex::Array4<amrex::Real> const& sum_array,
+                amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& plo,
+                amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi)
+            {
+                const auto [ii, jj, kk] = amrex::getParticleCell(p, plo, dxi).dim3();
+
+                amrex::ParticleReal const w  = p.rdata(PIdx::w);
+                amrex::ParticleReal const ux = p.rdata(PIdx::ux);
+                amrex::ParticleReal const uy = p.rdata(PIdx::uy);
+                amrex::ParticleReal const uz = p.rdata(PIdx::uz);
+                amrex::Gpu::Atomic::AddNoRet(&sum_array(ii, jj, kk, 0), (amrex::Real)(w));
+                amrex::Gpu::Atomic::AddNoRet(&sum_array(ii, jj, kk, 1), (amrex::Real)(w*ux));
+                amrex::Gpu::Atomic::AddNoRet(&sum_array(ii, jj, kk, 2), (amrex::Real)(w*uy));
+                amrex::Gpu::Atomic::AddNoRet(&sum_array(ii, jj, kk, 3), (amrex::Real)(w*uz));
+            });
+
+    // Divide by total weight to get mean velocities
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (amrex::MFIter mfi(sum_mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const amrex::Box& box = mfi.tilebox();
+        amrex::Array4<amrex::Real> const& sum_array = sum_mf.array(mfi);
+        amrex::ParallelFor(box,
+                [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    if (sum_array(i,j,k,0) > 0) {
+                        const amrex::Real invsum = 1._rt/sum_array(i,j,k,0);
+                        sum_array(i,j,k,1) *= invsum;
+                        sum_array(i,j,k,2) *= invsum;
+                        sum_array(i,j,k,3) *= invsum;
+                    }
+                });
+    }
+
+    // Pass 2: Calculate the 6 tensor components sum(w * du_i * du_j)
+    // ptensor has 6 components: xx, xy, xz, yy, yz, zz
+    const auto plo = Geom(lev).ProbLoArray();
+    const auto dxi = Geom(lev).InvCellSizeArray();
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
+    {
+        const long np = pti.numParticles();
+        auto& tile = pti.GetParticleTile();
+        auto ptd = tile.getParticleTileData();
+        amrex::ParticleReal* wp = pti.GetAttribs(PIdx::w).dataPtr();
+        amrex::ParticleReal* uxp = pti.GetAttribs(PIdx::ux).dataPtr();
+        amrex::ParticleReal* uyp = pti.GetAttribs(PIdx::uy).dataPtr();
+        amrex::ParticleReal* uzp = pti.GetAttribs(PIdx::uz).dataPtr();
+
+        amrex::Array4<amrex::Real> const& sum_array = sum_mf.array(pti);
+        amrex::Array4<amrex::Real> const& pt_array = ptensor->array(pti);
+
+        amrex::ParallelFor(np,
+            [=] AMREX_GPU_DEVICE (long ip) {
+                const auto p = WarpXParticleContainer::ParticleType(ptd, ip);
+                const auto [ii, jj, kk] = getParticleCell(p, plo, dxi).dim3();
+
+                const amrex::ParticleReal w  = wp[ip];
+                const amrex::ParticleReal dux = uxp[ip] - sum_array(ii, jj, kk, 1);
+                const amrex::ParticleReal duy = uyp[ip] - sum_array(ii, jj, kk, 2);
+                const amrex::ParticleReal duz = uzp[ip] - sum_array(ii, jj, kk, 3);
+
+                amrex::Gpu::Atomic::AddNoRet(&pt_array(ii, jj, kk, 0), (amrex::Real)(w*dux*dux)); // xx
+                amrex::Gpu::Atomic::AddNoRet(&pt_array(ii, jj, kk, 1), (amrex::Real)(w*dux*duy)); // xy
+                amrex::Gpu::Atomic::AddNoRet(&pt_array(ii, jj, kk, 2), (amrex::Real)(w*dux*duz)); // xz
+                amrex::Gpu::Atomic::AddNoRet(&pt_array(ii, jj, kk, 3), (amrex::Real)(w*duy*duy)); // yy
+                amrex::Gpu::Atomic::AddNoRet(&pt_array(ii, jj, kk, 4), (amrex::Real)(w*duy*duz)); // yz
+                amrex::Gpu::Atomic::AddNoRet(&pt_array(ii, jj, kk, 5), (amrex::Real)(w*duz*duz)); // zz
+            });
+    }
+
+    // Finalize: divide by cell volume and multiply by mass to get pressure in Pa
+    amrex::ParticleReal mass = m_mass;
+    const amrex::Real inv_cell_volume = 1._rt / (AMREX_D_TERM(
+        Geom(lev).CellSize(0),
+        * Geom(lev).CellSize(1),
+        * Geom(lev).CellSize(2)));
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (amrex::MFIter mfi(sum_mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const amrex::Box& box = mfi.tilebox();
+        amrex::Array4<amrex::Real> const& pt_array = ptensor->array(mfi);
+        amrex::ParallelFor(box,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                const amrex::Real factor = mass * inv_cell_volume;
+                for (int comp = 0; comp < 6; ++comp) {
+                    pt_array(i,j,k,comp) *= factor;
+                }
+            });
+    }
+
+}
+
+std::unique_ptr<amrex::MultiFab>
+WarpXParticleContainer::GetAverageNGPPressureTensor (int lev)
+{
+    auto const& ba = m_gdb->ParticleBoxArray(lev);
+    auto const& dm = m_gdb->DistributionMap(lev);
+
+    int const ncomps = 6;
+    int const ng = 0;
+    auto ptensor = std::make_unique<amrex::MultiFab>(ba, dm, ncomps, ng);
+    ptensor->setVal(0., 0, ncomps, ptensor->nGrowVect());
+
+    if (m_mass > 0.) {
+        DepositNGPPressureTensor(ptensor.get(), lev);
+    }
+
+    return ptensor;
+}
+
+void
+WarpXParticleContainer::DepositNGPHeatFlux (amrex::MultiFab* heatflux, const int lev)
+{
+
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_mass > 0.,
+        "The heat flux can not be calculated for a massless species.");
+
+    // Temporary cell-centered, multi-component MultiFab for storing particle sums
+    // comp 0: sum(w), comp 1: sum(w*ux), comp 2: sum(w*uy), comp 3: sum(w*uz)
+    int const sum_comps = 4;
+    amrex::MultiFab sum_mf(heatflux->boxArray(), heatflux->DistributionMap(), sum_comps, heatflux->nGrowVect());
+    sum_mf.setVal(0., 0, sum_comps, sum_mf.nGrowVect());
+
+    // Pass 1: Calculate the average velocity <u> per cell
+    ParticleToMesh(*this, sum_mf, lev,
+            [=] AMREX_GPU_DEVICE (const WarpXParticleContainer::SuperParticleType& p,
+                amrex::Array4<amrex::Real> const& sum_array,
+                amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& plo,
+                amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi)
+            {
+                const auto [ii, jj, kk] = amrex::getParticleCell(p, plo, dxi).dim3();
+
+                amrex::ParticleReal const w  = p.rdata(PIdx::w);
+                amrex::ParticleReal const ux = p.rdata(PIdx::ux);
+                amrex::ParticleReal const uy = p.rdata(PIdx::uy);
+                amrex::ParticleReal const uz = p.rdata(PIdx::uz);
+                amrex::Gpu::Atomic::AddNoRet(&sum_array(ii, jj, kk, 0), (amrex::Real)(w));
+                amrex::Gpu::Atomic::AddNoRet(&sum_array(ii, jj, kk, 1), (amrex::Real)(w*ux));
+                amrex::Gpu::Atomic::AddNoRet(&sum_array(ii, jj, kk, 2), (amrex::Real)(w*uy));
+                amrex::Gpu::Atomic::AddNoRet(&sum_array(ii, jj, kk, 3), (amrex::Real)(w*uz));
+            });
+
+    // Divide by total weight to get mean velocities
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (amrex::MFIter mfi(sum_mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const amrex::Box& box = mfi.tilebox();
+        amrex::Array4<amrex::Real> const& sum_array = sum_mf.array(mfi);
+        amrex::ParallelFor(box,
+                [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    if (sum_array(i,j,k,0) > 0) {
+                        const amrex::Real invsum = 1._rt/sum_array(i,j,k,0);
+                        sum_array(i,j,k,1) *= invsum;
+                        sum_array(i,j,k,2) *= invsum;
+                        sum_array(i,j,k,3) *= invsum;
+                    }
+                });
+    }
+
+    // Pass 2: Calculate the 3 heat flux components sum(w * |du|^2 * du_i)
+    // heatflux has 3 components: Qx, Qy, Qz
+    const auto plo = Geom(lev).ProbLoArray();
+    const auto dxi = Geom(lev).InvCellSizeArray();
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
+    {
+        const long np = pti.numParticles();
+        auto& tile = pti.GetParticleTile();
+        auto ptd = tile.getParticleTileData();
+        amrex::ParticleReal* wp = pti.GetAttribs(PIdx::w).dataPtr();
+        amrex::ParticleReal* uxp = pti.GetAttribs(PIdx::ux).dataPtr();
+        amrex::ParticleReal* uyp = pti.GetAttribs(PIdx::uy).dataPtr();
+        amrex::ParticleReal* uzp = pti.GetAttribs(PIdx::uz).dataPtr();
+
+        amrex::Array4<amrex::Real> const& sum_array = sum_mf.array(pti);
+        amrex::Array4<amrex::Real> const& hf_array = heatflux->array(pti);
+
+        amrex::ParallelFor(np,
+            [=] AMREX_GPU_DEVICE (long ip) {
+                const auto p = WarpXParticleContainer::ParticleType(ptd, ip);
+                const auto [ii, jj, kk] = getParticleCell(p, plo, dxi).dim3();
+
+                const amrex::ParticleReal w  = wp[ip];
+                const amrex::ParticleReal dux = uxp[ip] - sum_array(ii, jj, kk, 1);
+                const amrex::ParticleReal duy = uyp[ip] - sum_array(ii, jj, kk, 2);
+                const amrex::ParticleReal duz = uzp[ip] - sum_array(ii, jj, kk, 3);
+                const amrex::ParticleReal dusq = dux*dux + duy*duy + duz*duz;
+
+                amrex::Gpu::Atomic::AddNoRet(&hf_array(ii, jj, kk, 0), (amrex::Real)(w*dusq*dux)); // Qx
+                amrex::Gpu::Atomic::AddNoRet(&hf_array(ii, jj, kk, 1), (amrex::Real)(w*dusq*duy)); // Qy
+                amrex::Gpu::Atomic::AddNoRet(&hf_array(ii, jj, kk, 2), (amrex::Real)(w*dusq*duz)); // Qz
+            });
+    }
+
+    // Finalize: divide by cell volume and multiply by mass/2 to get heat flux in W/m^2
+    amrex::ParticleReal mass = m_mass;
+    const amrex::Real inv_cell_volume = 1._rt / (AMREX_D_TERM(
+        Geom(lev).CellSize(0),
+        * Geom(lev).CellSize(1),
+        * Geom(lev).CellSize(2)));
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (amrex::MFIter mfi(sum_mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const amrex::Box& box = mfi.tilebox();
+        amrex::Array4<amrex::Real> const& hf_array = heatflux->array(mfi);
+        amrex::ParallelFor(box,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                const amrex::Real factor = mass * inv_cell_volume / 2._rt;
+                for (int comp = 0; comp < 3; ++comp) {
+                    hf_array(i,j,k,comp) *= factor;
+                }
+            });
+    }
+
+}
+
+std::unique_ptr<amrex::MultiFab>
+WarpXParticleContainer::GetAverageNGPHeatFlux (int lev)
+{
+    auto const& ba = m_gdb->ParticleBoxArray(lev);
+    auto const& dm = m_gdb->DistributionMap(lev);
+
+    int const ncomps = 3;
+    int const ng = 0;
+    auto heatflux = std::make_unique<amrex::MultiFab>(ba, dm, ncomps, ng);
+    heatflux->setVal(0., 0, ncomps, heatflux->nGrowVect());
+
+    if (m_mass > 0.) {
+        DepositNGPHeatFlux(heatflux.get(), lev);
+    }
+
+    return heatflux;
+}
+
 /* \brief Calculate number density from the particles
  * \param number_density Full array of number density
  * \param lev         Level of box that contains particles

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2125,20 +2125,36 @@ WarpXParticleContainer::DepositNGPPressureTensor (amrex::MultiFab* ptensor, cons
 
     // Finalize: divide by cell volume and multiply by mass to get pressure in Pa
     amrex::ParticleReal mass = m_mass;
-    const amrex::Real inv_cell_volume = 1._rt / (AMREX_D_TERM(
-        Geom(lev).CellSize(0),
-        * Geom(lev).CellSize(1),
-        * Geom(lev).CellSize(2)));
+    auto const dV = AMREX_D_TERM(Geom(lev).CellSize(0), *Geom(lev).CellSize(1), *Geom(lev).CellSize(2));
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (amrex::MFIter mfi(sum_mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
         const amrex::Box& box = mfi.tilebox();
+
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+        int const box_lo_r = box.smallEnd(0);
+        amrex::XDim3 const xyzmin = WarpX::LowerCorner(box, lev, 0._rt);
+        amrex::Real const rmin = xyzmin.x;
+        amrex::Real const dr = Geom(lev).CellSize(0);
+#endif
+
         amrex::Array4<amrex::Real> const& pt_array = ptensor->array(mfi);
         amrex::ParallelFor(box,
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                const amrex::Real factor = mass * inv_cell_volume;
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
+                amrex::Real const r = rmin + (i - box_lo_r)*dr;
+                // This is (pi*(r+dr)**2 - pi*r**2)/dr
+                amrex::Real const volume_factor = MathConst::pi*(2.0_rt*r + dr);
+#elif defined(WARPX_DIM_RSPHERE)
+                amrex::Real const r = rmin + (i - box_lo_r)*dr;
+                amrex::Real const r_cell = r + 0.5_rt*dr;
+                amrex::Real const volume_factor = 4.0_rt*MathConst::pi*r_cell*r_cell;
+#else
+                amrex::Real constexpr volume_factor = 1._rt;
+#endif
+                const amrex::Real factor = mass / (dV * volume_factor);
                 for (int comp = 0; comp < 6; ++comp) {
                     pt_array(i,j,k,comp) *= factor;
                 }
@@ -2255,20 +2271,36 @@ WarpXParticleContainer::DepositNGPHeatFlux (amrex::MultiFab* heatflux, const int
 
     // Finalize: divide by cell volume and multiply by mass/2 to get heat flux in W/m^2
     amrex::ParticleReal mass = m_mass;
-    const amrex::Real inv_cell_volume = 1._rt / (AMREX_D_TERM(
-        Geom(lev).CellSize(0),
-        * Geom(lev).CellSize(1),
-        * Geom(lev).CellSize(2)));
+    auto const dV = AMREX_D_TERM(Geom(lev).CellSize(0), *Geom(lev).CellSize(1), *Geom(lev).CellSize(2));
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (amrex::MFIter mfi(sum_mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
         const amrex::Box& box = mfi.tilebox();
+
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+        int const box_lo_r = box.smallEnd(0);
+        amrex::XDim3 const xyzmin = WarpX::LowerCorner(box, lev, 0._rt);
+        amrex::Real const rmin = xyzmin.x;
+        amrex::Real const dr = Geom(lev).CellSize(0);
+#endif
+
         amrex::Array4<amrex::Real> const& hf_array = heatflux->array(mfi);
         amrex::ParallelFor(box,
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                const amrex::Real factor = mass * inv_cell_volume / 2._rt;
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
+                amrex::Real const r = rmin + (i - box_lo_r)*dr;
+                // This is (pi*(r+dr)**2 - pi*r**2)/dr
+                amrex::Real const volume_factor = MathConst::pi*(2.0_rt*r + dr);
+#elif defined(WARPX_DIM_RSPHERE)
+                amrex::Real const r = rmin + (i - box_lo_r)*dr;
+                amrex::Real const r_cell = r + 0.5_rt*dr;
+                amrex::Real const volume_factor = 4.0_rt*MathConst::pi*r_cell*r_cell;
+#else
+                amrex::Real constexpr volume_factor = 1._rt;
+#endif
+                const amrex::Real factor = mass / (dV * volume_factor) / 2._rt;
                 for (int comp = 0; comp < 3; ++comp) {
                     hf_array(i,j,k,comp) *= factor;
                 }


### PR DESCRIPTION
## Background & Design

This PR adds two new per-species cell-based diagnostics — **pressure tensor** (`P_<species>`) and **heat flux** (`Q_<species>`) — that extend the existing scalar temperature diagnostic (`T_<species>`). These quantities are useful for analyzing anisotropic heating, momentum transport, and non-equilibrium kinetic effects in plasma simulations.

### Physics
The pressure tensor components deposited in each cell are:

$$P_{ij} = \frac{m}{V_\text{cell}} \sum_p \left[ w_p (u_{i,p} - \bar{u}_i)(u_{j,p} - \bar{u}_j) \right] \quad [\text{Pa}]$$

The heat flux components are:

$$Q_i = \frac{m}{2 V_\text{cell}} \sum_p \left[ w_p |\mathbf{u}_p - \bar{\mathbf{u}}|^2 (u_{i,p} - \bar{u}_i) \right] \quad [\text{W/m}^2]$$

where $m$ is the species mass, $V_\text{cell}$ is the cell volume, $w_p$ is the macro-particle weight, $\mathbf{u} = \gamma \mathbf{v}$ is the 4-velocity, and $\bar{\mathbf{u}}$ is the weight-averaged mean velocity in the cell. The sums run over all particles deposited into each cell via NGP (nearest grid point).

The 6 independent components of the symmetric pressure tensor are output as `Pxx`, `Pxy`, `Pxz`, `Pyy`, `Pyz`, `Pzz`. By construction, the trace $(P_{xx} + P_{yy} + P_{zz})/3$ equals $n k_B T$, where $T$ is the scalar temperature diagnostic.





### Algorithm

Both diagnostics reuse the same robust two-pass approach introduced for `T_<species>`:

1. **Pass 1 (mean velocity):** NGP-deposit `sum(w)`, `sum(w·ux)`, `sum(w·uy)`, `sum(w·uz)` per cell, then normalize to get $\langle u \rangle$.
2. **Pass 2 (fluctuation moments):** Loop over particles again, computing $\delta u = u - \langle u \rangle$ per particle, and accumulate the appropriate products (`δu_i · δu_j` for pressure, `|δu|² · δu_i` for heat flux).

This two-step method avoids catastrophic cancellation when $\langle u \rangle \gg u_\text{rms}$ (the "large mean flow" regime), which would make a single-pass formula like $\langle u^2 \rangle - \langle u \rangle^2$ numerically unstable.

Currently the first pass is computed independently for each diagnostic that needs it (T, P, Q). Caching the shared mean-velocity MultiFab is a natural future optimization but is not included here.

### Multi-component output

Unlike the scalar `T_` and per-species `rho_` diagnostics (1 component each), `P_` produces 6 components and `Q_` produces 3. This required a change to how `m_varnames` is built in `Diagnostics::BaseReadParameters` — multi-component entries are expanded (e.g., `P_electron` → `Pxx_electron, Pxy_electron, ...`) so that `m_varnames` and `m_varnames_fields` can differ in length. The functor registration loop in `FullDiagnostics::InitializeFieldFunctors` was updated to index against `m_varnames_fields` rather than `m_varnames` to account for this.

### Status — Draft / Work in Progress

**This PR is a work in progress and we are seeking early feedback on the approach.**

Known limitations and open items:

- **Only tested in 3D Cartesian geometry.** The RZ/openPMD code path has the functor registration in place but has not been exercised. Other geometries (1D, 2D) have not been tested.
- **Occasional pathological cell values.** We are seeing sporadic extreme outlier values in individual cells for both pressure tensor and heat flux output. This likely occurs in cells with very few particles (1–2), where the variance estimate is poorly conditioned, but we have not yet root-caused it. A minimum particle count threshold or NaN/clamp guard may be appropriate.
- **No dedicated regression test.** The existing 3D collision test input was updated to include `Q_electron Q_ion`, but a proper CI test with checksum validation has not been added yet.
- **No caching of the first-pass mean velocity.** When T, P, and Q are all requested for the same species, the identical first pass runs three times. This is functionally correct but redundant.

Feedback welcome on any of the above, the API surface (`P_`/`Q_` naming convention), the multi-component expansion approach, or the physics definitions.