### PR TITLE
Remove predefined DensityInjector; replace with parser expressions

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1203,10 +1203,6 @@ Particle initialization
       and ``<species_name>.xmax`` (and same in all directions). This requires additional
       parameter ``<species_name>.density``. i.e., the plasma density in :math:`m^{-3}`.
 
-    * ``predefined``: Predefined density profile.
-      This requires additional parameters ``<species_name>.predefined_profile_name`` and ``<species_name>.predefined_profile_params``.
-      Currently, only a parabolic channel density profile is implemented.
-
     * ``parse_density_function``: the density is given by a function in the input file.
       It requires additional argument ``<species_name>.density_function(x,y,z)``, which is a
       mathematical expression for the density of the species, e.g.
@@ -1385,38 +1381,6 @@ Particle initialization
     * ``vzbar`` or ``true``: the species' average longitudinal velocity :math:`\overline{v_z}`
 
     * ``v``: each particle's velocity :math:`{\bf v}`, including transverse components
-
-* ``species_name.predefined_profile_name`` (`string`)
-    Only read if ``<species_name>.profile`` is ``predefined``.
-
-    * If ``parabolic_channel``, the plasma profile is a parabolic profile with
-      cosine-like ramps at the beginning and the end of the profile.
-      The density is given by
-
-      .. math::
-
-          n = n_0 n(x,y) n(z-z_0)
-
-      with
-
-      .. math::
-
-          n(x,y) = 1 + 4\frac{x^2+y^2}{k_p^2 R_c^4}
-
-      where :math:`k_p` is the plasma wavenumber associated with density :math:`n_0`.
-      Here, with :math:`z_0` as the start of the plasma, :math:`n(z-z_0)` is a cosine-like up-ramp from :math:`0` to :math:`L_{ramp,up}`,
-      constant to :math:`1` from :math:`L_{ramp,up}` to :math:`L_{ramp,up} + L_{plateau}`
-      and a cosine-like down-ramp from :math:`L_{ramp,up} + L_{plateau}` to
-      :math:`L_{ramp,up} + L_{plateau}+L_{ramp,down}`. All parameters are given
-      in ``predefined_profile_params``.
-
-* ``<species_name>.predefined_profile_params`` (list of `float`)
-    Parameters for the predefined profiles.
-
-    * If ``species_name.predefined_profile_name`` is ``parabolic_channel``,
-      ``predefined_profile_params`` contains a space-separated list of the
-      following parameters, in this order: :math:`z_0` :math:`L_{ramp,up}` :math:`L_{plateau}`
-      :math:`L_{ramp,down}` :math:`R_c` :math:`n_0`
 
 * ``<species_name>.do_backward_propagation`` (`bool`)
     Inject a backward-propagating beam to reduce the effect of charge-separation

--- a/Examples/Physics_applications/laser_acceleration/inputs_test_2d_laser_acceleration_boosted
+++ b/Examples/Physics_applications/laser_acceleration/inputs_test_2d_laser_acceleration_boosted
@@ -61,10 +61,19 @@ electrons.xmin = -120.e-6
 electrons.xmax =  120.e-6
 electrons.zmin = 0.5e-3
 electrons.zmax = .0035
-electrons.profile                 = "predefined"
-electrons.predefined_profile_name = "parabolic_channel"
-#         predefined_profile_params = z_start   ramp_up   plateau   ramp_down   rc       n0
-electrons.predefined_profile_params = .5e-3     .5e-3     2.e-3     .5e-3       50.e-6   3.5e24
+# Parabolic plasma channel profile: n0*(1 + 4*(x^2+y^2)/(kp^2*rc^4)) * n_long(z)
+# with kp = q_e/clight * sqrt(n0/(m_e*epsilon0))
+# and n_long(z) a cosine up-ramp, constant plateau, cosine down-ramp
+my_constants.pc_z_start   = 0.5e-3
+my_constants.pc_ramp_up   = 0.5e-3
+my_constants.pc_plateau   = 2.e-3
+my_constants.pc_ramp_down = 0.5e-3
+my_constants.pc_rc        = 50.e-6
+my_constants.pc_n0        = 3.5e24
+my_constants.pc_kp        = q_e/clight*sqrt(pc_n0/(m_e*epsilon0))
+
+electrons.profile = parse_density_function
+electrons.density_function(x,y,z) = pc_n0*(1+4*(x*x+y*y)/(pc_kp*pc_kp*pc_rc*pc_rc*pc_rc*pc_rc))*if(z<pc_z_start,0,if(z<pc_z_start+pc_ramp_up,0.5*(1-cos(pi*(z-pc_z_start)/pc_ramp_up)),if(z<pc_z_start+pc_ramp_up+pc_plateau,1,if(z<pc_z_start+pc_ramp_up+pc_plateau+pc_ramp_down,0.5*(1+cos(pi*(z-pc_z_start-pc_ramp_up-pc_plateau)/pc_ramp_down)),0))))
 electrons.do_continuous_injection = 1
 
 ions.charge = q_e
@@ -76,10 +85,8 @@ ions.xmin = -120.e-6
 ions.xmax =  120.e-6
 ions.zmin = 0.5e-3
 ions.zmax = .0035
-ions.profile                 = "predefined"
-ions.predefined_profile_name = "parabolic_channel"
-#    predefined_profile_params = z_start   ramp_up   plateau   ramp_down   rc       n0
-ions.predefined_profile_params = .5e-3     .5e-3     2.e-3     .5e-3       50.e-6   3.5e24
+ions.profile = parse_density_function
+ions.density_function(x,y,z) = pc_n0*(1+4*(x*x+y*y)/(pc_kp*pc_kp*pc_rc*pc_rc*pc_rc*pc_rc))*if(z<pc_z_start,0,if(z<pc_z_start+pc_ramp_up,0.5*(1-cos(pi*(z-pc_z_start)/pc_ramp_up)),if(z<pc_z_start+pc_ramp_up+pc_plateau,1,if(z<pc_z_start+pc_ramp_up+pc_plateau+pc_ramp_down,0.5*(1+cos(pi*(z-pc_z_start-pc_ramp_up-pc_plateau)/pc_ramp_down)),0))))
 ions.do_continuous_injection = 1
 
 beam.charge = -q_e

--- a/Examples/Physics_applications/laser_acceleration/inputs_test_2d_laser_acceleration_boosted
+++ b/Examples/Physics_applications/laser_acceleration/inputs_test_2d_laser_acceleration_boosted
@@ -74,7 +74,7 @@ my_constants.kp        = q_e/clight*sqrt(n0/(m_e*epsilon0))
 
 electrons.profile = parse_density_function
 electrons.density_function(x,y,z) = \
