### PR TITLE
Remove unused InjectorMomentumRadialExpansion

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1332,9 +1332,6 @@ Particle initialization
       to the Maxwell Boltzmann setting, which initializes non-relativistic plasma in their relativistic
       drifting frame.
 
-    * ``radial_expansion``: momentum depends on the radial coordinate linearly. This
-      can be controlled with additional parameter ``u_over_r`` which is the slope (``0.`` by default).
-
     * ``parse_momentum_function``: the momentum :math:`u = (u_{x},u_{y},u_{z})=(\gamma v_{x}/c,\gamma v_{y}/c,\gamma v_{z}/c)` is given by a function in the input
       file. It requires additional arguments ``<species_name>.momentum_function_ux(x,y,z)``,
       ``<species_name>.momentum_function_uy(x,y,z)`` and ``<species_name>.momentum_function_uz(x,y,z)``,

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -513,14 +513,21 @@ class GaussianBunchDistribution(picmistandard.PICMI_GaussianBunchDistribution):
 
         # --- Note that WarpX takes gamma*beta as input
         if np.any(np.not_equal(self.velocity_divergence, 0.0)):
+            u_over_x = self.velocity_divergence[0] / constants.c
+            u_over_y = self.velocity_divergence[1] / constants.c
+            u_over_z = self.velocity_divergence[2] / constants.c
             species.add_new_group_attr(
-                source_name, "momentum_distribution_type", "radial_expansion"
+                source_name, "momentum_distribution_type", "parse_momentum_function"
             )
             species.add_new_group_attr(
-                source_name, "u_over_r", self.velocity_divergence[0] / constants.c
+                source_name, "momentum_function_ux(x,y,z)", f"{u_over_x}*x"
             )
-            # species.add_new_group_attr(source_name, 'u_over_y', self.velocity_divergence[1]/constants.c)
-            # species.add_new_group_attr(source_name, 'u_over_z', self.velocity_divergence[2]/constants.c)
+            species.add_new_group_attr(
+                source_name, "momentum_function_uy(x,y,z)", f"{u_over_y}*y"
+            )
+            species.add_new_group_attr(
+                source_name, "momentum_function_uz(x,y,z)", f"{u_over_z}*z"
+            )
         elif np.any(np.not_equal(self.rms_velocity, 0.0)):
             species.add_new_group_attr(
                 source_name, "momentum_distribution_type", "gaussian"

--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -386,40 +386,6 @@ private:
     GetTemperature temperature;
 };
 
