### PR TITLE
Use new ruff-check pre-commit ID

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,7 +76,7 @@ repos:
   rev: v0.15.7
   hooks:
     # Run the linter
-    - id: ruff
+    - id: ruff-check
       args: [--fix, --exit-non-zero-on-fix]
     # Run the formatter
     - id: ruff-format


### PR DESCRIPTION
Just found out that the new pre-commit ID `ruff-check` was introduced a while ago in https://github.com/astral-sh/ruff-pre-commit/pull/124 and seems to be preferred to the old ID `ruff`. See also `ruff-pre-commit`'s main README file [github.com/astral-sh/ruff-pre-commit/blob/main/README.md](https://github.com/astral-sh/ruff-pre-commit/blob/main/README.md).