-    "n0*(1+4*(x*x+y*y)/(kp*kp*rc*rc*rc*rc))" \
+    "n0*(1+4*(x**2+y**2)/(kp**2*rc**4))" \
     "*if(z<z_start, 0," \
     "   if(z<z_start+ramp_up, 0.5*(1-cos(pi*(z-z_start)/ramp_up))," \
     "   if(z<z_start+ramp_up+plateau, 1," \
@@ -93,7 +93,7 @@ ions.zmin = 0.5e-3
 ions.zmax = .0035
 ions.profile = parse_density_function
 ions.density_function(x,y,z) = \
-    "n0*(1+4*(x*x+y*y)/(kp*kp*rc*rc*rc*rc))" \
+    "n0*(1+4*(x**2+y**2)/(kp**2*rc**4))" \
     "*if(z<z_start, 0," \
     "   if(z<z_start+ramp_up, 0.5*(1-cos(pi*(z-z_start)/ramp_up))," \
     "   if(z<z_start+ramp_up+plateau, 1," \

--- a/Examples/Physics_applications/laser_acceleration/inputs_test_2d_laser_acceleration_boosted
+++ b/Examples/Physics_applications/laser_acceleration/inputs_test_2d_laser_acceleration_boosted
@@ -64,16 +64,22 @@ electrons.zmax = .0035
 # Parabolic plasma channel profile: n0*(1 + 4*(x^2+y^2)/(kp^2*rc^4)) * n_long(z)
 # with kp = q_e/clight * sqrt(n0/(m_e*epsilon0))
 # and n_long(z) a cosine up-ramp, constant plateau, cosine down-ramp
-my_constants.pc_z_start   = 0.5e-3
-my_constants.pc_ramp_up   = 0.5e-3
-my_constants.pc_plateau   = 2.e-3
-my_constants.pc_ramp_down = 0.5e-3
-my_constants.pc_rc        = 50.e-6
-my_constants.pc_n0        = 3.5e24
-my_constants.pc_kp        = q_e/clight*sqrt(pc_n0/(m_e*epsilon0))
+my_constants.z_start   = 0.5e-3
+my_constants.ramp_up   = 0.5e-3
+my_constants.plateau   = 2.e-3
+my_constants.ramp_down = 0.5e-3
+my_constants.rc        = 50.e-6
+my_constants.n0        = 3.5e24
+my_constants.kp        = q_e/clight*sqrt(n0/(m_e*epsilon0))
 
 electrons.profile = parse_density_function
-electrons.density_function(x,y,z) = pc_n0*(1+4*(x*x+y*y)/(pc_kp*pc_kp*pc_rc*pc_rc*pc_rc*pc_rc))*if(z<pc_z_start,0,if(z<pc_z_start+pc_ramp_up,0.5*(1-cos(pi*(z-pc_z_start)/pc_ramp_up)),if(z<pc_z_start+pc_ramp_up+pc_plateau,1,if(z<pc_z_start+pc_ramp_up+pc_plateau+pc_ramp_down,0.5*(1+cos(pi*(z-pc_z_start-pc_ramp_up-pc_plateau)/pc_ramp_down)),0))))
+electrons.density_function(x,y,z) = \
+    "n0*(1+4*(x*x+y*y)/(kp*kp*rc*rc*rc*rc))" \
+    "*if(z<z_start, 0," \
+    "   if(z<z_start+ramp_up, 0.5*(1-cos(pi*(z-z_start)/ramp_up))," \
+    "   if(z<z_start+ramp_up+plateau, 1," \
+    "   if(z<z_start+ramp_up+plateau+ramp_down, 0.5*(1+cos(pi*(z-z_start-ramp_up-plateau)/ramp_down))," \
+    "   0))))"
 electrons.do_continuous_injection = 1
 
 ions.charge = q_e
@@ -86,7 +92,13 @@ ions.xmax =  120.e-6
 ions.zmin = 0.5e-3
 ions.zmax = .0035
 ions.profile = parse_density_function
-ions.density_function(x,y,z) = pc_n0*(1+4*(x*x+y*y)/(pc_kp*pc_kp*pc_rc*pc_rc*pc_rc*pc_rc))*if(z<pc_z_start,0,if(z<pc_z_start+pc_ramp_up,0.5*(1-cos(pi*(z-pc_z_start)/pc_ramp_up)),if(z<pc_z_start+pc_ramp_up+pc_plateau,1,if(z<pc_z_start+pc_ramp_up+pc_plateau+pc_ramp_down,0.5*(1+cos(pi*(z-pc_z_start-pc_ramp_up-pc_plateau)/pc_ramp_down)),0))))
+ions.density_function(x,y,z) = \
+    "n0*(1+4*(x*x+y*y)/(kp*kp*rc*rc*rc*rc))" \
+    "*if(z<z_start, 0," \
+    "   if(z<z_start+ramp_up, 0.5*(1-cos(pi*(z-z_start)/ramp_up))," \
+    "   if(z<z_start+ramp_up+plateau, 1," \
+    "   if(z<z_start+ramp_up+plateau+ramp_down, 0.5*(1+cos(pi*(z-z_start-ramp_up-plateau)/ramp_down))," \
+    "   0))))"
 ions.do_continuous_injection = 1
 
 beam.charge = -q_e

--- a/Examples/Tests/initial_plasma_profile/inputs_test_2d_parabolic_channel_initialization
+++ b/Examples/Tests/initial_plasma_profile/inputs_test_2d_parabolic_channel_initialization
@@ -45,16 +45,22 @@ electrons.zmax = 0.32
 # Parabolic plasma channel profile: n0*(1 + 4*(x^2+y^2)/(kp^2*rc^4)) * n_long(z)
 # with kp = q_e/clight * sqrt(n0/(m_e*epsilon0))
 # and n_long(z) a cosine up-ramp, constant plateau, cosine down-ramp
-my_constants.pc_z_start   = 0.0
-my_constants.pc_ramp_up   = 0.02
-my_constants.pc_plateau   = 0.297
-my_constants.pc_ramp_down = 0.003
-my_constants.pc_rc        = 40.e-6
-my_constants.pc_n0        = 1.7e23
-my_constants.pc_kp        = q_e/clight*sqrt(pc_n0/(m_e*epsilon0))
+my_constants.z_start   = 0.0
+my_constants.ramp_up   = 0.02
+my_constants.plateau   = 0.297
+my_constants.ramp_down = 0.003
+my_constants.rc        = 40.e-6
+my_constants.n0        = 1.7e23
+my_constants.kp        = q_e/clight*sqrt(n0/(m_e*epsilon0))
 
 electrons.profile = parse_density_function
