### PR TITLE
Update HPC3-UCI docs to use Python 3.14.3

### DIFF
--- a/Tools/machines/hpc3-uci/hpc3_gpu_warpx.profile.example
+++ b/Tools/machines/hpc3-uci/hpc3_gpu_warpx.profile.example
@@ -33,7 +33,8 @@ export PATH=${HOME}/sw/hpc3/gpu/adios2-2.10.2/bin:${PATH}
 #module load ccache  # missing
 
 # optional: for Python bindings
-module load python/3.10.2
+# Any supported Python >=3.11 module should work
+module load python/3.14.3
 
 if [ -d "${HOME}/sw/hpc3/gpu/venvs/warpx-gpu" ]
 then


### PR DESCRIPTION
This updates the HPC3-UCI installation profile example to use a supported newer Python module instead of `python/3.10.2`.

Tested on HPC3-UCI:
- `python/3.14.3`
- clean rebuild successful
- WarpX build completed successfully

This aligns HPC3-UCI instructions with the BLAST Python 3.11+ support direction !