### PR TITLE
Fix typo for rcylinder with plot files

### DIFF
--- a/Regression/Checksum/benchmarks_json/test_rcylinder_langmuir_multi.json
+++ b/Regression/Checksum/benchmarks_json/test_rcylinder_langmuir_multi.json
@@ -5,19 +5,19 @@
     "jr": 6257551220617.94
   },
   "ions": {
-    "particle_momentum_x": 3.425870821504487e-23,
-    "particle_momentum_y": 0.0,
-    "particle_momentum_z": 382.72240455000787,
+    "particle_momentum_x": 3.7388482272142796e-23,
+    "particle_momentum_y": 3.425870821504487e-23,
+    "particle_momentum_z": 0.0,
     "particle_position_x": 0.0020664123031742705,
-    "particle_position_z": 2028689591978760.2,
-    "particle_weight": 3.7388482272142796e-23
+    "particle_theta": 382.72240455000787,
+    "particle_weight": 2028689591978760.2
   },
   "electrons": {
-    "particle_momentum_x": 4.6688001999838496e-23,
-    "particle_momentum_y": 0.0,
-    "particle_momentum_z": 354.40354284919283,
+    "particle_momentum_x": 4.8741399077778497e-23,
+    "particle_momentum_y": 4.6688001999838496e-23,
+    "particle_momentum_z": 0.0,
     "particle_position_x": 0.0020649120078662852,
-    "particle_position_z": 2028689591978760.2,
-    "particle_weight": 4.8741399077778497e-23
+    "particle_theta": 354.40354284919283,
+    "particle_weight": 2028689591978760.2
   }
 }

--- a/Regression/Checksum/benchmarks_json/test_rsphere_langmuir_multi.json
+++ b/Regression/Checksum/benchmarks_json/test_rsphere_langmuir_multi.json
@@ -7,21 +7,21 @@
     "rho_ions": 18540410.10008985
   },
   "electrons": {
-    "particle_momentum_x": 3.0334060682797876e-23,
-    "particle_momentum_y": 3.1575520634461154e-23,
-    "particle_momentum_z": 353.04913517032816,
+    "particle_momentum_x": 2.919097620821435e-23,
+    "particle_momentum_y": 3.0334060682797876e-23,
+    "particle_momentum_z": 3.1575520634461154e-23,
+    "particle_phi": 135.44320683640075,
     "particle_position_x": 0.0020647775303261045,
-    "particle_position_z": 48603102683.91506,
-    "particle_theta": 135.44320683640075,
-    "particle_weight": 2.919097620821435e-23
+    "particle_theta": 353.04913517032816,
+    "particle_weight": 48603102683.91506
   },
   "ions": {
-    "particle_momentum_x": 3.23257109345242e-23,
-    "particle_momentum_y": 3.5009668127525345e-23,
-    "particle_momentum_z": 358.969883690795,
+    "particle_momentum_x": 3.911076299841057e-23,
+    "particle_momentum_y": 3.23257109345242e-23,
+    "particle_momentum_z": 3.5009668127525345e-23,
+    "particle_phi": 131.88763619212952,
     "particle_position_x": 0.002066412245428908,
-    "particle_position_z": 48603102683.91506,
-    "particle_theta": 131.88763619212952,
-    "particle_weight": 3.911076299841057e-23
+    "particle_theta": 358.969883690795,
+    "particle_weight": 48603102683.91506
   }
 }

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -370,15 +370,19 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
         Vector<int> int_flags;
         Vector<int> real_flags;
 
+        // This gets the names correct relative to what WarpX uses, but note that AMReX ignores
+        // these names and always writes the particles out with "x" as the first coordinate,
+        // "y" as the second, and "z" as the third independent of what geometry is being used.
 #if !defined (WARPX_DIM_1D_Z)
         real_names.push_back("position_x");
 #endif
-#if defined (WARPX_DIM_3D) || defined(WARPX_DIM_RZ)
+#if defined (WARPX_DIM_3D)
         real_names.push_back("position_y");
 #endif
-#if !defined(WARPX_DIM_RZ) && !defined(WARPX_DIM_RCYLINDER)
+#if !defined(WARPX_DIM_RCYLINDER) && !defined(WARPX_DIM_RSPHERE)
         real_names.push_back("position_z");
 #endif
+
         real_names.push_back("weight");
         real_names.push_back("momentum_x");
         real_names.push_back("momentum_y");

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -373,6 +373,7 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
         // This gets the names correct relative to what WarpX uses, but note that AMReX ignores
         // these names and always writes the particles out with "x" as the first coordinate,
         // "y" as the second, and "z" as the third independent of what geometry is being used.
+        // All that matters here is getting the correct number of positions.
 #if !defined (WARPX_DIM_1D_Z)
         real_names.push_back("position_x");
 #endif

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -376,7 +376,7 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
 #if defined (WARPX_DIM_3D) || defined(WARPX_DIM_RZ)
         real_names.push_back("position_y");
 #endif
-#if !defined(WARPX_DIM_RCYLINDER)
+#if !defined(WARPX_DIM_RZ) && !defined(WARPX_DIM_RCYLINDER)
         real_names.push_back("position_z");
 #endif
         real_names.push_back("weight");

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -376,7 +376,7 @@ FlushFormatPlotfile::WriteParticles(const std::string& dir,
 #if defined (WARPX_DIM_3D) || defined(WARPX_DIM_RZ)
         real_names.push_back("position_y");
 #endif
-#if !defined(WARPX_DIM_RZ)
+#if !defined(WARPX_DIM_RCYLINDER)
         real_names.push_back("position_z");
 #endif
         real_names.push_back("weight");


### PR DESCRIPTION
This fixes an error in the setup of the particle quantities when writing out data to plot files when using the rcylinder geometry. It also cleans up the setting of the names. A comment is added saying that the names given here are actually ignored by AMReX when writing the plotfile. All that matters is the getting the correct number of positions.