-electrons.density_function(x,y,z) = pc_n0*(1+4*(x*x+y*y)/(pc_kp*pc_kp*pc_rc*pc_rc*pc_rc*pc_rc))*if(z<pc_z_start,0,if(z<pc_z_start+pc_ramp_up,0.5*(1-cos(pi*(z-pc_z_start)/pc_ramp_up)),if(z<pc_z_start+pc_ramp_up+pc_plateau,1,if(z<pc_z_start+pc_ramp_up+pc_plateau+pc_ramp_down,0.5*(1+cos(pi*(z-pc_z_start-pc_ramp_up-pc_plateau)/pc_ramp_down)),0))))
+electrons.density_function(x,y,z) = \
+    "n0*(1+4*(x*x+y*y)/(kp*kp*rc*rc*rc*rc))" \
+    "*if(z<z_start, 0," \
+    "   if(z<z_start+ramp_up, 0.5*(1-cos(pi*(z-z_start)/ramp_up))," \
+    "   if(z<z_start+ramp_up+plateau, 1," \
+    "   if(z<z_start+ramp_up+plateau+ramp_down, 0.5*(1+cos(pi*(z-z_start-ramp_up-plateau)/ramp_down))," \
+    "   0))))"
 
 #################################
 ########## DIAGNOSTIC ###########

--- a/Examples/Tests/initial_plasma_profile/inputs_test_2d_parabolic_channel_initialization
+++ b/Examples/Tests/initial_plasma_profile/inputs_test_2d_parabolic_channel_initialization
@@ -42,10 +42,19 @@ electrons.ymin = -150.e-6
 electrons.ymax =  150.e-6
 electrons.zmin = 0.0
 electrons.zmax = 0.32
-electrons.profile                 = "predefined"
-electrons.predefined_profile_name = "parabolic_channel"
-#         predefined_profile_params = z_start   ramp_up   plateau   ramp_down   rc       n0
-electrons.predefined_profile_params = 0.0       .02       .297      .003        40.e-6   1.7e23
+# Parabolic plasma channel profile: n0*(1 + 4*(x^2+y^2)/(kp^2*rc^4)) * n_long(z)
+# with kp = q_e/clight * sqrt(n0/(m_e*epsilon0))
+# and n_long(z) a cosine up-ramp, constant plateau, cosine down-ramp
+my_constants.pc_z_start   = 0.0
+my_constants.pc_ramp_up   = 0.02
+my_constants.pc_plateau   = 0.297
+my_constants.pc_ramp_down = 0.003
+my_constants.pc_rc        = 40.e-6
+my_constants.pc_n0        = 1.7e23
+my_constants.pc_kp        = q_e/clight*sqrt(pc_n0/(m_e*epsilon0))
+
+electrons.profile = parse_density_function
+electrons.density_function(x,y,z) = pc_n0*(1+4*(x*x+y*y)/(pc_kp*pc_kp*pc_rc*pc_rc*pc_rc*pc_rc))*if(z<pc_z_start,0,if(z<pc_z_start+pc_ramp_up,0.5*(1-cos(pi*(z-pc_z_start)/pc_ramp_up)),if(z<pc_z_start+pc_ramp_up+pc_plateau,1,if(z<pc_z_start+pc_ramp_up+pc_plateau+pc_ramp_down,0.5*(1+cos(pi*(z-pc_z_start-pc_ramp_up-pc_plateau)/pc_ramp_down)),0))))
 
 #################################
 ########## DIAGNOSTIC ###########

--- a/Examples/Tests/initial_plasma_profile/inputs_test_2d_parabolic_channel_initialization
+++ b/Examples/Tests/initial_plasma_profile/inputs_test_2d_parabolic_channel_initialization
@@ -55,7 +55,7 @@ my_constants.kp        = q_e/clight*sqrt(n0/(m_e*epsilon0))
 
 electrons.profile = parse_density_function
 electrons.density_function(x,y,z) = \
-    "n0*(1+4*(x*x+y*y)/(kp*kp*rc*rc*rc*rc))" \
+    "n0*(1+4*(x**2+y**2)/(kp**2*rc**4))" \
     "*if(z<z_start, 0," \
     "   if(z<z_start+ramp_up, 0.5*(1-cos(pi*(z-z_start)/ramp_up))," \
     "   if(z<z_start+ramp_up+plateau, 1," \

--- a/Examples/Tests/nci_psatd_stability/inputs_test_2d_comoving_psatd_hybrid
+++ b/Examples/Tests/nci_psatd_stability/inputs_test_2d_comoving_psatd_hybrid
@@ -72,7 +72,7 @@ my_constants.kp        = q_e/clight*sqrt(n0/(m_e*epsilon0))
 
 electrons.profile = parse_density_function
 electrons.density_function(x,y,z) = \
-    "n0*(1+4*(x*x+y*y)/(kp*kp*rc*rc*rc*rc))" \
+    "n0*(1+4*(x**2+y**2)/(kp**2*rc**4))" \
     "*if(z<z_start, 0," \
     "   if(z<z_start+ramp_up, 0.5*(1-cos(pi*(z-z_start)/ramp_up))," \
     "   if(z<z_start+ramp_up+plateau, 1," \
@@ -91,7 +91,7 @@ ions.zmin = 0.
 ions.zmax = 15000.e-6
 ions.profile = parse_density_function
 ions.density_function(x,y,z) = \
-    "n0*(1+4*(x*x+y*y)/(kp*kp*rc*rc*rc*rc))" \
+    "n0*(1+4*(x**2+y**2)/(kp**2*rc**4))" \
     "*if(z<z_start, 0," \
     "   if(z<z_start+ramp_up, 0.5*(1-cos(pi*(z-z_start)/ramp_up))," \
     "   if(z<z_start+ramp_up+plateau, 1," \

--- a/Examples/Tests/nci_psatd_stability/inputs_test_2d_comoving_psatd_hybrid
+++ b/Examples/Tests/nci_psatd_stability/inputs_test_2d_comoving_psatd_hybrid
@@ -62,16 +62,22 @@ electrons.zmax = 15000.e-6
 # Parabolic plasma channel profile: n0*(1 + 4*(x^2+y^2)/(kp^2*rc^4)) * n_long(z)
 # with kp = q_e/clight * sqrt(n0/(m_e*epsilon0))
 # and n_long(z) a cosine up-ramp, constant plateau, cosine down-ramp
