### PR TITLE
Collisions: replace ndt with ndt_supercycle and ndt_subcycle

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2268,8 +2268,16 @@ Details about the collision models can be found in the :ref:`theory section <mul
     If using ``bremsstrahlung``, the product species must be of type photon.
     If using ``linear_compton``, these should be two species: first, a photon species, and second, a lepton species, in this exact order.
 
-* ``<collision_name>.ndt`` (`int`) optional
-    Execute collision every # time steps. The default value is 1.
+* ``<collision_name>.ndt_supercycle`` (`int`) optional
+    Execute collision once every ``ndt_supercycle`` PIC time steps.
+    The effective collision time step is ``dt_collision = ndt_supercycle * dt_PIC``.
+    Must be >= 1. Mutually exclusive with ``ndt_subcycle``. Default is 1.
+
+* ``<collision_name>.ndt_subcycle`` (`int`) optional
+    Execute collision ``ndt_subcycle`` times per PIC time step.
+    The effective collision time step is ``dt_collision = dt_PIC / ndt_subcycle``.
+    Must be >= 1. Mutually exclusive with ``ndt_supercycle``.
+    Useful when a large PIC time step is desired but collisions require finer time resolution.
 
 * ``<collision_name>.CoulombLog`` (`float`) optional
     Only for ``pairwisecoulomb``. A provided fixed Coulomb logarithm of the

--- a/Examples/Physics_applications/capacitive_discharge/inputs_base_1d_picmi.py
+++ b/Examples/Physics_applications/capacitive_discharge/inputs_base_1d_picmi.py
@@ -293,7 +293,7 @@ class CapacitiveDischargeExample(object):
                 name="coll_elec_dsmc",
                 species=[self.electrons, self.neutrals],
                 product_species=[self.electrons, self.ions],
-                ndt=4,
+                ndt_supercycle=4,
                 scattering_processes=ionization,
             )
             electron_colls_mcc = picmi.MCCCollisions(
@@ -302,7 +302,7 @@ class CapacitiveDischargeExample(object):
                 background_density=self.gas_density,
                 background_temperature=self.gas_temp,
                 background_mass=self.ions.mass,
-                ndt=self.mcc_subcycling_steps,
+                ndt_supercycle=self.mcc_subcycling_steps,
                 scattering_processes=electron_scattering_processes,
             )
             electron_colls = [electron_colls_mcc, electron_colls_dsmc]
@@ -313,7 +313,7 @@ class CapacitiveDischargeExample(object):
                 background_density=self.gas_density,
                 background_temperature=self.gas_temp,
                 background_mass=self.ions.mass,
-                ndt=self.mcc_subcycling_steps,
+                ndt_supercycle=self.mcc_subcycling_steps,
                 scattering_processes=electron_scattering_processes,
             )
             electron_colls = [electron_colls_mcc]
@@ -327,7 +327,7 @@ class CapacitiveDischargeExample(object):
             ion_colls = picmi.DSMCCollisions(
                 name="coll_ion",
                 species=[self.ions, self.neutrals],
-                ndt=5,
+                ndt_supercycle=5,
                 scattering_processes=ion_scattering_processes,
             )
         else:
@@ -336,7 +336,7 @@ class CapacitiveDischargeExample(object):
                 species=self.ions,
                 background_density=self.gas_density,
                 background_temperature=self.gas_temp,
-                ndt=self.mcc_subcycling_steps,
+                ndt_supercycle=self.mcc_subcycling_steps,
                 scattering_processes=ion_scattering_processes,
             )
         ion_colls = [ion_colls]

--- a/Examples/Tests/collision/CMakeLists.txt
+++ b/Examples/Tests/collision/CMakeLists.txt
@@ -62,6 +62,16 @@ add_warpx_test(
 )
 
 add_warpx_test(
+    test_3d_collision_iso_subcycle  # name
+    3  # dims
+    1  # nprocs
+    inputs_test_3d_collision_iso_subcycle  # inputs
+    "analysis_collision_3d_isotropization.py diags/diag1000010"  # analysis
+    "analysis_default_regression.py --path diags/diag1000010"  # checksum
+    OFF  # dependency
+)
+
+add_warpx_test(
     test_3d_collision_xyz  # name
     3  # dims
     1  # nprocs

--- a/Examples/Tests/collision/inputs_test_3d_collision_iso
+++ b/Examples/Tests/collision/inputs_test_3d_collision_iso
@@ -50,7 +50,7 @@ electron.do_not_deposit = 1
 collisions.collision_names = collision1
 collision1.species = electron electron
 collision1.CoulombLog = 2.0
-collision1.ndt_supercycle = 1
+
 
 # Diagnostics
 diagnostics.diags_names = diag1

--- a/Examples/Tests/collision/inputs_test_3d_collision_iso_subcycle
+++ b/Examples/Tests/collision/inputs_test_3d_collision_iso_subcycle
@@ -21,7 +21,7 @@ boundary.field_hi = periodic periodic periodic
 #################################
 warpx.serialize_initial_conditions = 1
 warpx.verbose = 1
-warpx.const_dt = 1.4e-17
+warpx.const_dt = 1.4e-16
 
 # Order of particle shape factors
 algo.particle_shape = 1
@@ -50,9 +50,9 @@ electron.do_not_deposit = 1
 collisions.collision_names = collision1
 collision1.species = electron electron
 collision1.CoulombLog = 2.0
-collision1.ndt_supercycle = 1
+collision1.ndt_subcycle = 10
 
 # Diagnostics
 diagnostics.diags_names = diag1
-diag1.intervals = 100
+diag1.intervals = 10
 diag1.diag_type = Full

--- a/Examples/Tests/collision/inputs_test_3d_collision_iso_subcycle
+++ b/Examples/Tests/collision/inputs_test_3d_collision_iso_subcycle
@@ -1,58 +1,8 @@
-#################################
-####### GENERAL PARAMETERS ######
-#################################
-stop_time = 1.4e-15
-amr.n_cell = 8 8 8
-amr.max_grid_size = 8
-amr.blocking_factor = 8
-amr.max_level = 0
-geometry.dims = 3
-geometry.prob_lo = 0.    0.    0.
-geometry.prob_hi = 4.0e-6  4.0e-6  4.0e-6
+# base input parameters
+FILE = inputs_test_3d_collision_iso
 
-#################################
-###### Boundary Condition #######
-#################################
-boundary.field_lo = periodic periodic periodic
-boundary.field_hi = periodic periodic periodic
-
-#################################
-############ NUMERICS ###########
-#################################
-warpx.serialize_initial_conditions = 1
-warpx.verbose = 1
+# Use a 10x larger PIC timestep with ndt_subcycle=10, so the collision
+# timestep remains unchanged (dt_collision = 1.4e-17 s, 100 iterations total)
 warpx.const_dt = 1.4e-16
-
-# Order of particle shape factors
-algo.particle_shape = 1
-algo.maxwell_solver = none
-
-#################################
-############ PLASMA #############
-#################################
-particles.species_names = electron
-
-electron.charge = -q_e
-electron.mass = m_e
-electron.injection_style = "NRandomPerCell"
-electron.num_particles_per_cell = 1000
-electron.profile = constant
-electron.density = 1.116e28
-electron.momentum_distribution_type = "gaussian"
-electron.ux_th = 0.0033163331635535603
-electron.uy_th = 0.00315918518549115
-electron.uz_th = 0.00315918518549115
-electron.do_not_deposit = 1
-
-#################################
-############ COLLISION ##########
-#################################
-collisions.collision_names = collision1
-collision1.species = electron electron
-collision1.CoulombLog = 2.0
 collision1.ndt_subcycle = 10
-
-# Diagnostics
-diagnostics.diags_names = diag1
 diag1.intervals = 10
-diag1.diag_type = Full

--- a/Examples/Tests/collision/inputs_test_3d_collision_xyz
+++ b/Examples/Tests/collision/inputs_test_3d_collision_xyz
@@ -68,9 +68,9 @@ collision3.species = ion ion
 collision1.CoulombLog = 15.9
 collision2.CoulombLog = 15.9
 collision3.CoulombLog = 15.9
-collision1.ndt = 10
-collision2.ndt = 10
-collision3.ndt = 10
+collision1.ndt_supercycle = 10
+collision2.ndt_supercycle = 10
+collision3.ndt_supercycle = 10
 
 # Diagnostics
 diagnostics.diags_names = diag1 diag_parser_filter diag_uniform_filter diag_random_filter

--- a/Examples/Tests/ionization_dsmc/inputs_base_3d
+++ b/Examples/Tests/ionization_dsmc/inputs_base_3d
@@ -90,7 +90,7 @@ collisions.collision_names = ioniz
 ioniz.ionization_energy = 13.59844
 ioniz.product_species = electrons ions
 ioniz.ionization_target_species = neutrals
-ioniz.ndt = 1
+ioniz.ndt_supercycle = 1
 ioniz.scattering_processes = ionization
 ioniz.type = dsmc
 

--- a/Examples/Tests/ionization_dsmc/inputs_base_3d
+++ b/Examples/Tests/ionization_dsmc/inputs_base_3d
@@ -90,7 +90,6 @@ collisions.collision_names = ioniz
 ioniz.ionization_energy = 13.59844
 ioniz.product_species = electrons ions
 ioniz.ionization_target_species = neutrals
-ioniz.ndt_supercycle = 1
 ioniz.scattering_processes = ionization
 ioniz.type = dsmc
 

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2794,7 +2794,7 @@ class CoulombCollisions(picmistandard.base._ClassWithInit):
         self.ndt_supercycle = ndt_supercycle
         self.ndt_subcycle = ndt_subcycle
 
-        if 'ndt' in kw:
+        if "ndt" in kw:
             raise ValueError(
                 "`ndt` is no longer a valid option for collisions."
                 "Please use `ndt_supercycle` instead (run collision every N PIC steps)."
@@ -2876,7 +2876,7 @@ class MCCCollisions(picmistandard.base._ClassWithInit):
         self.ndt_supercycle = ndt_supercycle
         self.ndt_subcycle = ndt_subcycle
 
-        if 'ndt' in kw:
+        if "ndt" in kw:
             raise ValueError(
                 "`ndt` is no longer a valid option for collisions."
                 "Please use `ndt_supercycle` instead (run collision every N PIC steps)."
@@ -2962,7 +2962,7 @@ class DSMCCollisions(picmistandard.base._ClassWithInit):
         self.ndt_supercycle = ndt_supercycle
         self.ndt_subcycle = ndt_subcycle
 
-        if 'ndt' in kw:
+        if "ndt" in kw:
             raise ValueError(
                 "`ndt` is no longer a valid option for collisions."
                 "Please use `ndt_supercycle` instead (run collision every N PIC steps)."

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2779,7 +2779,15 @@ class CoulombCollisions(picmistandard.base._ClassWithInit):
         Mutually exclusive with ndt_supercycle.
     """
 
-    def __init__(self, name, species, CoulombLog=None, ndt_supercycle=None, ndt_subcycle=None, **kw):
+    def __init__(
+        self,
+        name,
+        species,
+        CoulombLog=None,
+        ndt_supercycle=None,
+        ndt_subcycle=None,
+        **kw,
+    ):
         self.name = name
         self.species = species
         self.CoulombLog = CoulombLog
@@ -2926,8 +2934,14 @@ class DSMCCollisions(picmistandard.base._ClassWithInit):
     """
 
     def __init__(
-        self, name, species, scattering_processes, product_species=None,
-        ndt_supercycle=None, ndt_subcycle=None, **kw
+        self,
+        name,
+        species,
+        scattering_processes,
+        product_species=None,
+        ndt_supercycle=None,
+        ndt_subcycle=None,
+        **kw,
     ):
         self.name = name
         self.species = species

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2768,15 +2768,23 @@ class CoulombCollisions(picmistandard.base._ClassWithInit):
         Value of the Coulomb log to use in the collision cross section.
         If not supplied, it is calculated from the local conditions.
 
-    ndt: integer, optional
-        The collisions will be applied every "ndt" steps. Must be 1 or larger.
+    ndt_supercycle: integer, optional
+        Run collision once every ndt_supercycle PIC time steps
+        (dt_collision = ndt_supercycle * dt_PIC). Must be >= 1.
+        Mutually exclusive with ndt_subcycle. Default is 1.
+
+    ndt_subcycle: integer, optional
+        Run collision ndt_subcycle times per PIC time step
+        (dt_collision = dt_PIC / ndt_subcycle). Must be >= 1.
+        Mutually exclusive with ndt_supercycle.
     """
 
-    def __init__(self, name, species, CoulombLog=None, ndt=None, **kw):
+    def __init__(self, name, species, CoulombLog=None, ndt_supercycle=None, ndt_subcycle=None, **kw):
         self.name = name
         self.species = species
         self.CoulombLog = CoulombLog
-        self.ndt = ndt
+        self.ndt_supercycle = ndt_supercycle
+        self.ndt_subcycle = ndt_subcycle
 
         self.handle_init(kw)
 
@@ -2785,7 +2793,8 @@ class CoulombCollisions(picmistandard.base._ClassWithInit):
         collision.type = "pairwisecoulomb"
         collision.species = [species.name for species in self.species]
         collision.CoulombLog = self.CoulombLog
-        collision.ndt = self.ndt
+        collision.ndt_supercycle = self.ndt_supercycle
+        collision.ndt_subcycle = self.ndt_subcycle
 
 
 class MCCCollisions(picmistandard.base._ClassWithInit):
@@ -2819,8 +2828,15 @@ class MCCCollisions(picmistandard.base._ClassWithInit):
         The maximum background density. When the background_density is an expression, this must also
         be specified.
 
-    ndt: integer, optional
-        The collisions will be applied every "ndt" steps. Must be 1 or larger.
+    ndt_supercycle: integer, optional
+        Run collision once every ndt_supercycle PIC time steps
+        (dt_collision = ndt_supercycle * dt_PIC). Must be >= 1.
+        Mutually exclusive with ndt_subcycle. Default is 1.
+
+    ndt_subcycle: integer, optional
+        Run collision ndt_subcycle times per PIC time step
+        (dt_collision = dt_PIC / ndt_subcycle). Must be >= 1.
+        Mutually exclusive with ndt_supercycle.
     """
 
     def __init__(
@@ -2832,7 +2848,8 @@ class MCCCollisions(picmistandard.base._ClassWithInit):
         scattering_processes,
         background_mass=None,
         max_background_density=None,
-        ndt=None,
+        ndt_supercycle=None,
+        ndt_subcycle=None,
         **kw,
     ):
         self.name = name
@@ -2842,7 +2859,8 @@ class MCCCollisions(picmistandard.base._ClassWithInit):
         self.background_mass = background_mass
         self.scattering_processes = scattering_processes
         self.max_background_density = max_background_density
-        self.ndt = ndt
+        self.ndt_supercycle = ndt_supercycle
+        self.ndt_subcycle = ndt_subcycle
 
         self.handle_init(kw)
 
@@ -2864,7 +2882,8 @@ class MCCCollisions(picmistandard.base._ClassWithInit):
             collision.background_temperature = self.background_temperature
         collision.background_mass = self.background_mass
         collision.max_background_density = self.max_background_density
-        collision.ndt = self.ndt
+        collision.ndt_supercycle = self.ndt_supercycle
+        collision.ndt_subcycle = self.ndt_subcycle
 
         collision.scattering_processes = self.scattering_processes.keys()
         for process, kw in self.scattering_processes.items():
@@ -2895,18 +2914,27 @@ class DSMCCollisions(picmistandard.base._ClassWithInit):
         The species produced by collision processes (currently both
         ionization and charge-exchange require defining the product species).
 
-    ndt: integer, optional
-        The collisions will be applied every "ndt" steps. Must be 1 or larger.
+    ndt_supercycle: integer, optional
+        Run collision once every ndt_supercycle PIC time steps
+        (dt_collision = ndt_supercycle * dt_PIC). Must be >= 1.
+        Mutually exclusive with ndt_subcycle. Default is 1.
+
+    ndt_subcycle: integer, optional
+        Run collision ndt_subcycle times per PIC time step
+        (dt_collision = dt_PIC / ndt_subcycle). Must be >= 1.
+        Mutually exclusive with ndt_supercycle.
     """
 
     def __init__(
-        self, name, species, scattering_processes, product_species=None, ndt=None, **kw
+        self, name, species, scattering_processes, product_species=None,
+        ndt_supercycle=None, ndt_subcycle=None, **kw
     ):
         self.name = name
         self.species = species
         self.scattering_processes = scattering_processes
         self.product_species = product_species
-        self.ndt = ndt
+        self.ndt_supercycle = ndt_supercycle
+        self.ndt_subcycle = ndt_subcycle
 
         self.handle_init(kw)
 
@@ -2918,7 +2946,8 @@ class DSMCCollisions(picmistandard.base._ClassWithInit):
             collision.product_species = [
                 species.name for species in self.product_species
             ]
-        collision.ndt = self.ndt
+        collision.ndt_supercycle = self.ndt_supercycle
+        collision.ndt_subcycle = self.ndt_subcycle
 
         collision.scattering_processes = self.scattering_processes.keys()
         for process, kw in self.scattering_processes.items():

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -2794,6 +2794,12 @@ class CoulombCollisions(picmistandard.base._ClassWithInit):
         self.ndt_supercycle = ndt_supercycle
         self.ndt_subcycle = ndt_subcycle
 
+        if 'ndt' in kw:
+            raise ValueError(
+                "`ndt` is no longer a valid option for collisions."
+                "Please use `ndt_supercycle` instead (run collision every N PIC steps)."
+            )
+
         self.handle_init(kw)
 
     def collision_initialize_inputs(self):
@@ -2869,6 +2875,12 @@ class MCCCollisions(picmistandard.base._ClassWithInit):
         self.max_background_density = max_background_density
         self.ndt_supercycle = ndt_supercycle
         self.ndt_subcycle = ndt_subcycle
+
+        if 'ndt' in kw:
+            raise ValueError(
+                "`ndt` is no longer a valid option for collisions."
+                "Please use `ndt_supercycle` instead (run collision every N PIC steps)."
+            )
 
         self.handle_init(kw)
 
@@ -2949,6 +2961,12 @@ class DSMCCollisions(picmistandard.base._ClassWithInit):
         self.product_species = product_species
         self.ndt_supercycle = ndt_supercycle
         self.ndt_subcycle = ndt_subcycle
+
+        if 'ndt' in kw:
+            raise ValueError(
+                "`ndt` is no longer a valid option for collisions."
+                "Please use `ndt_supercycle` instead (run collision every N PIC steps)."
+            )
 
         self.handle_init(kw)
 

--- a/Regression/Checksum/benchmarks_json/test_3d_collision_iso.json
+++ b/Regression/Checksum/benchmarks_json/test_3d_collision_iso.json
@@ -1,13 +1,4 @@
 {
-  "electron": {
-    "particle_momentum_x": 3.584563185767114e-19,
-    "particle_momentum_y": 3.5813935070430885e-19,
-    "particle_momentum_z": 3.5811977574194173e-19,
-    "particle_position_x": 1.0241269526772612,
-    "particle_position_y": 1.0239426996055672,
-    "particle_position_z": 1.024063864523814,
-    "particle_weight": 714240000000.0
-  },
   "lev=0": {
     "Bx": 0.0,
     "By": 0.0,
@@ -18,5 +9,14 @@
     "jx": 0.0,
     "jy": 0.0,
     "jz": 0.0
+  },
+  "electron": {
+    "particle_momentum_x": 3.5845119534938725e-19,
+    "particle_momentum_y": 3.575205381143318e-19,
+    "particle_momentum_z": 3.580855050926396e-19,
+    "particle_position_x": 1.0241922531943715,
+    "particle_position_y": 1.0238995904636492,
+    "particle_position_z": 1.0240333505172017,
+    "particle_weight": 714240000000.0
   }
 }

--- a/Regression/Checksum/benchmarks_json/test_3d_collision_iso.json
+++ b/Regression/Checksum/benchmarks_json/test_3d_collision_iso.json
@@ -1,4 +1,13 @@
 {
+  "electron": {
+    "particle_momentum_x": 3.584563185767114e-19,
+    "particle_momentum_y": 3.5813935070430885e-19,
+    "particle_momentum_z": 3.5811977574194173e-19,
+    "particle_position_x": 1.0241269526772612,
+    "particle_position_y": 1.0239426996055672,
+    "particle_position_z": 1.024063864523814,
+    "particle_weight": 714240000000.0
+  },
   "lev=0": {
     "Bx": 0.0,
     "By": 0.0,
@@ -9,14 +18,5 @@
     "jx": 0.0,
     "jy": 0.0,
     "jz": 0.0
-  },
-  "electron": {
-    "particle_momentum_x": 3.5845119534938725e-19,
-    "particle_momentum_y": 3.575205381143318e-19,
-    "particle_momentum_z": 3.580855050926396e-19,
-    "particle_position_x": 1.0241922531943715,
-    "particle_position_y": 1.0238995904636492,
-    "particle_position_z": 1.0240333505172017,
-    "particle_weight": 714240000000.0
   }
 }

--- a/Regression/Checksum/benchmarks_json/test_3d_collision_iso_subcycle.json
+++ b/Regression/Checksum/benchmarks_json/test_3d_collision_iso_subcycle.json
@@ -1,0 +1,22 @@
+{
+  "electron": {
+    "particle_momentum_x": 3.58036364637382e-19,
+    "particle_momentum_y": 3.5828513507063086e-19,
+    "particle_momentum_z": 3.5843699347104005e-19,
+    "particle_position_x": 1.024138952652597,
+    "particle_position_y": 1.023906699603133,
+    "particle_position_z": 1.0240598645142904,
+    "particle_weight": 714240000000.0
+  },
+  "lev=0": {
+    "Bx": 0.0,
+    "By": 0.0,
+    "Bz": 0.0,
+    "Ex": 0.0,
+    "Ey": 0.0,
+    "Ez": 0.0,
+    "jx": 0.0,
+    "jy": 0.0,
+    "jz": 0.0
+  }
+}

--- a/Regression/Checksum/benchmarks_json/test_3d_collision_iso_subcycle.json
+++ b/Regression/Checksum/benchmarks_json/test_3d_collision_iso_subcycle.json
@@ -1,13 +1,4 @@
 {
-  "electron": {
-    "particle_momentum_x": 3.58036364637382e-19,
-    "particle_momentum_y": 3.5828513507063086e-19,
-    "particle_momentum_z": 3.5843699347104005e-19,
-    "particle_position_x": 1.024138952652597,
-    "particle_position_y": 1.023906699603133,
-    "particle_position_z": 1.0240598645142904,
-    "particle_weight": 714240000000.0
-  },
   "lev=0": {
     "Bx": 0.0,
     "By": 0.0,
@@ -18,5 +9,14 @@
     "jx": 0.0,
     "jy": 0.0,
     "jz": 0.0
+  },
+  "electron": {
+    "particle_momentum_x": 3.5795400145128457e-19,
+    "particle_momentum_y": 3.583439820100901e-19,
+    "particle_momentum_z": 3.57998270145055e-19,
+    "particle_position_x": 1.0241802531945836,
+    "particle_position_y": 1.0239195904635428,
+    "particle_position_z": 1.0240253505022627,
+    "particle_weight": 714240000000.0
   }
 }

--- a/Source/Particles/Collision/CollisionBase.H
+++ b/Source/Particles/Collision/CollisionBase.H
@@ -14,6 +14,8 @@
 
 #include <string>
 
+enum class CollisionSteppingMode { Supercycle, Subcycle };
+
 class CollisionBase
 {
 public:
@@ -29,14 +31,21 @@ public:
 
     virtual ~CollisionBase() = default;
 
-    [[nodiscard]] int get_ndt() const {return m_ndt;}
+    void BackwardCompatibility () const;
+
+    [[nodiscard]] int get_ndt() const { return m_ndt; }
+
+    [[nodiscard]] CollisionSteppingMode get_collision_stepping_mode() const
+        { return m_collision_stepping_mode; }
 
     [[nodiscard]] bool use_global_debye_length() const {return m_use_global_debye_length;}
 
 protected:
 
+    std::string m_collision_name;
     amrex::Vector<std::string> m_species_names;
-    int m_ndt;
+    int m_ndt = 1;
+    CollisionSteppingMode m_collision_stepping_mode = CollisionSteppingMode::Supercycle;
 
     bool m_use_global_debye_length = false;
 

--- a/Source/Particles/Collision/CollisionBase.H
+++ b/Source/Particles/Collision/CollisionBase.H
@@ -31,7 +31,7 @@ public:
 
     virtual ~CollisionBase() = default;
 
-    void BackwardCompatibility () const;
+    void BackwardCompatibility ();
 
     [[nodiscard]] int get_ndt() const { return m_ndt; }
 

--- a/Source/Particles/Collision/CollisionBase.cpp
+++ b/Source/Particles/Collision/CollisionBase.cpp
@@ -64,6 +64,5 @@ CollisionBase::BackwardCompatibility ()
         !pp_collision_name.query("ndt", backward_int),
         "<collision_name>.ndt is no longer a valid option. "
         "Please use <collision_name>.ndt_supercycle (run collision every N PIC steps) "
-        "or <collision_name>.ndt_subcycle (run collision N times per PIC step) instead."
     );
 }

--- a/Source/Particles/Collision/CollisionBase.cpp
+++ b/Source/Particles/Collision/CollisionBase.cpp
@@ -41,16 +41,12 @@ CollisionBase::CollisionBase (const std::string& collision_name)
         );
         m_ndt = ndt_subcycle;
         m_collision_stepping_mode = CollisionSteppingMode::Subcycle;
-    } else {
-        if (has_supercycle) {
-            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                ndt_supercycle >= 1,
-                "<collision_name>.ndt_supercycle must be >= 1."
-            );
-            m_ndt = ndt_supercycle;
-        } else {
-            m_ndt = 1;
-        }
+    } else if (has_supercycle) {
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+            ndt_supercycle >= 1,
+            "<collision_name>.ndt_supercycle must be >= 1."
+        );
+        m_ndt = ndt_supercycle;
         m_collision_stepping_mode = CollisionSteppingMode::Supercycle;
     }
 }

--- a/Source/Particles/Collision/CollisionBase.cpp
+++ b/Source/Particles/Collision/CollisionBase.cpp
@@ -7,19 +7,63 @@
 #include "CollisionBase.H"
 
 #include "Utils/Parser/ParserUtils.H"
+#include "Utils/TextMsg.H"
 
 #include <AMReX_ParmParse.H>
 
 CollisionBase::CollisionBase (const std::string& collision_name)
 {
+    m_collision_name = collision_name;
+    BackwardCompatibility();
 
     // read collision species
     const amrex::ParmParse pp_collision_name(collision_name);
     pp_collision_name.getarr("species", m_species_names);
 
-    // number of time steps between collisions
-    int ndt = 1;
-    utils::parser::queryWithParser(
-        pp_collision_name, "ndt", ndt);
-    m_ndt = ndt;
+    // time step control: ndt_supercycle or ndt_subcycle (mutually exclusive)
+    int ndt_supercycle = 0;
+    int ndt_subcycle   = 0;
+    const bool has_supercycle = utils::parser::queryWithParser(
+        pp_collision_name, "ndt_supercycle", ndt_supercycle);
+    const bool has_subcycle   = utils::parser::queryWithParser(
+        pp_collision_name, "ndt_subcycle", ndt_subcycle);
+
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+        !(has_supercycle && has_subcycle),
+        "<collision_name>.ndt_supercycle and <collision_name>.ndt_subcycle "
+        "are mutually exclusive. Specify at most one."
+    );
+
+    if (has_subcycle) {
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+            ndt_subcycle >= 1,
+            "<collision_name>.ndt_subcycle must be >= 1."
+        );
+        m_ndt                     = ndt_subcycle;
+        m_collision_stepping_mode = CollisionSteppingMode::Subcycle;
+    } else {
+        if (has_supercycle) {
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                ndt_supercycle >= 1,
+                "<collision_name>.ndt_supercycle must be >= 1."
+            );
+            m_ndt = ndt_supercycle;
+        } else {
+            m_ndt = 1;
+        }
+        m_collision_stepping_mode = CollisionSteppingMode::Supercycle;
+    }
+}
+
+void
+CollisionBase::BackwardCompatibility ()
+{
+    const amrex::ParmParse pp_collision_name(m_collision_name);
+    int backward_int;
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+        !pp_collision_name.query("ndt", backward_int),
+        "<collision_name>.ndt is no longer a valid option. "
+        "Please use <collision_name>.ndt_supercycle (run collision every N PIC steps) "
+        "or <collision_name>.ndt_subcycle (run collision N times per PIC step) instead."
+    );
 }

--- a/Source/Particles/Collision/CollisionBase.cpp
+++ b/Source/Particles/Collision/CollisionBase.cpp
@@ -22,10 +22,10 @@ CollisionBase::CollisionBase (const std::string& collision_name)
 
     // time step control: ndt_supercycle or ndt_subcycle (mutually exclusive)
     int ndt_supercycle = 0;
-    int ndt_subcycle   = 0;
+    int ndt_subcycle = 0;
     const bool has_supercycle = utils::parser::queryWithParser(
         pp_collision_name, "ndt_supercycle", ndt_supercycle);
-    const bool has_subcycle   = utils::parser::queryWithParser(
+    const bool has_subcycle = utils::parser::queryWithParser(
         pp_collision_name, "ndt_subcycle", ndt_subcycle);
 
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
@@ -39,7 +39,7 @@ CollisionBase::CollisionBase (const std::string& collision_name)
             ndt_subcycle >= 1,
             "<collision_name>.ndt_subcycle must be >= 1."
         );
-        m_ndt                     = ndt_subcycle;
+        m_ndt = ndt_subcycle;
         m_collision_stepping_mode = CollisionSteppingMode::Subcycle;
     } else {
         if (has_supercycle) {

--- a/Source/Particles/Collision/CollisionHandler.cpp
+++ b/Source/Particles/Collision/CollisionHandler.cpp
@@ -126,9 +126,21 @@ void CollisionHandler::doCollisions ( int step, amrex::Real cur_time, amrex::Rea
     }
 
     for (auto& collision : allcollisions) {
-        int const ndt = collision->get_ndt();
-        if ( step % ndt == 0 ) {
-            collision->doCollisions(cur_time, dt*ndt, mypc);
+        const int ndt                       = collision->get_ndt();
+        const auto collision_stepping_mode  = collision->get_collision_stepping_mode();
+
+        if (collision_stepping_mode == CollisionSteppingMode::Subcycle) {
+            // Run ndt times per PIC step, each with dt_collision = dt / ndt
+            const amrex::Real dt_sub = dt / static_cast<amrex::Real>(ndt);
+            for (int i_sub = 0; i_sub < ndt; ++i_sub) {
+                const amrex::Real sub_time = cur_time + i_sub * dt_sub;
+                collision->doCollisions(sub_time, dt_sub, mypc);
+            }
+        } else {
+            // Supercycle: run once every ndt PIC steps, with dt_collision = dt * ndt
+            if ( step % ndt == 0 ) {
+                collision->doCollisions(cur_time, dt*ndt, mypc);
+            }
         }
     }
 

--- a/Source/Particles/Collision/CollisionHandler.cpp
+++ b/Source/Particles/Collision/CollisionHandler.cpp
@@ -131,7 +131,7 @@ void CollisionHandler::doCollisions ( int step, amrex::Real cur_time, amrex::Rea
 
         if (collision_stepping_mode == CollisionSteppingMode::Subcycle) {
             // Run ndt times per PIC step, each with dt_collision = dt / ndt
-            const amrex::Real dt_sub = dt / static_cast<amrex::Real>(ndt);
+            const amrex::Real dt_sub = dt / ndt;
             for (int i_sub = 0; i_sub < ndt; ++i_sub) {
                 const amrex::Real sub_time = cur_time + i_sub * dt_sub;
                 collision->doCollisions(sub_time, dt_sub, mypc);

--- a/Source/Particles/Collision/CollisionHandler.cpp
+++ b/Source/Particles/Collision/CollisionHandler.cpp
@@ -130,7 +130,7 @@ void CollisionHandler::doCollisions ( int step, amrex::Real cur_time, amrex::Rea
         const auto collision_stepping_mode  = collision->get_collision_stepping_mode();
 
         if (collision_stepping_mode == CollisionSteppingMode::Subcycle) {
-            // Run ndt times per PIC step, each with dt_collision = dt / ndt
+            // Subcycle: run ndt times per PIC step, each with dt_collision = dt / ndt
             const amrex::Real dt_sub = dt / ndt;
             for (int i_sub = 0; i_sub < ndt; ++i_sub) {
                 const amrex::Real sub_time = cur_time + i_sub * dt_sub;

--- a/Source/Particles/Collision/CollisionHandler.cpp
+++ b/Source/Particles/Collision/CollisionHandler.cpp
@@ -126,8 +126,8 @@ void CollisionHandler::doCollisions ( int step, amrex::Real cur_time, amrex::Rea
     }
 
     for (auto& collision : allcollisions) {
-        const int ndt                       = collision->get_ndt();
-        const auto collision_stepping_mode  = collision->get_collision_stepping_mode();
+        const int ndt = collision->get_ndt();
+        const auto collision_stepping_mode = collision->get_collision_stepping_mode();
 
         if (collision_stepping_mode == CollisionSteppingMode::Subcycle) {
             // Subcycle: run ndt times per PIC step, each with dt_collision = dt / ndt


### PR DESCRIPTION
## Summary

- Replaces `<collision_name>.ndt` (removed, now raises a backward-compatibility error) with two mutually exclusive options:
  - `ndt_supercycle = N`: run collision every N PIC steps with `dt_collision = N * dt_PIC` (same as old `ndt`)
  - `ndt_subcycle = N`: run collision N times per PIC step with `dt_collision = dt_PIC / N`, enabling a coarser PIC loop when the collision timescale is the limiting factor
- Updates PICMI (`CoulombCollisions`, `MCCCollisions`, `DSMCCollisions`) and all existing test inputs accordingly
- Adds `test_3d_collision_iso_subcycle`: uses a 10× larger PIC `dt` with `ndt_subcycle = 10`, producing the same 100 collision iterations at `dt_collision = 1.4e-17 s` as the baseline isotropization test

🤖 Generated with [Claude Code](https://claude.com/claude-code)