### PR TITLE
Remove unnecessary warning when using OpenPMD

### DIFF
--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -449,17 +449,6 @@ void WarpXOpenPMDPlot::SetStep (int ts, const std::string& dirPrefix, int file_m
     m_dirPrefix = dirPrefix;
     m_file_min_digits = file_min_digits;
 
-    if( ! isBTD ) {
-        if (m_CurrentStep >= ts) {
-            // note m_Series is reset in Init(), so using m_Series->iterations.contains(ts) is only able to check the
-            // last written step in m_Series's life time, but not other earlier written steps by other m_Series
-            ablastr::warn_manager::WMRecordWarning("Diagnostics",
-                    " Warning from openPMD writer: Already written iteration:"
-                    + std::to_string(ts)
-                );
-        }
-    }
-
     m_CurrentStep = ts;
     Init(openPMD::Access::CREATE, isBTD);
 }


### PR DESCRIPTION
I have a case where I write the diagnostic output using OpenPMD, and also use the `BoundaryScraping` diagnostic which also writes out using OpenPMD. For time steps when both diagnostics are being written out, I see this warning appear:
```
* --> [!! ] [Diagnostics] [raised once]
*     Warning from openPMD writer: Already written iteration:200
*     @ Raised by: ALL
```
This is caused by the code in `WarpXOpenPMDPlot::SetStep` which checks whether OpenPMD output has already been made on the current step. In my case, it already has since it is writing OpenPMD output for the diagnostic files and the boundary scraping data. This should be normal behavior and should not be raising a warning.

It is not clear why this check is made and why the warning is needed. Is there a case where OpenPMD could be improperly called multiple times in a single time step? Is this meant for the Python interface in case a user does write data out multiple times in a time step? Does calling it multiple times on the same step cause problems?

This warning does not seem needed and should not be appearing in normal usage, so this PR deletes it.