-my_constants.pc_z_start   = 0.
-my_constants.pc_ramp_up   = 0.5e-3
-my_constants.pc_plateau   = 14.e-3
-my_constants.pc_ramp_down = 0.5e-3
-my_constants.pc_rc        = 30.e-6
-my_constants.pc_n0        = 1.e24
-my_constants.pc_kp        = q_e/clight*sqrt(pc_n0/(m_e*epsilon0))
+my_constants.z_start   = 0.
+my_constants.ramp_up   = 0.5e-3
+my_constants.plateau   = 14.e-3
+my_constants.ramp_down = 0.5e-3
+my_constants.rc        = 30.e-6
+my_constants.n0        = 1.e24
+my_constants.kp        = q_e/clight*sqrt(n0/(m_e*epsilon0))
 
 electrons.profile = parse_density_function
-electrons.density_function(x,y,z) = pc_n0*(1+4*(x*x+y*y)/(pc_kp*pc_kp*pc_rc*pc_rc*pc_rc*pc_rc))*if(z<pc_z_start,0,if(z<pc_z_start+pc_ramp_up,0.5*(1-cos(pi*(z-pc_z_start)/pc_ramp_up)),if(z<pc_z_start+pc_ramp_up+pc_plateau,1,if(z<pc_z_start+pc_ramp_up+pc_plateau+pc_ramp_down,0.5*(1+cos(pi*(z-pc_z_start-pc_ramp_up-pc_plateau)/pc_ramp_down)),0))))
+electrons.density_function(x,y,z) = \
+    "n0*(1+4*(x*x+y*y)/(kp*kp*rc*rc*rc*rc))" \
+    "*if(z<z_start, 0," \
+    "   if(z<z_start+ramp_up, 0.5*(1-cos(pi*(z-z_start)/ramp_up))," \
+    "   if(z<z_start+ramp_up+plateau, 1," \
+    "   if(z<z_start+ramp_up+plateau+ramp_down, 0.5*(1+cos(pi*(z-z_start-ramp_up-plateau)/ramp_down))," \
+    "   0))))"
 electrons.do_continuous_injection = 1
 
 ions.charge = q_e
@@ -84,7 +90,13 @@ ions.xmax =  45.e-6
 ions.zmin = 0.
 ions.zmax = 15000.e-6
 ions.profile = parse_density_function
-ions.density_function(x,y,z) = pc_n0*(1+4*(x*x+y*y)/(pc_kp*pc_kp*pc_rc*pc_rc*pc_rc*pc_rc))*if(z<pc_z_start,0,if(z<pc_z_start+pc_ramp_up,0.5*(1-cos(pi*(z-pc_z_start)/pc_ramp_up)),if(z<pc_z_start+pc_ramp_up+pc_plateau,1,if(z<pc_z_start+pc_ramp_up+pc_plateau+pc_ramp_down,0.5*(1+cos(pi*(z-pc_z_start-pc_ramp_up-pc_plateau)/pc_ramp_down)),0))))
+ions.density_function(x,y,z) = \
+    "n0*(1+4*(x*x+y*y)/(kp*kp*rc*rc*rc*rc))" \
+    "*if(z<z_start, 0," \
+    "   if(z<z_start+ramp_up, 0.5*(1-cos(pi*(z-z_start)/ramp_up))," \
+    "   if(z<z_start+ramp_up+plateau, 1," \
+    "   if(z<z_start+ramp_up+plateau+ramp_down, 0.5*(1+cos(pi*(z-z_start-ramp_up-plateau)/ramp_down))," \
+    "   0))))"
 ions.do_continuous_injection = 1
 
 beam.charge = -q_e

--- a/Examples/Tests/nci_psatd_stability/inputs_test_2d_comoving_psatd_hybrid
+++ b/Examples/Tests/nci_psatd_stability/inputs_test_2d_comoving_psatd_hybrid
@@ -59,9 +59,19 @@ electrons.xmin = -45.e-6
 electrons.xmax =  45.e-6
 electrons.zmin = 0.
 electrons.zmax = 15000.e-6
-electrons.profile = "predefined"
-electrons.predefined_profile_name = "parabolic_channel"
-electrons.predefined_profile_params = 0. 0.5e-3 14.e-3 0.5e-3 30.e-6 1.e24
+# Parabolic plasma channel profile: n0*(1 + 4*(x^2+y^2)/(kp^2*rc^4)) * n_long(z)
+# with kp = q_e/clight * sqrt(n0/(m_e*epsilon0))
+# and n_long(z) a cosine up-ramp, constant plateau, cosine down-ramp
+my_constants.pc_z_start   = 0.
+my_constants.pc_ramp_up   = 0.5e-3
+my_constants.pc_plateau   = 14.e-3
+my_constants.pc_ramp_down = 0.5e-3
+my_constants.pc_rc        = 30.e-6
+my_constants.pc_n0        = 1.e24
+my_constants.pc_kp        = q_e/clight*sqrt(pc_n0/(m_e*epsilon0))
+
+electrons.profile = parse_density_function
+electrons.density_function(x,y,z) = pc_n0*(1+4*(x*x+y*y)/(pc_kp*pc_kp*pc_rc*pc_rc*pc_rc*pc_rc))*if(z<pc_z_start,0,if(z<pc_z_start+pc_ramp_up,0.5*(1-cos(pi*(z-pc_z_start)/pc_ramp_up)),if(z<pc_z_start+pc_ramp_up+pc_plateau,1,if(z<pc_z_start+pc_ramp_up+pc_plateau+pc_ramp_down,0.5*(1+cos(pi*(z-pc_z_start-pc_ramp_up-pc_plateau)/pc_ramp_down)),0))))
 electrons.do_continuous_injection = 1
 
 ions.charge = q_e
@@ -73,9 +83,8 @@ ions.xmin = -45.e-6
 ions.xmax =  45.e-6
 ions.zmin = 0.
 ions.zmax = 15000.e-6
-ions.profile = "predefined"
-ions.predefined_profile_name = "parabolic_channel"
-ions.predefined_profile_params = 0. 0.5e-3 14.e-3 0.5e-3 30.e-6 1.e24
+ions.profile = parse_density_function
+ions.density_function(x,y,z) = pc_n0*(1+4*(x*x+y*y)/(pc_kp*pc_kp*pc_rc*pc_rc*pc_rc*pc_rc))*if(z<pc_z_start,0,if(z<pc_z_start+pc_ramp_up,0.5*(1-cos(pi*(z-pc_z_start)/pc_ramp_up)),if(z<pc_z_start+pc_ramp_up+pc_plateau,1,if(z<pc_z_start+pc_ramp_up+pc_plateau+pc_ramp_down,0.5*(1+cos(pi*(z-pc_z_start-pc_ramp_up-pc_plateau)/pc_ramp_down)),0))))
 ions.do_continuous_injection = 1
 
 beam.charge = -q_e

