### PR TITLE
[WIP] Make DSMC charge exchange locally charge conserving

### DIFF
--- a/Examples/Tests/collision/CMakeLists.txt
+++ b/Examples/Tests/collision/CMakeLists.txt
@@ -92,6 +92,16 @@ add_warpx_test(
 )
 
 add_warpx_test(
+    test_2d_charge_exchange_dsmc  # name
+    2  # dims
+    1  # nprocs
+    inputs_test_2d_charge_exchange_dsmc  # inputs
+    "analysis_test_2d_collisions_split_momentum_push.py --path diags/reducedfiles/"  # analysis
+    "analysis_default_regression.py --path diags/diag1/"  # checksum
+    OFF  # dependency
+)
+
+add_warpx_test(
     test_2d_collisions_split_momentum_push_electrostatic  # name
     2  # dims
     1  # nprocs

--- a/Examples/Tests/collision/inputs_test_2d_charge_exchange_dsmc
+++ b/Examples/Tests/collision/inputs_test_2d_charge_exchange_dsmc
@@ -1,0 +1,125 @@
+# 2D charge exchange collision test (DSMC), with electrostatic solver.
+# Electrons (neutralizing background) + He+ ions + He neutrals.
+# He+ and He undergo DSMC charge exchange using the He resonant cross-section.
+# The electrostatic solver is active; total energy (field + particle) conservation
+# is verified using analysis_test_2d_collisions_split_momentum_push.py.
+
+# algo
+algo.field_gathering = energy-conserving
+algo.particle_shape = 2
+
+# amr
+amr.max_level = 0
+amr.n_cell = 16 16
+
+# boundary
+boundary.field_hi = periodic periodic
+boundary.field_lo = periodic periodic
+boundary.particle_hi = periodic periodic
+boundary.particle_lo = periodic periodic
+
+# collisions
+collisions.collision_names = cx_col
+cx_col.type = dsmc
+cx_col.scattering_processes = charge_exchange
+cx_col.species = Heplus He
+cx_col.product_species = He Heplus
+cx_col.charge_exchange_cross_section = ../../../../warpx-data/MCC_cross_sections/He/charge_exchange.dat
+
+# diagnostics
+diagnostics.diags_names = diag1
+diag1.diag_type = Full
+diag1.format = openpmd
+diag1.intervals = 2000
+diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho
+diag1.write_species = 1
+diag1.species = electrons Heplus He
+diag1.electrons.variables = w x z ux uy uz
+diag1.Heplus.variables = w x z ux uy uz
+diag1.He.variables = w x z ux uy uz
+
+# electrons (neutralizing background for He+)
+electrons.charge = -q_e
+electrons.density = n0
+electrons.injection_style = "NUniformPerCell"
+electrons.mass = m_e
+electrons.momentum_distribution_type = gaussian
+electrons.num_particles_per_cell_each_dim = 8 8
+electrons.profile = constant
+electrons.species_type = electron
+electrons.ux_th = sqrt(Te*q_e/m_e)/clight
+electrons.uy_th = sqrt(Te*q_e/m_e)/clight
+electrons.uz_th = sqrt(Te*q_e/m_e)/clight
+electrons.xmax = 10*de0
+electrons.xmin = 0
+electrons.zmax = 10*de0
+electrons.zmin = 0
+
+# Heplus (He+ ions undergoing charge exchange)
+Heplus.charge = q_e
+Heplus.density = n0
+Heplus.injection_style = "NUniformPerCell"
+Heplus.mass = m_He
+Heplus.momentum_distribution_type = gaussian
+Heplus.num_particles_per_cell_each_dim = 8 8
+Heplus.profile = constant
+Heplus.ux_th = sqrt(Ti*q_e/m_He)/clight
+Heplus.uy_th = sqrt(Ti*q_e/m_He)/clight
+Heplus.uz_th = sqrt(Ti*q_e/m_He)/clight
+Heplus.xmax = 10*de0
+Heplus.xmin = 0
+Heplus.zmax = 10*de0
+Heplus.zmin = 0
+
+# He (neutral He atoms undergoing charge exchange)
+He.charge = 0
+He.density = n0
+He.injection_style = "NUniformPerCell"
+He.mass = m_He
+He.momentum_distribution_type = gaussian
+He.num_particles_per_cell_each_dim = 8 8
+He.profile = constant
+He.ux_th = sqrt(Ti*q_e/m_He)/clight
+He.uy_th = sqrt(Ti*q_e/m_He)/clight
+He.uz_th = sqrt(Ti*q_e/m_He)/clight
+He.xmax = 10*de0
+He.xmin = 0
+He.zmax = 10*de0
+He.zmin = 0
+
+# reduced diagnostics
+field_energy.intervals = 1
+field_energy.type = FieldEnergy
+particle_energy.intervals = 1
+particle_energy.type = ParticleEnergy
+
+# geometry
+geometry.dims = 2
+geometry.prob_hi = 10*de0 10*de0
+geometry.prob_lo = 0. 0.
+
+# interpolation
+interpolation.galerkin_scheme = 1
+
+# max_step
+max_step = 2000
+
+# my_constants
+my_constants.m_He = 4*m_p           # He mass, kg
+my_constants.n0 = 1e30              # number density, m^-3
+my_constants.Te = 100.              # electron temperature, eV
+my_constants.Ti = 100.              # He ion/neutral temperature, eV
+my_constants.wpe = q_e*sqrt(n0/(m_e*epsilon0))   # electron plasma frequency, rad/s
+my_constants.de0 = clight/wpe       # electron skin depth, m
+my_constants.dt = 0.1/wpe           # time step (electron timescale), s
+
+# particles
+particles.species_names = electrons Heplus He
+
+# warpx
+warpx.const_dt = dt
+warpx.do_electrostatic = labframe
+warpx.reduced_diags_names = field_energy particle_energy
+warpx.serialize_initial_conditions = 1
+warpx.use_filter = 0
+warpx.verbose = 1

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -141,7 +141,8 @@ public:
             [=] AMREX_GPU_DEVICE (index_type i) -> index_type {
                 return ((mask[i] > 0) &
                         (mask[i] != int(ScatteringProcessType::IONIZATION)) &
-                        (mask[i] != int(ScatteringProcessType::TWOPRODUCT_REACTION))) ? 1 : 0;
+                        (mask[i] != int(ScatteringProcessType::TWOPRODUCT_REACTION)) &
+                        (mask[i] != int(ScatteringProcessType::CHARGE_EXCHANGE))) ? 1 : 0;
             },
             [=] AMREX_GPU_DEVICE (index_type i, index_type s) { no_product_offsets_data[i] = s; },
             amrex::Scan::Type::exclusive, amrex::Scan::retSum
