### PR TITLE
Document LLM-Agents Usage

### DIFF
--- a/Docs/source/developers/how_to_develop_with_llms.rst
+++ b/Docs/source/developers/how_to_develop_with_llms.rst
@@ -1,0 +1,107 @@
+.. _developers-llm:
+
+LLM-Assisted WarpX Development
+==============================
+
+Large Language Models (LLMs) can assist with WarpX development tasks such as navigating the codebase, understanding existing implementations, writing new features, debugging, adding tests, and preparing pull requests.
+This guide documents how the WarpX repository is configured for LLM-based coding assistants and how to get the most out of them.
+
+.. note::
+
+   LLM-generated code should always be reviewed carefully.
+   LLMs can hallucinate APIs, miss physics constraints, or produce code that compiles but is incorrect.
+   The configurations described below help by providing accurate, up-to-date context, but developer judgment remains essential.
+
+   The WarpX community thus urges you to perform a careful, manual review of all LLM-generated code and documentation before sending a pull-request.
+   This is important, otherwise you risk to waste the valuable time of our most proficient developers that will need to review your bot-generated code.
+   (Be considerate that WarpX developers can prompt an LLM just as efficiently as you can. Your critical thinking skill to make sense of the bot generated code and make it sensible for review and maintainable for the long term is what is needed!)
+
+.. note::
+
+   This section is not understood as an endorsement of any of the listed (or unlisted) coding assistants or MCP services.
+   Contributions to this section documenting further services, clients, skills, etc. are encouraged.
+
+
+CLAUDE.md / AGENTS.md
+---------------------
+
+The repository includes a ``CLAUDE.md`` file (with a symbolic link as ``AGENTS.md``) at its root.
+These files are automatically loaded by LLM coding assistants (Claude Code reads ``CLAUDE.md``; other tools such as OpenAI Codex CLI read ``AGENTS.md``) to provide project-specific instructions.
+
+The file contains in a compressed form for an LLM agent:
+
+- **Project overview**: what WarpX is, its dimensionalities and compute backends.
+- **Development environment**: how to activate the conda build environment.
+- **Build commands**: CMake configure, build, and install commands with all key options (``WarpX_DIMS``, ``WarpX_COMPUTE``, ``WarpX_PYTHON``, etc.).
+- **Testing**: how to list and run CTest tests, add new tests, and handle checksums.
+- **Linting and formatting**: pre-commit setup, clang-format and Ruff configuration.
+- **Code architecture**: source layout, key patterns (``MultiFab``, ``MultiParticleContainer``), and compile-time macros.
+- **C++ style**: indentation, naming conventions, include order.
+- **Backward compatibility**: how to handle renamed or removed input parameters.
+- **Version control**: branch conventions (``development`` as main branch), PR workflow.
+
+With this file present, an LLM assistant working inside the WarpX repository will automatically know how to build, test, and style code without being told each time.
+
+To update these instructions, edit ``AGENTS.md``.
+Keep this file under 300 lines to preserve LLM context.
+
+
+Skills
+------
+
+WarpX defines reusable *skills* in the ``.claude/skills/`` directory.
+Skills are scripted workflows that an LLM assistant can execute on demand, automating multi-step tasks that follow a fixed procedure.
+
+Currently available skills:
+
+``/new-paper-highlight``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Adds a new paper to the WarpX science highlights documentation (``Docs/source/highlights.rst``).
+
+Usage (in Claude Code):
+
+.. code-block:: text
+
+   /new-paper-highlight https://doi.org/10.1103/PhysRevLett.133.045002
+
+The skill will:
+
+#. Fetch the paper metadata (authors, title, journal, DOI) from the provided URL.
+#. Choose the appropriate highlights section (e.g., Plasma-Based Acceleration, HPC and Numerics).
+#. Format the entry in the RST style used in the file.
+#. Create a branch, commit the change, and optionally open a pull request.
+
+To add new skills, create a directory under ``.claude/skills/<skill-name>/`` containing a ``SKILL.md`` file that describes the step-by-step procedure.
+
+
+Documentation Context via MCP Servers
+--------------------------------------
+
+LLM assistants work best when they can query up-to-date project documentation.
+The :ref:`AI-Assisted Input File Design <ai_input_design>` workflow page describes how to set up `Model Context Protocol (MCP) <https://modelcontextprotocol.io>`__ servers for this purpose.
+That setup is equally useful for development tasks: the same documentation context that helps write input files also helps an assistant understand WarpX internals, AMReX and pyAMReX APIs, and conventions when writing C++ or Python code.
+
+See :ref:`ai_input_design` for general MCP setup instructions with Context7.
+
+WarpX and Dependency Documentation on Context7
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Since WarpX builds on top of `AMReX <https://amrex-codes.github.io/amrex/>`__, `pyAMReX <https://pyamrex.readthedocs.io>`__, and `openPMD-api <https://openpmd-api.readthedocs.io>`__, providing documentation for these dependencies alongside WarpX documentation gives the assistant much richer context for development tasks.
+
+The following documentation is available through Context7:
+
+- **WarpX**: `context7.com/blast-warpx/warpx <https://context7.com/blast-warpx/warpx>`__
+- **AMReX**: `context7.com/amrex-codes/amrex <https://context7.com/amrex-codes/amrex>`__
+- **pyAMReX**: `context7.com/amrex-codes/pyamrex <https://context7.com/amrex-codes/pyamrex>`__
+- **openPMD-api**: `context7.com/openpmd/openpmd-api <https://context7.com/openpmd/openpmd-api>`__
+- **pybind11**: `context7.com/pybind/pybind11 <https://context7.com/pybind/pybind11>`__
+
+When all five are configured, the assistant can look up AMReX data structures (e.g., ``MultiFab``, ``ParticleContainer``, ``Geometry``), pyAMReX and pybind11 binding patterns, and openPMD I/O APIs directly, which is especially helpful when working on:
+
+- Field solver implementations that use AMReX mesh data structures
+- Particle routines built on ``amrex::ParticleContainer``
+- Python bindings that wrap C++ classes via pybind11 and pyAMReX
+- I/O and diagnostic code that interacts with AMReX plotfiles or openPMD
+
+For instructions on configuring Context7 as an MCP server in your coding assistant (Claude Code, Cursor, VS Code, Windsurf, Codex CLI, and others), see the `Context7 client documentation <https://context7.com/docs/resources/all-clients>`__ and the :ref:`ai_input_design` page.

