### PR TITLE
PICMI: Particle Filter in BTD

### DIFF
--- a/Examples/Tests/boosted_diags/CMakeLists.txt
+++ b/Examples/Tests/boosted_diags/CMakeLists.txt
@@ -10,3 +10,13 @@ add_warpx_test(
     "analysis_default_regression.py --path diags/diag1000003"  # checksum
     OFF  # dependency
 )
+
+add_warpx_test(
+    test_3d_laser_acceleration_btd_picmi  # name
+    3  # dims
+    2  # nprocs
+    inputs_test_3d_laser_acceleration_btd_picmi.py  # inputs
+    "analysis.py diags/diag1000003"  # analysis
+    "analysis_default_regression.py --path diags/diag1000003"  # checksum
+    OFF  # dependency
+)

--- a/Examples/Tests/boosted_diags/analysis.py
+++ b/Examples/Tests/boosted_diags/analysis.py
@@ -41,11 +41,15 @@ Ez_plotfile = data[("mesh", "Ez")].to_ndarray()
 # Read data from new back-transformed diagnostics (openPMD)
 series = io.Series("./diags/diag2/openpmd_%T.h5", io.Access.read_only)
 ds_openpmd = series.iterations[3]
-Ez_openpmd = ds_openpmd.meshes["E"]["z"].load_chunk()
-Ez_openpmd = Ez_openpmd.transpose()
-series.flush()
-# Compare arrays to check consistency between new BTD formats (plotfile and openPMD)
-assert np.allclose(Ez_plotfile, Ez_openpmd, rtol=rtol, atol=atol)
+# Compare field data if diag2 contains meshes (not the case for particle-only BTD)
+if len(ds_openpmd.meshes) > 0:
+    Ez_openpmd = ds_openpmd.meshes["E"]["z"].load_chunk()
+    Ez_openpmd = Ez_openpmd.transpose()
+    series.flush()
+    # Compare arrays to check consistency between new BTD formats (plotfile and openPMD)
+    assert np.allclose(Ez_plotfile, Ez_openpmd, rtol=rtol, atol=atol)
+else:
+    series.flush()
 
 # Check that particle random sub-selection has been applied
 ts = OpenPMDTimeSeries("./diags/diag2/")

