### PR TITLE
Updates to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ The cmake build directory is always inside the repository root (or worktree root
 
 ```bash
 # Configure (common development build with Python bindings)
-cmake -S . -B build -DWarpX_DIMS=3 -DWarpX_PYTHON=ON
+cmake --fresh -S . -B build -DWarpX_DIMS=3 -DWarpX_PYTHON=ON
 
 # Build
 cmake --build build -j 8

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ If this environment does not yet exist, create it as described in `Docs/source/i
 
 ## Build Commands
 
-The build directory is always `build/` inside the repository root (or worktree root). Never look for or create a build directory outside of the current working directory.
+The cmake build directory is always inside the repository root (or worktree root). Never look for or create a build directory outside of the current working directory.
 
 ```bash
 # Configure (common development build with Python bindings)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ If this environment does not yet exist, create it as described in `Docs/source/i
 
 ## Build Commands
 
+The build directory is always `build/` inside the repository root (or worktree root). Never look for or create a build directory outside of the current working directory.
+
 ```bash
 # Configure (common development build with Python bindings)
 cmake -S . -B build -DWarpX_DIMS=3 -DWarpX_PYTHON=ON
@@ -124,9 +126,12 @@ Commits should limit any formatting changes of unchanged code.
 
 In `.cpp` files: (1) corresponding header, (2) WarpX headers, (3) WarpX forward declarations, (4) AMReX headers, (5) AMReX forward declarations, (6) third-party headers, (7) standard library. Each group alphabetically sorted with blank lines between groups.
 
+## Backward Compatibility
+
+When a change removes or renames a user-facing input parameter, add a guard to the relevant `BackwardCompatibility()` method — e.g., in `Source/WarpX.cpp` or `Source/Particles/PhysicalParticleContainer.cpp`.
+
 ## Version Control
 
 - Main branch: `development` (not `main`)
 - Fork-and-branch workflow; PRs target `development`
 - Pull requests with features and bug fixes need to add a test for coverage.
-- Pull requests require a clear, helpful, concise pull request description and must pass all existing and new tests.


### PR DESCRIPTION
This PR makes a few changes to AGENTS.md based on usage experience and common mistakes made by agents:

- Remind the agents to handle backward compatibility, when modifying the user interface.
- Agents should never look for or create a build directory outside the current working directory. (WarpX instructions typically create the build directory inside the current directory and developers typically stick to this. When the agent tries to look outside of the current directory, it temporarily stops the agent and triggers tedious permission messages to the human user.)
- Remove unneeded, generic instruction about PRs: agents naturally know about the generic best practices for PRs.