--- a/Examples/Tests/nci_psatd_stability/inputs_test_2d_galilean_psatd_hybrid
+++ b/Examples/Tests/nci_psatd_stability/inputs_test_2d_galilean_psatd_hybrid
@@ -57,9 +57,19 @@ electrons.xmin = -45.e-6
 electrons.xmax =  45.e-6
 electrons.zmin = 0.
 electrons.zmax = 15000.e-6
-electrons.profile = "predefined"
-electrons.predefined_profile_name = "parabolic_channel"
-electrons.predefined_profile_params = 0. 0.5e-3 14.e-3 0.5e-3 30.e-6 1.e24
+# Parabolic plasma channel profile: n0*(1 + 4*(x^2+y^2)/(kp^2*rc^4)) * n_long(z)
+# with kp = q_e/clight * sqrt(n0/(m_e*epsilon0))
+# and n_long(z) a cosine up-ramp, constant plateau, cosine down-ramp
+my_constants.pc_z_start   = 0.
+my_constants.pc_ramp_up   = 0.5e-3
+my_constants.pc_plateau   = 14.e-3
+my_constants.pc_ramp_down = 0.5e-3
+my_constants.pc_rc        = 30.e-6
+my_constants.pc_n0        = 1.e24
+my_constants.pc_kp        = q_e/clight*sqrt(pc_n0/(m_e*epsilon0))
+
+electrons.profile = parse_density_function
+electrons.density_function(x,y,z) = pc_n0*(1+4*(x*x+y*y)/(pc_kp*pc_kp*pc_rc*pc_rc*pc_rc*pc_rc))*if(z<pc_z_start,0,if(z<pc_z_start+pc_ramp_up,0.5*(1-cos(pi*(z-pc_z_start)/pc_ramp_up)),if(z<pc_z_start+pc_ramp_up+pc_plateau,1,if(z<pc_z_start+pc_ramp_up+pc_plateau+pc_ramp_down,0.5*(1+cos(pi*(z-pc_z_start-pc_ramp_up-pc_plateau)/pc_ramp_down)),0))))
 electrons.do_continuous_injection = 1
 
 ions.charge = q_e
@@ -71,9 +81,8 @@ ions.xmin = -45.e-6
 ions.xmax =  45.e-6
 ions.zmin = 0.
 ions.zmax = 15000.e-6
-ions.profile = "predefined"
-ions.predefined_profile_name = "parabolic_channel"
-ions.predefined_profile_params = 0. 0.5e-3 14.e-3 0.5e-3 30.e-6 1.e24
+ions.profile = parse_density_function
+ions.density_function(x,y,z) = pc_n0*(1+4*(x*x+y*y)/(pc_kp*pc_kp*pc_rc*pc_rc*pc_rc*pc_rc))*if(z<pc_z_start,0,if(z<pc_z_start+pc_ramp_up,0.5*(1-cos(pi*(z-pc_z_start)/pc_ramp_up)),if(z<pc_z_start+pc_ramp_up+pc_plateau,1,if(z<pc_z_start+pc_ramp_up+pc_plateau+pc_ramp_down,0.5*(1+cos(pi*(z-pc_z_start-pc_ramp_up-pc_plateau)/pc_ramp_down)),0))))
 ions.do_continuous_injection = 1
 
 beam.charge = -q_e

--- a/Examples/Tests/nci_psatd_stability/inputs_test_2d_galilean_psatd_hybrid
+++ b/Examples/Tests/nci_psatd_stability/inputs_test_2d_galilean_psatd_hybrid
@@ -60,16 +60,22 @@ electrons.zmax = 15000.e-6
 # Parabolic plasma channel profile: n0*(1 + 4*(x^2+y^2)/(kp^2*rc^4)) * n_long(z)
 # with kp = q_e/clight * sqrt(n0/(m_e*epsilon0))
 # and n_long(z) a cosine up-ramp, constant plateau, cosine down-ramp
-my_constants.pc_z_start   = 0.
-my_constants.pc_ramp_up   = 0.5e-3
-my_constants.pc_plateau   = 14.e-3
-my_constants.pc_ramp_down = 0.5e-3
-my_constants.pc_rc        = 30.e-6
-my_constants.pc_n0        = 1.e24
-my_constants.pc_kp        = q_e/clight*sqrt(pc_n0/(m_e*epsilon0))
+my_constants.z_start   = 0.
+my_constants.ramp_up   = 0.5e-3
+my_constants.plateau   = 14.e-3
+my_constants.ramp_down = 0.5e-3
+my_constants.rc        = 30.e-6
+my_constants.n0        = 1.e24
+my_constants.kp        = q_e/clight*sqrt(n0/(m_e*epsilon0))
 
 electrons.profile = parse_density_function
-electrons.density_function(x,y,z) = pc_n0*(1+4*(x*x+y*y)/(pc_kp*pc_kp*pc_rc*pc_rc*pc_rc*pc_rc))*if(z<pc_z_start,0,if(z<pc_z_start+pc_ramp_up,0.5*(1-cos(pi*(z-pc_z_start)/pc_ramp_up)),if(z<pc_z_start+pc_ramp_up+pc_plateau,1,if(z<pc_z_start+pc_ramp_up+pc_plateau+pc_ramp_down,0.5*(1+cos(pi*(z-pc_z_start-pc_ramp_up-pc_plateau)/pc_ramp_down)),0))))
+electrons.density_function(x,y,z) = \
+    "n0*(1+4*(x*x+y*y)/(kp*kp*rc*rc*rc*rc))" \
+    "*if(z<z_start, 0," \
+    "   if(z<z_start+ramp_up, 0.5*(1-cos(pi*(z-z_start)/ramp_up))," \
+    "   if(z<z_start+ramp_up+plateau, 1," \
+    "   if(z<z_start+ramp_up+plateau+ramp_down, 0.5*(1+cos(pi*(z-z_start-ramp_up-plateau)/ramp_down))," \
+    "   0))))"
 electrons.do_continuous_injection = 1
 
 ions.charge = q_e
@@ -82,7 +88,13 @@ ions.xmax =  45.e-6
 ions.zmin = 0.
 ions.zmax = 15000.e-6
 ions.profile = parse_density_function
