### PR TITLE
ablastr: replace protected n_grow member with public nGrowVect()

### DIFF
--- a/Source/ablastr/utils/Communication.cpp
+++ b/Source/ablastr/utils/Communication.cpp
@@ -116,7 +116,7 @@ void FillBoundary (amrex::MultiFab &mf,
 
 void FillBoundary (amrex::MultiFab &mf, bool do_single_precision_comms, const amrex::Periodicity &period, std::optional<bool> nodal_sync)
 {
-    amrex::IntVect const ng = mf.n_grow;
+    amrex::IntVect const ng = mf.nGrowVect();
     FillBoundary(mf, ng, do_single_precision_comms, period, nodal_sync);
 }
 


### PR DESCRIPTION
## Summary
`ablastr::utils::communication::FillBoundary(MultiFab&, ...)` was reading the guard-cell vector via `mf.n_grow`, a `protected` data member of AMReX's `FabArrayBase` that is not part of the public API. Recent AMReX releases tightened encapsulation, causing build failures with newer AMReX snapshots. All other call sites in the same file already use the public accessor `mf.nGrowVect()`.

## Fix
Replace `mf.n_grow` with `mf.nGrowVect()`.

Fixes #6642

## Test plan
- [ ] Builds cleanly against recent AMReX

🤖 Generated with [Claude Code](https://claude.com/claude-code)