### PR TITLE
Add skill to answer user question

### DIFF
--- a/.claude/skills/warpx-answer-user-question/SKILL.md
+++ b/.claude/skills/warpx-answer-user-question/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: warpx-answer-user-question
+description: Draft a response to a WarpX user question (from a GitHub issue, discussion, or email).
+---
+
+# Answer WarpX User Question
+
+Draft a helpful, accurate response to a WarpX user question, in the style of an experienced WarpX developer.
+
+## Step 1 — Gather the question
+
+If a GitHub issue or discussion URL was provided, fetch it with `gh`. If a plain-text question was pasted, use it directly.
+
+Identify:
+- **What the user is trying to do** (their end goal, not just their literal question)
+- **What they have tried** (input file snippets, error messages, partial results)
+- **Their apparent expertise level** (new to WarpX? PIC codes in general? HPC?)
+- **What information is missing** that would be needed to give a complete answer
+
+## Step 2 — Categorize the question
+
+Assign the question to one or more of these categories:
+
+| Category | Typical signals |
+|---|---|
+| **A. Installation / Build** | CMake errors, missing libraries, conda/spack, CUDA compilation, module conflicts |
+| **B. Input File / Parameters** | Wrong parameter name or value, PICMI vs native syntax, laser setup, particle injection, boundary conditions |
+| **C. Diagnostics & Output** | Output format, reduced diagnostics syntax, checkpoint/restart, post-processing |
+| **D. Physics / Numerical** | Numerical heating, energy non-conservation, CFL, boosted frame artifacts, resolution |
+| **E. Feature Availability** | "Does WarpX support X?" |
+| **F. Performance & HPC** | Slow I/O, OOM, multi-node MPI, GPU choice |
+| **G. Python / PICMI** | `pywarpx` API, callbacks, `add_particles`, PICMI vs native mapping |
+| **H. Bug Report** | Reproducible unexpected behavior, wrong results, crashes |
+
+## Step 3 — Search for relevant information
+
+Before drafting any answer, actively search. The answer must be grounded in WarpX code, docs, and prior issues — not generated from general knowledge.
+
+Search these sources as relevant to the category:
+
+**Documentation** (`Docs/source/`):
+- `usage/parameters.rst` — all input parameters (the primary reference)
+- `usage/python.rst` — PICMI/Python interface
+- `install/cmake.rst` — build options
+- `dataanalysis/` — output formats, openPMD, post-processing tools
+- `theory/` — numerical methods
+
+**Source code** — key directories:
+- `Source/Laser/`, `Source/Particles/`, `Source/FieldSolver/`, `Source/Diagnostics/`, `Source/BoundaryConditions/`, `Source/Python/`
+- For parameter reading: search for `pp.query`/`pp.get` with the parameter name
+- For reduced diagnostics: `Source/Diagnostics/ReducedDiags/`
+
+**Examples** (`Examples/Tests/`, `Examples/Physics_applications/`):
+- Search for examples that demonstrate the relevant feature
+
+**Past GitHub issues and discussions**:
+- Search issues and discussions for similar questions and their resolutions
+- For feature availability: also search open issues/PRs for planned work
+
+## Step 4 — Assess whether more information is needed
+
+Decide: **do you have enough information to give a complete, accurate answer?**
+
+If not, identify the 1-3 most important missing pieces. Common things to ask for:
+- Full input file (or the relevant section)
+- Full error message or stack trace
+- WarpX version, platform, CMake configuration (for build issues)
+- Minimal reproducible script (for Python/PICMI issues)
+
+## Step 5 — Draft the response
+
+**Tone** — match the style of experienced WarpX developers:
+- Warm and welcoming: open with "Hi @username," or "Thanks for your question!"
+- Patient and non-condescending
+- Direct: give the answer first, then the explanation
+- Concrete: include corrected input file snippets or code examples inline
+- Honest about limitations: if a feature doesn't exist, say so clearly
+- Close with "Let us know if you have any further questions"
+
+**Structure by situation:**
+
+**Answerable question:** (1) Direct answer upfront, (2) explanation if needed, (3) corrected snippet or example, (4) link to relevant docs page on `warpx.readthedocs.io` or example file in repo, (5) gotcha warning if applicable (see below), (6) invite follow-up.
+
+**Bug report:** (1) Confirm the bug with explanation, (2) workaround if one exists, (3) state if a fix PR will be opened (only if true), (4) ask user to verify once merged.
+
+**Missing info:** (1) Explain what's needed and why, (2) provide partial answer if possible.
+
+**Feature not available:** (1) Confirm clearly, (2) explain workarounds (Python callbacks, post-processing, etc.), (3) link to tracking issue/PR if one exists, (4) invite contribution.
+
+**Common gotchas to check proactively:**
+- Wrong sign on `q_tot` for electrons (must be negative; positive silently causes `BeamRelevant` to output zeros)
+- CFL too low for EM laser simulations (should be ~0.999, not 0.9)
+- Missing `<diag_name>.intervals` on reduced diagnostics (nothing is written)
+- HDF5 I/O slow on HPC filesystems — recommend ADIOS2 BP (`openpmd_backend = bp`)
+- `get_particle_uz()` returns a list of per-box arrays in Python, not a flat array
+- PICMI `focal_position` (absolute position) vs native `profile_focal_distance` (distance from antenna) — different sign conventions
+- `do_continuous_injection` is for moving-window plasma injection only, not for fixed-domain plasma sources
+- `particle_fields` parser expressions cannot cross-reference other computed moments
+
+## Step 6 — Present the draft
+
+Show the draft to the user and ask:
+
+> Does this response look good? Would you like me to adjust anything before you post it?
+
+Only post the reply to GitHub if the user explicitly asks. Always show the draft first.

