### PR TITLE
Docs: delete redundant arXiv links

### DIFF
--- a/Docs/source/refs.bib
+++ b/Docs/source/refs.bib
@@ -472,7 +472,6 @@ year = {2021}
       eprint={2009.13645},
       archivePrefix={arXiv},
       primaryClass={physics.acc-ph},
-      url={https://arxiv.org/abs/2009.13645},
 }
 
 @article{VayFELA2009,
@@ -535,7 +534,6 @@ year = {2021}
       eprint={1301.0272},
       archivePrefix={arXiv},
       primaryClass={physics.space-ph},
-      url={https://arxiv.org/abs/1301.0272},
 }
 
 @article{QuickpicParallel,
@@ -716,7 +714,6 @@ author = {Habib, Salman and Roser, Robert and Gerber, Richard and Antypas, Katie
 eprint = {1603.09303},
 month = {Mar},
 title = {{ASCR/HEP Exascale Requirements Review Report}},
-url = {http://arxiv.org/abs/1603.09303},
 year = {2016}
 }
 @article{Shadwickpop09,


### PR DESCRIPTION
The 'eprint' field already creates a link to arXiv.org