-ions.density_function(x,y,z) = pc_n0*(1+4*(x*x+y*y)/(pc_kp*pc_kp*pc_rc*pc_rc*pc_rc*pc_rc))*if(z<pc_z_start,0,if(z<pc_z_start+pc_ramp_up,0.5*(1-cos(pi*(z-pc_z_start)/pc_ramp_up)),if(z<pc_z_start+pc_ramp_up+pc_plateau,1,if(z<pc_z_start+pc_ramp_up+pc_plateau+pc_ramp_down,0.5*(1+cos(pi*(z-pc_z_start-pc_ramp_up-pc_plateau)/pc_ramp_down)),0))))
+ions.density_function(x,y,z) = \
+    "n0*(1+4*(x*x+y*y)/(kp*kp*rc*rc*rc*rc))" \
+    "*if(z<z_start, 0," \
+    "   if(z<z_start+ramp_up, 0.5*(1-cos(pi*(z-z_start)/ramp_up))," \
+    "   if(z<z_start+ramp_up+plateau, 1," \
+    "   if(z<z_start+ramp_up+plateau+ramp_down, 0.5*(1+cos(pi*(z-z_start-ramp_up-plateau)/ramp_down))," \
+    "   0))))"
 ions.do_continuous_injection = 1
 
 beam.charge = -q_e

--- a/Examples/Tests/nci_psatd_stability/inputs_test_2d_galilean_psatd_hybrid
+++ b/Examples/Tests/nci_psatd_stability/inputs_test_2d_galilean_psatd_hybrid
@@ -70,7 +70,7 @@ my_constants.kp        = q_e/clight*sqrt(n0/(m_e*epsilon0))
 
 electrons.profile = parse_density_function
 electrons.density_function(x,y,z) = \
-    "n0*(1+4*(x*x+y*y)/(kp*kp*rc*rc*rc*rc))" \
+    "n0*(1+4*(x**2+y**2)/(kp**2*rc**4))" \
     "*if(z<z_start, 0," \
     "   if(z<z_start+ramp_up, 0.5*(1-cos(pi*(z-z_start)/ramp_up))," \
     "   if(z<z_start+ramp_up+plateau, 1," \
@@ -89,7 +89,7 @@ ions.zmin = 0.
 ions.zmax = 15000.e-6
 ions.profile = parse_density_function
 ions.density_function(x,y,z) = \
-    "n0*(1+4*(x*x+y*y)/(kp*kp*rc*rc*rc*rc))" \
+    "n0*(1+4*(x**2+y**2)/(kp**2*rc**4))" \
     "*if(z<z_start, 0," \
     "   if(z<z_start+ramp_up, 0.5*(1-cos(pi*(z-z_start)/ramp_up))," \
     "   if(z<z_start+ramp_up+plateau, 1," \

--- a/Examples/Tests/restart/inputs_base_3d
+++ b/Examples/Tests/restart/inputs_base_3d
@@ -27,9 +27,9 @@ warpx.cfl = .99
 warpx.do_moving_window = 1
 warpx.moving_window_dir = z
 warpx.moving_window_v = 1. # in units of the speed of light
-my_constants.dens  = 1e+23
-my_constants.pc_rc = 40.e-6
-my_constants.pc_kp = q_e/clight*sqrt(dens/(m_e*epsilon0))
+my_constants.dens = 1e+23
+my_constants.rc   = 40.e-6
+my_constants.kp   = q_e/clight*sqrt(dens/(m_e*epsilon0))
 
 # Order of particle shape factors
 algo.particle_shape = 3
@@ -100,7 +100,9 @@ plasma_e.ymax =  100.e-6
 # Parabolic plasma channel profile with no ramps (step function in z):
 # dens*(1 + 4*(x^2+y^2)/(kp^2*rc^4)) for 0 <= z < 3, else 0
 plasma_e.profile = parse_density_function
-plasma_e.density_function(x,y,z) = if(z<0,0,if(z<3,dens*(1+4*(x*x+y*y)/(pc_kp*pc_kp*pc_rc*pc_rc*pc_rc*pc_rc)),0))
+plasma_e.density_function(x,y,z) = \
+    "if(z<0, 0," \
+    "   if(z<3, dens*(1+4*(x*x+y*y)/(kp*kp*rc*rc*rc*rc)), 0))"
 plasma_e.num_particles_per_cell_each_dim = 1 1 1
 plasma_e.momentum_distribution_type = "at_rest"
 plasma_e.do_continuous_injection = 1
@@ -111,7 +113,9 @@ plasma_p.injection_style = "NUniformPerCell"
 plasma_p.zmin = -100.e-6
 plasma_p.zmax = 0.2
 plasma_p.profile = parse_density_function
-plasma_p.density_function(x,y,z) = if(z<0,0,if(z<3,dens*(1+4*(x*x+y*y)/(pc_kp*pc_kp*pc_rc*pc_rc*pc_rc*pc_rc)),0))
+plasma_p.density_function(x,y,z) = \
+    "if(z<0, 0," \
+    "   if(z<3, dens*(1+4*(x*x+y*y)/(kp*kp*rc*rc*rc*rc)), 0))"
 plasma_p.xmin = -100.e-6
 plasma_p.xmax =  100.e-6
 plasma_p.ymin = -100.e-6

--- a/Examples/Tests/restart/inputs_base_3d
+++ b/Examples/Tests/restart/inputs_base_3d
@@ -102,7 +102,7 @@ plasma_e.ymax =  100.e-6
 plasma_e.profile = parse_density_function
 plasma_e.density_function(x,y,z) = \
     "if(z<0, 0," \
-    "   if(z<3, dens*(1+4*(x*x+y*y)/(kp*kp*rc*rc*rc*rc)), 0))"
+    "   if(z<3, dens*(1+4*(x**2+y**2)/(kp**2*rc**4)), 0))"
 plasma_e.num_particles_per_cell_each_dim = 1 1 1
 plasma_e.momentum_distribution_type = "at_rest"
 plasma_e.do_continuous_injection = 1
@@ -115,7 +115,7 @@ plasma_p.zmax = 0.2
 plasma_p.profile = parse_density_function
 plasma_p.density_function(x,y,z) = \
     "if(z<0, 0," \
-    "   if(z<3, dens*(1+4*(x*x+y*y)/(kp*kp*rc*rc*rc*rc)), 0))"
+    "   if(z<3, dens*(1+4*(x**2+y**2)/(kp**2*rc**4)), 0))"
 plasma_p.xmin = -100.e-6
 plasma_p.xmax =  100.e-6
 plasma_p.ymin = -100.e-6

--- a/Examples/Tests/restart/inputs_base_3d
+++ b/Examples/Tests/restart/inputs_base_3d
@@ -28,6 +28,8 @@ warpx.do_moving_window = 1
 warpx.moving_window_dir = z
 warpx.moving_window_v = 1. # in units of the speed of light
 my_constants.dens  = 1e+23
+my_constants.pc_rc = 40.e-6
+my_constants.pc_kp = q_e/clight*sqrt(dens/(m_e*epsilon0))
 
 # Order of particle shape factors
 algo.particle_shape = 3