--- a/Docs/source/developers/how_to_develop_with_llms.rst
+++ b/Docs/source/developers/how_to_develop_with_llms.rst
@@ -12,9 +12,9 @@ This guide documents how the WarpX repository is configured for LLM-based coding
    LLMs can hallucinate APIs, miss physics constraints, or produce code that compiles but is incorrect.
    The configurations described below help by providing accurate, up-to-date context, but developer judgment remains essential.
 
-   The WarpX community thus urges you to perform a careful, manual review of all LLM-generated code and documentation before sending a pull-request.
-   This is important, otherwise you risk to waste the valuable time of our most proficient developers that will need to review your bot-generated code.
-   (Be considerate that WarpX developers can prompt an LLM just as efficiently as you can. Your critical thinking skill to make sense of the bot generated code and make it sensible for review and maintainable for the long term is what is needed!)
+   The WarpX community thus urges you to perform a careful, manual review of all LLM-generated code and documentation before asking for a review of your pull-request.
+   This is important, otherwise you risk to waste the valuable time of our most proficient developers that will need to review your LLM-generated code.
+   (Be considerate that WarpX developers can prompt an LLM just as efficiently as you can. Your critical thinking skill to make sense of the LLM-generated code and make it sensible for review and maintainable for the long term is what is needed!)
 
 .. note::
 
@@ -27,10 +27,10 @@ This guide documents how the WarpX repository is configured for LLM-based coding
    Keep instructions concise (e.g., in ``CLAUDE.md``), break complex tasks into focused sessions, and provide targeted context rather than overwhelming the assistant with information.
 
 
-CLAUDE.md / AGENTS.md
+AGENTS.md / CLAUDE.md
 ---------------------
 