--- a/.claude/skills/warpx-answer-user-question/SKILL.md
+++ b/.claude/skills/warpx-answer-user-question/SKILL.md
@@ -74,13 +74,12 @@ If not, identify the 1-3 most important missing pieces. Common things to ask for
 - Direct: give the answer first, then the explanation
 - Concrete: include corrected input file snippets or code examples inline
 - Honest about limitations: if a feature doesn't exist, say so clearly
-- Close with "Let us know if you have any further questions"
 
 **Structure by situation:**
 
-**Answerable question:** (1) Direct answer upfront, (2) explanation if needed, (3) corrected snippet or example, (4) link to relevant docs page on `warpx.readthedocs.io` or example file in repo, (5) gotcha warning if applicable (see below), (6) invite follow-up.
+**Answerable question:** (1) Direct answer upfront, (2) explanation if needed, (3) corrected snippet or example, (4) link to relevant docs page on `warpx.readthedocs.io` or example file in repo
 
-**Bug report:** (1) Confirm the bug with explanation, (2) workaround if one exists, (3) state if a fix PR will be opened (only if true), (4) ask user to verify once merged.
+**Bug report:** (1) Confirm the bug with explanation, (2) workaround if one exists, (3) state if a fix PR is already open, (4) ask user to verify once merged.
 
 **Missing info:** (1) Explain what's needed and why, (2) provide partial answer if possible.
 
@@ -98,8 +97,8 @@ If not, identify the 1-3 most important missing pieces. Common things to ask for
 
 ## Step 6 — Present the draft
 
-Show the draft to the user and ask:
+Show the draft and ask:
 
 > Does this response look good? Would you like me to adjust anything before you post it?
 
-Only post the reply to GitHub if the user explicitly asks. Always show the draft first.
+Only post the reply to GitHub if asked explicitly. Always show the draft first.

--- a/.claude/skills/warpx-answer-user-question/SKILL.md
+++ b/.claude/skills/warpx-answer-user-question/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: warpx-answer-user-question
 description: Draft a response to a WarpX user question (from a GitHub issue, discussion, or email).
+disable-model-invocation: true
 ---
 
 # Answer WarpX User Question
@@ -9,7 +10,7 @@ Draft a helpful, accurate response to a WarpX user question, in the style of an 
 
 ## Step 1 — Gather the question
 
