### PR TITLE
Improve docu and fix LabFrameFieldDiagnostic bug

### DIFF
--- a/Docs/source/usage/python.rst
+++ b/Docs/source/usage/python.rst
@@ -34,7 +34,7 @@ Simulation and Grid Setup
 -------------------------
 
 .. autoclass:: pywarpx.picmi.Simulation
-    :members: step, add_species, add_laser, add_applied_field, write_input_file
+    :members: step, add_species, add_laser, add_applied_field, add_interaction, add_diagnostic, write_input_file
 
 .. autoclass:: pywarpx.picmi.Cartesian3DGrid
 

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -4276,8 +4276,8 @@ class LabFrameFieldDiagnostic(
                     fields_to_plot.add(dataname)
                 elif dataname in J_fields_list:
                     fields_to_plot.add(dataname.lower())
-                elif dataname.startswith("rho_"):
-                    # Adds rho_species diagnostic
+                elif dataname == "rho":
+                    # Add rho diagnostic
                     fields_to_plot.add(dataname)
 
             # --- Convert the set to a sorted list so that the order


### PR DESCRIPTION
This PR fixed a bug in the picmi implementation of the `LabFrameFieldDiagnostic`. The current implementation tried to add `rho_<species>`:
```
elif dataname.startswith("rho_"):
    # Adds rho_species diagnostic
    fields_to_plot.add(dataname)
```
This doesn't work as `rho_<species>` are not implemented for BackTransformed diagnostics.

Second update is improving documentation. The `Simulation` class was missing docu of members `add_diagnostic` and `add_interaction`, both of which are useful to know, particularly when running with field ionization.