### PR TITLE
Use species_type in picmi

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -336,6 +336,7 @@ class Species(picmistandard.PICMI_Species):
 
         self.species = pywarpx.Bucket.Bucket(
             self.name,
+            species_type=self.species_type,
             mass=self.mass,
             charge=self.charge,
             injection_style=None,
@@ -371,8 +372,6 @@ class Species(picmistandard.PICMI_Species):
             resampling_algorithm_delta_u=self.resampling_algorithm_delta_u,
             do_temperature_deposition=self.do_temperature_deposition,
         )
-
-        self.species.species_type = self.species_type
 
         # add reflection models
         self.species.add_new_attr("reflection_model_xlo(E)", self.reflection_model_xlo)

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -197,34 +197,23 @@ class Species(picmistandard.PICMI_Species):
     """
 
     def init(self, kw):
-        if self.particle_type == "electron":
-            if self.charge is None:
-                self.charge = "-q_e"
-            if self.mass is None:
-                self.mass = "m_e"
-        elif self.particle_type == "positron":
-            if self.charge is None:
-                self.charge = "q_e"
-            if self.mass is None:
-                self.mass = "m_e"
-        elif self.particle_type == "proton":
-            if self.charge is None:
-                self.charge = "q_e"
-            if self.mass is None:
-                self.mass = "m_p"
-        elif self.particle_type == "anti-proton":
-            if self.charge is None:
-                self.charge = "-q_e"
-            if self.mass is None:
-                self.mass = "m_p"
+        self.species_type = None
+        if self.particle_type in [
+            "unspecified",
+            "electron",
+            "positron",
+            "muon",
+            "antimuon",
+            "photon",
+            "neutron",
+            "proton",
+            "antiproton",
+            "alpha",
+        ]:
+            self.species_type = self.particle_type
         else:
             if self.charge is None and self.charge_state is not None:
-                if self.charge_state == +1.0:
-                    self.charge = "q_e"
-                elif self.charge_state == -1.0:
-                    self.charge = "-q_e"
-                else:
-                    self.charge = self.charge_state * constants.q_e
+                self.charge = f"{self.charge_state}*q_e"
             if self.particle_type is not None:
                 # Match a string of the format '#nXx', with the '#n' optional isotope number.
                 m = re.match(r"(?P<iso>#[\d+])*(?P<sym>[A-Za-z]+)", self.particle_type)
@@ -382,6 +371,8 @@ class Species(picmistandard.PICMI_Species):
             resampling_algorithm_delta_u=self.resampling_algorithm_delta_u,
             do_temperature_deposition=self.do_temperature_deposition,
         )
+
+        self.species.species_type = self.species_type
 
         # add reflection models
         self.species.add_new_attr("reflection_model_xlo(E)", self.reflection_model_xlo)

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -479,17 +479,10 @@ class GaussianBunchDistribution(picmistandard.PICMI_GaussianBunchDistribution):
         # --- Only PseudoRandomLayout is supported
         species.add_new_group_attr(source_name, "npart", layout.n_macroparticles)
 
-        # --- Calculate the total charge. Note that charge might be a string instead of a number.
-        charge = species.charge
-        if charge == "q_e" or charge == "+q_e":
-            charge = constants.q_e
-        elif charge == "-q_e":
-            charge = -constants.q_e
-        species.add_new_group_attr(
-            source_name, "q_tot", self.n_physical_particles * charge
-        )
+        # --- Total number of real particles
+        species.add_new_group_attr(source_name, "npart_real", self.n_physical_particles)
         if density_scale is not None:
-            species.add_new_group_attr(source_name, "q_tot", density_scale)
+            species.add_new_group_attr(source_name, "npart_real", density_scale)
 
         # --- The PICMI standard doesn't yet have a way of specifying these values.
         # --- They should default to the size of the domain. They are not typically

--- a/Source/Particles/SpeciesPhysicalProperties.H
+++ b/Source/Particles/SpeciesPhysicalProperties.H
@@ -14,7 +14,7 @@
 #include <string>
 
 enum struct PhysicalSpecies{
-    unspecified=0, electron, positron, muon, antimuon, photon, neutron, hydrogen, proton, hydrogen2, hydrogen3,
+    unspecified=0, electron, positron, muon, antimuon, photon, neutron, hydrogen, proton, antiproton, hydrogen2, hydrogen3,
     helium, helium3, helium4, lithium, lithium6, lithium7, beryllium, beryllium9, boron, boron10, boron11, carbon,
     carbon12, carbon13, carbon14, nitrogen, nitrogen14, nitrogen15, oxygen, oxygen16, oxygen17, oxygen18, fluorine,
     fluorine19, neon, neon20, neon21, neon22, aluminium, argon, copper, xenon, gold};

--- a/Source/Particles/SpeciesPhysicalProperties.cpp
+++ b/Source/Particles/SpeciesPhysicalProperties.cpp
@@ -38,6 +38,7 @@ namespace {
         {"hydrogen3"  , PhysicalSpecies::hydrogen3},
         {"tritium"    , PhysicalSpecies::hydrogen3},
         {"proton"     , PhysicalSpecies::proton},
+        {"antiproton" , PhysicalSpecies::antiproton},
         {"helium"     , PhysicalSpecies::helium},
         {"helium3"    , PhysicalSpecies::helium3},
         {"helium4"    , PhysicalSpecies::helium4},
@@ -84,6 +85,7 @@ namespace {
         {PhysicalSpecies::neutron    , "neutron"},
         {PhysicalSpecies::hydrogen   , "hydrogen"},
         {PhysicalSpecies::proton     , "proton"},
+        {PhysicalSpecies::antiproton , "antiproton"},
         {PhysicalSpecies::hydrogen2  , "hydrogen2"},
         {PhysicalSpecies::hydrogen3  , "hydrogen3"},
         {PhysicalSpecies::helium     , "helium"},
@@ -153,6 +155,9 @@ namespace {
         {PhysicalSpecies::proton, Properties{
             PhysConst::m_p,
             PhysConst::q_e}},
+        {PhysicalSpecies::antiproton, Properties{
+            PhysConst::m_p,
+            -PhysConst::q_e}},
         {PhysicalSpecies::hydrogen, Properties{
              amrex::Real(1.00797) * PhysConst::m_u - amrex::Real(1) * PhysConst::m_e,
              amrex::Real(1) * PhysConst::q_e}},


### PR DESCRIPTION
This changes how the species are specified in the picmi interface for basic particles (not in the periodic table). Now it uses the C++ input parameter `species_type`, relying on the C++ to set the mass and charge appropriately (instead of having it duplicated in Python). Also, this now includes the `photon` species type.

Some comments:
- Previously, it was called "anti-proton" but is now "antiproton", which is a change in the API. The version without the dash is the standard naming. Should the one with the dash still be accepted?
- The elements are specified differently between the C++ and Python. The C++ has a small number of elements defined, with names like "hydrogen3". The Python needs the element symbol with the isotope as the prefix, "#3H". Should the picmi interface accept the C++ style naming?