-If a GitHub issue or discussion URL was provided, fetch it with `gh`. If a plain-text question was pasted, use it directly.
+If a plain-text question was pasted, use it directly. If a GitHub issue or discussion URL was provided, fetch it with `gh` and read the **full thread** (all comments and replies), not just the opening post — the answer or key context is often in subsequent comments.
 
 Identify:
 - **What the user is trying to do** (their end goal, not just their literal question)
@@ -66,13 +67,28 @@ If not, identify the 1-3 most important missing pieces. Common things to ask for
 - WarpX version, platform, CMake configuration (for build issues)
 - Minimal reproducible script (for Python/PICMI issues)
 
-## Step 5 — Draft the response
+If information is missing, proceed directly to Step 6 and draft a "Missing info" reply — do not attempt the Step 5 escalation check, since you cannot yet assess the complexity of the issue.
+
+## Step 5 — Decide whether to draft a response or escalate
+
+Before drafting, check whether the question is within the agent's ability to answer reliably.
+**Stop and report to the skill invoker (the WarpX developer running this skill) instead of drafting a GitHub reply** if the issue falls into either of these categories:
+
+- **Non-trivial bug**: all the information needed to reproduce the issue is present (input file, error message, reproducing script, platform details), but determining the root cause requires running the code, inspecting runtime state, or deeper investigation of WarpX internals that cannot be done through static analysis alone.
+- **Complicated physics or numerics question**: the question requires domain expertise to answer correctly (e.g., interpreting anomalous simulation results, choosing numerical parameters for an unconventional setup, evaluating algorithm trade-offs) and cannot be answered with confidence from documentation, past issues, and source code alone.
+
+In these cases, report to the skill invoker:
+
+> This issue appears to require deeper investigation (or domain expertise) that goes beyond what I can reliably provide. I recommend that a WarpX developer look into this directly.
+
+Then briefly summarize what is known, what makes the question hard, and what a developer would need to look at.
+
+## Step 6 — Draft the response
 
 **Tone** — match the style of experienced WarpX developers:
-- Warm and welcoming: open with "Hi @username," or "Thanks for your question!"
-- Patient and non-condescending
+- Warm, welcoming
 - Direct: give the answer first, then the explanation
-- Concrete: include corrected input file snippets or code examples inline
+- Concrete: include corrected input file snippets or links to the documentation and/or online examples
 - Honest about limitations: if a feature doesn't exist, say so clearly
 
 **Structure by situation:**
@@ -85,17 +101,7 @@ If not, identify the 1-3 most important missing pieces. Common things to ask for
 
 **Feature not available:** (1) Confirm clearly, (2) explain workarounds (Python callbacks, post-processing, etc.), (3) link to tracking issue/PR if one exists, (4) invite contribution.
 
-**Common gotchas to check proactively:**
-- Wrong sign on `q_tot` for electrons (must be negative; positive silently causes `BeamRelevant` to output zeros)
-- CFL too low for EM laser simulations (should be ~0.999, not 0.9)
-- Missing `<diag_name>.intervals` on reduced diagnostics (nothing is written)
-- HDF5 I/O slow on HPC filesystems — recommend ADIOS2 BP (`openpmd_backend = bp`)
-- `get_particle_uz()` returns a list of per-box arrays in Python, not a flat array
-- PICMI `focal_position` (absolute position) vs native `profile_focal_distance` (distance from antenna) — different sign conventions
-- `do_continuous_injection` is for moving-window plasma injection only, not for fixed-domain plasma sources
-- `particle_fields` parser expressions cannot cross-reference other computed moments
-
-## Step 6 — Present the draft
+## Step 7 — Present the draft
 
 Show the draft and ask:
 

--- a/.claude/skills/warpx-answer-user-question/SKILL.md
+++ b/.claude/skills/warpx-answer-user-question/SKILL.md
@@ -47,7 +47,7 @@ Search these sources as relevant to the category:
 
 **Source code** — key directories:
 - `Source/Laser/`, `Source/Particles/`, `Source/FieldSolver/`, `Source/Diagnostics/`, `Source/BoundaryConditions/`, `Source/Python/`
-- For parameter reading: search for `pp.query`/`pp.get` with the parameter name
+- For parameter reading: search for `query`/`queryWithParser`/`add`/`addarr`/`queryAdd` with the parameter name
 - For reduced diagnostics: `Source/Diagnostics/ReducedDiags/`
 
 **Examples** (`Examples/Tests/`, `Examples/Physics_applications/`):