--- a/Examples/Tests/boosted_diags/inputs_test_3d_laser_acceleration_btd_picmi.py
+++ b/Examples/Tests/boosted_diags/inputs_test_3d_laser_acceleration_btd_picmi.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+
+from pywarpx import picmi
+
+# Physical constants
+c = picmi.constants.c
+q_e = picmi.constants.q_e
+
+# Physical domain
+xmin = -128.0e-6
+xmax = 128.0e-6
+ymin = -128.0e-6
+ymax = 128.0e-6
+zmin = -40.0e-6
+zmax = 0.0
+
+# Grid
+nx = 32
+ny = 32
+nz = 64
+
+grid = picmi.Cartesian3DGrid(
+    number_of_cells=[nx, ny, nz],
+    lower_bound=[xmin, ymin, zmin],
+    upper_bound=[xmax, ymax, zmax],
+    lower_boundary_conditions=["periodic", "periodic", "dirichlet"],
+    upper_boundary_conditions=["periodic", "periodic", "dirichlet"],
+    lower_boundary_conditions_particles=["periodic", "periodic", "absorbing"],
+    upper_boundary_conditions_particles=["periodic", "periodic", "absorbing"],
+    moving_window_velocity=[0.0, 0.0, c],
+    warpx_max_grid_size=64,
+    warpx_blocking_factor=32,
+)
+
+# Solver
+solver = picmi.ElectromagneticSolver(
+    grid=grid,
+    method="CKC",
+    cfl=1.0,
+)
+
+# --- Plasma species
+
+plasma_density = 3.5e24
+
+electron_dist = picmi.UniformDistribution(
+    density=plasma_density,
+    lower_bound=[-120.0e-6, -120.0e-6, 0.0],
+    upper_bound=[120.0e-6, 120.0e-6, 0.003],
+    fill_in=True,
+)
+electrons = picmi.Species(
+    particle_type="electron",
+    name="electrons",
+    initial_distribution=electron_dist,
+)
+
+ion_dist = picmi.UniformDistribution(
+    density=plasma_density,
+    lower_bound=[-120.0e-6, -120.0e-6, 0.0],
+    upper_bound=[120.0e-6, 120.0e-6, 0.003],
+    fill_in=True,
+)
+ions = picmi.Species(
+    particle_type="proton",
+    name="ions",
+    initial_distribution=ion_dist,
+)
+
+# --- Beam
+
+beam_dist = picmi.GaussianBunchDistribution(
+    n_physical_particles=1.0e-14 / q_e,
+    rms_bunch_size=[1.0e-6, 1.0e-6, 0.2e-6],
+    centroid_position=[0.0, 0.0, -20.0e-6],
+    centroid_velocity=[0.0, 0.0, 200000.0 * c],
+    rms_velocity=[0.2 * c, 0.2 * c, 20.0 * c],
+)
+beam = picmi.Species(
+    particle_type="electron",
+    name="beam",
+    initial_distribution=beam_dist,
+)
+
+# --- Laser
+
+position_z = -0.1e-6
+profile_t_peak = 40.0e-15
+profile_focal_distance = 0.5e-3
+
+laser = picmi.GaussianLaser(
+    wavelength=0.81e-6,
+    waist=45.0e-6,
+    duration=20.0e-15,
+    focal_position=[0.0, 0.0, profile_focal_distance + position_z],
+    centroid_position=[0.0, 0.0, position_z - c * profile_t_peak],
+    propagation_direction=[0, 0, 1],
+    polarization_direction=[0, 1, 0],
+    E0=2.0e12,
+    fill_in=False,
+)
+laser_antenna = picmi.LaserAntenna(
+    position=[0.0, 0.0, position_z],
+    normal_vector=[0, 0, 1],
+)
+
+# --- Back-transformed diagnostics
+
+# diag1: BTD fields (plotfile)
+btd_field_diag = picmi.LabFrameFieldDiagnostic(
+    name="diag1",
+    grid=grid,
+    num_snapshots=4,
+    dt_snapshots=0.001 / c,
+    data_list=["E", "B", "J", "rho"],
+    warpx_format="plotfile",
+    warpx_buffer_size=32,
+)
+
+# diag2: BTD particles with beam sub-sampling (openPMD)
+btd_particle_diag = picmi.LabFrameParticleDiagnostic(
+    name="diag2",
+    grid=grid,
+    num_snapshots=4,
+    dt_snapshots=0.001 / c,
+    species=[beam],
+    warpx_random_fraction={beam: 0.5},
+    warpx_format="openpmd",
+    warpx_openpmd_backend="h5",
+    warpx_intervals="0:3:2, 1:3:2",
+    warpx_buffer_size=32,
+)
+
+# --- Simulation
+
+sim = picmi.Simulation(
+    solver=solver,
+    verbose=1,
+    gamma_boost=10.0,
+    particle_shape="cubic",
+    warpx_use_filter=1,
+    warpx_use_fdtd_nci_corr=1,
+    warpx_serialize_initial_conditions=1,
+    warpx_current_deposition_algo="esirkepov",
+    warpx_particle_pusher_algo="vay",
+    warpx_zmax_plasma_to_compute_max_step=0.0055,
+)
+
+sim.add_species(
+    electrons,
+    layout=picmi.GriddedLayout(grid=grid, n_macroparticle_per_cell=[1, 1, 1]),
+)
+sim.add_species(
+    ions,
+    layout=picmi.GriddedLayout(grid=grid, n_macroparticle_per_cell=[1, 1, 1]),
+)
+sim.add_species(
+    beam,
+    layout=picmi.PseudoRandomLayout(n_macroparticles=1000, grid=grid),
+)
+
+sim.add_laser(laser, injection_method=laser_antenna)
+
+sim.add_diagnostic(btd_field_diag)
+sim.add_diagnostic(btd_particle_diag)
+
+sim.step()

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -4483,21 +4483,16 @@ class LabFrameParticleDiagnostic(
         else:
             species_names = [self.species.name]
 
-        # check if random fraction is specified and whether a value is given per species
-        random_fraction = {}
-        random_fraction_default = self.random_fraction
-        if isinstance(self.random_fraction, dict):
-            random_fraction_default = 1.0
-            for key, val in self.random_fraction.items():
-                random_fraction[key.name] = val
-
-        # check if uniform stride is specified and whether a value is given per species
-        uniform_stride = {}
-        uniform_stride_default = self.uniform_stride
-        if isinstance(self.uniform_stride, dict):
-            uniform_stride_default = 1
-            for key, val in self.uniform_stride.items():
-                uniform_stride[key.name] = val
+        rf = (
+            {k.name: v for k, v in self.random_fraction.items()}
+            if isinstance(self.random_fraction, dict)
+            else self.random_fraction
+        )
+        us = (
+            {k.name: v for k, v in self.uniform_stride.items()}
+            if isinstance(self.uniform_stride, dict)
+            else self.uniform_stride
+        )
 
         if self.mangle_dict is None:
             # Only do this once so that the same variables are used in this diagnostics
@@ -4508,8 +4503,8 @@ class LabFrameParticleDiagnostic(
             diag = pywarpx.Bucket.Bucket(
                 self.name + "." + name,
                 variables=variables,
-                random_fraction=random_fraction.get(name, random_fraction_default),
-                uniform_stride=uniform_stride.get(name, uniform_stride_default),
+                random_fraction=rf.get(name, None) if isinstance(rf, dict) else rf,
+                uniform_stride=us.get(name, None) if isinstance(us, dict) else us,
             )
             expression = pywarpx.my_constants.mangle_expression(
                 self.plot_filter_function, self.mangle_dict

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -4331,6 +4331,22 @@ class LabFrameParticleDiagnostic(
     warpx_buffer_size: integer, optional
         Passed to <diagnostic name>.buffer_size
 
+    warpx_random_fraction: float or dict, optional
+        Random fraction of particles to include in the diagnostic. If a float
+        is given the same fraction will be used for all species, if a dictionary
+        is given the keys should be species with the value specifying the random
+        fraction for that species.
+
+    warpx_uniform_stride: integer or dict, optional
+        Stride to down select to the particles to include in the diagnostic.
+        If an integer is given the same stride will be used for all species, if
+        a dictionary is given the keys should be species with the value
+        specifying the stride for that species.
+
+    warpx_plot_filter_function: string, optional
+        Analytic expression to down select the particles in the diagnostic.
+        Filtering is applied in the lab frame after back-transformation.
+
     warpx_verbose: int, optional
         Verbosity level to use for printing diagnostic output information.
     """
@@ -4343,7 +4359,23 @@ class LabFrameParticleDiagnostic(
         self.intervals = kw.pop("warpx_intervals", None)
         self.file_min_digits = kw.pop("warpx_file_min_digits", None)
         self.buffer_size = kw.pop("warpx_buffer_size", None)
+        self.random_fraction = kw.pop("warpx_random_fraction", None)
+        self.uniform_stride = kw.pop("warpx_uniform_stride", None)
+        self.plot_filter_function = kw.pop("warpx_plot_filter_function", None)
         self.verbose = kw.pop("warpx_verbose", None)
+
+        self.user_defined_kw = {}
+        if self.plot_filter_function is not None:
+            # This allows variables to be used in the plot_filter_function, but
+            # in order not to break other codes, the variables must begin with "warpx_"
+            for k in list(kw.keys()):
+                if k.startswith("warpx_") and re.search(
+                    r"\b%s\b" % k, self.plot_filter_function
+                ):
+                    self.user_defined_kw[k] = kw[k]
+                    del kw[k]
+
+        self.mangle_dict = None
 
     def diagnostic_initialize_inputs(self):
         self.add_diagnostic()
@@ -4451,8 +4483,38 @@ class LabFrameParticleDiagnostic(
         else:
             species_names = [self.species.name]
 
+        # check if random fraction is specified and whether a value is given per species
+        random_fraction = {}
+        random_fraction_default = self.random_fraction
+        if isinstance(self.random_fraction, dict):
+            random_fraction_default = 1.0
+            for key, val in self.random_fraction.items():
+                random_fraction[key.name] = val
+
+        # check if uniform stride is specified and whether a value is given per species
+        uniform_stride = {}
+        uniform_stride_default = self.uniform_stride
+        if isinstance(self.uniform_stride, dict):
+            uniform_stride_default = 1
+            for key, val in self.uniform_stride.items():
+                uniform_stride[key.name] = val
+
+        if self.mangle_dict is None:
+            # Only do this once so that the same variables are used in this distribution
+            # is used multiple times
+            self.mangle_dict = pywarpx.my_constants.add_keywords(self.user_defined_kw)
+
         for name in species_names:
-            diag = pywarpx.Bucket.Bucket(self.name + "." + name, variables=variables)
+            diag = pywarpx.Bucket.Bucket(
+                self.name + "." + name,
+                variables=variables,
+                random_fraction=random_fraction.get(name, random_fraction_default),
+                uniform_stride=uniform_stride.get(name, uniform_stride_default),
+            )
+            expression = pywarpx.my_constants.mangle_expression(
+                self.plot_filter_function, self.mangle_dict
+            )
+            diag.__setattr__("plot_filter_function(t,x,y,z,ux,uy,uz)", expression)
             self.diagnostic._species_dict[name] = diag
 
 

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -4500,7 +4500,7 @@ class LabFrameParticleDiagnostic(
                 uniform_stride[key.name] = val
 
         if self.mangle_dict is None:
-            # Only do this once so that the same variables are used in this distribution
+            # Only do this once so that the same variables are used in this diagnostics
             # is used multiple times
             self.mangle_dict = pywarpx.my_constants.add_keywords(self.user_defined_kw)
 

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -4483,16 +4483,12 @@ class LabFrameParticleDiagnostic(
         else:
             species_names = [self.species.name]
 
-        rf = (
-            {k.name: v for k, v in self.random_fraction.items()}
-            if isinstance(self.random_fraction, dict)
-            else self.random_fraction
-        )
-        us = (
-            {k.name: v for k, v in self.uniform_stride.items()}
-            if isinstance(self.uniform_stride, dict)
-            else self.uniform_stride
-        )
+        def _resolve(attr, name):
+            if isinstance(attr, dict):
+                return next(
+                    (v for k, v in attr.items() if getattr(k, "name", k) == name), None
+                )
+            return attr
 
         if self.mangle_dict is None:
             # Only do this once so that the same variables are used in this diagnostics
@@ -4503,8 +4499,8 @@ class LabFrameParticleDiagnostic(
             diag = pywarpx.Bucket.Bucket(
                 self.name + "." + name,
                 variables=variables,
-                random_fraction=rf.get(name, None) if isinstance(rf, dict) else rf,
-                uniform_stride=us.get(name, None) if isinstance(us, dict) else us,
+                random_fraction=_resolve(self.random_fraction, name),
+                uniform_stride=_resolve(self.uniform_stride, name),
             )
             expression = pywarpx.my_constants.mangle_expression(
                 self.plot_filter_function, self.mangle_dict


### PR DESCRIPTION
openPMD already supports filtering particles after transformation to the lab frame. Expose this in `LabFrameParticleDiagnostic` now.

Docs: [preview](https://warpx--6708.org.readthedocs.build/en/6708/usage/python.html#pywarpx.picmi.LabFrameParticleDiagnostic)

- [x] idea for a test? Maybe a gamma filter in one of the existing LWFA tests? -- oh, we have not PICMI test yet with boosted frame

Ref.:
- https://github.com/BLAST-WarpX/warpx/discussions/6611#discussioncomment-16295539
- plotfiles: #6709