### PR TITLE
Fix uninitialized sa_flags in signal handler registration

### DIFF
--- a/Source/ablastr/utils/SignalHandling.cpp
+++ b/Source/ablastr/utils/SignalHandling.cpp
@@ -114,7 +114,7 @@ void
 SignalHandling::InitSignalHandling ()
 {
 #if defined(__linux__) || defined(__APPLE__)
-    struct sigaction sa;
+    struct sigaction sa{};
     sigemptyset(&sa.sa_mask);
     for (int signal_number = 0; signal_number < NUM_SIGNALS; ++signal_number) {
         signal_received_flags[signal_number] = false;


### PR DESCRIPTION
## Summary

I have been experiencing repeated and repeatable WarpX failures on Perlmutter and Frontier when the application is terminated without much or any error output upon signaling the second `USR2` signal to initiate a checkpoint.  This may not be the root cause but is certainly a bug to be fixed.

- Zero-initialize `struct sigaction` in `InitSignalHandling()` to prevent undefined behavior from uninitialized `sa_flags`
- Without value-initialization, the stack-allocated struct can contain garbage in `sa_flags`, which may include `SA_RESETHAND` (making the handler one-shot) or other flags that alter signal delivery semantics
- This is the likely root cause of the "second USR2 kills job" failure pattern where the first signal-triggered checkpoint succeeds but the second signal terminates the process (exit code 0:12 = unhandled USR2)

## Details

The fix is a one-character change: `struct sigaction sa;` → `struct sigaction sa{};`

The `sigemptyset(&sa.sa_mask)` call only zeros the signal mask member — it does not touch `sa_flags` or `sa_restorer`. Only `sa_handler` was explicitly set, leaving `sa_flags` with whatever was on the stack.

Neither GCC (`-Wall -Wextra -fanalyzer`) nor Clang (`-Weverything`) detect this — `sigaction` is an opaque C struct and `sigemptyset` takes a pointer, so compilers cannot reason about which fields remain uninitialized.

AMReX itself is not affected — it uses the simpler `std::signal()` API which has no struct to initialize.

## Test plan

- [X] Existing signal-handling tests continue to pass
- [x] Manual verification: send multiple USR2 signals to a running simulation and confirm checkpoints are written each time without the process being killed
