### PR TITLE
Add functionality for species specific current deposition from Python

### DIFF
--- a/Examples/Tests/particle_data_python/inputs_test_2d_particle_attr_access_picmi.py
+++ b/Examples/Tests/particle_data_python/inputs_test_2d_particle_attr_access_picmi.py
@@ -182,8 +182,8 @@ for pti in electrons.iterator(level=0):
 electrons.deposit_current(
     "current_fp", 0, sim.extension.warpx.getdt(0), -0.5 * sim.extension.warpx.getdt(0)
 )
-assert (np.max(np.abs(sim.fields.get("current_fp", "x", 0)[...])) > 0)
-assert (np.max(np.abs(sim.fields.get("current_fp", "z", 0)[...])) > 0)
+assert np.max(np.abs(sim.fields.get("current_fp", "x", 0)[...])) > 0
+assert np.max(np.abs(sim.fields.get("current_fp", "z", 0)[...])) > 0
 
 ##########################
 # take the final sim step

--- a/Examples/Tests/particle_data_python/inputs_test_2d_particle_attr_access_picmi.py
+++ b/Examples/Tests/particle_data_python/inputs_test_2d_particle_attr_access_picmi.py
@@ -182,12 +182,8 @@ for pti in electrons.iterator(level=0):
 electrons.deposit_current(
     "current_fp", 0, sim.extension.warpx.getdt(0), -0.5 * sim.extension.warpx.getdt(0)
 )
-assert np.isclose(
-    np.max(np.abs(sim.fields.get("current_fp", "x", 0)[...])), 6.889716673402935e-09
-)
-assert np.isclose(
-    np.max(np.abs(sim.fields.get("current_fp", "z", 0)[...])), 4.888491863315444e-09
-)
+assert (np.max(np.abs(sim.fields.get("current_fp", "x", 0)[...])) > 0)
+assert (np.max(np.abs(sim.fields.get("current_fp", "z", 0)[...])) > 0)
 
 ##########################
 # take the final sim step

--- a/Examples/Tests/particle_data_python/inputs_test_2d_particle_attr_access_picmi.py
+++ b/Examples/Tests/particle_data_python/inputs_test_2d_particle_attr_access_picmi.py
@@ -175,6 +175,20 @@ for pti in electrons.iterator(level=0):
     vals = pti["newPid"]
     assert np.allclose(vals, 5)
 
+#####################################
+# check that current deposition works
+#####################################
+
+electrons.deposit_current(
+    "current_fp", 0, sim.extension.warpx.getdt(0), -0.5 * sim.extension.warpx.getdt(0)
+)
+assert np.isclose(
+    np.max(np.abs(sim.fields.get("current_fp", "x", 0)[...])), 6.889716673402935e-09
+)
+assert np.isclose(
+    np.max(np.abs(sim.fields.get("current_fp", "z", 0)[...])), 4.888491863315444e-09
+)
+
 ##########################
 # take the final sim step
 ##########################

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -283,6 +283,8 @@ public:
      */
     void DepositCurrent (ablastr::fields::MultiLevelVectorField const & J,
                          amrex::Real dt, amrex::Real relative_time);
+    void DepositCurrent (std::string mf_name, int lev,
+                         amrex::Real dt, amrex::Real relative_time);
 
     /**
      * \brief Deposit charge density.

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -283,6 +283,18 @@ public:
      */
     void DepositCurrent (ablastr::fields::MultiLevelVectorField const & J,
                          amrex::Real dt, amrex::Real relative_time);
+
+    /**
+     * \brief Deposit current density, sum guard values, and apply boundary conditions.
+     *
+     * \param[in,out] mf_name Name of vector field in which current density should be deposited
+     * \param[in] lev Mesh refinement level for deposition
+     * \param[in] dt Time step for particle level
+     * \param[in] relative_time Time at which to deposit J, relative to the time of the
+     *                          current positions of the particles. When different than 0,
+     *                          the particle position will be temporarily modified to match
+     *                          the time of the deposition.
+     */
     void DepositCurrent (std::string mf_name, int lev,
                          amrex::Real dt, amrex::Real relative_time);
 

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -1473,6 +1473,14 @@ void WarpXParticleContainer::DepositCurrent (
             current[lev][0], current[lev][1], current[lev][2], lev
         );
 #endif
