### PR TITLE
Serialization.H : refactor and bugfixing

### DIFF
--- a/Source/ablastr/utils/Serialization.H
+++ b/Source/ablastr/utils/Serialization.H
@@ -87,7 +87,7 @@ namespace ablastr::utils::serialization
 
             return str;
         }
-        else if constexpr (std::is_trivially_copyable<T>())
+        else
         {
             auto temp = std::array<char, sizeof(T)>{};
             std::copy(it, it + sizeof(T), temp.begin());

--- a/Source/ablastr/utils/Serialization.H
+++ b/Source/ablastr/utils/Serialization.H
@@ -27,7 +27,8 @@ namespace ablastr::utils::serialization
     * @param[in] val a variable of type T to be serialized
     * @param[in, out] vec a reference to the vector to which the byte representation of val is appended
     */
-    template <typename T>
+    template <typename T,
+        std::enable_if_t<std::is_trivially_copyable_v<T> || std::is_same_v<T, std::string>, bool> = true>
     void put_in(const T &val, std::vector<char> &vec)
     {
         if constexpr (std::is_same<T, std::string>())
@@ -40,9 +41,6 @@ namespace ablastr::utils::serialization
         }
         else
         {
-            static_assert(std::is_trivially_copyable<T>(),
-                "Cannot serialize non-trivally copyable types, except std::string.");
-
             const auto *ptr_val = reinterpret_cast<const char *>(&val);
             std::copy(ptr_val, ptr_val + sizeof(T), std::back_inserter(vec));
         }
@@ -51,8 +49,8 @@ namespace ablastr::utils::serialization
     /**
     * This function transforms an std::vector<T> into a vector of chars holding its
     * byte representation and it appends this vector at the end of an
-    * existing vector of chars. T must be either a trivially copyable type or an std::string.
-    * A specialization exists in case val is a vector of chars.
+    * existing vector of chars.T must be an admissible type for
+    * the put_in function.
     *
     * @tparam T the variable type
     * @param[in] val a variable of type T to be serialized
@@ -61,21 +59,9 @@ namespace ablastr::utils::serialization
     template <typename T>
     void put_in_vec(const std::vector<T> &val, std::vector<char> &vec)
     {
-        if constexpr (std::is_same<T, char>())
-        {
-            put_in(static_cast<int>(val.size()), vec);
-            vec.insert(vec.end(), val.begin(), val.end());
-        }
-        else
-        {
-            static_assert(std::is_trivially_copyable<T>() || std::is_same<T, std::string>(),
-                "Cannot serialize vectors of non-trivally copyable types"
-                ", except vectors of std::string.");
-
-            put_in(static_cast<int>(val.size()), vec);
-            for (const auto &el : val) {
-                put_in(el, vec);
-            }
+        put_in(static_cast<int>(val.size()), vec);
+        for (const auto &el : val) {
+            put_in(el, vec);
         }
     }
 
@@ -89,7 +75,8 @@ namespace ablastr::utils::serialization
     * @param[in, out] it the iterator to a byte vector
     * @return the variable extracted from the byte array
     */
-    template <typename T>
+    template <typename T,
+        std::enable_if_t<std::is_trivially_copyable_v<T> || std::is_same_v<T, std::string>, bool> = true>
     T get_out(std::vector<char>::const_iterator &it)
     {
         if constexpr (std::is_same<T, std::string>())
@@ -100,12 +87,8 @@ namespace ablastr::utils::serialization
 
             return str;
         }
-        else
+        else if constexpr (std::is_trivially_copyable<T>())
         {
-            static_assert(std::is_trivially_copyable<T>(),
-                "Cannot extract non-trivally copyable types from char vectors,"
-                " with the exception of std::string.");
-
             auto temp = std::array<char, sizeof(T)>{};
             std::copy(it, it + sizeof(T), temp.begin());
             it += sizeof(T);
@@ -119,8 +102,8 @@ namespace ablastr::utils::serialization
     /**
     * This function extracts an std::vector<T> from a byte vector, at the position
     * given by a std::vector<char> iterator. The iterator is then advanced according to
-    * the number of bytes read from the byte vector. T must be either a trivially copyable type
-    * or an std::string.
+    * the number of bytes read from the byte vector. T must be an admissible type for
+    * the get_out function.
     *
     * @tparam T the variable type (must be trivially copyable)
     * @param[in, out] it the iterator to a byte vector
@@ -129,29 +112,14 @@ namespace ablastr::utils::serialization
     template <typename T>
     std::vector<T> get_out_vec(std::vector<char>::const_iterator &it)
     {
-        if constexpr (std::is_same<T, std::string>())
-        {
-            const auto length = get_out<int>(it);
-            std::vector<char> res(length);
-            std::copy(it, it + length, res.begin());
-            it += length;
+        const auto length = get_out<int>(it);
 
-            return res;
+        std::vector<T> res(length);
+        for (int i = 0; i < length; ++i) {
+            res[i] = get_out<T>(it);
         }
-        else
-        {
-            static_assert(std::is_trivially_copyable<T>() || std::is_same<T, std::string>(),
-                "Cannot extract non-trivally copyable types from char vectors,"
-                " with the exception of std::string.");
 
-            const auto length = get_out<int>(it);
-            std::vector<T> res(length);
-            for (int i = 0; i < length; ++i) {
-                res[i] = get_out<T>(it);
-            }
-
-            return res;
-        }
+        return res;
     }
 }
 


### PR DESCRIPTION
This PR simplifies `Serialization.H` and should close https://github.com/BLAST-WarpX/warpx/issues/6641 (note that, while https://github.com/BLAST-WarpX/warpx/issues/6641 was a real bug, it would have resulted in a compilation-time error).

### Changes

- functions to serialize/de-serialize are conceived to work only on trivially copyable variables and strings (with the vector version able to work on an std::vector` of those types). Before this was enforced with a `static_assert`, now we use SFINAE. 

- before, checks on types with static asserts were done, unnecessarily, in both `get_out` and `get_out_vec` (`put_in` and `put_in_vec`). Since `get_out_vec` calls `get_out<T>`, the check on `T` is now only done in  `get_out<T>` . The docstring has been updated to reflect this. 

- `get_out_vec` and `put_in_vec` have been simplified : now they only read the number of elements and then they call `get_out` and `put_in` the appropriate number of times.

### Tests

I've compiled WarpX in debug mode and I ran the test https://warpx.readthedocs.io/en/latest/developers/warning_logger.html , obtaining exactly the same warnings reported in the documentation.