@@ -55,7 +55,7 @@ Search these sources as relevant to the category:
 
 **Past GitHub issues and discussions**:
 - Search issues and discussions for similar questions and their resolutions
-- For feature availability: also search open issues/PRs for planned work
+- For feature availability: also search open issues/PRs for planned features and fixes
 
 ## Step 4 — Assess whether more information is needed
 

--- a/.claude/skills/warpx-answer-user-question/SKILL.md
+++ b/.claude/skills/warpx-answer-user-question/SKILL.md
@@ -43,7 +43,6 @@ Search these sources as relevant to the category:
 - `usage/python.rst` — PICMI/Python interface
 - `install/cmake.rst` — build options
 - `dataanalysis/` — output formats, openPMD, post-processing tools
-- `theory/` — numerical methods
 
 **Source code** — key directories:
 - `Source/Laser/`, `Source/Particles/`, `Source/FieldSolver/`, `Source/Diagnostics/`, `Source/BoundaryConditions/`, `Source/Python/`

--- a/.claude/skills/warpx-new-paper-highlight/SKILL.md
+++ b/.claude/skills/warpx-new-paper-highlight/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: new-paper-highlight
+name: warpx-new-paper-highlight
 description: Add a new paper to the WarpX science highlights documentation (`Docs/source/highlights.rst`).
 disable-model-invocation: true
 ---

--- a/Docs/source/developers/how_to_develop_with_llms.rst
+++ b/Docs/source/developers/how_to_develop_with_llms.rst
@@ -46,10 +46,31 @@ Skills
 WarpX defines reusable *skills* in the ``.claude/skills/`` directory.
 Skills are scripted workflows that an LLM assistant can execute on demand, automating multi-step tasks that follow a fixed procedure.
 
+All WarpX skills use the prefix ``warpx-`` for easy discovery (start typing ``/warpx`` to see them).
+
 Currently available skills:
 
-``/new-paper-highlight``
-^^^^^^^^^^^^^^^^^^^^^^^^
+``/warpx-answer-user-question``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Drafts a response to a WarpX user question from a GitHub issue, discussion, or email.
+
+Usage (in Claude Code):
+
+.. code-block:: text
+
+   /warpx-answer-user-question https://github.com/BLAST-WarpX/warpx/discussions/1234
+
+The skill will:
+
+#. Fetch the question from the provided URL (or use a pasted question directly).
+#. Categorize the question (installation, input parameters, diagnostics, physics, etc.).
+#. Search the WarpX source code, documentation, and past issues for relevant information.
+#. Draft a response in the style of an experienced WarpX developer.
+#. Present the draft for review before posting.
+
+``/warpx-new-paper-highlight``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Adds a new paper to the WarpX science highlights documentation (``Docs/source/highlights.rst``).
 
@@ -57,7 +78,7 @@ Usage (in Claude Code):
 
 .. code-block:: text
 
-   /new-paper-highlight https://doi.org/10.1103/PhysRevLett.133.045002
+   /warpx-new-paper-highlight https://doi.org/10.1103/PhysRevLett.133.045002
 
 The skill will:
 

--- a/Docs/source/developers/how_to_develop_with_llms.rst
+++ b/Docs/source/developers/how_to_develop_with_llms.rst
@@ -51,7 +51,7 @@ All WarpX skills use the prefix ``warpx-`` for easy discovery (start typing ``/w
 Currently available skills:
 
 ``/warpx-answer-user-question``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Drafts a response to a WarpX user question from a GitHub issue, discussion, or email.
 
@@ -70,7 +70,7 @@ The skill will:
 #. Present the draft for review before posting.
 
 ``/warpx-new-paper-highlight``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Adds a new paper to the WarpX science highlights documentation (``Docs/source/highlights.rst``).
 


### PR DESCRIPTION
This skill was written by Claude code after reading Github issues and discussions and observing how we (WarpX developers) interact with users.

This PR also renames WarpX skills so that they all start with `warpx-` (easier to search for when starting to type a slash command.)