@@ -95,10 +97,10 @@ plasma_e.xmin = -100.e-6
 plasma_e.xmax =  100.e-6
 plasma_e.ymin = -100.e-6
 plasma_e.ymax =  100.e-6
-plasma_e.profile                 = "predefined"
-plasma_e.predefined_profile_name = "parabolic_channel"
-# predefined_profile_params = z_start   ramp_up plateau ramp_down rc  n0
-plasma_e.predefined_profile_params = 0. 0. 3. 0. 40.e-6 dens
+# Parabolic plasma channel profile with no ramps (step function in z):
+# dens*(1 + 4*(x^2+y^2)/(kp^2*rc^4)) for 0 <= z < 3, else 0
+plasma_e.profile = parse_density_function
+plasma_e.density_function(x,y,z) = if(z<0,0,if(z<3,dens*(1+4*(x*x+y*y)/(pc_kp*pc_kp*pc_rc*pc_rc*pc_rc*pc_rc)),0))
 plasma_e.num_particles_per_cell_each_dim = 1 1 1
 plasma_e.momentum_distribution_type = "at_rest"
 plasma_e.do_continuous_injection = 1
@@ -108,10 +110,8 @@ plasma_p.mass = m_p
 plasma_p.injection_style = "NUniformPerCell"
 plasma_p.zmin = -100.e-6
 plasma_p.zmax = 0.2
-plasma_p.profile                 = "predefined"
-plasma_p.predefined_profile_name = "parabolic_channel"
-# predefined_profile_params = z_start   ramp_up plateau ramp_down rc  n0
-plasma_p.predefined_profile_params = 0. 0. 3. 0. 40.e-6 dens
+plasma_p.profile = parse_density_function
+plasma_p.density_function(x,y,z) = if(z<0,0,if(z<3,dens*(1+4*(x*x+y*y)/(pc_kp*pc_kp*pc_rc*pc_rc*pc_rc*pc_rc)),0))
 plasma_p.xmin = -100.e-6
 plasma_p.xmax =  100.e-6
 plasma_p.ymin = -100.e-6

--- a/Source/Initialization/InjectorDensity.H
+++ b/Source/Initialization/InjectorDensity.H
@@ -10,7 +10,6 @@
 #define WARPX_INJECTOR_DENSITY_H_
 
 #include "Initialization/ExternalField.H"
-#include "Utils/WarpXConst.H"
 
 #include <AMReX.H>
 #include <AMReX_Array.H>
@@ -19,12 +18,10 @@
 #include <AMReX_DistributionMapping.H>
 #include <AMReX_Geometry.H>
 #include <AMReX_GpuQualifiers.H>
-#include <AMReX_Math.H>
 #include <AMReX_Parser.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Vector.H>
 
-#include <cmath>
 #include <functional>
 #include <string>
 
@@ -60,69 +57,6 @@ struct InjectorDensityParser
     }
 
     amrex::ParserExecutor<3> m_parser;
-};
-
-// struct whose getDensity returns local density computed from predefined profile.
-struct InjectorDensityPredefined
-{
-    InjectorDensityPredefined (std::string const& a_species_name);
-
-    void clear ();
-
-    [[nodiscard]]
-    AMREX_GPU_HOST_DEVICE
-    amrex::Real
-    getDensity (amrex::Real x, amrex::Real y, amrex::Real z) const noexcept
-    {
-        // Choices for profile are:
-        // - parabolic_channel
-        switch (profile)
-        {
-        case Profile::parabolic_channel:
-        {
-            // These are cast as double to ensure sufficient precision in the
-            // initialized profile density profile; without these, single and
-            // double precision versions of the executable can show disagreement
-            // From testing, it seems that (for at least some setups), it is only
-            // necessary to case n0 as double to get good agreement between single
-            // and double precision, but just in case, all are cast as double.
-            const double z_start   = p[0];
-            const double ramp_up   = p[1];
-            const double plateau   = p[2];
-            const double ramp_down = p[3];
-            const double rc        = p[4];
-            const double n0        = p[5];
-            const double kp = PhysConst::q_e/PhysConst::c
-                *std::sqrt( n0/(PhysConst::m_e*PhysConst::epsilon_0) );
-            double n;
-
-            // Longitudinal profile, normalized to 1
-            if        ((z-z_start)>=0               and
-                       (z-z_start)<ramp_up ) {
-                n = 0.5*(1.-std::cos(MathConst::pi*(z-z_start)/ramp_up));
-            } else if ((z-z_start)>=ramp_up         and
-                       (z-z_start)< ramp_up+plateau ) {
-                n = 1.;
-            } else if ((z-z_start)>=ramp_up+plateau and
-                       (z-z_start)< ramp_up+plateau+ramp_down) {
-                n = 0.5*(1.+std::cos(MathConst::pi*((z-z_start)-ramp_up-plateau)/ramp_down));
-            } else {
-                n = 0.;
-            }
-            // Multiply by transverse profile, and physical density
-            n *= n0*(1.+4.*(x*x+y*y)/(kp*kp*rc*rc*rc*rc));
-            return static_cast<amrex::Real>(n);
-        }
-        default:
-            amrex::Abort("InjectorDensityPredefined: how did we get here?");
-            return amrex::Real(0.0);
-        }
-    }
-
-private:
-    enum struct Profile { null, parabolic_channel };
-    Profile profile{Profile::null};
-    amrex::GpuArray<amrex::Real,6> p;
 };
 
 // struct whose getDensity returns density from file.
@@ -182,7 +116,6 @@ private:
 // instance of:
 // - InjectorDensityConstant  : to generate constant density;
 // - InjectorDensityParser    : to generate density from parser;
-// - InjectorDensityPredefined: to generate density from predefined profile;
 // - InjectorDensityFromFile  : to generate density from file;
 // The choice is made at runtime, depending in the constructor called.
 // This mimics virtual functions.
@@ -198,12 +131,6 @@ struct InjectorDensity
     InjectorDensity (InjectorDensityParser* t, amrex::ParserExecutor<3> const& a_parser)
         : type(Type::parser),
           object(t,a_parser)
-    { }
-
-    // This constructor stores a InjectorDensityPredefined in union object.
-    InjectorDensity (InjectorDensityPredefined* t, std::string const& a_species_name)
-        : type(Type::predefined),
-          object(t,a_species_name)
     { }
 
     // This constructor stores a InjectorDensityFromFile in union object.
@@ -256,10 +183,6 @@ struct InjectorDensity
         {
             return object.constant.getDensity(x,y,z);
         }