-The repository includes a ``CLAUDE.md`` file (with a symbolic link as ``AGENTS.md``) at its root.
+The repository includes an ``AGENTS.md`` file at its root (as well as a ``CLAUDE.md``, which directly points to ``AGENTS.md``.) 
 These files are automatically loaded by LLM coding assistants (Claude Code reads ``CLAUDE.md``; other tools such as OpenAI Codex CLI read ``AGENTS.md``) to provide project-specific instructions.
 
 The file contains in a compressed form for an LLM agent:
@@ -102,7 +102,7 @@ The following documentation is available through Context7:
 - **openPMD-api**: `context7.com/openpmd/openpmd-api <https://context7.com/openpmd/openpmd-api>`__
 - **pybind11**: `context7.com/pybind/pybind11 <https://context7.com/pybind/pybind11>`__
 
-When all five are configured, the assistant can look up AMReX data structures (e.g., ``MultiFab``, ``ParticleContainer``, ``Geometry``), pyAMReX and pybind11 binding patterns, and openPMD I/O APIs directly, which is especially helpful when working on:
+When all five are configured, the assistant can look up AMReX data structures (e.g., ``MultiFab``, ``ParticleContainer``, ``Geometry``), pyAMReX and pybind11 binding patterns, and openPMD I/O APIs directly, which is especially helpful when working, for instance, on:
 
 - Field solver implementations that use AMReX mesh data structures
 - Particle routines built on ``amrex::ParticleContainer``

--- a/Docs/source/developers/how_to_develop_with_llms.rst
+++ b/Docs/source/developers/how_to_develop_with_llms.rst
@@ -24,7 +24,7 @@ This guide documents how the WarpX repository is configured for LLM-based coding
 .. tip::
 
    When working with LLM coding assistants, keep in mind that *"most best practices are based on one constraint: [the] context window fills up fast, and performance degrades as it fills"* (`Claude Code Best Practices <https://code.claude.com/docs/en/best-practices>`__).
-   Keep instructions concise (e.g., in ``CLAUDE.md``), break complex tasks into focused sessions, and provide targeted context rather than overwhelming the assistant with information.
+   Keep instructions concise, use plan modes, break complex tasks into focused sessions, and provide targeted context rather than overwhelming the assistant with information.
 
 
 AGENTS.md / CLAUDE.md
@@ -33,18 +33,7 @@ AGENTS.md / CLAUDE.md
 The repository includes an ``AGENTS.md`` file at its root (as well as a ``CLAUDE.md``, which directly points to ``AGENTS.md``.)
 These files are automatically loaded by LLM coding assistants (Claude Code reads ``CLAUDE.md``; other tools such as OpenAI Codex CLI read ``AGENTS.md``) to provide project-specific instructions.
 
-The file contains in a compressed form for an LLM agent:
-
-- **Project overview**: what WarpX is, its dimensionalities and compute backends.
-- **Development environment**: how to activate the conda build environment.
-- **Build commands**: CMake configure, build, and install commands with all key options (``WarpX_DIMS``, ``WarpX_COMPUTE``, ``WarpX_PYTHON``, etc.).
-- **Testing**: how to list and run CTest tests, add new tests, and handle checksums.
-- **Linting and formatting**: pre-commit setup, clang-format and Ruff configuration.
-- **Code architecture**: source layout, key patterns (``MultiFab``, ``MultiParticleContainer``), and compile-time macros.
-- **C++ style**: indentation, naming conventions, include order.
-- **Backward compatibility**: how to handle renamed or removed input parameters.
-- **Version control**: branch conventions (``development`` as main branch), PR workflow.
-
+The file contains in a compressed form instructions for an LLM agent:
 With this file present, an LLM assistant working inside the WarpX repository will automatically know how to build, test, and style code without being told each time.
 
 To update these instructions, edit ``AGENTS.md``.
@@ -102,7 +91,8 @@ The following documentation is available through Context7:
 - **openPMD-api**: `context7.com/openpmd/openpmd-api <https://context7.com/openpmd/openpmd-api>`__
 - **pybind11**: `context7.com/pybind/pybind11 <https://context7.com/pybind/pybind11>`__
 
