### PR TITLE
Evolve: use finest_level instead of max_level to gate RedistributeLocal

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -724,7 +724,7 @@ void WarpX::HandleParticlesAtBoundaries (int step, amrex::Real cur_time, int num
         // Electromagnetic solver: due to CFL condition, particles can
         // only move by one or two cells per time step
         // The implicit scheme can allow additional cell crossings, as specified by particle_max_grid_crossings.
-        if (max_level == 0) {
+        if (finest_level == 0) {
             int num_redistribute_ghost = num_moved;
             if ((m_v_galilean[0]!=0) or (m_v_galilean[1]!=0) or (m_v_galilean[2]!=0)) {
                 // Galilean algorithm ; particles can move by up to one additional cell beyond the max number


### PR DESCRIPTION
## Summary
`HandleParticlesAtBoundaries` was using `max_level == 0` to decide whether to use the cheap `RedistributeLocal` path. But `max_level` is the configured maximum AMR depth, while `finest_level` is the number of currently active levels. Whenever a user sets `amr.max_level > 0` to allow future refinement, the local redistribute was bypassed unconditionally — even when the hierarchy currently had only one level and the optimization would have been valid and faster.

## Fix
Replace `max_level == 0` with `finest_level == 0`.

Fixes #6653

🤖 Generated with [Claude Code](https://claude.com/claude-code)