### PR TITLE
Make DSMC code more readable

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -45,13 +45,21 @@ public:
     SplitAndScatterFunc (const std::string& collision_name, MultiParticleContainer const * mypc);
 
     /**
-     * \brief Function that performs the particle scattering and injection due
-     * to binary collisions.
+     * \brief Function that performs binary collision between two macroparticles
+     *  (referred to as "reactant species" in the code below)
      *
-     * Product species are arranged in slots 0 through m_num_product_species-1.
-     * Slots 0 and 1 always correspond to the first and second reactant species, respectively. For reaction
-     * events that produce new species (ionization, charge exchange, two-product
-     * reaction), slots 2 and 3 hold the true output species.
+     * During a collision, new macroparticles can be created in different species,
+     * which are arranged in slots 0 through m_num_product_species-1.
+     *
+     * Slots 0 and 1 always correspond to the first and second reactant species, respectively.
+     * This is because, physically, some of the reacting particles can still be present after the collision
+     * (e.g., if the collision is elastic scattering), but with modified properties (e.g., modified momentum).
+     * In the code, this is handled by creating *new* macroparticles in the reactant species, whose weight
+     * is subtracted from the reacting macroparticles.
+     * (This approach is used because the two reactant macroparticles may have different weights.)
+     *
+     * For collisions that, physically, produce new particles (e.g., ionization, charge exchange, two-product
+     * reaction), slots 2 and 3 hold the true product species.
      *
      * @param[in]     n_total_pairs         total number of particle pairs across all cells.
      * @param[in,out] ptile0                particle tile for the first reactant species (slot 0);

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -48,7 +48,42 @@ public:
      * \brief Function that performs the particle scattering and injection due
      * to binary collisions.
      *
-     * \return num_added the number of particles added to each species.
+     * Product species are arranged in slots 0 through m_num_product_species-1.
+     * Slots 0 and 1 always correspond to the two reactant species. For reaction
+     * events that produce new species (ionization, charge exchange, two-product
+     * reaction), slots 2 and 3 hold the true output species.
+     *
+     * @param[in]     n_total_pairs         total number of particle pairs across all cells.
+     * @param[in,out] ptile1                particle tile for reactant species occupying slot 0;
+     *                                      weights may be reduced by the collision.
+     * @param[in,out] ptile2                particle tile for reactant species occupying slot 1;
+     *                                      weights may be reduced by the collision.
+     * @param[in]     pc_products           pointers to all product species containers
+     *                                      (size m_num_product_species); used for mass queries
+     *                                      and runtime attribute initialization.
+     * @param[in,out] tile_products         array of pointers to product particle tiles
+     *                                      (size m_num_product_species); new particles are
+     *                                      appended to each tile.
+     * @param[in]     m0                    rest mass of reactant species in slot 0.
+     * @param[in]     m1                    rest mass of reactant species in slot 1.
+     * @param[in]     mask                  per-pair collision type: 0 = no collision,
+     *                                      otherwise cast of ScatteringProcessType to int.
+     * @param[in,out] products_np           on input: current particle count of each product
+     *                                      tile; updated to the pre-addition count so that
+     *                                      newly added particles can be correctly addressed
+     *                                      even when the same container appears in multiple
+     *                                      slots (e.g. e- + H -> 2 e- + H+).
+     * @param[in]     copy_species1         array of SmartCopy functors (size m_num_product_species);
+     *                                      copy_species1[k] copies a particle FROM reactant
+     *                                      species in slot 0 INTO product slot k.
+     * @param[in]     copy_species2         same as copy_species1 but copies FROM reactant
+     *                                      species in slot 1.
+     * @param[in]     p_pair_indices_1      per-pair index of the reactant species (slot 0) particle.
+     * @param[in]     p_pair_indices_2      per-pair index of the reactant species (slot 1) particle.
+     * @param[in]     p_pair_reaction_weight per-pair weight assigned to newly created product
+     *                                      particles; also the amount subtracted from the
+     *                                      colliding macroparticle weights.
+     * \return num_added                    number of particles added to each product slot.
      */
     AMREX_INLINE
     amrex::Vector<int> operator() (
@@ -56,7 +91,7 @@ public:
         ParticleTileType& ptile1, ParticleTileType& ptile2,
         const amrex::Vector<WarpXParticleContainer*>& pc_products,
         ParticleTileType** AMREX_RESTRICT tile_products,
-        const amrex::ParticleReal m1, const amrex::ParticleReal m2,
+        const amrex::ParticleReal m0, const amrex::ParticleReal m1,
         const amrex::Vector<amrex::ParticleReal>& /*products_mass*/,
         const index_type* AMREX_RESTRICT mask,
         amrex::Vector<index_type>& products_np,
@@ -69,6 +104,21 @@ public:
     {
         using namespace amrex::literals;
 
+        // Product species slot layout (m_num_product_species slots total):
+        //   Slot 0: copy of reactant species 1, i.e. the species from ptile1 (always present)
+        //   Slot 1: copy of reactant species 2, i.e. the species from ptile2 (always present)
+        //   Slot 2: first true output species   (only when m_num_product_species == 4)
+        //   Slot 3: second true output species  (only when m_num_product_species == 4)
+        //
+        // For non-reaction events (elastic, back, forward scattering), only slots 0 and 1
+        // receive new particles: one weight-split copy per reactant per colliding pair.
+        // These are counted by `no_product_total` and NOT reflected in `m_num_products_host`.
+        //
+        // For reaction events (ionization, two-product reaction, charge exchange), slots 2
+        // and 3 receive one new particle per event. For ionization, slot 0 also receives one
+        // particle (the surviving incident species copy). These counts are stored in
+        // `m_num_products_host[i]` and multiplied by `with_product_total` to get the totals.
+
         // Return a vector of zeros, indicating that for all the "product" species
         // there were no new particles added.
         if (n_total_pairs == 0) { return amrex::Vector<int>(m_num_product_species, 0); }
@@ -80,7 +130,6 @@ public:
         // have values >1
         amrex::Gpu::DeviceVector<index_type> no_product_offsets(n_total_pairs);
         index_type* AMREX_RESTRICT no_product_offsets_data = no_product_offsets.data();
-        const index_type* AMREX_RESTRICT no_product_p_offsets = no_product_offsets.dataPtr();
         auto const no_product_total = amrex::Scan::PrefixSum<index_type>(n_total_pairs,
             [=] AMREX_GPU_DEVICE (index_type i) -> index_type {
                 return ((mask[i] > 0) &
@@ -108,7 +157,6 @@ public:
         // have values >1
         amrex::Gpu::DeviceVector<index_type> with_product_offsets(n_total_pairs);
         index_type* AMREX_RESTRICT with_product_offsets_data = with_product_offsets.data();
-        const index_type* AMREX_RESTRICT with_product_p_offsets = with_product_offsets.dataPtr();
         auto const with_product_total = amrex::Scan::PrefixSum<index_type>(n_total_pairs,
             [=] AMREX_GPU_DEVICE (index_type i) -> index_type {
                 return ((mask[i] == int(ScatteringProcessType::IONIZATION)) |
@@ -138,8 +186,8 @@ public:
             tile_products[i]->resize(products_np[i] + num_added_vec[i]);
         }
 
-        const auto soa_1 = ptile1.getParticleTileData();
-        const auto soa_2 = ptile2.getParticleTileData();
+        const auto soa_0 = ptile1.getParticleTileData();
+        const auto soa_1 = ptile2.getParticleTileData();
 
         // Create necessary GPU vectors, that will be used in the kernel below
         amrex::Vector<SoaData_type> soa_products;
@@ -169,12 +217,12 @@ public:
         const int num_product_species = m_num_product_species;
         const auto reaction_energy = m_reaction_energy;
 
-        // Grab the masses of the reaction products
-        amrex::ParticleReal mass_product1 = 0;
-        amrex::ParticleReal mass_product2 = 0;
+        // Grab the masses of the true product species (slots 2 and 3)
+        amrex::ParticleReal mass_slot2 = 0;
+        amrex::ParticleReal mass_slot3 = 0;
         if (num_product_species > 2) {
-            mass_product1 = pc_products[2]->getMass();
-            mass_product2 = pc_products[3]->getMass();
+            mass_slot2 = pc_products[2]->getMass();
+            mass_slot3 = pc_products[3]->getMass();
         }
 
         // First perform all non-product producing collisions
@@ -183,27 +231,27 @@ public:
         {
             if ((mask[i] > 0) & (mask[i] != int(ScatteringProcessType::IONIZATION)) & (mask[i] != int(ScatteringProcessType::TWOPRODUCT_REACTION)))
             {
-                const auto product1_index = products_np_data[0] + no_product_p_offsets[i];
+                const auto slot0_idx = products_np_data[0] + no_product_offsets_data[i];
                 // Make a copy of the particle from species 1
-                copy_species1[0](soa_products_data[0], soa_1, static_cast<int>(p_pair_indices_1[i]),
-                                static_cast<int>(product1_index), engine);
+                copy_species1[0](soa_products_data[0], soa_0, static_cast<int>(p_pair_indices_1[i]),
+                                static_cast<int>(slot0_idx), engine);
                 // Set the weight of the new particles to p_pair_reaction_weight[i]
-                soa_products_data[0].m_rdata[PIdx::w][product1_index] = p_pair_reaction_weight[i];
+                soa_products_data[0].m_rdata[PIdx::w][slot0_idx] = p_pair_reaction_weight[i];
 
-                const auto product2_index = products_np_data[1] + no_product_p_offsets[i];
+                const auto slot1_idx = products_np_data[1] + no_product_offsets_data[i];
                 // Make a copy of the particle from species 2
-                copy_species2[1](soa_products_data[1], soa_2, static_cast<int>(p_pair_indices_2[i]),
-                                static_cast<int>(product2_index), engine);
+                copy_species2[1](soa_products_data[1], soa_1, static_cast<int>(p_pair_indices_2[i]),
+                                static_cast<int>(slot1_idx), engine);
                 // Set the weight of the new particles to p_pair_reaction_weight[i]
-                soa_products_data[1].m_rdata[PIdx::w][product2_index] = p_pair_reaction_weight[i];
+                soa_products_data[1].m_rdata[PIdx::w][slot1_idx] = p_pair_reaction_weight[i];
 
                 // Set the child particle properties appropriately
-                auto& ux1 = soa_products_data[0].m_rdata[PIdx::ux][product1_index];
-                auto& uy1 = soa_products_data[0].m_rdata[PIdx::uy][product1_index];
-                auto& uz1 = soa_products_data[0].m_rdata[PIdx::uz][product1_index];
-                auto& ux2 = soa_products_data[1].m_rdata[PIdx::ux][product2_index];
-                auto& uy2 = soa_products_data[1].m_rdata[PIdx::uy][product2_index];
-                auto& uz2 = soa_products_data[1].m_rdata[PIdx::uz][product2_index];
+                auto& ux0 = soa_products_data[0].m_rdata[PIdx::ux][slot0_idx];
+                auto& uy0 = soa_products_data[0].m_rdata[PIdx::uy][slot0_idx];
+                auto& uz0 = soa_products_data[0].m_rdata[PIdx::uz][slot0_idx];
+                auto& ux1 = soa_products_data[1].m_rdata[PIdx::ux][slot1_idx];
+                auto& uy1 = soa_products_data[1].m_rdata[PIdx::uy][slot1_idx];
+                auto& uz1 = soa_products_data[1].m_rdata[PIdx::uz][slot1_idx];
 
 #if (defined WARPX_DIM_RZ)
                 /* In RZ geometry, macroparticles can collide with other macroparticles
@@ -216,48 +264,48 @@ public:
                 * there is a corresponding assert statement at initialization.)
                 */
                 amrex::ParticleReal const theta = (
-                    soa_products_data[1].m_rdata[PIdx::theta][product2_index]
-                    - soa_products_data[0].m_rdata[PIdx::theta][product1_index]
+                    soa_products_data[1].m_rdata[PIdx::theta][slot1_idx]
+                    - soa_products_data[0].m_rdata[PIdx::theta][slot0_idx]
                 );
-                amrex::ParticleReal const ux1buf = ux1;
-                ux1 = ux1buf*std::cos(theta) - uy1*std::sin(theta);
-                uy1 = ux1buf*std::sin(theta) + uy1*std::cos(theta);
+                amrex::ParticleReal const ux0buf = ux0;
+                ux0 = ux0buf*std::cos(theta) - uy0*std::sin(theta);
+                uy0 = ux0buf*std::sin(theta) + uy0*std::cos(theta);
 #endif
 
                 // for simplicity (for now) we assume non-relativistic particles
                 // and simply calculate the center-of-momentum velocity from the
                 // rest masses
                 // TODO: this could be made relativistic by using TwoProductComputeProductMomenta
-                auto const uCOM_x = (m1 * ux1 + m2 * ux2) / (m1 + m2);
-                auto const uCOM_y = (m1 * uy1 + m2 * uy2) / (m1 + m2);
-                auto const uCOM_z = (m1 * uz1 + m2 * uz2) / (m1 + m2);
+                auto const uCOM_x = (m0 * ux0 + m1 * ux1) / (m0 + m1);
+                auto const uCOM_y = (m0 * uy0 + m1 * uy1) / (m0 + m1);
+                auto const uCOM_z = (m0 * uz0 + m1 * uz1) / (m0 + m1);
 
                 // transform to COM frame
+                ux0 -= uCOM_x;
+                uy0 -= uCOM_y;
+                uz0 -= uCOM_z;
                 ux1 -= uCOM_x;
                 uy1 -= uCOM_y;
                 uz1 -= uCOM_z;
-                ux2 -= uCOM_x;
-                uy2 -= uCOM_y;
-                uz2 -= uCOM_z;
 
                 if (mask[i] == int(ScatteringProcessType::ELASTIC)) {
                     // randomly rotate the velocity vector for the first particle
                     ParticleUtils::RandomizeVelocity(
-                        ux1, uy1, uz1, std::sqrt(ux1*ux1 + uy1*uy1 + uz1*uz1), engine
+                        ux0, uy0, uz0, std::sqrt(ux0*ux0 + uy0*uy0 + uz0*uz0), engine
                     );
                     // set the second particles velocity so that the total momentum
                     // is zero
-                    ux2 = -ux1 * m1 / m2;
-                    uy2 = -uy1 * m1 / m2;
-                    uz2 = -uz1 * m1 / m2;
+                    ux1 = -ux0 * m0 / m1;
+                    uy1 = -uy0 * m0 / m1;
+                    uz1 = -uz0 * m0 / m1;
                 } else if (mask[i] == int(ScatteringProcessType::BACK)) {
                     // reverse the velocity vectors of both particles
+                    ux0 *= -1.0_prt;
+                    uy0 *= -1.0_prt;
+                    uz0 *= -1.0_prt;
                     ux1 *= -1.0_prt;
                     uy1 *= -1.0_prt;
                     uz1 *= -1.0_prt;
-                    ux2 *= -1.0_prt;
-                    uy2 *= -1.0_prt;
-                    uz2 *= -1.0_prt;
                 } else if (mask[i] == int(ScatteringProcessType::FORWARD)) {
                     amrex::Abort("Forward scattering with DSMC not implemented yet.");
                 }
@@ -265,18 +313,18 @@ public:
                     amrex::Abort("Unknown scattering process.");
                 }
                 // transform back to labframe
+                ux0 += uCOM_x;
+                uy0 += uCOM_y;
+                uz0 += uCOM_z;
                 ux1 += uCOM_x;
                 uy1 += uCOM_y;
                 uz1 += uCOM_z;
-                ux2 += uCOM_x;
-                uy2 += uCOM_y;
-                uz2 += uCOM_z;
 
 #if (defined WARPX_DIM_RZ)
                 /* Undo the earlier velocity rotation. */
-                amrex::ParticleReal const ux1buf_new = ux1;
-                ux1 = ux1buf_new*std::cos(-theta) - uy1*std::sin(-theta);
-                uy1 = ux1buf_new*std::sin(-theta) + uy1*std::cos(-theta);
+                amrex::ParticleReal const ux0buf_new = ux0;
+                ux0 = ux0buf_new*std::cos(-theta) - uy0*std::sin(-theta);
+                uy0 = ux0buf_new*std::sin(-theta) + uy0*std::cos(-theta);
 #endif
             }
 
@@ -284,35 +332,35 @@ public:
             else if (mask[i] == int(ScatteringProcessType::TWOPRODUCT_REACTION))
             {
                 // create a copy of the first product species at the location of species 1
-                const auto reactant1_index = static_cast<int>(p_pair_indices_1[i]);
-                const auto product1_index = products_np_data[2] + with_product_p_offsets[i];
-                copy_species1[2](soa_products_data[2], soa_1, reactant1_index,
-                                static_cast<int>(product1_index), engine);
+                const auto src0_idx = static_cast<int>(p_pair_indices_1[i]);
+                const auto slot2_idx = products_np_data[2] + with_product_offsets_data[i];
+                copy_species1[2](soa_products_data[2], soa_0, src0_idx,
+                                static_cast<int>(slot2_idx), engine);
                 // Set the weight of the new particle to p_pair_reaction_weight[i]
-                soa_products_data[2].m_rdata[PIdx::w][product1_index] = p_pair_reaction_weight[i];
+                soa_products_data[2].m_rdata[PIdx::w][slot2_idx] = p_pair_reaction_weight[i];
 
                 // create a copy of the other product species at the location of species 2
-                const auto reactant2_index = static_cast<int>(p_pair_indices_2[i]);
-                const auto product2_index = products_np_data[3] + with_product_p_offsets[i];
-                copy_species2[3](soa_products_data[3], soa_2, reactant2_index,
-                                static_cast<int>(product2_index), engine);
+                const auto src1_idx = static_cast<int>(p_pair_indices_2[i]);
+                const auto slot3_idx = products_np_data[3] + with_product_offsets_data[i];
+                copy_species2[3](soa_products_data[3], soa_1, src1_idx,
+                                static_cast<int>(slot3_idx), engine);
                 // Set the weight of the new particle to p_pair_reaction_weight[i]
-                soa_products_data[3].m_rdata[PIdx::w][product2_index] = p_pair_reaction_weight[i];
+                soa_products_data[3].m_rdata[PIdx::w][slot3_idx] = p_pair_reaction_weight[i];
 
                 // Update the momenta of the products
                 TwoProductComputeProductMomenta(
-                    soa_1.m_rdata[PIdx::ux][reactant1_index],
-                    soa_1.m_rdata[PIdx::uy][reactant1_index],
-                    soa_1.m_rdata[PIdx::uz][reactant1_index], m1,
-                    soa_2.m_rdata[PIdx::ux][reactant2_index],
-                    soa_2.m_rdata[PIdx::uy][reactant2_index],
-                    soa_2.m_rdata[PIdx::uz][reactant2_index], m2,
-                    soa_products_data[2].m_rdata[PIdx::ux][product1_index],
-                    soa_products_data[2].m_rdata[PIdx::uy][product1_index],
-                    soa_products_data[2].m_rdata[PIdx::uz][product1_index], mass_product1,
-                    soa_products_data[3].m_rdata[PIdx::ux][product2_index],
-                    soa_products_data[3].m_rdata[PIdx::uy][product2_index],
-                    soa_products_data[3].m_rdata[PIdx::uz][product2_index], mass_product2,
+                    soa_0.m_rdata[PIdx::ux][src0_idx],
+                    soa_0.m_rdata[PIdx::uy][src0_idx],
+                    soa_0.m_rdata[PIdx::uz][src0_idx], m0,
+                    soa_1.m_rdata[PIdx::ux][src1_idx],
+                    soa_1.m_rdata[PIdx::uy][src1_idx],
+                    soa_1.m_rdata[PIdx::uz][src1_idx], m1,
+                    soa_products_data[2].m_rdata[PIdx::ux][slot2_idx],
+                    soa_products_data[2].m_rdata[PIdx::uy][slot2_idx],
+                    soa_products_data[2].m_rdata[PIdx::uz][slot2_idx], mass_slot2,
+                    soa_products_data[3].m_rdata[PIdx::ux][slot3_idx],
+                    soa_products_data[3].m_rdata[PIdx::uy][slot3_idx],
+                    soa_products_data[3].m_rdata[PIdx::uz][slot3_idx], mass_slot3,
                     -reaction_energy*PhysConst::q_e,
                     // TwoProductComputeProductMomenta expects the *released* energy here, hence the negative sign
                     // We also convert from eV to Joules
@@ -323,41 +371,41 @@ public:
             }
             else if (mask[i] == int(ScatteringProcessType::IONIZATION))
             {
-                const auto species1_index = products_np_data[0] + no_product_total + with_product_p_offsets[i];
-                // Make a copy of the particle from species 1
-                copy_species1[0](soa_products_data[0], soa_1, static_cast<int>(p_pair_indices_1[i]),
-                               static_cast<int>(species1_index), engine);
+                const auto slot0_idx = products_np_data[0] + no_product_total + with_product_offsets_data[i];
+                // Make a copy of the particle from species 1 (incident species, slot 0)
+                copy_species1[0](soa_products_data[0], soa_0, static_cast<int>(p_pair_indices_1[i]),
+                               static_cast<int>(slot0_idx), engine);
                 // Set the weight of the new particles to p_pair_reaction_weight[i]
-                soa_products_data[0].m_rdata[PIdx::w][species1_index] = p_pair_reaction_weight[i];
+                soa_products_data[0].m_rdata[PIdx::w][slot0_idx] = p_pair_reaction_weight[i];
 
                 // create a copy of the first product species at the location of species 2
-                // (species2 is the "target species", i.e. the species that is ionized)
-                const auto product1_index = products_np_data[2] + with_product_p_offsets[i];
-                copy_species2[2](soa_products_data[2], soa_2, static_cast<int>(p_pair_indices_2[i]),
-                                static_cast<int>(product1_index), engine);
+                // (species in slot 1 is the "target species", i.e. the species that is ionized)
+                const auto slot2_idx = products_np_data[2] + with_product_offsets_data[i];
+                copy_species2[2](soa_products_data[2], soa_1, static_cast<int>(p_pair_indices_2[i]),
+                                static_cast<int>(slot2_idx), engine);
                 // Set the weight of the new particle to p_pair_reaction_weight[i]
-                soa_products_data[2].m_rdata[PIdx::w][product1_index] = p_pair_reaction_weight[i];
+                soa_products_data[2].m_rdata[PIdx::w][slot2_idx] = p_pair_reaction_weight[i];
 
                 // create a copy of the other product species at the location of species 2
-                // (species2 is the "target species", i.e. the species that is ionized)
-                const auto product2_index = products_np_data[3] + with_product_p_offsets[i];
-                copy_species2[3](soa_products_data[3], soa_2, static_cast<int>(p_pair_indices_2[i]),
-                                static_cast<int>(product2_index), engine);
+                // (species in slot 1 is the "target species", i.e. the species that is ionized)
+                const auto slot3_idx = products_np_data[3] + with_product_offsets_data[i];
+                copy_species2[3](soa_products_data[3], soa_1, static_cast<int>(p_pair_indices_2[i]),
+                                static_cast<int>(slot3_idx), engine);
                 // Set the weight of the new particle to p_pair_reaction_weight[i]
-                soa_products_data[3].m_rdata[PIdx::w][product2_index] = p_pair_reaction_weight[i];
+                soa_products_data[3].m_rdata[PIdx::w][slot3_idx] = p_pair_reaction_weight[i];
 
                 // Grab the colliding particle velocities to calculate the COM
                 // Note that the two product particles currently have the same
                 // velocity as the "target" particle
-                auto& ux1 = soa_products_data[0].m_rdata[PIdx::ux][species1_index];
-                auto& uy1 = soa_products_data[0].m_rdata[PIdx::uy][species1_index];
-                auto& uz1 = soa_products_data[0].m_rdata[PIdx::uz][species1_index];
-                auto& ux_p1 = soa_products_data[2].m_rdata[PIdx::ux][product1_index];
-                auto& uy_p1 = soa_products_data[2].m_rdata[PIdx::uy][product1_index];
-                auto& uz_p1 = soa_products_data[2].m_rdata[PIdx::uz][product1_index];
-                auto& ux_p2 = soa_products_data[3].m_rdata[PIdx::ux][product2_index];
-                auto& uy_p2 = soa_products_data[3].m_rdata[PIdx::uy][product2_index];
-                auto& uz_p2 = soa_products_data[3].m_rdata[PIdx::uz][product2_index];
+                auto& ux0 = soa_products_data[0].m_rdata[PIdx::ux][slot0_idx];
+                auto& uy0 = soa_products_data[0].m_rdata[PIdx::uy][slot0_idx];
+                auto& uz0 = soa_products_data[0].m_rdata[PIdx::uz][slot0_idx];
+                auto& ux2 = soa_products_data[2].m_rdata[PIdx::ux][slot2_idx];
+                auto& uy2 = soa_products_data[2].m_rdata[PIdx::uy][slot2_idx];
+                auto& uz2 = soa_products_data[2].m_rdata[PIdx::uz][slot2_idx];
+                auto& ux3 = soa_products_data[3].m_rdata[PIdx::ux][slot3_idx];
+                auto& uy3 = soa_products_data[3].m_rdata[PIdx::uy][slot3_idx];
+                auto& uz3 = soa_products_data[3].m_rdata[PIdx::uz][slot3_idx];
 
 #if (defined WARPX_DIM_RZ)
                 /* In RZ geometry, macroparticles can collide with other macroparticles
@@ -370,38 +418,38 @@ public:
                 * there is a corresponding assert statement at initialization.)
                 */
                 amrex::ParticleReal const theta = (
-                    soa_products_data[2].m_rdata[PIdx::theta][product1_index]
-                    - soa_products_data[0].m_rdata[PIdx::theta][species1_index]
+                    soa_products_data[2].m_rdata[PIdx::theta][slot2_idx]
+                    - soa_products_data[0].m_rdata[PIdx::theta][slot0_idx]
                 );
-                amrex::ParticleReal const ux1buf = ux1;
-                ux1 = ux1buf*std::cos(theta) - uy1*std::sin(theta);
-                uy1 = ux1buf*std::sin(theta) + uy1*std::cos(theta);
+                amrex::ParticleReal const ux0buf = ux0;
+                ux0 = ux0buf*std::cos(theta) - uy0*std::sin(theta);
+                uy0 = ux0buf*std::sin(theta) + uy0*std::cos(theta);
 #endif
 
                 // for simplicity (for now) we assume non-relativistic particles
                 // and simply calculate the center-of-momentum velocity from the
                 // rest masses
-                auto const uCOM_x = (m1 * ux1 + m2 * ux_p2) / (m1 + m2);
-                auto const uCOM_y = (m1 * uy1 + m2 * uy_p2) / (m1 + m2);
-                auto const uCOM_z = (m1 * uz1 + m2 * uz_p2) / (m1 + m2);
+                auto const uCOM_x = (m0 * ux0 + m1 * ux3) / (m0 + m1);
+                auto const uCOM_y = (m0 * uy0 + m1 * uy3) / (m0 + m1);
+                auto const uCOM_z = (m0 * uz0 + m1 * uz3) / (m0 + m1);
 
                 // transform to COM frame
-                ux1 -= uCOM_x;
-                uy1 -= uCOM_y;
-                uz1 -= uCOM_z;
-                ux_p1 -= uCOM_x;
-                uy_p1 -= uCOM_y;
-                uz_p1 -= uCOM_z;
-                ux_p2 -= uCOM_x;
-                uy_p2 -= uCOM_y;
-                uz_p2 -= uCOM_z;
+                ux0 -= uCOM_x;
+                uy0 -= uCOM_y;
+                uz0 -= uCOM_z;
+                ux2 -= uCOM_x;
+                uy2 -= uCOM_y;
+                uz2 -= uCOM_z;
+                ux3 -= uCOM_x;
+                uy3 -= uCOM_y;
+                uz3 -= uCOM_z;
 
                 // calculate kinetic energy of the collision (in eV)
                 const amrex::ParticleReal E1 = (
-                    0.5_prt * m1 * (ux1*ux1 + uy1*uy1 + uz1*uz1) / PhysConst::q_e
+                    0.5_prt * m0 * (ux0*ux0 + uy0*uy0 + uz0*uz0) / PhysConst::q_e
                 );
                 const amrex::ParticleReal E2 = (
-                    0.5_prt * m2 * (ux_p2*ux_p2 + uy_p2*uy_p2 + uz_p2*uz_p2) / PhysConst::q_e
+                    0.5_prt * m1 * (ux3*ux3 + uy3*uy3 + uz3*uz3) / PhysConst::q_e
                 );
                 const amrex::ParticleReal E_coll = E1 + E2;
 
@@ -449,7 +497,7 @@ public:
 
                 // calculate the value of C
                 const double C = std::sqrt(E_out / (
-                    n_0*n_0 / (2.0 * m1) + n_1*n_1 / (2.0 * mass_product1) + n_2*n_2 / (2.0 * mass_product2)
+                    n_0*n_0 / (2.0 * m0) + n_1*n_1 / (2.0 * mass_slot2) + n_2*n_2 / (2.0 * mass_slot3)
                 ));
 
                 // Now that appropriate momenta are set for each outgoing species
@@ -472,34 +520,34 @@ public:
                 const double sin_phi = std::sin(phi);
 
                 // calculate the velocity components for each particle
-                ux1 = static_cast<amrex::ParticleReal>(C * n_0 / m1 * cos_theta * cos_phi);
-                uy1 = static_cast<amrex::ParticleReal>(C * n_0 / m1 * cos_theta * sin_phi);
-                uz1 = static_cast<amrex::ParticleReal>(-C * n_0 / m1 * sin_theta);
+                ux0 = static_cast<amrex::ParticleReal>(C * n_0 / m0 * cos_theta * cos_phi);
+                uy0 = static_cast<amrex::ParticleReal>(C * n_0 / m0 * cos_theta * sin_phi);
+                uz0 = static_cast<amrex::ParticleReal>(-C * n_0 / m0 * sin_theta);
 
-                ux_p1 = static_cast<amrex::ParticleReal>(C * n_1 / mass_product1 * (-cos_alpha * cos_theta * cos_phi - sin_alpha * sin_phi));
-                uy_p1 = static_cast<amrex::ParticleReal>(C * n_1 / mass_product1 * (-cos_alpha * cos_theta * sin_phi + sin_alpha * cos_phi));
-                uz_p1 = static_cast<amrex::ParticleReal>(C * n_1 / mass_product1 * (cos_alpha * sin_theta));
+                ux2 = static_cast<amrex::ParticleReal>(C * n_1 / mass_slot2 * (-cos_alpha * cos_theta * cos_phi - sin_alpha * sin_phi));
+                uy2 = static_cast<amrex::ParticleReal>(C * n_1 / mass_slot2 * (-cos_alpha * cos_theta * sin_phi + sin_alpha * cos_phi));
+                uz2 = static_cast<amrex::ParticleReal>(C * n_1 / mass_slot2 * (cos_alpha * sin_theta));
 
-                ux_p2 = static_cast<amrex::ParticleReal>(C * n_2 / mass_product2 * (-cos_gamma * cos_theta * cos_phi + sin_gamma * sin_phi));
-                uy_p2 = static_cast<amrex::ParticleReal>(C * n_2 / mass_product2 * (-cos_gamma * cos_theta * sin_phi - sin_gamma * cos_phi));
-                uz_p2 = static_cast<amrex::ParticleReal>(C * n_2 / mass_product2 * (cos_gamma * sin_theta));
+                ux3 = static_cast<amrex::ParticleReal>(C * n_2 / mass_slot3 * (-cos_gamma * cos_theta * cos_phi + sin_gamma * sin_phi));
+                uy3 = static_cast<amrex::ParticleReal>(C * n_2 / mass_slot3 * (-cos_gamma * cos_theta * sin_phi - sin_gamma * cos_phi));
+                uz3 = static_cast<amrex::ParticleReal>(C * n_2 / mass_slot3 * (cos_gamma * sin_theta));
 
                 // transform back to labframe
-                ux1 += uCOM_x;
-                uy1 += uCOM_y;
-                uz1 += uCOM_z;
-                ux_p1 += uCOM_x;
-                uy_p1 += uCOM_y;
-                uz_p1 += uCOM_z;
-                ux_p2 += uCOM_x;
-                uy_p2 += uCOM_y;
-                uz_p2 += uCOM_z;
+                ux0 += uCOM_x;
+                uy0 += uCOM_y;
+                uz0 += uCOM_z;
+                ux2 += uCOM_x;
+                uy2 += uCOM_y;
+                uz2 += uCOM_z;
+                ux3 += uCOM_x;
+                uy3 += uCOM_y;
+                uz3 += uCOM_z;
 
 #if (defined WARPX_DIM_RZ)
                 /* Undo the earlier velocity rotation. */
-                amrex::ParticleReal const ux1buf_new = ux1;
-                ux1 = ux1buf_new*std::cos(-theta) - uy1*std::sin(-theta);
-                uy1 = ux1buf_new*std::sin(-theta) + uy1*std::cos(-theta);
+                amrex::ParticleReal const ux0buf_new = ux0;
+                ux0 = ux0buf_new*std::cos(-theta) - uy0*std::sin(-theta);
+                uy0 = ux0buf_new*std::sin(-theta) + uy0*std::cos(-theta);
 #endif
             }
         });
@@ -522,8 +570,10 @@ private:
     int m_num_product_species;
     // If ionization collisions are included, what is the energy cost
     amrex::ParticleReal m_reaction_energy = 0.0;
-    // Vectors of size m_num_product_species storing how many particles of a given species are
-    // produced by a collision event.
+    // Vector of size m_num_product_species: for each product slot, the number of new particles
+    // created per *reaction* event (ionization, two-product reaction, charge exchange).
+    // Weight-split particles added to slots 0 and 1 during non-reaction events are NOT counted
+    // here; they are tracked separately via `no_product_total` inside operator().
     amrex::Gpu::HostVector<int> m_num_products_host;
     CollisionType m_collision_type;
 };

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -49,14 +49,14 @@ public:
      * to binary collisions.
      *
      * Product species are arranged in slots 0 through m_num_product_species-1.
-     * Slots 0 and 1 always correspond to the two reactant species. For reaction
+     * Slots 0 and 1 always correspond to the first and other reactant species, respectively. For reaction
      * events that produce new species (ionization, charge exchange, two-product
      * reaction), slots 2 and 3 hold the true output species.
      *
      * @param[in]     n_total_pairs         total number of particle pairs across all cells.
-     * @param[in,out] ptile1                particle tile for reactant species occupying slot 0;
+     * @param[in,out] ptile0                particle tile for the first reactant species (slot 0);
      *                                      weights may be reduced by the collision.
-     * @param[in,out] ptile2                particle tile for reactant species occupying slot 1;
+     * @param[in,out] ptile1                particle tile for the other reactant species (slot 1);
      *                                      weights may be reduced by the collision.
      * @param[in]     pc_products           pointers to all product species containers
      *                                      (size m_num_product_species); used for mass queries
@@ -64,8 +64,8 @@ public:
      * @param[in,out] tile_products         array of pointers to product particle tiles
      *                                      (size m_num_product_species); new particles are
      *                                      appended to each tile.
-     * @param[in]     m0                    rest mass of reactant species in slot 0.
-     * @param[in]     m1                    rest mass of reactant species in slot 1.
+     * @param[in]     m0                    rest mass of the first reactant species (slot 0).
+     * @param[in]     m1                    rest mass of the other reactant species (slot 1).
      * @param[in]     mask                  per-pair collision type: 0 = no collision,
      *                                      otherwise cast of ScatteringProcessType to int.
      * @param[in,out] products_np           on input: current particle count of each product
@@ -73,13 +73,13 @@ public:
      *                                      newly added particles can be correctly addressed
      *                                      even when the same container appears in multiple
      *                                      slots (e.g. e- + H -> 2 e- + H+).
-     * @param[in]     copy_species1         array of SmartCopy functors (size m_num_product_species);
-     *                                      copy_species1[k] copies a particle FROM reactant
-     *                                      species in slot 0 INTO product slot k.
-     * @param[in]     copy_species2         same as copy_species1 but copies FROM reactant
-     *                                      species in slot 1.
-     * @param[in]     p_pair_indices_1      per-pair index of the reactant species (slot 0) particle.
-     * @param[in]     p_pair_indices_2      per-pair index of the reactant species (slot 1) particle.
+     * @param[in]     copy_species0         array of SmartCopy functors (size m_num_product_species);
+     *                                      copy_species0[k] copies a particle FROM the first
+     *                                      reactant species (slot 0) INTO product slot k.
+     * @param[in]     copy_species1         same as copy_species0 but copies FROM the other
+     *                                      reactant species (slot 1).
+     * @param[in]     p_pair_indices_0      per-pair index of the first reactant species (slot 0) particle.
+     * @param[in]     p_pair_indices_1      per-pair index of the other reactant species (slot 1) particle.
      * @param[in]     p_pair_reaction_weight per-pair weight assigned to newly created product
      *                                      particles; also the amount subtracted from the
      *                                      colliding macroparticle weights.
@@ -88,25 +88,25 @@ public:
     AMREX_INLINE
     amrex::Vector<int> operator() (
         const index_type& n_total_pairs,
-        ParticleTileType& ptile1, ParticleTileType& ptile2,
+        ParticleTileType& ptile0, ParticleTileType& ptile1,
         const amrex::Vector<WarpXParticleContainer*>& pc_products,
         ParticleTileType** AMREX_RESTRICT tile_products,
         const amrex::ParticleReal m0, const amrex::ParticleReal m1,
         const amrex::Vector<amrex::ParticleReal>& /*products_mass*/,
         const index_type* AMREX_RESTRICT mask,
         amrex::Vector<index_type>& products_np,
+        const SmartCopy* AMREX_RESTRICT copy_species0,
         const SmartCopy* AMREX_RESTRICT copy_species1,
-        const SmartCopy* AMREX_RESTRICT copy_species2,
+        const index_type* AMREX_RESTRICT p_pair_indices_0,
         const index_type* AMREX_RESTRICT p_pair_indices_1,
-        const index_type* AMREX_RESTRICT p_pair_indices_2,
         const amrex::ParticleReal* AMREX_RESTRICT p_pair_reaction_weight,
         const amrex::ParticleReal* /*p_product_data*/ ) const
     {
         using namespace amrex::literals;
 
         // Product species slot layout (m_num_product_species slots total):
-        //   Slot 0: copy of reactant species 1, i.e. the species from ptile1 (always present)
-        //   Slot 1: copy of reactant species 2, i.e. the species from ptile2 (always present)
+        //   Slot 0: copy of the first reactant species, i.e. the species from ptile0 (always present)
+        //   Slot 1: copy of the other reactant species, i.e. the species from ptile1 (always present)
         //   Slot 2: first true output species   (only when m_num_product_species == 4)
         //   Slot 3: second true output species  (only when m_num_product_species == 4)
         //
@@ -143,10 +143,9 @@ public:
         amrex::Vector<int> num_added_vec(m_num_product_species, 0);
         for (int i = 0; i < 2; i++)
         {
-            // Record the number of non product producing events lead to new
-            // particles for species1 and 2. Only 1 particle is created for
-            // each species (the piece that breaks off to have equal weight)
-            // particles.
+            // Record the number of non-reaction events that lead to new particles
+            // for the first and other reactant species (slots 0 and 1). Only 1
+            // weight-split particle is created per reactant per event.
             num_added_vec[i] = static_cast<int>(no_product_total);
         }
 
@@ -186,8 +185,8 @@ public:
             tile_products[i]->resize(products_np[i] + num_added_vec[i]);
         }
 
-        const auto soa_0 = ptile1.getParticleTileData();
-        const auto soa_1 = ptile2.getParticleTileData();
+        const auto soa_0 = ptile0.getParticleTileData();
+        const auto soa_1 = ptile1.getParticleTileData();
 
         // Create necessary GPU vectors, that will be used in the kernel below
         amrex::Vector<SoaData_type> soa_products;
@@ -232,15 +231,15 @@ public:
             if ((mask[i] > 0) & (mask[i] != int(ScatteringProcessType::IONIZATION)) & (mask[i] != int(ScatteringProcessType::TWOPRODUCT_REACTION)))
             {
                 const auto slot0_idx = products_np_data[0] + no_product_offsets_data[i];
-                // Make a copy of the particle from species 1
-                copy_species1[0](soa_products_data[0], soa_0, static_cast<int>(p_pair_indices_1[i]),
+                // Make a copy of the particle from the first reactant species
+                copy_species0[0](soa_products_data[0], soa_0, static_cast<int>(p_pair_indices_0[i]),
                                 static_cast<int>(slot0_idx), engine);
                 // Set the weight of the new particles to p_pair_reaction_weight[i]
                 soa_products_data[0].m_rdata[PIdx::w][slot0_idx] = p_pair_reaction_weight[i];
 
                 const auto slot1_idx = products_np_data[1] + no_product_offsets_data[i];
-                // Make a copy of the particle from species 2
-                copy_species2[1](soa_products_data[1], soa_1, static_cast<int>(p_pair_indices_2[i]),
+                // Make a copy of the particle from the other reactant species
+                copy_species1[1](soa_products_data[1], soa_1, static_cast<int>(p_pair_indices_1[i]),
                                 static_cast<int>(slot1_idx), engine);
                 // Set the weight of the new particles to p_pair_reaction_weight[i]
                 soa_products_data[1].m_rdata[PIdx::w][slot1_idx] = p_pair_reaction_weight[i];
@@ -331,18 +330,18 @@ public:
             // Next perform all product-producing collisions
             else if (mask[i] == int(ScatteringProcessType::TWOPRODUCT_REACTION))
             {
-                // create a copy of the first product species at the location of species 1
-                const auto src0_idx = static_cast<int>(p_pair_indices_1[i]);
+                // create a copy of the first product species at the location of the first reactant species
+                const auto src0_idx = static_cast<int>(p_pair_indices_0[i]);
                 const auto slot2_idx = products_np_data[2] + with_product_offsets_data[i];
-                copy_species1[2](soa_products_data[2], soa_0, src0_idx,
+                copy_species0[2](soa_products_data[2], soa_0, src0_idx,
                                 static_cast<int>(slot2_idx), engine);
                 // Set the weight of the new particle to p_pair_reaction_weight[i]
                 soa_products_data[2].m_rdata[PIdx::w][slot2_idx] = p_pair_reaction_weight[i];
 
-                // create a copy of the other product species at the location of species 2
-                const auto src1_idx = static_cast<int>(p_pair_indices_2[i]);
+                // create a copy of the other product species at the location of the other reactant species
+                const auto src1_idx = static_cast<int>(p_pair_indices_1[i]);
                 const auto slot3_idx = products_np_data[3] + with_product_offsets_data[i];
-                copy_species2[3](soa_products_data[3], soa_1, src1_idx,
+                copy_species1[3](soa_products_data[3], soa_1, src1_idx,
                                 static_cast<int>(slot3_idx), engine);
                 // Set the weight of the new particle to p_pair_reaction_weight[i]
                 soa_products_data[3].m_rdata[PIdx::w][slot3_idx] = p_pair_reaction_weight[i];
@@ -372,24 +371,24 @@ public:
             else if (mask[i] == int(ScatteringProcessType::IONIZATION))
             {
                 const auto slot0_idx = products_np_data[0] + no_product_total + with_product_offsets_data[i];
-                // Make a copy of the particle from species 1 (incident species, slot 0)
-                copy_species1[0](soa_products_data[0], soa_0, static_cast<int>(p_pair_indices_1[i]),
+                // Make a copy of the particle from the first reactant species (incident species, slot 0)
+                copy_species0[0](soa_products_data[0], soa_0, static_cast<int>(p_pair_indices_0[i]),
                                static_cast<int>(slot0_idx), engine);
                 // Set the weight of the new particles to p_pair_reaction_weight[i]
                 soa_products_data[0].m_rdata[PIdx::w][slot0_idx] = p_pair_reaction_weight[i];
 
-                // create a copy of the first product species at the location of species 2
-                // (species in slot 1 is the "target species", i.e. the species that is ionized)
+                // create a copy of the first product species at the location of the other reactant species
+                // (the other reactant species in slot 1 is the "target species", i.e. the species that is ionized)
                 const auto slot2_idx = products_np_data[2] + with_product_offsets_data[i];
-                copy_species2[2](soa_products_data[2], soa_1, static_cast<int>(p_pair_indices_2[i]),
+                copy_species1[2](soa_products_data[2], soa_1, static_cast<int>(p_pair_indices_1[i]),
                                 static_cast<int>(slot2_idx), engine);
                 // Set the weight of the new particle to p_pair_reaction_weight[i]
                 soa_products_data[2].m_rdata[PIdx::w][slot2_idx] = p_pair_reaction_weight[i];
 
-                // create a copy of the other product species at the location of species 2
-                // (species in slot 1 is the "target species", i.e. the species that is ionized)
+                // create a copy of the other product species at the location of the other reactant species
+                // (the other reactant species in slot 1 is the "target species", i.e. the species that is ionized)
                 const auto slot3_idx = products_np_data[3] + with_product_offsets_data[i];
-                copy_species2[3](soa_products_data[3], soa_1, static_cast<int>(p_pair_indices_2[i]),
+                copy_species1[3](soa_products_data[3], soa_1, static_cast<int>(p_pair_indices_1[i]),
                                 static_cast<int>(slot3_idx), engine);
                 // Set the weight of the new particle to p_pair_reaction_weight[i]
                 soa_products_data[3].m_rdata[PIdx::w][slot3_idx] = p_pair_reaction_weight[i];

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -49,7 +49,7 @@ public:
      * to binary collisions.
      *
      * Product species are arranged in slots 0 through m_num_product_species-1.
-     * Slots 0 and 1 always correspond to the first and other reactant species, respectively. For reaction
+     * Slots 0 and 1 always correspond to the first and second reactant species, respectively. For reaction
      * events that produce new species (ionization, charge exchange, two-product
      * reaction), slots 2 and 3 hold the true output species.
      *
@@ -144,7 +144,7 @@ public:
         for (int i = 0; i < 2; i++)
         {
             // Record the number of non-reaction events that lead to new particles
-            // for the first and other reactant species (slots 0 and 1). Only 1
+            // for the first and second reactant species (slots 0 and 1). Only 1
             // weight-split particle is created per reactant per event.
             num_added_vec[i] = static_cast<int>(no_product_total);
         }

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -45,7 +45,7 @@ public:
     SplitAndScatterFunc (const std::string& collision_name, MultiParticleContainer const * mypc);
 
     /**
-     * \brief Function that performs binary collision between two macroparticles
+     * \brief Function that performs binary collision between macroparticle pairs
      *  (referred to as "reactant species" in the code below)
      *
      * During a collision, new macroparticles can be created in different species,
@@ -55,13 +55,14 @@ public:
      * This is because, physically, some of the reacting particles can still be present after the collision
      * (e.g., if the collision is elastic scattering), but with modified properties (e.g., modified momentum).
      * In the code, this is handled by creating *new* macroparticles in the reactant species, whose weight
-     * is subtracted from the reacting macroparticles.
-     * (This approach is used because the two reactant macroparticles may have different weights.)
+     * is subtracted from the reacting macroparticles. (This approach is used in order to handle the fact
+     * that the two reactant macroparticles may have different weights.)
      *
      * For collisions that, physically, produce new particles (e.g., ionization, charge exchange, two-product
      * reaction), slots 2 and 3 hold the true product species.
      *
-     * @param[in]     n_total_pairs         total number of particle pairs across all cells.
+     * @param[in]     n_total_pairs         total number of colliding particle pairs
+     *                                      (across all cells) handled by this kernel.
      * @param[in,out] ptile0                particle tile for the first reactant species (slot 0);
      *                                      weights may be reduced by the collision.
      * @param[in,out] ptile1                particle tile for the other reactant species (slot 1);
@@ -76,20 +77,18 @@ public:
      * @param[in]     m1                    rest mass of the other reactant species (slot 1).
      * @param[in]     mask                  per-pair collision type: 0 = no collision,
      *                                      otherwise cast of ScatteringProcessType to int.
-     * @param[in,out] products_np           on input: current particle count of each product
-     *                                      tile; updated to the pre-addition count so that
-     *                                      newly added particles can be correctly addressed
-     *                                      even when the same container appears in multiple
-     *                                      slots (e.g. e- + H -> 2 e- + H+).
+     * @param[in,out] products_np           macroparticle count of each product tile; updated in this
+     *                                      kernel to reflect the number of new macroparticles added in each species.
      * @param[in]     copy_species0         array of SmartCopy functors (size m_num_product_species);
      *                                      copy_species0[k] copies a particle FROM the first
      *                                      reactant species (slot 0) INTO product slot k.
-     * @param[in]     copy_species1         same as copy_species0 but copies FROM the other
-     *                                      reactant species (slot 1).
+     * @param[in]     copy_species1         array of SmartCopy functors (size m_num_product_species);
+     *                                      copy_species1[k] copies a particle FROM the other
+     *                                      reactant species (slot 1) INTO product slot k.
      * @param[in]     p_pair_indices_0      per-pair index of the first reactant species (slot 0) particle.
      * @param[in]     p_pair_indices_1      per-pair index of the other reactant species (slot 1) particle.
      * @param[in]     p_pair_reaction_weight per-pair weight assigned to newly created product
-     *                                      particles; also the amount subtracted from the
+     *                                      macroparticles; also the amount subtracted from the
      *                                      colliding macroparticle weights.
      * \return num_added                    number of particles added to each product slot.
      */
@@ -115,24 +114,24 @@ public:
         // Product species slot layout (m_num_product_species slots total):
         //   Slot 0: copy of the first reactant species, i.e. the species from ptile0 (always present)
         //   Slot 1: copy of the other reactant species, i.e. the species from ptile1 (always present)
-        //   Slot 2: first true output species   (only when m_num_product_species == 4)
-        //   Slot 3: second true output species  (only when m_num_product_species == 4)
+        //   Slot 2: first true product species
+        //   Slot 3: second true product species
         //
-        // For non-reaction events (elastic, back, forward scattering), only slots 0 and 1
-        // receive new particles: one weight-split copy per reactant per colliding pair.
+        // For non-product producing collisions (elastic, back, forward scattering), only slots 0
+        // and 1 receive new macroparticles: one weight-split copy per reactant per colliding pair.
         // These are counted by `no_product_total` and NOT reflected in `m_num_products_host`.
         //
-        // For reaction events (ionization, two-product reaction, charge exchange), slots 2
-        // and 3 receive one new particle per event. For ionization, slot 0 also receives one
-        // particle (the surviving incident species copy). These counts are stored in
+        // For product-producing collisions (ionization, two-product reaction, charge exchange),
+        // slots 2 and 3 receive one new particle per event. For ionization, slot 0 also receives one
+        // particle (the surviving reactant species copy). These counts are stored in
         // `m_num_products_host[i]` and multiplied by `with_product_total` to get the totals.
 
-        // Return a vector of zeros, indicating that for all the "product" species
-        // there were no new particles added.
+        // If there are no colliding pairs, skip the rest of this kernel and return a vector of
+        // zeros, indicating that for all the "product" species, there were no new macroparticles added.
         if (n_total_pairs == 0) { return amrex::Vector<int>(m_num_product_species, 0); }
 
-        // The following is used to calculate the appropriate offsets for processes
-        // that do not produce macroparticles in new species (i.e., not ionization, not two-product reaction).
+        // The following is used to calculate the appropriate offsets for
+        // non-product producing collisions (i.e., not ionization, not two-product reaction).
         // Note that a standard cummulative sum is not appropriate since the
         // mask is also used to specify the type of collision and can therefore
         // have values >1
@@ -151,7 +150,7 @@ public:
         amrex::Vector<int> num_added_vec(m_num_product_species, 0);
         for (int i = 0; i < 2; i++)
         {
-            // Record the number of non-reaction events that lead to new particles
+            // Record the number of non-product producing collisions that lead to new particles
             // for the first and second reactant species (slots 0 and 1). Only 1
             // weight-split particle is created per reactant per event.
             num_added_vec[i] = static_cast<int>(no_product_total);
@@ -373,13 +372,13 @@ public:
                     // We also convert from eV to Joules
                     false,
                     // no angular scattering: the products' momenta have the same direction
-                    // as that of the incident particle, in the center-of-mass frame
+                    // as that of the reactant particle, in the center-of-mass frame
                     engine);
             }
             else if (mask[i] == int(ScatteringProcessType::IONIZATION))
             {
                 const auto slot0_idx = products_np_data[0] + no_product_total + with_product_offsets_data[i];
-                // Make a copy of the particle from the first reactant species (incident species, slot 0)
+                // Make a copy of the particle from the first reactant species (slot 0)
                 copy_species0[0](soa_products_data[0], soa_0, static_cast<int>(p_pair_indices_0[i]),
                                static_cast<int>(slot0_idx), engine);
                 // Set the weight of the new particles to p_pair_reaction_weight[i]

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.cpp
@@ -35,8 +35,8 @@ SplitAndScatterFunc::SplitAndScatterFunc (const std::string& collision_name,
             // For ionization:
             if (std::find(scattering_processes.begin(), scattering_processes.end(), "ionization") != scattering_processes.end()) {
                 m_num_product_species = 4;
-                m_num_products_host.push_back(1); // slot 0: first reactant (incident/non-target) species; 1 particle per ionization event
-                m_num_products_host.push_back(0); // slot 1: other reactant (target) species; consumed by reaction, no new reaction-product particles
+                m_num_products_host.push_back(1); // slot 0: first reactant (incident/non-target) species; 1 scattered particle per ionization event
+                m_num_products_host.push_back(0); // slot 1: other reactant (target) species; consumed by reaction, no new reaction-produced particle
                 m_num_products_host.push_back(1); // slot 2: first true product species (e.g. ejected electron)
                 m_num_products_host.push_back(1); // slot 3: second true product species (e.g. resulting ion)
 
@@ -48,8 +48,8 @@ SplitAndScatterFunc::SplitAndScatterFunc (const std::string& collision_name,
             if (std::find(scattering_processes.begin(), scattering_processes.end(), "charge_exchange") != scattering_processes.end() ||
                 std::find(scattering_processes.begin(), scattering_processes.end(), "two_product_reaction") != scattering_processes.end()) {
                 m_num_product_species = 4;
-                m_num_products_host.push_back(0); // slot 0: first reactant species; consumed by reaction, no new reaction-product particles
-                m_num_products_host.push_back(0); // slot 1: other reactant species; consumed by reaction, no new reaction-product particles
+                m_num_products_host.push_back(0); // slot 0: first reactant species; consumed by reaction, no new reaction-produced particles
+                m_num_products_host.push_back(0); // slot 1: other reactant species; consumed by reaction, no new reaction-produced particles
                 m_num_products_host.push_back(1); // slot 2: first true product species
                 m_num_products_host.push_back(1); // slot 3: second true product species
 
@@ -59,8 +59,8 @@ SplitAndScatterFunc::SplitAndScatterFunc (const std::string& collision_name,
 
         } else {
             m_num_product_species = 2;
-            m_num_products_host.push_back(0); // slot 0: first reactant species; no reaction-product particles (only weight-split copies)
-            m_num_products_host.push_back(0); // slot 1: other reactant species; no reaction-product particles (only weight-split copies)
+            m_num_products_host.push_back(0);
+            m_num_products_host.push_back(0);
         }
     }
     else

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.cpp
@@ -35,10 +35,10 @@ SplitAndScatterFunc::SplitAndScatterFunc (const std::string& collision_name,
             // For ionization:
             if (std::find(scattering_processes.begin(), scattering_processes.end(), "ionization") != scattering_processes.end()) {
                 m_num_product_species = 4;
-                m_num_products_host.push_back(1); // the non-target species
-                m_num_products_host.push_back(0); // the target species
-                m_num_products_host.push_back(1); // first product species
-                m_num_products_host.push_back(1); // second product species
+                m_num_products_host.push_back(1); // slot 0: incident (non-target) species; 1 particle per ionization event
+                m_num_products_host.push_back(0); // slot 1: target species; consumed by reaction, no new reaction-product particles
+                m_num_products_host.push_back(1); // slot 2: first true product species (e.g. ejected electron)
+                m_num_products_host.push_back(1); // slot 3: second true product species (e.g. resulting ion)
 
                 // get the reaction energy
                 pp_collision_name.get("ionization_energy", m_reaction_energy);
@@ -48,10 +48,10 @@ SplitAndScatterFunc::SplitAndScatterFunc (const std::string& collision_name,
             if (std::find(scattering_processes.begin(), scattering_processes.end(), "charge_exchange") != scattering_processes.end() ||
                 std::find(scattering_processes.begin(), scattering_processes.end(), "two_product_reaction") != scattering_processes.end()) {
                 m_num_product_species = 4;
-                m_num_products_host.push_back(0); // the colliding species are consumed in the reaction
-                m_num_products_host.push_back(0); // the colliding species are consumed in the reaction
-                m_num_products_host.push_back(1); // first product species
-                m_num_products_host.push_back(1); // second product species
+                m_num_products_host.push_back(0); // slot 0: reactant species 1; consumed by reaction, no new reaction-product particles
+                m_num_products_host.push_back(0); // slot 1: reactant species 2; consumed by reaction, no new reaction-product particles
+                m_num_products_host.push_back(1); // slot 2: first true product species
+                m_num_products_host.push_back(1); // slot 3: second true product species
 
                 // get the reaction energy, assuming zero energy for charge exchange
                 pp_collision_name.query("two_product_reaction_energy", m_reaction_energy);
@@ -59,8 +59,8 @@ SplitAndScatterFunc::SplitAndScatterFunc (const std::string& collision_name,
 
         } else {
             m_num_product_species = 2;
-            m_num_products_host.push_back(0);
-            m_num_products_host.push_back(0);
+            m_num_products_host.push_back(0); // slot 0: reactant species 1; no reaction-product particles (only weight-split copies)
+            m_num_products_host.push_back(0); // slot 1: reactant species 2; no reaction-product particles (only weight-split copies)
         }
     }
     else

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.cpp
@@ -35,8 +35,8 @@ SplitAndScatterFunc::SplitAndScatterFunc (const std::string& collision_name,
             // For ionization:
             if (std::find(scattering_processes.begin(), scattering_processes.end(), "ionization") != scattering_processes.end()) {
                 m_num_product_species = 4;
-                m_num_products_host.push_back(1); // slot 0: incident (non-target) species; 1 particle per ionization event
-                m_num_products_host.push_back(0); // slot 1: target species; consumed by reaction, no new reaction-product particles
+                m_num_products_host.push_back(1); // slot 0: first reactant (incident/non-target) species; 1 particle per ionization event
+                m_num_products_host.push_back(0); // slot 1: other reactant (target) species; consumed by reaction, no new reaction-product particles
                 m_num_products_host.push_back(1); // slot 2: first true product species (e.g. ejected electron)
                 m_num_products_host.push_back(1); // slot 3: second true product species (e.g. resulting ion)
 
@@ -48,8 +48,8 @@ SplitAndScatterFunc::SplitAndScatterFunc (const std::string& collision_name,
             if (std::find(scattering_processes.begin(), scattering_processes.end(), "charge_exchange") != scattering_processes.end() ||
                 std::find(scattering_processes.begin(), scattering_processes.end(), "two_product_reaction") != scattering_processes.end()) {
                 m_num_product_species = 4;
-                m_num_products_host.push_back(0); // slot 0: reactant species 1; consumed by reaction, no new reaction-product particles
-                m_num_products_host.push_back(0); // slot 1: reactant species 2; consumed by reaction, no new reaction-product particles
+                m_num_products_host.push_back(0); // slot 0: first reactant species; consumed by reaction, no new reaction-product particles
+                m_num_products_host.push_back(0); // slot 1: other reactant species; consumed by reaction, no new reaction-product particles
                 m_num_products_host.push_back(1); // slot 2: first true product species
                 m_num_products_host.push_back(1); // slot 3: second true product species
 
@@ -59,8 +59,8 @@ SplitAndScatterFunc::SplitAndScatterFunc (const std::string& collision_name,
 
         } else {
             m_num_product_species = 2;
-            m_num_products_host.push_back(0); // slot 0: reactant species 1; no reaction-product particles (only weight-split copies)
-            m_num_products_host.push_back(0); // slot 1: reactant species 2; no reaction-product particles (only weight-split copies)
+            m_num_products_host.push_back(0); // slot 0: first reactant species; no reaction-product particles (only weight-split copies)
+            m_num_products_host.push_back(0); // slot 1: other reactant species; no reaction-product particles (only weight-split copies)
         }
     }
     else


### PR DESCRIPTION
## Summary

Refactor `SplitAndScatterFunc` to use consistent 0-based product slot indexing and add documentation explaining the reactant/product species layout.

### Motivation

The file mixes two indexing conventions: reactant-side variables (`m1`, `m2`, `soa_1`, `soa_2`) use 1-based names, while the product slot arrays (`products_np`, `soa_products_data`, `m_num_products_host`) are 0-indexed. Within the collision kernel, this creates systematic off-by-one confusion — for example `product1_index` addressed slot 0, `mass_product1` was the mass of `pc_products[2]`, and the ionization branch used a completely different naming pattern (`species1_index`) for the same concept.

### Changes

**Renames in `SplitAndScatterFunc.H`** (all local to the function)

| Before | After | Reason |
|---|---|---|
| `ptile1`, `ptile2` (parameters) | `ptile0`, `ptile1` | match slot 0 / slot 1 indexing |
| `copy_species1`, `copy_species2` (parameters) | `copy_species0`, `copy_species1` | same |
| `p_pair_indices_1`, `p_pair_indices_2` (parameters) | `p_pair_indices_0`, `p_pair_indices_1` | same |
| `m1`, `m2` (parameters) | `m0`, `m1` | same |
| `soa_1`, `soa_2` | `soa_0`, `soa_1` | same |
| `product1_index` / `product2_index` (elastic block) | `slot0_idx` / `slot1_idx` | explicitly names the target slot |
| `reactant1_index` / `reactant2_index` (two-product block) | `src0_idx` / `src1_idx` | distinguishes source indices from destination slot indices |
| `product1_index` / `product2_index` (two-product & ionization blocks) | `slot2_idx` / `slot3_idx` | reflect actual array positions |
| `species1_index` (ionization block) | `slot0_idx` | consistent with elastic block |
| `ux1/ux2`, `ux_p1/ux_p2` (velocity refs) | `ux0/ux1`, `ux2/ux3` | slot-indexed throughout |
| `mass_product1` / `mass_product2` | `mass_slot2` / `mass_slot3` | match `pc_products[2]`/`[3]` |

**Documentation**
- Added a full `@param` docstring to `operator()`, documenting every argument including the
  non-obvious semantics of `copy_species1[k]`, `mask`, and `products_np`.
- Added a block comment at the top of the function body explaining the product slot layout
  and the two separate particle-count paths (`no_product_total` vs `m_num_products_host`).
- Clarified the `m_num_products_host` member comment and all `push_back` comments in the
  constructor to use "slot N: ..." phrasing.

**Cleanup**
- Removed the redundant `no_product_p_offsets` and `with_product_p_offsets` pointer aliases
  (`.data()` and `.dataPtr()` return the same pointer; unified to a single name each).
