### PR TITLE
Fix potential out of bounds in accelerator lattice element finder

### DIFF
--- a/Source/AcceleratorLattice/LatticeElementFinder.H
+++ b/Source/AcceleratorLattice/LatticeElementFinder.H
@@ -126,6 +126,7 @@ struct LatticeElementFinderDevice
     bool m_initialized = false;
 
     /* Size and location of the index lookup table */
+    int m_nz;
     amrex::Real m_zmin;
     amrex::Real m_dz;
     amrex::Real m_dt;
@@ -172,6 +173,10 @@ struct LatticeElementFinderDevice
         // Find location of partice in the indices grid
         // (which is in the boosted frame)
         const int iz = static_cast<int>((z - m_zmin)/m_dz);
+
+        // This check shouldn't be needed since the particle should always
+        // be within the grid, but it is added for safety.
+        if (iz < 0 || m_nz <= iz) { return; }
 
         constexpr amrex::ParticleReal inv_c2 = 1._prt/(PhysConst::c*PhysConst::c);
         amrex::ParticleReal const gamma = std::sqrt(1._prt + (m_ux[i]*m_ux[i] + m_uy[i]*m_uy[i] + m_uz[i]*m_uz[i])*inv_c2);

--- a/Source/AcceleratorLattice/LatticeElementFinder.H
+++ b/Source/AcceleratorLattice/LatticeElementFinder.H
@@ -176,7 +176,7 @@ struct LatticeElementFinderDevice
 
         // This check shouldn't be needed since the particle should always
         // be within the grid, but it is added for safety.
-        if (iz < 0 || m_nz <= iz) { return; }
+        if (iz < 0 || iz >= m_nz) { return; }
 
         constexpr amrex::ParticleReal inv_c2 = 1._prt/(PhysConst::c*PhysConst::c);
         amrex::ParticleReal const gamma = std::sqrt(1._prt + (m_ux[i]*m_ux[i] + m_uy[i]*m_uy[i] + m_uz[i]*m_uz[i])*inv_c2);

--- a/Source/AcceleratorLattice/LatticeElementFinder.cpp
+++ b/Source/AcceleratorLattice/LatticeElementFinder.cpp
@@ -113,6 +113,7 @@ LatticeElementFinderDevice::InitLatticeElementFinderDevice (WarpXParIter const& 
     m_gamma_boost = WarpX::gamma_boost;
     m_uz_boost = std::sqrt(WarpX::gamma_boost*WarpX::gamma_boost - 1._prt)*PhysConst::c;
 
+    m_nz = h_finder.m_nz;
     m_zmin = h_finder.m_zmin;
     m_dz = h_finder.m_dz;
     m_time = h_finder.m_time;


### PR DESCRIPTION
This addresses issue #6644.

The comment from the issue:
"This change should not be necessary since when the routine is called, the particle will always be within the bounds of the grid and `iz` should always have a valid value. Though, I will make the change out of code safety."