### PR TITLE
Update checksum documentation

### DIFF
--- a/Docs/source/developers/how_to_test.rst
+++ b/Docs/source/developers/how_to_test.rst
@@ -220,6 +220,7 @@ Alternatively, it is also possible to reset a checksum file locally by running t
      CHECKSUM_RESET=ON ctest --test-dir build -R laser_acceleration
 
 Note that it is possible that the checksum values generated locally on your computer architecture may differ from the ones generated remotely by the autometed tests on the architecture provided by the CI runners.
+
 .. _developers-testing-naming:
 
 Naming conventions for automated tests

--- a/Docs/source/developers/how_to_test.rst
+++ b/Docs/source/developers/how_to_test.rst
@@ -195,17 +195,16 @@ Here is the help message of the default regression analysis script, including us
          --skip-fields     skip fields when comparing checksums
          --skip-particles  skip particles when comparing checksums
 
-How to reset checksums locally
-------------------------------
+How to reset checksums
+----------------------
 
-It is possible to reset a checksum file locally by running the corresponding test with ``ctest`` with the environment variable ``CHECKSUM_RESET=ON``. For example:
+Your code changes may sometimes change the results that WarpX produces.
+This is automatically detected by the automated tests (run as part of a PR) and by comparing the WarpX results with the reference values stored in the checksum files.
 
-  .. code-block:: bash
-
-       CHECKSUM_RESET=ON ctest --test-dir build -R laser_acceleration
-
-Alternatively, it is also possible to reset multiple checksum files automatically using the output of our Azure pipelines, which can be useful for code changes that result in resetting a large number of checksum files.
-Go to the directory `Tools/DevUtils <https://github.com/BLAST-WarpX/warpx/tree/development/Tools/DevUtils>`__ and run the Python script `update_benchmarks_from_azure_output.py <https://github.com/BLAST-WarpX/warpx/blob/development/Tools/DevUtils/update_benchmarks_from_azure_output.py>`__ with the ``--pr-number`` option:
+**If** the differences are expected, you can reset the checksum files automatically using the output
+of the tests that were run as part of the PR. To do so, go to the directory
+`Tools/DevUtils <https://github.com/BLAST-WarpX/warpx/tree/development/Tools/DevUtils>`__ and run the Python script
+`update_benchmarks_from_azure_output.py <https://github.com/BLAST-WarpX/warpx/blob/development/Tools/DevUtils/update_benchmarks_from_azure_output.py>`__ with the ``--pr-number`` option:
 
 .. code:: bash
 

--- a/Docs/source/developers/how_to_test.rst
+++ b/Docs/source/developers/how_to_test.rst
@@ -199,10 +199,10 @@ How to reset checksums
 ----------------------
 
 Your code changes may sometimes change the results that WarpX produces.
-This is automatically detected by the automated tests (run as part of a PR) and by comparing the WarpX results with the reference values stored in the checksum files.
+This is automatically detected by the automated tests (which run every time a commit is pushed to the head branch of an open PR) through comparison of the WarpX results with the reference values stored in the checksum files.
 
 **If** the differences are expected, you can reset the checksum files automatically using the output
-of the tests that were run as part of the PR. To do so, go to the directory
+of the automated tests. To do so, go to the directory
 `Tools/DevUtils <https://github.com/BLAST-WarpX/warpx/tree/development/Tools/DevUtils>`__ and run the Python script
 `update_benchmarks_from_azure_output.py <https://github.com/BLAST-WarpX/warpx/blob/development/Tools/DevUtils/update_benchmarks_from_azure_output.py>`__ with the ``--pr-number`` option:
 
@@ -219,6 +219,7 @@ Alternatively, it is also possible to reset a checksum file locally by running t
 
      CHECKSUM_RESET=ON ctest --test-dir build -R laser_acceleration
 
+Note that it is possible that the checksum values generated locally on your computer architecture may differ from the ones generated remotely by the autometed tests on the architecture provided by the CI runners.
 .. _developers-testing-naming:
 
 Naming conventions for automated tests

--- a/Docs/source/developers/how_to_test.rst
+++ b/Docs/source/developers/how_to_test.rst
@@ -213,6 +213,12 @@ of the tests that were run as part of the PR. To do so, go to the directory
 This requires the `GitHub CLI <https://cli.github.com/>`__ (``gh``) to be installed and authenticated.
 The script will automatically find the failing Azure Pipelines jobs for the pull request, download their logs, and update all checksum benchmark files that did not pass the checksum analysis.
 
+Alternatively, it is also possible to reset a checksum file locally by running the corresponding test with ``ctest`` with the environment variable ``CHECKSUM_RESET=ON``. For example:
+
+  .. code-block:: bash
+
+     CHECKSUM_RESET=ON ctest --test-dir build -R laser_acceleration
+
 .. _developers-testing-naming:
 
 Naming conventions for automated tests


### PR DESCRIPTION
In the [documentation](https://warpx.readthedocs.io/en/latest/developers/how_to_test.html#how-to-reset-checksums-locally), we advertise resetting the checksum locally (CHECKSUM_RESET=ON). 

However, we know that this rarely works in practice (the local checksum differs from the ones we get on Azure). For this reason, people in practice almost always reset the checksums from Azure.

This updates the documentation to remove `CHECKSUM_RESET=ON`