### PR TITLE
Particles: fix always-true bounds check in DepositCharge

### DIFF
--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -1456,7 +1456,7 @@ WarpXParticleContainer::DepositCharge (WarpXParIter& pti, RealVector const& wp,
                                        const int thread_num, const int lev, const int depos_lev)
 {
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        rho->nComp() >= icomp - 1,
+        rho->nComp() >= (icomp + 1) * WarpX::ncomps,
         "Cannot deposit charge in rho component icomp=" + std::to_string(icomp) +
         ": not enough components allocated (" + std::to_string(rho->nComp()) + "!"
     );
@@ -1787,7 +1787,7 @@ WarpXParticleContainer::DepositCharge (amrex::MultiFab* rho,
                                        const int icomp)
 {
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        rho->nComp() >= icomp - 1,
+        rho->nComp() >= (icomp + 1) * WarpX::ncomps,
         "Cannot deposit charge in rho component icomp=" + std::to_string(icomp) +
         ": not enough components allocated (" + std::to_string(rho->nComp()) + "!"
     );


### PR DESCRIPTION
## Summary
Both overloads of `DepositCharge` guarded the component index with:
```cpp
rho->nComp() >= icomp - 1
```
This condition is trivially true for any non-negative `icomp` (a `MultiFab` always has at least one component), so it never actually catches out-of-bounds requests. The alias constructed just below starts at `icomp * WarpX::ncomps`, so the correct guard is:
```cpp
rho->nComp() >= (icomp + 1) * WarpX::ncomps
```

## Fix
Update both assertion sites to use the correct bound.

Fixes #6655

🤖 Generated with [Claude Code](https://claude.com/claude-code)