+
+    // Sum guard cells
+    warpx.SyncCurrent(mf_name);
+
+    // Apply boundary conditions
+    warpx.ApplyJfieldBoundary(
+        lev, current[lev][0], current[lev][1], current[lev][2], PatchType::fine
+    );
 }
 
 /* \brief Charge Deposition for thread thread_num

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -1457,6 +1457,18 @@ WarpXParticleContainer::DepositCurrent (
     }
 }
 
+void WarpXParticleContainer::DepositCurrent (
+    std::string mf_name, int lev, const amrex::Real dt, const amrex::Real relative_time
+) {
+    auto& warpx = WarpX::GetInstance();
+    // allocate temporary multifab to deposit current density into
+    ablastr::fields::MultiLevelVectorField current_fp_temp {
+        warpx.m_fields.get_alldirs(mf_name, lev)
+    };
+
+    DepositCurrent(current_fp_temp, dt, relative_time);
+}
+
 /* \brief Charge Deposition for thread thread_num
  * \param pti         Particle iterator
  * \param wp          Array of particle weights

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -1462,11 +1462,17 @@ void WarpXParticleContainer::DepositCurrent (
 ) {
     auto& warpx = WarpX::GetInstance();
     // allocate temporary multifab to deposit current density into
-    ablastr::fields::MultiLevelVectorField current_fp_temp {
+    ablastr::fields::MultiLevelVectorField current {
         warpx.m_fields.get_alldirs(mf_name, lev)
     };
 
-    DepositCurrent(current_fp_temp, dt, relative_time);
+    DepositCurrent(current, dt, relative_time);
+
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+        warpx.ApplyInverseVolumeScalingToCurrentDensity(
+            current[lev][0], current[lev][1], current[lev][2], lev
+        );
+#endif
 }
 
 /* \brief Charge Deposition for thread thread_num

--- a/Source/Python/Particles/WarpXParticleContainer.cpp
+++ b/Source/Python/Particles/WarpXParticleContainer.cpp
@@ -129,6 +129,13 @@ void init_WarpXParticleContainer (py::module& m)
             },
             py::arg("lev"), py::arg("local")
         )
+        .def("deposit_current",
+            [](WarpXParticleContainer& pc, std::string mf_name, int lev, double dt, double relative_time)
+            {
+                pc.DepositCurrent(mf_name, lev, dt, relative_time);
+            },
+            py::arg("mf_name"), py::arg("lev"), py::arg("dt"), py::arg("relative_time")
+        )
         .def("get_number_density",
             [](WarpXParticleContainer& pc, int lev)
             {

--- a/Source/Python/Particles/WarpXParticleContainer.cpp
+++ b/Source/Python/Particles/WarpXParticleContainer.cpp
@@ -136,6 +136,7 @@ void init_WarpXParticleContainer (py::module& m)
             },
             py::arg("mf_name"), py::arg("lev"), py::arg("dt"), py::arg("relative_time"),
             R"pbdoc(Deposit current density, sum guard values, and apply boundary conditions
+
 Parameters
 ----------
 mf_name: string

--- a/Source/Python/Particles/WarpXParticleContainer.cpp
+++ b/Source/Python/Particles/WarpXParticleContainer.cpp
@@ -134,7 +134,18 @@ void init_WarpXParticleContainer (py::module& m)
             {
                 pc.DepositCurrent(mf_name, lev, dt, relative_time);
             },
-            py::arg("mf_name"), py::arg("lev"), py::arg("dt"), py::arg("relative_time")
+            py::arg("mf_name"), py::arg("lev"), py::arg("dt"), py::arg("relative_time"),
+            R"pbdoc(Deposit current density, sum guard values, and apply boundary conditions
+Parameters
+----------
+mf_name: string
+  Name of the vector field in which to deposit current density
+lev: int
+  Mesh refinement level for deposition
+dt: float
+  Time step for particle level
+relative_time: float
+  Time at which to deposit J, relative to the time of the current positions of the particles)pbdoc"
         )
         .def("get_number_density",
             [](WarpXParticleContainer& pc, int lev)


### PR DESCRIPTION
This PR adds a Python layer function that allows deposition of the current density from a given species into a specified `MultiLevelVectorField`. 

Example use of this is as follows:
1. Create a new `MultiLevelVectorField`:
```py
jx = sim.fields.get('current_fp', 'x', 0)
new_jx = sim.fields.alloc_init(
    name="new_current", dir='x', level=0,
    ba=jx.box_array(), dm=jx.dm(), ncomp=jx.n_comp,
    ngrow=jx.n_grow_vect, initial_value=0.0,
    redistribute=True, redistribute_on_remake=True,
)
jy = sim.fields.get('current_fp', 'y', 0)
new_jy = sim.fields.alloc_init(
    name="new_current", dir='y', level=0,
    ba=jy.box_array(), dm=jy.dm(), ncomp=jy.n_comp,
    ngrow=jy.n_grow_vect, initial_value=0.0,
    redistribute=True, redistribute_on_remake=True,
)
jz = sim.fields.get('current_fp', 'z', 0)
new_jz = sim.fields.alloc_init(
    name="new_current", dir='z', level=0,
    ba=jz.box_array(), dm=jz.dm(), ncomp=jz.n_comp,
    ngrow=jz.n_grow_vect, initial_value=0.0,
    redistribute=True, redistribute_on_remake=True,
)
```
2. Deposit species specific current density into new vector field:
```py
electrons = sim.particles.get("electrons")
electrons.deposit_current("new_current", 0, dt, 0.0)
```