@@ -166,7 +167,8 @@ public:
         auto const with_product_total = amrex::Scan::PrefixSum<index_type>(n_total_pairs,
             [=] AMREX_GPU_DEVICE (index_type i) -> index_type {
                 return ((mask[i] == int(ScatteringProcessType::IONIZATION)) |
-                        (mask[i] == int(ScatteringProcessType::TWOPRODUCT_REACTION))) ? 1 : 0;
+                        (mask[i] == int(ScatteringProcessType::TWOPRODUCT_REACTION)) |
+                        (mask[i] == int(ScatteringProcessType::CHARGE_EXCHANGE))) ? 1 : 0;
             },
             [=] AMREX_GPU_DEVICE (index_type i, index_type s) { with_product_offsets_data[i] = s; },
             amrex::Scan::Type::exclusive, amrex::Scan::retSum
@@ -235,7 +237,7 @@ public:
         amrex::ParallelForRNG(n_total_pairs,
         [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
         {
-            if ((mask[i] > 0) & (mask[i] != int(ScatteringProcessType::IONIZATION)) & (mask[i] != int(ScatteringProcessType::TWOPRODUCT_REACTION)))
+            if ((mask[i] > 0) & (mask[i] != int(ScatteringProcessType::IONIZATION)) & (mask[i] != int(ScatteringProcessType::TWOPRODUCT_REACTION)) & (mask[i] != int(ScatteringProcessType::CHARGE_EXCHANGE)))
             {
                 const auto slot0_idx = products_np_data[0] + no_product_offsets_data[i];
                 // Make a copy of the particle from the first reactant species
@@ -335,7 +337,8 @@ public:
             }
 
             // Next perform all product-producing collisions
-            else if (mask[i] == int(ScatteringProcessType::TWOPRODUCT_REACTION))
+            else if ((mask[i] == int(ScatteringProcessType::TWOPRODUCT_REACTION)) ||
+                     (mask[i] == int(ScatteringProcessType::CHARGE_EXCHANGE)))
             {
                 // create a copy of the first product species at the location of the first reactant species
                 const auto src0_idx = static_cast<int>(p_pair_indices_0[i]);
@@ -352,6 +355,16 @@ public:
                                 static_cast<int>(slot3_idx), engine);
                 // Set the weight of the new particle to p_pair_reaction_weight[i]
                 soa_products_data[3].m_rdata[PIdx::w][slot3_idx] = p_pair_reaction_weight[i];
+
+                // For charge exchange, swap positions: each product appears at the position
+                // of the *other* reactant, reflecting the physical transfer of charge across space.
+                // Position components occupy indices 0 through PIdx::w-1 in m_rdata.
+                if (mask[i] == int(ScatteringProcessType::CHARGE_EXCHANGE)) {
+                    for (int idim = 0; idim < PIdx::w; ++idim) {
+                        soa_products_data[2].m_rdata[idim][slot2_idx] = soa_1.m_rdata[idim][src1_idx];
+                        soa_products_data[3].m_rdata[idim][slot3_idx] = soa_0.m_rdata[idim][src0_idx];
+                    }
+                }
 
                 // Update the momenta of the products
                 TwoProductComputeProductMomenta(

--- a/Source/Particles/Collision/ScatteringProcess.H
+++ b/Source/Particles/Collision/ScatteringProcess.H
@@ -22,6 +22,7 @@ enum class ScatteringProcessType {
     ELASTIC,
     BACK,
     TWOPRODUCT_REACTION,
+    CHARGE_EXCHANGE,
     EXCITATION,
     IONIZATION,
     FORWARD,

--- a/Source/Particles/Collision/ScatteringProcess.cpp
+++ b/Source/Particles/Collision/ScatteringProcess.cpp
@@ -81,7 +81,7 @@ ScatteringProcess::parseProcessType(const std::string& scattering_process)
     } else if (scattering_process == "back") {
         return ScatteringProcessType::BACK;
     } else if (scattering_process == "charge_exchange") {
-        return ScatteringProcessType::TWOPRODUCT_REACTION;
+        return ScatteringProcessType::CHARGE_EXCHANGE;
     } else if (scattering_process == "two_product_reaction") {
         return ScatteringProcessType::TWOPRODUCT_REACTION;
     } else if (scattering_process == "ionization") {


### PR DESCRIPTION
- Added a test that shows that energy conservation breaks with the current charge exchange implementation, when using the electrostatic solver. This is because the current implemention is not locally charge conserving.