-        case Type::predefined:
-        {
-            return object.predefined.getDensity(x,y,z);
-        }
         case Type::fromfile:
         {
             return object.fromfile.getDensity(x,y,z);
@@ -273,7 +196,7 @@ struct InjectorDensity
     }
 
 private:
-    enum struct Type { constant, predefined, parser, fromfile };
+    enum struct Type { constant, parser, fromfile };
     Type type;
 
     // An instance of union Object constructs and stores any one of
@@ -283,14 +206,11 @@ private:
             : constant(a_rho) {}
         Object (InjectorDensityParser*, amrex::ParserExecutor<3> const& a_parser) noexcept
             : parser(a_parser) {}
-        Object (InjectorDensityPredefined*, std::string const& a_species_name)
-            : predefined(a_species_name) {}
         Object (InjectorDensityFromFile*, std::string const& a_file_name,
                 amrex::Geometry const& a_geom, bool a_distributed)
             : fromfile(a_file_name, a_geom, a_distributed) {}
         InjectorDensityConstant   constant;
         InjectorDensityParser     parser;
-        InjectorDensityPredefined predefined;
         InjectorDensityFromFile   fromfile;
     };
     Object object;

--- a/Source/Initialization/InjectorDensity.cpp
+++ b/Source/Initialization/InjectorDensity.cpp
@@ -7,16 +7,7 @@
  */
 #include "InjectorDensity.H"
 
-#include "Utils/Parser/ParserUtils.H"
-#include "Utils/TextMsg.H"
-
-#include <AMReX_BLassert.H>
 #include <AMReX_OpenMP.H>
-#include <AMReX_ParmParse.H>
-
-#include <algorithm>
-#include <cctype>
-#include <vector>
 
 using namespace amrex;
 
@@ -26,11 +17,6 @@ void InjectorDensity::clear ()
     {
     case Type::parser:
     {
-        break;
-    }
-    case Type::predefined:
-    {
-        object.predefined.clear();
         break;
     }
     case Type::fromfile:
@@ -114,39 +100,6 @@ bool InjectorDensity::distributed () const
     } else {
         return false;
     }
-}
-
-InjectorDensityPredefined::InjectorDensityPredefined (
-    std::string const& a_species_name)
-{
-    const ParmParse pp_species_name(a_species_name);
-
-    std::vector<amrex::Real> v;
-    // Read parameters for the predefined plasma profile.
-    utils::parser::getArrWithParser(
-        pp_species_name, "predefined_profile_params", v);
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(v.size() <= 6,
-                                     "Too many parameters for InjectorDensityPredefined");
-    for (int i = 0; i < static_cast<int>(v.size()); ++i) {
-        p[i] = v[i];
-    }
-
-    // Parse predefined profile name, and update member variable profile.
-    std::string which_profile_s;
-    pp_species_name.query("predefined_profile_name", which_profile_s);
-    std::transform(which_profile_s.begin(), which_profile_s.end(),
-                   which_profile_s.begin(), ::tolower);
-    if (which_profile_s == "parabolic_channel"){
-        profile = Profile::parabolic_channel;
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(v.size() > 5,
-            "InjectorDensityPredefined::parabolic_channel: not enough parameters");
-    }
-}
-
-// Note that we are not allowed to have non-trivial destructor.
-// So we rely on clear() to free memory if needed.
-void InjectorDensityPredefined::clear ()
-{
 }
 
 InjectorDensityFromFile::InjectorDensityFromFile (std::string const& a_file_name,

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -404,6 +404,13 @@ PhysicalParticleContainer::BackwardCompatibility ()
         WARPX_ABORT_WITH_MESSAGE("<species>.plot_species is not supported anymore. "
                      "Please use the new syntax for diagnostics, see documentation.");
     }
+
+    std::string backward_string;
+    if (pp_species_name.query("profile", backward_string) && backward_string == "predefined"){
+        WARPX_ABORT_WITH_MESSAGE(
+            "<species>.profile = predefined is no longer supported. "
+            "Please use <species>.profile = parse_density_function instead.");
+    }
 }
 
 void PhysicalParticleContainer::InitData ()

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -405,8 +405,8 @@ PhysicalParticleContainer::BackwardCompatibility ()
                      "Please use the new syntax for diagnostics, see documentation.");
     }
 
-    std::string backward_string;
-    if (pp_species_name.query("profile", backward_string) && backward_string == "predefined"){
+    std::string backward_profile_type;
+    if (pp_species_name.query("profile", backward_profile_type) && backward_profile_type == "predefined"){
         WARPX_ABORT_WITH_MESSAGE(
             "<species>.profile = predefined is no longer supported. "
             "Please use <species>.profile = parse_density_function instead.");

--- a/Source/Utils/SpeciesUtils.cpp
+++ b/Source/Utils/SpeciesUtils.cpp
@@ -94,9 +94,6 @@ namespace SpeciesUtils {
             utils::parser::getWithParser(pp_species, source_name, "density", density);
             // Construct InjectorDensity with InjectorDensityConstant.
             h_inj_rho.reset(new InjectorDensity((InjectorDensityConstant*)nullptr, density));
-        } else if (rho_prof_s == "predefined") {
-            // Construct InjectorDensity with InjectorDensityPredefined.
-            h_inj_rho.reset(new InjectorDensity((InjectorDensityPredefined*)nullptr,species_name));
         } else if (rho_prof_s == "parse_density_function") {
             std::string str_density_function;
             utils::parser::Store_parserString(pp_species, source_name, "density_function(x,y,z)", str_density_function);


### PR DESCRIPTION
## Motivation

WarpX is now used for fusion, space physics, and many other applications beyond laser-plasma acceleration. Hardcoding a laser-plasma-specific plasma channel profile in C++ is overly specific. The `parse_density_function` mechanism is the right general-purpose tool for this, and the hard-coded plasma channel profile can be removed.

## Summary

- Removes the `predefined` density injector and its `parabolic_channel` profile from the C++ code (`InjectorDensityPredefined` struct, constructor, dispatch, enum value, union member).
- Replaces all 5 input files that used this profile with equivalent `parse_density_function` expressions using `my_constants` for the channel parameters.
- Removes the corresponding documentation from `parameters.rst`.
- Adds a backward-compatibility error in `BackwardCompatibility()` so users who still have `<species>.profile = predefined` in their input files get a clear message to switch to `parse_density_function`.

The parabolic channel formula implemented in C++ was:

```
n(x,y,z) = n0 * (1 + 4*(x²+y²)/(kp²*rc⁴)) * n_long(z)
```

where `kp = q_e/clight * sqrt(n0/(m_e*epsilon0))` and `n_long(z)` is a cosine up-ramp / constant plateau / cosine down-ramp. This is now expressed directly in the input files via the parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)