### PR TITLE
Add enum to handle scattering angle in fusion reactions

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2260,6 +2260,12 @@ Details about the collision models can be found in the :ref:`theory section <mul
     ``probability_threshold``, WarpX reduces the event multiplier for
     that collisions such that the probability approches ``probability_target_value``.
 
+* ``<collision_name>.scattering_angle`` (`string`, optional, default: ``isotropic``)
+    Only for ``nuclearfusion``. The scattering angle for the products of the fusion reaction.
+    The possible values are ``isotropic`` and ``forward``.
+    With ``isotropic``, the scattering angle is drawn from an isotropic distribution.
+    With ``forward``, the scattering angle is set to zero, i.e. the products are emitted in the same direction as the reactant.
+
 * ``<collision_name>.background_density`` (`float`)
     Only for ``background_mcc`` and ``background_stopping``. The density of the background in :math:`m^{-3}`.
     Can also provide ``<collision_name>.background_density(x,y,z,t)`` using the parser

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2260,7 +2260,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
     ``probability_threshold``, WarpX reduces the event multiplier for
     that collisions such that the probability approches ``probability_target_value``.
 
-* ``<collision_name>.scattering_angle`` (`string`, optional, default: ``isotropic``)
+* ``<collision_name>.scattering_angle_model`` (`string`, optional, default: ``isotropic``)
     Only for ``nuclearfusion``. The scattering angle for the products of the fusion reaction.
     The possible values are ``isotropic`` and ``forward``.
     With ``isotropic``, the scattering angle is drawn from an isotropic distribution.

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -317,7 +317,7 @@ public:
                     -reaction_energy*PhysConst::q_e,
                     // TwoProductComputeProductMomenta expects the *released* energy here, hence the negative sign
                     // We also convert from eV to Joules
-                    /*scattering_angle=*/ScatteringAngle::Forward,
+                    ScatteringAngle::Forward,
                     // no angular scattering: the products' momenta have the same direction
                     // as that of the incident particle, in the center-of-mass frame
                     engine);

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -15,6 +15,7 @@
 #include "Particles/ParticleCreation/SmartCopy.H"
 #include "Particles/WarpXParticleContainer.H"
 #include "Utils/ParticleUtils.H"
+#include "Utils/WarpXAlgorithmSelection.H"
 
 /**
  * \brief This class defines an operator to create product particles from DSMC
@@ -316,7 +317,7 @@ public:
                     -reaction_energy*PhysConst::q_e,
                     // TwoProductComputeProductMomenta expects the *released* energy here, hence the negative sign
                     // We also convert from eV to Joules
-                    false,
+                    /*scattering_angle=*/ScatteringAngle::Forward,
                     // no angular scattering: the products' momenta have the same direction
                     // as that of the incident particle, in the center-of-mass frame
                     engine);

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -317,7 +317,7 @@ public:
                     -reaction_energy*PhysConst::q_e,
                     // TwoProductComputeProductMomenta expects the *released* energy here, hence the negative sign
                     // We also convert from eV to Joules
-                    ScatteringAngle::Forward,
+                    ScatteringAngleModel::Forward,
                     // no angular scattering: the products' momenta have the same direction
                     // as that of the incident particle, in the center-of-mass frame
                     engine);

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
@@ -16,7 +16,6 @@
 #include "Particles/WarpXParticleContainer.H"
 #include "Utils/Parser/ParserUtils.H"
 #include "Utils/TextMsg.H"
-#include "Utils/WarpXAlgorithmSelection.H"
 
 #include <AMReX_Algorithm.H>
 #include <AMReX_DenseBins.H>
@@ -62,7 +61,6 @@ public:
         m_probability_threshold{amrex::ParticleReal{0.02}}, // default fusion probability threshold
         m_probability_target_value{amrex::ParticleReal{0.002}}, // default fusion probability target_value
         m_fusion_type{BinaryCollisionUtils::get_nuclear_fusion_type(collision_name, mypc)},
-        m_scattering_angle{ScatteringAngle::Default},
         m_isSameSpecies{isSameSpecies}
     {
 
@@ -78,13 +76,11 @@ public:
         utils::parser::queryWithParser(
             pp_collision_name, "probability_target_value",
             m_probability_target_value);
-        pp_collision_name.query_enum_sloppy("scattering_angle", m_scattering_angle, "-_");
 
         m_exe.m_fusion_multiplier = m_fusion_multiplier;
         m_exe.m_probability_threshold = m_probability_threshold;
         m_exe.m_probability_target_value = m_probability_target_value;
         m_exe.m_fusion_type = m_fusion_type;
-        m_exe.m_scattering_angle = m_scattering_angle;
         m_exe.m_isSameSpecies = m_isSameSpecies;
     }
 
@@ -242,7 +238,6 @@ public:
         amrex::ParticleReal m_probability_threshold;
         amrex::ParticleReal m_probability_target_value;
         NuclearFusionType m_fusion_type;
-        ScatteringAngle m_scattering_angle;
         bool m_computeSpeciesDensities = false;
         bool m_computeSpeciesTemperatures = false;
         bool m_need_product_data = false;
@@ -266,7 +261,6 @@ private:
     amrex::ParticleReal m_probability_threshold;
     amrex::ParticleReal m_probability_target_value;
     NuclearFusionType m_fusion_type;
-    ScatteringAngle m_scattering_angle;
     bool m_isSameSpecies;
 
     Executor m_exe;

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
@@ -16,6 +16,7 @@
 #include "Particles/WarpXParticleContainer.H"
 #include "Utils/Parser/ParserUtils.H"
 #include "Utils/TextMsg.H"
+#include "Utils/WarpXAlgorithmSelection.H"
 
 #include <AMReX_Algorithm.H>
 #include <AMReX_DenseBins.H>
@@ -61,6 +62,7 @@ public:
         m_probability_threshold{amrex::ParticleReal{0.02}}, // default fusion probability threshold
         m_probability_target_value{amrex::ParticleReal{0.002}}, // default fusion probability target_value
         m_fusion_type{BinaryCollisionUtils::get_nuclear_fusion_type(collision_name, mypc)},
+        m_scattering_angle{ScatteringAngle::Default},
         m_isSameSpecies{isSameSpecies}
     {
 
@@ -76,11 +78,13 @@ public:
         utils::parser::queryWithParser(
             pp_collision_name, "probability_target_value",
             m_probability_target_value);
+        pp_collision_name.query_enum_sloppy("scattering_angle", m_scattering_angle, "-_");
 
         m_exe.m_fusion_multiplier = m_fusion_multiplier;
         m_exe.m_probability_threshold = m_probability_threshold;
         m_exe.m_probability_target_value = m_probability_target_value;
         m_exe.m_fusion_type = m_fusion_type;
+        m_exe.m_scattering_angle = m_scattering_angle;
         m_exe.m_isSameSpecies = m_isSameSpecies;
     }
 
@@ -238,6 +242,7 @@ public:
         amrex::ParticleReal m_probability_threshold;
         amrex::ParticleReal m_probability_target_value;
         NuclearFusionType m_fusion_type;
+        ScatteringAngle m_scattering_angle;
         bool m_computeSpeciesDensities = false;
         bool m_computeSpeciesTemperatures = false;
         bool m_need_product_data = false;
@@ -261,6 +266,7 @@ private:
     amrex::ParticleReal m_probability_threshold;
     amrex::ParticleReal m_probability_target_value;
     NuclearFusionType m_fusion_type;
+    ScatteringAngle m_scattering_angle;
     bool m_isSameSpecies;
 
     Executor m_exe;

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/ProtonBoronFusionInitializeMomentum.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/ProtonBoronFusionInitializeMomentum.H
@@ -11,6 +11,7 @@
 #include "Particles/Collision/BinaryCollision/TwoProductUtil.H"
 #include "Particles/WarpXParticleContainer.H"
 #include "Utils/ParticleUtils.H"
+#include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
 
 #include <AMReX_DenseBins.H>
@@ -106,7 +107,7 @@ namespace {
             ux_alpha1, uy_alpha1, uz_alpha1, static_cast<amrex::ParticleReal>(m_alpha),
             ux_Be, uy_Be, uz_Be, static_cast<amrex::ParticleReal>(m_beryllium),
             E_fusion,
-            /*isotropic_scattering=*/true,
+            /*scattering_angle=*/ScatteringAngle::Isotropic,
             engine);
 
         // Compute momentum of beryllium in lab frame

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/ProtonBoronFusionInitializeMomentum.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/ProtonBoronFusionInitializeMomentum.H
@@ -55,6 +55,7 @@ namespace {
      * @param[in] idx_alpha_start index of first produced alpha macroparticle
      * @param[in] m1 mass of first colliding species
      * @param[in] m2 mass of second colliding species
+     * @param[in] scattering_angle the scattering angle distribution to use
      * @param[in] engine the random engine
      */
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
@@ -64,6 +65,7 @@ namespace {
                             const index_type& idx_1, const index_type& idx_2,
                             const index_type& idx_alpha_start,
                             const amrex::ParticleReal& m1, const amrex::ParticleReal& m2,
+                            ScatteringAngle const scattering_angle,
                             const amrex::RandomEngine& engine)
     {
         // General notations in this function:
@@ -107,7 +109,7 @@ namespace {
             ux_alpha1, uy_alpha1, uz_alpha1, static_cast<amrex::ParticleReal>(m_alpha),
             ux_Be, uy_Be, uz_Be, static_cast<amrex::ParticleReal>(m_beryllium),
             E_fusion,
-            /*scattering_angle=*/ScatteringAngle::Isotropic,
+            scattering_angle,
             engine);
 
         // Compute momentum of beryllium in lab frame

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/ProtonBoronFusionInitializeMomentum.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/ProtonBoronFusionInitializeMomentum.H
@@ -55,7 +55,7 @@ namespace {
      * @param[in] idx_alpha_start index of first produced alpha macroparticle
      * @param[in] m1 mass of first colliding species
      * @param[in] m2 mass of second colliding species
-     * @param[in] scattering_angle the scattering angle distribution to use
+     * @param[in] scattering_angle_model the scattering angle distribution to use
      * @param[in] engine the random engine
      */
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
@@ -65,7 +65,7 @@ namespace {
                             const index_type& idx_1, const index_type& idx_2,
                             const index_type& idx_alpha_start,
                             const amrex::ParticleReal& m1, const amrex::ParticleReal& m2,
-                            ScatteringAngle const scattering_angle,
+                            ScatteringAngleModel const scattering_angle_model,
                             const amrex::RandomEngine& engine)
     {
         // General notations in this function:
@@ -109,7 +109,7 @@ namespace {
             ux_alpha1, uy_alpha1, uz_alpha1, static_cast<amrex::ParticleReal>(m_alpha),
             ux_Be, uy_Be, uz_Be, static_cast<amrex::ParticleReal>(m_beryllium),
             E_fusion,
-            scattering_angle,
+            scattering_angle_model,
             engine);
 
         // Compute momentum of beryllium in lab frame

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/TwoProductFusionInitializeMomentum.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/TwoProductFusionInitializeMomentum.H
@@ -10,6 +10,7 @@
 
 #include "Particles/Collision/BinaryCollision/TwoProductUtil.H"
 #include "Particles/WarpXParticleContainer.H"
+#include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/ParticleUtils.H"
 #include "Utils/WarpXConst.H"
 
@@ -77,7 +78,7 @@ namespace {
             ux1_out, uy1_out, uz1_out, m1_out,
             ux2_out, uy2_out, uz2_out, m2_out,
             E_fusion,
-            /*isotropic_scattering=*/true,
+            /*scattering_angle=*/ScatteringAngle::Isotropic,
             engine);
 
         // Fill momentum of product species (note that we actually

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/TwoProductFusionInitializeMomentum.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/TwoProductFusionInitializeMomentum.H
@@ -50,6 +50,7 @@ namespace {
      * @param[in] m1_out mass of first product species
      * @param[in] m2_out mass of second product species
      * @param[in] E_fusion energy released in the fusion reaction
+     * @param[in] scattering_angle the scattering angle distribution to use
      * @param[in] engine the random engine
      */
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
@@ -61,6 +62,7 @@ namespace {
                             const amrex::ParticleReal& m1_in, const amrex::ParticleReal& m2_in,
                             const amrex::ParticleReal& m1_out, const amrex::ParticleReal& m2_out,
                             const amrex::ParticleReal& E_fusion,
+                            ScatteringAngle const scattering_angle,
                             const amrex::RandomEngine& engine)
     {
         using namespace amrex::literals;
@@ -78,7 +80,7 @@ namespace {
             ux1_out, uy1_out, uz1_out, m1_out,
             ux2_out, uy2_out, uz2_out, m2_out,
             E_fusion,
-            /*scattering_angle=*/ScatteringAngle::Isotropic,
+            scattering_angle,
             engine);
 
         // Fill momentum of product species (note that we actually

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/TwoProductFusionInitializeMomentum.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/TwoProductFusionInitializeMomentum.H
@@ -50,7 +50,7 @@ namespace {
      * @param[in] m1_out mass of first product species
      * @param[in] m2_out mass of second product species
      * @param[in] E_fusion energy released in the fusion reaction
-     * @param[in] scattering_angle the scattering angle distribution to use
+     * @param[in] scattering_angle_model the scattering angle distribution to use
      * @param[in] engine the random engine
      */
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
@@ -62,7 +62,7 @@ namespace {
                             const amrex::ParticleReal& m1_in, const amrex::ParticleReal& m2_in,
                             const amrex::ParticleReal& m1_out, const amrex::ParticleReal& m2_out,
                             const amrex::ParticleReal& E_fusion,
-                            ScatteringAngle const scattering_angle,
+                            ScatteringAngleModel const scattering_angle_model,
                             const amrex::RandomEngine& engine)
     {
         using namespace amrex::literals;
@@ -80,7 +80,7 @@ namespace {
             ux1_out, uy1_out, uz1_out, m1_out,
             ux2_out, uy2_out, uz2_out, m2_out,
             E_fusion,
-            scattering_angle,
+            scattering_angle_model,
             engine);
 
         // Fill momentum of product species (note that we actually

--- a/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
@@ -167,7 +167,7 @@ public:
         const int t_num_product_species = m_num_product_species;
         const int* AMREX_RESTRICT p_num_products_device = m_num_products_device.data();
         const CollisionType t_collision_type = m_collision_type;
-        const ScatteringAngle t_scattering_angle = m_scattering_angle;
+        const ScatteringAngleModel t_scattering_angle_model = m_scattering_angle_model;
 
         amrex::ParallelForRNG(n_total_pairs,
         [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
@@ -206,7 +206,7 @@ public:
                     ProtonBoronFusionInitializeMomentum(soa_1, soa_2, soa_products_data[0],
                                                         p_pair_indices_1[i], p_pair_indices_2[i],
                                                         product_start_index, m1, m2,
-                                                        t_scattering_angle, engine);
+                                                        t_scattering_angle_model, engine);
                 }
                 else if (BinaryCollisionUtils::is_two_product_fusion_type(t_collision_type))
                 {
@@ -219,7 +219,7 @@ public:
                         products_np_data[0] + 2*p_offsets[i]*p_num_products_device[0],
                         products_np_data[1] + 2*p_offsets[i]*p_num_products_device[1],
                         m1, m2, products_mass_data[0], products_mass_data[1], fusion_energy,
-                        t_scattering_angle, engine);
+                        t_scattering_angle_model, engine);
                 }
                 else if(t_collision_type == CollisionType::LinearBreitWheeler){
                     LinearBreitWheelerInitializeMomentum(soa_1, soa_2,
@@ -263,7 +263,7 @@ private:
     amrex::Gpu::DeviceVector<int> m_num_products_device;
     amrex::Gpu::HostVector<int> m_num_products_host;
     CollisionType m_collision_type;
-    ScatteringAngle m_scattering_angle{ScatteringAngle::Default};
+    ScatteringAngleModel m_scattering_angle_model{ScatteringAngleModel::Default};
 };
 
 

--- a/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.H
@@ -167,6 +167,7 @@ public:
         const int t_num_product_species = m_num_product_species;
         const int* AMREX_RESTRICT p_num_products_device = m_num_products_device.data();
         const CollisionType t_collision_type = m_collision_type;
+        const ScatteringAngle t_scattering_angle = m_scattering_angle;
 
         amrex::ParallelForRNG(n_total_pairs,
         [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
@@ -204,7 +205,8 @@ public:
                                                            p_num_products_device[0];
                     ProtonBoronFusionInitializeMomentum(soa_1, soa_2, soa_products_data[0],
                                                         p_pair_indices_1[i], p_pair_indices_2[i],
-                                                        product_start_index, m1, m2, engine);
+                                                        product_start_index, m1, m2,
+                                                        t_scattering_angle, engine);
                 }
                 else if (BinaryCollisionUtils::is_two_product_fusion_type(t_collision_type))
                 {
@@ -216,7 +218,8 @@ public:
                         p_pair_indices_1[i], p_pair_indices_2[i],
                         products_np_data[0] + 2*p_offsets[i]*p_num_products_device[0],
                         products_np_data[1] + 2*p_offsets[i]*p_num_products_device[1],
-                        m1, m2, products_mass_data[0], products_mass_data[1], fusion_energy, engine);
+                        m1, m2, products_mass_data[0], products_mass_data[1], fusion_energy,
+                        t_scattering_angle, engine);
                 }
                 else if(t_collision_type == CollisionType::LinearBreitWheeler){
                     LinearBreitWheelerInitializeMomentum(soa_1, soa_2,
@@ -260,6 +263,7 @@ private:
     amrex::Gpu::DeviceVector<int> m_num_products_device;
     amrex::Gpu::HostVector<int> m_num_products_host;
     CollisionType m_collision_type;
+    ScatteringAngle m_scattering_angle{ScatteringAngle::Default};
 };
 
 

--- a/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.cpp
@@ -52,6 +52,12 @@ ParticleCreationFunc::ParticleCreationFunc (const std::string& collision_name,
         WARPX_ABORT_WITH_MESSAGE("Unknown collision type in ParticleCreationFunc");
     }
 
+    if (m_collision_type == CollisionType::ProtonBoronToAlphasFusion
+        || BinaryCollisionUtils::is_two_product_fusion_type(m_collision_type))
+    {
+        pp_collision_name.query_enum_sloppy("scattering_angle", m_scattering_angle, "-_");
+    }
+
 #ifdef AMREX_USE_GPU
      m_num_products_device.resize(m_num_product_species);
      amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, m_num_products_host.begin(),

--- a/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.cpp
@@ -55,7 +55,7 @@ ParticleCreationFunc::ParticleCreationFunc (const std::string& collision_name,
     if (m_collision_type == CollisionType::ProtonBoronToAlphasFusion
         || BinaryCollisionUtils::is_two_product_fusion_type(m_collision_type))
     {
-        pp_collision_name.query_enum_sloppy("scattering_angle", m_scattering_angle, "-_");
+        pp_collision_name.query_enum_sloppy("scattering_angle_model", m_scattering_angle_model, "-_");
     }
 
 #ifdef AMREX_USE_GPU

--- a/Source/Particles/Collision/BinaryCollision/TwoProductUtil.H
+++ b/Source/Particles/Collision/BinaryCollision/TwoProductUtil.H
@@ -43,7 +43,7 @@ namespace {
      * @param[out] u2z_out normalized momentum of the second product macroparticles along z (in m.s^-1)
      * @param[in] m2_out mass of the second product macroparticles
      * @param[in] E_reaction energy liberated during the reaction
-     * @param[in] scattering_angle strategy to determine the scattering angle in the center-of-mass frame.
+     * @param[in] scattering_angle the scattering angle distribution to use
      * @param[in] engine the random engine (used to calculate the angle of emission of the products)
      */
     AMREX_GPU_HOST_DEVICE AMREX_INLINE

--- a/Source/Particles/Collision/BinaryCollision/TwoProductUtil.H
+++ b/Source/Particles/Collision/BinaryCollision/TwoProductUtil.H
@@ -139,7 +139,7 @@ namespace {
         else if (scattering_angle == ScatteringAngle::Forward) {
             // Forward scattering: the products have the same direction as the incident particle in the center of mass frame
             amrex::ParticleReal p1x_star_in, p1y_star_in, p1z_star_in;
-            if (vc_sq > std::numeric_limits<amrex::ParticleReal>::min())
+            if ( vc_sq > std::numeric_limits<amrex::ParticleReal>::min() )
             {
                 // Convert momentum of first incident particle to lab frame, using equation (2)
                 // of F. Perez et al., Phys.Plasmas.19.083104 (2012)

--- a/Source/Particles/Collision/BinaryCollision/TwoProductUtil.H
+++ b/Source/Particles/Collision/BinaryCollision/TwoProductUtil.H
@@ -43,7 +43,7 @@ namespace {
      * @param[out] u2z_out normalized momentum of the second product macroparticles along z (in m.s^-1)
      * @param[in] m2_out mass of the second product macroparticles
      * @param[in] E_reaction energy liberated during the reaction
-     * @param[in] scattering_angle the scattering angle distribution to use
+     * @param[in] scattering_angle_model the scattering angle distribution to use
      * @param[in] engine the random engine (used to calculate the angle of emission of the products)
      */
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
@@ -65,7 +65,7 @@ namespace {
                             amrex::ParticleReal& u2z_out,
                             const amrex::ParticleReal& m2_out,
                             const amrex::ParticleReal& E_reaction,
-                            ScatteringAngle scattering_angle,
+                            ScatteringAngleModel scattering_angle_model,
                             const amrex::RandomEngine& engine )
     {
         using namespace amrex::literals;
@@ -133,12 +133,12 @@ namespace {
         amrex::ParticleReal px_star_out = 0.0_prt;
         amrex::ParticleReal py_star_out = 0.0_prt;
         amrex::ParticleReal pz_star_out = 0.0_prt;
-        if (scattering_angle == ScatteringAngle::Isotropic) {
+        if (scattering_angle_model == ScatteringAngleModel::Isotropic) {
             // Isotropic scattering: the angle of emission of the products in the center of mass frame is random
             ParticleUtils::RandomizeVelocity(px_star_out, py_star_out, pz_star_out, std::sqrt(p_star_f_sq),
                                              engine);
         }
-        else if (scattering_angle == ScatteringAngle::Forward) {
+        else if (scattering_angle_model == ScatteringAngleModel::Forward) {
             // Forward scattering: the products have the same direction as the incident particle in the center of mass frame
             amrex::ParticleReal p1x_star_in, p1y_star_in, p1z_star_in;
             if ( vc_sq > std::numeric_limits<amrex::ParticleReal>::min() )

--- a/Source/Particles/Collision/BinaryCollision/TwoProductUtil.H
+++ b/Source/Particles/Collision/BinaryCollision/TwoProductUtil.H
@@ -130,7 +130,9 @@ namespace {
         const amrex::ParticleReal gc = 1._prt / std::sqrt( 1._prt - vc_sq*inv_csq );
 
         // Compute momentum of first product in the center of mass frame
-        amrex::ParticleReal px_star_out, py_star_out, pz_star_out;
+        amrex::ParticleReal px_star_out = 0.0_prt;
+        amrex::ParticleReal py_star_out = 0.0_prt;
+        amrex::ParticleReal pz_star_out = 0.0_prt;
         if (scattering_angle == ScatteringAngle::Isotropic) {
             // Isotropic scattering: the angle of emission of the products in the center of mass frame is random
             ParticleUtils::RandomizeVelocity(px_star_out, py_star_out, pz_star_out, std::sqrt(p_star_f_sq),

--- a/Source/Particles/Collision/BinaryCollision/TwoProductUtil.H
+++ b/Source/Particles/Collision/BinaryCollision/TwoProductUtil.H
@@ -9,6 +9,7 @@
 #define WARPX_TWO_PRODUCT_UTIL_H
 
 #include "Utils/ParticleUtils.H"
+#include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
 
 #include <AMReX_Math.H>
@@ -42,10 +43,7 @@ namespace {
      * @param[out] u2z_out normalized momentum of the second product macroparticles along z (in m.s^-1)
      * @param[in] m2_out mass of the second product macroparticles
      * @param[in] E_reaction energy liberated during the reaction
-     * @param[in] isotropic_scattering flag to indicate whether the particles are scattered isotropically.
-     * If true, the particles are scattered isotropically in the center-of-mass frame.
-     * If false, the particles momentum do not change direction, in the center-of-mass frame.
-     * (but the magnitude of the momentum may change, esp. if E_reaction is non-zero)
+     * @param[in] scattering_angle strategy to determine the scattering angle in the center-of-mass frame.
      * @param[in] engine the random engine (used to calculate the angle of emission of the products)
      */
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
@@ -67,7 +65,7 @@ namespace {
                             amrex::ParticleReal& u2z_out,
                             const amrex::ParticleReal& m2_out,
                             const amrex::ParticleReal& E_reaction,
-                            const bool isotropic_scattering,
+                            ScatteringAngle scattering_angle,
                             const amrex::RandomEngine& engine )
     {
         using namespace amrex::literals;
@@ -133,17 +131,15 @@ namespace {
 
         // Compute momentum of first product in the center of mass frame
         amrex::ParticleReal px_star_out, py_star_out, pz_star_out;
-        if (isotropic_scattering) {
-            // Assume isotropic scattering in the center-of-mass frame
+        if (scattering_angle == ScatteringAngle::Isotropic) {
+            // Isotropic scattering: the angle of emission of the products in the center of mass frame is random
             ParticleUtils::RandomizeVelocity(px_star_out, py_star_out, pz_star_out, std::sqrt(p_star_f_sq),
                                              engine);
         }
-        else {
-            // Assume that the momentum of the products has the same direction
-            // as that of the incident particle in the center of mass frame
-
+        else if (scattering_angle == ScatteringAngle::Forward) {
+            // Forward scattering: the products have the same direction as the incident particle in the center of mass frame
             amrex::ParticleReal p1x_star_in, p1y_star_in, p1z_star_in;
-            if ( vc_sq > std::numeric_limits<amrex::ParticleReal>::min() )
+            if (vc_sq > std::numeric_limits<amrex::ParticleReal>::min())
             {
                 // Convert momentum of first incident particle to lab frame, using equation (2)
                 // of F. Perez et al., Phys.Plasmas.19.083104 (2012)

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -194,7 +194,6 @@ AMREX_ENUM(
     ScatteringAngle,
     Forward,    /**< Scattering angle is zero, i.e., products have the same direction as the incident particle in the center of mass frame */
     Isotropic,  /**< Scattering angle is random, i.e., products are scattered isotropically in the center of mass frame */
-    Anisotropic, /**< Scattering angle follows a specific distribution, i.e., products are scattered anisotropically in the center of mass frame */
     Default = Isotropic  /**< Isotropic */
 );
 

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -191,7 +191,7 @@ AMREX_ENUM(
 /** \brief For binary collision algorithms, the strategy to determine
  *  the scattering angle in the center of mass frame */
 AMREX_ENUM(
-    ScatteringAngle,
+    ScatteringAngleModel,
     Forward,    /**< Scattering angle is zero, i.e., products have the same direction as the incident particle in the center of mass frame */
     Isotropic,  /**< Scattering angle is random, i.e., products are scattered isotropically in the center of mass frame */
     Default = Isotropic  /**< Isotropic */

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -188,4 +188,14 @@ AMREX_ENUM(
     Default = Full
 );
 
+/** \brief For binary collision algorithms, the strategy to determine
+ *  the scattering angle in the center of mass frame */
+AMREX_ENUM(
+    ScatteringAngle,
+    Forward,    /**< Scattering angle is zero, i.e., products have the same direction as the incident particle in the center of mass frame */
+    Isotropic,  /**< Scattering angle is random, i.e., products are scattered isotropically in the center of mass frame */
+    Anisotropic, /**< Scattering angle follows a specific distribution, i.e., products are scattered anisotropically in the center of mass frame */
+    Default = Isotropic  /**< Isotropic */
+);
+
 #endif // WARPX_UTILS_WARPXALGORITHMSELECTION_H_


### PR DESCRIPTION
## Overview

Add a new `AMREX_ENUM` for the algorithm to choose the scattering angle in fusion reactions. The current options are `Isotropic` (default) and `Forward`. In future PRs, we will add an `Anisotropic` option to account for the algorithm outlined in #6637.

## To do

This PR:
- [x] Implement new enum to handle scattering angle algorithm
- [x] Implement user interface to set scattering angle algorithm
- [x] Update tests: no update needed, use default enum value
- [x] Update documentation

Future PRs:
- Add and implement `Anisotropic` option

## Related PRs

- #6707

## Related issues

- #6637

## References

- Higginson et al., J. Comput. Phys. 388 (2019), [doi.org/10.1016/j.jcp.2019.03.020](https://doi.org/10.1016/j.jcp.2019.03.020)
-  Drosg et al., INDC (AUS)-0019, [www-nds.iaea.org/records/t5vy7-v2d27](www-nds.iaea.org/records/t5vy7-v2d27)