-When all five are configured, the assistant can look up AMReX data structures (e.g., ``MultiFab``, ``ParticleContainer``, ``Geometry``), pyAMReX and pybind11 binding patterns, and openPMD I/O APIs directly, which is especially helpful when working, for instance, on:
+When Context7 connected, the assistant can look up any of those when needed:
+AMReX data structures (e.g., ``MultiFab``, ``ParticleContainer``, ``Geometry``), pyAMReX and pybind11 binding patterns, and openPMD I/O APIs directly, which is especially helpful when working, for instance, on:
 
 - Field solver implementations that use AMReX mesh data structures
 - Particle routines built on ``amrex::ParticleContainer``

--- a/Docs/source/developers/how_to_develop_with_llms.rst
+++ b/Docs/source/developers/how_to_develop_with_llms.rst
@@ -21,6 +21,11 @@ This guide documents how the WarpX repository is configured for LLM-based coding
    This section is not understood as an endorsement of any of the listed (or unlisted) coding assistants or MCP services.
    Contributions to this section documenting further services, clients, skills, etc. are encouraged.
 
+.. tip::
+
+   When working with LLM coding assistants, keep in mind that *"most best practices are based on one constraint: [the] context window fills up fast, and performance degrades as it fills"* (`Claude Code Best Practices <https://code.claude.com/docs/en/best-practices>`__).
+   Keep instructions concise (e.g., in ``CLAUDE.md``), break complex tasks into focused sessions, and provide targeted context rather than overwhelming the assistant with information.
+
 
 CLAUDE.md / AGENTS.md
 ---------------------

--- a/Docs/source/developers/how_to_develop_with_llms.rst
+++ b/Docs/source/developers/how_to_develop_with_llms.rst
@@ -30,7 +30,7 @@ This guide documents how the WarpX repository is configured for LLM-based coding
 AGENTS.md / CLAUDE.md
 ---------------------
 
-The repository includes an ``AGENTS.md`` file at its root (as well as a ``CLAUDE.md``, which directly points to ``AGENTS.md``.) 
+The repository includes an ``AGENTS.md`` file at its root (as well as a ``CLAUDE.md``, which directly points to ``AGENTS.md``.)
 These files are automatically loaded by LLM coding assistants (Claude Code reads ``CLAUDE.md``; other tools such as OpenAI Codex CLI read ``AGENTS.md``) to provide project-specific instructions.
 
 The file contains in a compressed form for an LLM agent:

--- a/Docs/source/developers/how_to_develop_with_llms.rst
+++ b/Docs/source/developers/how_to_develop_with_llms.rst
@@ -89,6 +89,9 @@ The following documentation is available through Context7:
 - **AMReX**: `context7.com/amrex-codes/amrex <https://context7.com/amrex-codes/amrex>`__
 - **pyAMReX**: `context7.com/amrex-codes/pyamrex <https://context7.com/amrex-codes/pyamrex>`__
 - **openPMD-api**: `context7.com/openpmd/openpmd-api <https://context7.com/openpmd/openpmd-api>`__
+- **openPMD-viewer**: `context7.com/openpmd/openpmd-viewer <https://context7.com/openpmd/openpmd-viewer>`__
+- **PICSAR-QED**: `context7.com/ecp-warpx/picsar <https://context7.com/ecp-warpx/picsar>`__
+- **PICMI**: `context7.com/picmi-standard/picmi <https://context7.com/picmi-standard/picmi>`__
 - **pybind11**: `context7.com/pybind/pybind11 <https://context7.com/pybind/pybind11>`__
 
 When Context7 connected, the assistant can look up any of those when needed:

--- a/Docs/source/developers/how_to_guides.rst
+++ b/Docs/source/developers/how_to_guides.rst
@@ -13,3 +13,4 @@ How-To Guides
    how_to_run_clang_tidy
    how_to_compile_locally
    how_to_write_the_docs
+   how_to_develop_with_llms

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -7,6 +7,10 @@ This section describes the list of parameters that can be set in the WarpX input
 
 Examples of inputs files can be found in the :ref:`Examples <usage-examples>` section.
 
