### PR TITLE
Add explanatory comments to `RedistributeLocal`

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -730,15 +730,15 @@ void WarpX::HandleParticlesAtBoundaries (int step, amrex::Real cur_time, int num
         // only move by one or two cells per time step
         // The implicit scheme can allow additional cell crossings, as specified by particle_max_grid_crossings.
         if (finest_level == 0) {
-            int num_redistribute_ghost = num_moved;
+            int max_cells_travelled = num_moved;
             if ((m_v_galilean[0]!=0) or (m_v_galilean[1]!=0) or (m_v_galilean[2]!=0)) {
                 // Galilean algorithm ; particles can move by up to one additional cell beyond the max number
-                num_redistribute_ghost += particle_max_grid_crossings + 1;
+                max_cells_travelled += particle_max_grid_crossings + 1;
             } else {
                 // Standard algorithm ; particles can move by up to the max number
-                num_redistribute_ghost += particle_max_grid_crossings;
+                max_cells_travelled += particle_max_grid_crossings;
             }
-            mypc->RedistributeLocal(num_redistribute_ghost);
+            mypc->RedistributeLocal(max_cells_travelled);
         }
         else {
             mypc->Redistribute();

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -811,7 +811,7 @@ void
 MultiParticleContainer::RedistributeLocal (const int num_ghost)
 {
     for (auto& pc : allcontainers) {
-        pc->Redistribute(0, 0, 0, num_ghost);
+        pc->Redistribute(0, 0, num_ghost, 1);
     }
 }
 

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -808,10 +808,12 @@ MultiParticleContainer::deleteInvalidParticles ()
 }
 
 void
-MultiParticleContainer::RedistributeLocal (const int num_ghost)
+MultiParticleContainer::RedistributeLocal (const int max_cells_travelled)
 {
     for (auto& pc : allcontainers) {
-        pc->Redistribute(0, 0, num_ghost, 1);
+        // The local argument specifies the number of cells a particle
+        // might have travelled outside its current tile / box.
+        pc->Redistribute(/*lev_min=*/0, /*lev_max=*/0, /*nGrow=*/0, /*local=*/max_cells_travelled);
     }
 }
 


### PR DESCRIPTION
Based on https://github.com/BLAST-WarpX/warpx/pull/6735/changes#r3030628717.

I don't have any specific indication that this leads to incorrect results, but in looking at the redistribute calls in `WarpX::HandleParticlesAtBoundaries` I noticed that `MultiParticleContainer::RedistributeLocal` seems to have a typo. Currently the `num_ghost` integer is passed to the `local` argument in the inherited function, while the `nGrow` argument is hard coded to 0.

Parent function prototype:
```
void Redistribute (int lev_min = 0, int lev_max = -1, int nGrow = 0, int local=0,
                       bool remove_negative=true);
```