### PR TITLE
Move ReadMovingWindowParameters from WarpXUtil to read_moving_window_parameters in WarpXInit

### DIFF
--- a/Source/Initialization/WarpXInit.H
+++ b/Source/Initialization/WarpXInit.H
@@ -7,6 +7,8 @@
 #ifndef WARPX_INIT_H_
 #define WARPX_INIT_H_
 
+#include <AMReX_REAL.H>
+
 namespace warpx::initialization
 {
     /** Initializes, in the following order:
@@ -34,6 +36,18 @@ namespace warpx::initialization
     /** Check that warpx.dims matches the binary name
     */
     void check_dims ();
+
+    /** Reads the moving window parameters
+     *
+     * @param[out] do_moving_window           if the moving window is enabled
+     * @param[out] start_moving_window_steps  step at which the moving window is started
+     * @param[out] end_moving_window_step     step at which the moving window is stopped
+     * @param[out] moving_window_dir          direction of the moving window
+     * @param[out] moving_window_v            velocity of the moving  window
+    */
+    void read_moving_window_parameters (
+        int& do_moving_window, int& start_moving_window_step, int& end_moving_window_step,
+        int& moving_window_dir, amrex::Real& moving_window_v);
 }
 
 #endif //WARPX_INIT_H_

--- a/Source/Initialization/WarpXInit.H
+++ b/Source/Initialization/WarpXInit.H
@@ -39,11 +39,11 @@ namespace warpx::initialization
 
     /** Reads the moving window parameters
      *
-     * @param[out] do_moving_window           if the moving window is enabled
-     * @param[out] start_moving_window_steps  step at which the moving window is started
-     * @param[out] end_moving_window_step     step at which the moving window is stopped
-     * @param[out] moving_window_dir          direction of the moving window
-     * @param[out] moving_window_v            velocity of the moving  window
+     * @param[out] do_moving_window          if the moving window is enabled
+     * @param[out] start_moving_window_step  step at which the moving window is started
+     * @param[out] end_moving_window_step    step at which the moving window is stopped
+     * @param[out] moving_window_dir         direction of the moving window
+     * @param[out] moving_window_v           velocity of the moving  window
     */
     void read_moving_window_parameters (
         int& do_moving_window, int& start_moving_window_step, int& end_moving_window_step,

--- a/Source/Initialization/WarpXInit.cpp
+++ b/Source/Initialization/WarpXInit.cpp
@@ -8,6 +8,8 @@
 #include "WarpXInit.H"
 
 #include "Initialization/WarpXAMReXInit.H"
+#include "Utils/Parser/ParserUtils.H"
+#include "Utils/WarpXConst.H"
 #include "Utils/TextMsg.H"
 
 #include <AMReX.H>
@@ -109,4 +111,43 @@ void warpx::initialization::check_dims()
         dims_error.append(dims_compiled).append("' to inputs file.");
     }
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(dims == dims_compiled, dims_error);
+}
+
+void warpx::initialization::read_moving_window_parameters(
+    int& do_moving_window, int& start_moving_window_step, int& end_moving_window_step,
+    [[maybe_unused]] int& moving_window_dir, amrex::Real& moving_window_v)
+{
+    const amrex::ParmParse pp_warpx("warpx");
+    pp_warpx.query("do_moving_window", do_moving_window);
+    if (do_moving_window) {
+        utils::parser::queryWithParser(
+            pp_warpx, "start_moving_window_step", start_moving_window_step);
+        utils::parser::queryWithParser(
+            pp_warpx, "end_moving_window_step", end_moving_window_step);
+        std::string s;
+        pp_warpx.get("moving_window_dir", s);
+
+        if (s == "z" || s == "Z") {
+#ifdef WARPX_ZINDEX
+            moving_window_dir = WARPX_ZINDEX;
+#endif
+        }
+#if defined(WARPX_DIM_3D)
+        else if (s == "y" || s == "Y") {
+            moving_window_dir = 1;
+        }
+#endif
+#if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_3D)
+        else if (s == "x" || s == "X") {
+            moving_window_dir = 0;
+        }
+#endif
+        else {
+            WARPX_ABORT_WITH_MESSAGE("Unknown moving_window_dir: "+s);
+        }
+
+        utils::parser::getWithParser(
+            pp_warpx, "moving_window_v", moving_window_v);
+        moving_window_v *= PhysConst::c;
+    }
 }

--- a/Source/Utils/WarpXUtil.H
+++ b/Source/Utils/WarpXUtil.H
@@ -31,10 +31,6 @@
 void ReadBoostedFrameParameters(amrex::Real& gamma_boost, amrex::Real& beta_boost,
                                 amrex::Vector<int>& boost_direction);
 
-void ReadMovingWindowParameters(
-    int& do_moving_window, int& start_moving_window_step, int& end_moving_window_step,
-    int& moving_window_dir, amrex::Real& moving_window_v);
-
 void ConvertLabParamsToBoost();
 
 /** Check the warpx.dims matches the binary name & set up RZ gridding

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -76,45 +76,6 @@ void ReadBoostedFrameParameters(Real& gamma_boost, Real& beta_boost,
 #endif
 }
 
-void ReadMovingWindowParameters(
-    int& do_moving_window, int& start_moving_window_step, int& end_moving_window_step,
-    [[maybe_unused]] int& moving_window_dir, amrex::Real& moving_window_v)
-{
-    const ParmParse pp_warpx("warpx");
-    pp_warpx.query("do_moving_window", do_moving_window);
-    if (do_moving_window) {
-        utils::parser::queryWithParser(
-            pp_warpx, "start_moving_window_step", start_moving_window_step);
-        utils::parser::queryWithParser(
-            pp_warpx, "end_moving_window_step", end_moving_window_step);
-        std::string s;
-        pp_warpx.get("moving_window_dir", s);
-
-        if (s == "z" || s == "Z") {
-#ifdef WARPX_ZINDEX
-            moving_window_dir = WARPX_ZINDEX;
-#endif
-        }
-#if defined(WARPX_DIM_3D)
-        else if (s == "y" || s == "Y") {
-            moving_window_dir = 1;
-        }
-#endif
-#if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_3D)
-        else if (s == "x" || s == "X") {
-            moving_window_dir = 0;
-        }
-#endif
-        else {
-            WARPX_ABORT_WITH_MESSAGE("Unknown moving_window_dir: "+s);
-        }
-
-        utils::parser::getWithParser(
-            pp_warpx, "moving_window_v", moving_window_v);
-        moving_window_v *= PhysConst::c;
-    }
-}
-
 void ConvertLabParamsToBoost()
 {
     Real gamma_boost = 1., beta_boost = 0.;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -275,7 +275,7 @@ void WarpX::MakeWarpX ()
 {
     warpx::initialization::check_dims();
 
-    ReadMovingWindowParameters(
+    warpx::initialization::read_moving_window_parameters(
         do_moving_window, start_moving_window_step, end_moving_window_step,
         moving_window_dir, moving_window_v);
 


### PR DESCRIPTION
This is a cleaning PR. `ReadMovingWindowParameters` is logically related to the initialization of WarpX, so I think that it should go to `Source/Initialization/WarpXInit.H` . 
With the occasion, I've also added a docstring.