-/**
- * \brief struct whose getMomentum returns momentum for 1 particle, for
- * radial expansion.
- *
- * Note - u_over_r is expected to be the normalized momentum gamma*beta
- * divided by the physical position in SI units.
-**/
-struct InjectorMomentumRadialExpansion
-{
-    InjectorMomentumRadialExpansion (amrex::Real a_u_over_r) noexcept
-        : u_over_r(a_u_over_r)
-        {}
-
-    [[nodiscard]]
-    AMREX_GPU_HOST_DEVICE
-    amrex::XDim3
-    getMomentum (amrex::Real x, amrex::Real y, amrex::Real z,
-                 amrex::RandomEngine const&) const noexcept
-    {
-        return {x*u_over_r, y*u_over_r, z*u_over_r};
-    }
-
-    [[nodiscard]]
-    AMREX_GPU_HOST_DEVICE
-    amrex::XDim3
-    getBulkMomentum (amrex::Real x, amrex::Real y, amrex::Real z) const noexcept
-    {
-        return {x*u_over_r, y*u_over_r, z*u_over_r};
-    }
-
-private:
-    amrex::Real u_over_r;
-};
-
 // struct whose getMomentum returns local momentum computed from parser.
 struct InjectorMomentumParser
 {
@@ -496,7 +462,6 @@ struct InjectorMomentumGaussianParser
 // - InjectorMomentumConstant       : to generate constant density;
 // - InjectorMomentumGaussian       : to generate gaussian distribution;
 // - InjectorMomentumGaussianFlux   : to generate v*gaussian distribution;
-// - InjectorMomentumRadialExpansion: to generate radial expansion;
 // - InjectorMomentumParser         : to generate momentum from parser;
 // - InjectorMomentumGaussianParser : to generate momentum and thermal spread from parser;
 // The choice is made at runtime, depending in the constructor called.
@@ -570,13 +535,6 @@ struct InjectorMomentum
            object(t, temperature, velocity)
     { }
 
-    // This constructor stores a InjectorMomentumRadialExpansion in union object.
-    InjectorMomentum (InjectorMomentumRadialExpansion* t,
-                      amrex::Real u_over_r)
-        : type(Type::radial_expansion),
-          object(t, u_over_r)
-    { }
-
     // Explicitly prevent the compiler from generating copy constructors
     // and copy assignment operators.
     InjectorMomentum (InjectorMomentum const&) = delete;
@@ -631,10 +589,6 @@ struct InjectorMomentum
         {
             return object.constant.getMomentum(x,y,z,engine);
         }
-        case Type::radial_expansion:
-        {
-            return object.radial_expansion.getMomentum(x,y,z,engine);
-        }
         default:
         {
             amrex::Abort("InjectorMomentum: unknown type");
@@ -684,10 +638,6 @@ struct InjectorMomentum
         {
             return object.constant.getBulkMomentum(x,y,z);
         }
-        case Type::radial_expansion:
-        {
-            return object.radial_expansion.getBulkMomentum(x,y,z);
-        }
         default:
         {
             amrex::Abort("InjectorMomentum: unknown type");
@@ -696,14 +646,13 @@ struct InjectorMomentum
         }
     }
 
-    enum struct Type { constant, gaussian, gaussianflux, uniform, boltzmann, juttner, radial_expansion, parser, gaussianparser };
+    enum struct Type { constant, gaussian, gaussianflux, uniform, boltzmann, juttner, parser, gaussianparser };
     Type type;
 
 private:
 
     // An instance of union Object constructs and stores any one of
-    // the objects declared (constant or gaussian or
-    // radial_expansion or parser).
+    // the objects declared (constant or gaussian or parser).
     union Object {
         Object (InjectorMomentumConstant*,
                 amrex::Real a_ux, amrex::Real a_uy, amrex::Real a_uz) noexcept
@@ -730,9 +679,6 @@ private:
         Object (InjectorMomentumJuttner*,
                 GetTemperature const& t, GetVelocity const& b) noexcept
             : juttner(t,b) {}
-        Object (InjectorMomentumRadialExpansion*,
-                amrex::Real u_over_r) noexcept
-            : radial_expansion(u_over_r) {}
         Object (InjectorMomentumParser*,
                 amrex::ParserExecutor<3> const& a_ux_parser,
                 amrex::ParserExecutor<3> const& a_uy_parser,
@@ -753,7 +699,6 @@ private:
         InjectorMomentumUniform uniform;
         InjectorMomentumBoltzmann boltzmann;
         InjectorMomentumJuttner juttner;
-        InjectorMomentumRadialExpansion radial_expansion;
         InjectorMomentumParser parser;
         InjectorMomentumGaussianParser gaussianparser;
     };

--- a/Source/Initialization/InjectorMomentum.cpp
+++ b/Source/Initialization/InjectorMomentum.cpp
@@ -21,7 +21,6 @@ void InjectorMomentum::clear () // NOLINT(readability-make-member-function-const
     case Type::boltzmann:
     case Type::juttner:
     case Type::constant:
-    case Type::radial_expansion:
     {
         break;
     }

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -404,6 +404,14 @@ PhysicalParticleContainer::BackwardCompatibility ()
         WARPX_ABORT_WITH_MESSAGE("<species>.plot_species is not supported anymore. "
                      "Please use the new syntax for diagnostics, see documentation.");
     }
+
+    std::string backward_mom_dist;
+    if (pp_species_name.query("momentum_distribution_type", backward_mom_dist) &&
+        backward_mom_dist == "radial_expansion") {
+        WARPX_ABORT_WITH_MESSAGE(
+            "<species>.momentum_distribution_type = radial_expansion has been removed. "
+            "Please use momentum_distribution_type = parse_momentum_function instead.");
+    }
 }
 
 void PhysicalParticleContainer::InitData ()

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -409,7 +409,7 @@ PhysicalParticleContainer::BackwardCompatibility ()
     if (pp_species_name.query("momentum_distribution_type", backward_mom_dist) &&
         backward_mom_dist == "radial_expansion") {
         WARPX_ABORT_WITH_MESSAGE(
-            "<species>.momentum_distribution_type = radial_expansion has been removed. "
+            "<species>.momentum_distribution_type = radial_expansion is not supported anymore. "
             "Please use momentum_distribution_type = parse_momentum_function instead.");
     }
 }

--- a/Source/Utils/SpeciesUtils.cpp
+++ b/Source/Utils/SpeciesUtils.cpp
@@ -222,12 +222,6 @@ namespace SpeciesUtils {
             const GetVelocity getVel(*h_mom_vel);
             // Construct InjectorMomentum with InjectorMomentumJuttner.
             h_inj_mom.reset(new InjectorMomentum((InjectorMomentumJuttner*)nullptr, getTemp, getVel));
-        } else if (mom_dist_s == "radial_expansion") {
-            amrex::Real u_over_r = 0._rt;
-            utils::parser::queryWithParser(pp_species, source_name, "u_over_r", u_over_r);
-            // Construct InjectorMomentum with InjectorMomentumRadialExpansion.
-            h_inj_mom.reset(new InjectorMomentum
-                            ((InjectorMomentumRadialExpansion*)nullptr, u_over_r));
         } else if (mom_dist_s == "parse_momentum_function") {
             std::string str_momentum_function_ux;
             std::string str_momentum_function_uy;


### PR DESCRIPTION
## Summary

- Removes the `radial_expansion` momentum distribution type (`InjectorMomentumRadialExpansion`) and all associated code, as it is not used in practice, had no test coverage and adds unnecessary complexity.
- The same behavior is fully reproducible with the existing `parse_momentum_function` type.
- Updates the PICMI interface to use `parse_momentum_function` when `velocity_divergence` is set, now also correctly supporting per-axis divergence rates.
- Adds a `BackwardCompatibility` check in `PhysicalParticleContainer` that raises a clear error if a user sets `momentum_distribution_type = radial_expansion`, directing them to use `parse_momentum_function` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)