+.. tip::
+
+   If you enjoy AI/LLM/agentic workflows, see our :ref:`AI (LLM)-Assisted Input File Design <ai_input_design>` section, too.
+
 .. note::
 
    WarpX's input parameters are read via AMReX's `ParmParse <https://amrex-codes.github.io/amrex/docs_html/Basics.html#parmparse>`__.

--- a/Docs/source/usage/python.rst
+++ b/Docs/source/usage/python.rst
@@ -9,6 +9,10 @@ This documents on how to use WarpX as a Python script (e.g., ``python3 PICMI_scr
 WarpX uses the `PICMI standard <https://github.com/picmi-standard/picmi>`__ for its Python input files.
 Complete example input files can be found in :ref:`the examples section <usage-examples>`.
 
+.. tip::
+
+   If you enjoy AI/LLM/agentic workflows, see our :ref:`AI (LLM)-Assisted Input File Design <ai_input_design>` section, too.
+
 In the input file, instances of classes are created defining the various aspects of the simulation.
 A variable of type :py:class:`pywarpx.picmi.Simulation` is the central object to which all other options are passed, defining the simulation time, field solver, registered species, etc.
 

--- a/Docs/source/usage/workflows.rst
+++ b/Docs/source/usage/workflows.rst
@@ -20,3 +20,4 @@ This section collects typical user workflows and best practices for WarpX.
    workflows/archiving
    workflows/ml_dataset_training
    workflows/optimas
+   workflows/ai_input_design

--- a/Docs/source/usage/workflows/ai_input_design.rst
+++ b/Docs/source/usage/workflows/ai_input_design.rst
@@ -1,0 +1,73 @@
+.. _ai_input_design:
+
+AI (LLM)-Assisted Input File Design
+===================================
+
+Large Language Models (LLMs) can accelerate the process of creating and modifying WarpX input files and Python (PICMI) scripts.
+By providing an LLM-based coding assistant with WarpX documentation as context, users can describe a simulation setup in natural language and receive a draft input file or Python script, ask for explanations of existing parameters, or request modifications to an existing configuration.
+
+This workflow is equally applicable to:
+
+- **WarpX input files** (:ref:`parameter list files <running-cpp-parameters>`)
+- **Python/PICMI scripts** (:ref:`Python scripts <usage-picmi>`)
+
+.. note::
+
+   LLM-generated input files and scripts should always be reviewed carefully before use.
+   LLMs tend to halluscinate options that do not exist or might miss the mental context of your physics.
+   The guide below tries to improve this situation by providing LLMs all WarpX examples and documentation automatically, but this remains an active and rapidly evolving field of tooling.
+
+   Validate physics parameters, boundary conditions, grid resolution, and numerical settings against your domain knowledge and the `WarpX documentation <https://warpx.readthedocs.io>`__.
+
+
+.. note::
+
+   This section is not understood as an endorsement of any of any of the listed (or unlisted) coding assistants or MCP services.
+   Contributions to this section documenting further services, clients, skills, etc are encouraged.
+
+How It Works: MCP Servers
+-------------------------
+
+`Model Context Protocol (MCP) <https://modelcontextprotocol.io>`__ servers are a standardized way to provide external context, such as library documentation, to LLM-based coding assistants.
+When an MCP server is configured, the assistant can query up-to-date WarpX documentation on demand, rather than relying solely on its training data.
+
+Setting Up Context7 as an MCP Server
+------------------------------------
+
+`Context7 <https://context7.com>`__ is a service that indexes open-source project documentation and serves it through the MCP protocol.
+WarpX documentation is available at:
+
+    `context7.com/blast-warpx/warpx <https://context7.com/blast-warpx/warpx>`__
+
+Once connected, a coding assistant (Claude Code, Cursor, VS Code Copilot, Windsurf, etc.) can retrieve relevant sections of the WarpX documentation in real time when helping you write or debug input files and PICMI scripts.
+
+When writing Python/PICMI scripts, users will also encounter `pyAMReX <https://pyamrex.readthedocs.io>`__ APIs (e.g., for accessing mesh and particle data, callbacks, or custom field initialization).
+Adding pyAMReX documentation as an additional Context7 source gives the assistant the ability to look up these APIs:
+
+- **pyAMReX**: `context7.com/amrex-codes/pyamrex <https://context7.com/amrex-codes/pyamrex>`__
+
+For popular coding assistants, see the `Context7 documentation <https://context7.com/docs/resources/all-clients>`__ to configure `WarpX <https://context7.com/blast-warpx/warpx>`.
+
+.. tip::
+
+   Some clients support optional API key authentication.
+   See the `Context7 client docs <https://context7.com/docs/resources/all-clients>`__ for details on API keys and OAuth options.
+
+After creating a personal account, Context7 is free within limits for open source projects.
+
+Best Practices
+--------------
+
+#. **Start from examples.**
+   Run your coding existant inside the WarpX source directory.
+   Point the assistant to an existing input file or PICMI script from the ``Examples/`` directory and ask it to adapt the setup to your needs.
+
+#. **Iterate incrementally.**
+   Start with a minimal working configuration, verify it runs, then ask the assistant to add complexity (diagnostics, additional species, field solvers, etc.).
+
+#. **Cross-check with documentation.**
+   Use the assistant to look up parameter meanings and valid ranges in the WarpX docs, especially for numerical parameters like solvers, resolution, CFL, and filter settings.
+
+#. **Validate before production runs.**
+   Always run a short test simulation and inspect the output before committing to a large-scale run.
+   The ``Examples/`` directory contains analysis scripts that can serve as templates for validation.

--- a/Docs/source/usage/workflows/ai_input_design.rst
+++ b/Docs/source/usage/workflows/ai_input_design.rst
@@ -58,6 +58,9 @@ After creating a personal account, Context7 is free within limits for open sourc
 Best Practices
 --------------
 
+When working with LLM coding assistants, keep in mind that *"most best practices are based on one constraint: [the] context window fills up fast, and performance degrades as it fills"* (`Claude Code Best Practices <https://code.claude.com/docs/en/best-practices>`__).
+Starting from examples and iterating incrementally — as described below — helps keep sessions focused and productive.
+
 #. **Start from examples.**
    Run your coding existant inside the WarpX source directory.
    Point the assistant to an existing input file or PICMI script from the ``Examples/`` directory and ask it to adapt the setup to your needs.

--- a/Docs/source/usage/workflows/ai_input_design.rst
+++ b/Docs/source/usage/workflows/ai_input_design.rst
@@ -14,7 +14,7 @@ This workflow is equally applicable to:
 .. note::
 
    LLM-generated input files and scripts should always be reviewed carefully before use.
-   LLMs tend to halluscinate options that do not exist or might miss the mental context of your physics.
+   LLMs tend to hallucinate options that do not exist or might miss the mental context of your physics.
    The guide below tries to improve this situation by providing LLMs all WarpX examples and documentation automatically, but this remains an active and rapidly evolving field of tooling.
 
    Validate physics parameters, boundary conditions, grid resolution, and numerical settings against your domain knowledge and the `WarpX documentation <https://warpx.readthedocs.io>`__.
@@ -62,7 +62,7 @@ When working with LLM coding assistants, keep in mind that *"most best practices
 Starting from examples and iterating incrementally — as described below — helps keep sessions focused and productive.
 
 #. **Start from examples.**
-   Run your coding existant inside the WarpX source directory.
+   Run your coding agent inside the WarpX source directory.
    Point the assistant to an existing input file or PICMI script from the ``Examples/`` directory and ask it to adapt the setup to your needs.
 
 #. **Iterate incrementally.**

--- a/Docs/source/usage/workflows/ai_input_design.rst
+++ b/Docs/source/usage/workflows/ai_input_design.rst
@@ -4,11 +4,11 @@ AI (LLM)-Assisted Input File Design
 ===================================
 
 Large Language Models (LLMs) can accelerate the process of creating and modifying WarpX input files and Python (PICMI) scripts.
-By providing an LLM-based coding assistant with WarpX documentation as context, users can describe a simulation setup in natural language and receive a draft input file or Python script, ask for explanations of existing parameters, or request modifications to an existing configuration.
+By providing an LLM-based coding assistant with WarpX documentation as context, users can describe a simulation setup in natural language and receive a draft parameter list file or Python script, ask for explanations of existing parameters, or request modifications to an existing configuration.
 
 This workflow is equally applicable to:
 
-- **WarpX input files** (:ref:`parameter list files <running-cpp-parameters>`)
+- **WarpX parameter list files** (:ref:`parameter list files <running-cpp-parameters>`)
 - **Python/PICMI scripts** (:ref:`Python scripts <usage-picmi>`)
 
 .. note::
@@ -46,7 +46,7 @@ Adding pyAMReX documentation as an additional Context7 source gives the assistan
 
 - **pyAMReX**: `context7.com/amrex-codes/pyamrex <https://context7.com/amrex-codes/pyamrex>`__
 
-For popular coding assistants, see the `Context7 documentation <https://context7.com/docs/resources/all-clients>`__ to configure `WarpX <https://context7.com/blast-warpx/warpx>`.
+To configure Context7 for your coding assistant, see the `Context7 documentation <https://context7.com/docs/resources/all-clients>`__.
 
 .. tip::
 

--- a/Docs/source/usage/workflows/ai_input_design.rst
+++ b/Docs/source/usage/workflows/ai_input_design.rst
@@ -39,14 +39,12 @@ WarpX documentation is available at:
 
     `context7.com/blast-warpx/warpx <https://context7.com/blast-warpx/warpx>`__
 
-Once connected, a coding assistant (Claude Code, Cursor, VS Code Copilot, Windsurf, etc.) can retrieve relevant sections of the WarpX documentation in real time when helping you write or debug input files and PICMI scripts.
-
-When writing Python/PICMI scripts, users will also encounter `pyAMReX <https://pyamrex.readthedocs.io>`__ APIs (e.g., for accessing mesh and particle data, callbacks, or custom field initialization).
-Adding pyAMReX documentation as an additional Context7 source gives the assistant the ability to look up these APIs:
+When writing Python/PICMI scripts, users will also encounter `pyAMReX <https://pyamrex.readthedocs.io>`__ APIs (e.g., for accessing mesh and particle data, callbacks, or custom field initialization):
 
 - **pyAMReX**: `context7.com/amrex-codes/pyamrex <https://context7.com/amrex-codes/pyamrex>`__
 
 To configure Context7 for your coding assistant, see the `Context7 documentation <https://context7.com/docs/resources/all-clients>`__.
+Once connected, a coding assistant (Claude Code, Cursor, VS Code Copilot, Windsurf, etc.) can retrieve relevant sections of all the above projects in real time when helping you write or debug input files and PICMI scripts.
 
 .. tip::
 
@@ -59,7 +57,7 @@ Best Practices
 --------------
 
 When working with LLM coding assistants, keep in mind that *"most best practices are based on one constraint: [the] context window fills up fast, and performance degrades as it fills"* (`Claude Code Best Practices <https://code.claude.com/docs/en/best-practices>`__).
-Starting from examples and iterating incrementally — as described below — helps keep sessions focused and productive.
+Starting from examples and iterating incrementally as described below and making a plan with the LLM assistant helps keep sessions focused and productive.
 
 #. **Start from examples.**
    Run your coding agent inside the WarpX source directory.

--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,0 @@
-{
-  "url": "https://context7.com/blast-warpx/warpx",
-  "public_key": "pk_l8yoMPvm1YmDQDFMZagmO"
-}

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/blast-warpx/warpx",
+  "public_key": "pk_l8yoMPvm1YmDQDFMZagmO"
+}


### PR DESCRIPTION
Document how to use LLM agents, MCP servers and skills for [WarpX usage](https://warpx--6689.org.readthedocs.build/en/6689/usage/workflows/ai_input_design.html) and [development](https://warpx--6689.org.readthedocs.build/en/6689/developers/how_to_develop_with_llms.html).

~Add [Context7 claim file](https://context7.com/docs/howto/verification) for [WarpX](https://context7.com/blast-warpx/warpx).~ -> #6704

cc @asalmgren 