### PR TITLE
`Parameters.rst`: Consistent Double Backticks

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -125,12 +125,12 @@ Simulation Time
 ---------------
 
 .. pp:param:: max_step
-    :type: `integer`
+    :type: ``integer``
 
     The number of PIC cycles to perform.
 
 .. pp:param:: stop_time
-    :type: `float`
+    :type: ``float``
     :unit: seconds
 
     The maximum physical time of the simulation. Can be provided instead of :pp:param:`max_step`. If both
@@ -140,19 +140,19 @@ Simulation Time
     Note: in boosted-frame simulations, :pp:param:`stop_time` refers to the time in the boosted frame.
 
 .. pp:param:: warpx.zmax_plasma_to_compute_max_step
-    :type: `float`
+    :type: ``float``
     :optional:
 
     Can be useful when running in a boosted frame. If specified, automatically
     calculates the number of iterations required in the boosted frame for the
-    lower `z` end of the simulation domain to reach
+    lower ``z`` end of the simulation domain to reach
     :pp:param:`warpx.zmax_plasma_to_compute_max_step` (typically the plasma end,
     given in the lab frame). The value of :pp:param:`max_step` is overwritten, and
     printed to standard output. Currently only works if the Lorentz boost and
     the moving window are along the z direction.
 
 .. pp:param:: warpx.compute_max_step_from_btd
-    :type: `integer`
+    :type: ``integer``
     :default: 0
     :optional:
 
@@ -171,21 +171,21 @@ Overall simulation parameters
 -----------------------------
 
 .. pp:param:: authors
-    :type: `string`
+    :type: ``string``
     :comment: e.g. ``"Jane Doe <jane@example.com>, Jimmy Joe <jimmy@example.com>"``
 
     Authors of an input file / simulation setup.
     When provided, this information is added as metadata to (openPMD) output files.
 
 .. pp:param:: warpx.used_inputs_file
-    :type: `string`
+    :type: ``string``
     :default: ``warpx_used_inputs``
 
     Name of a file that WarpX writes to archive the used inputs.
     The context of this file will contain an exact copy of all explicitly and implicitly used inputs parameters, including those :ref:`extended and overwritten from the command line <usage_run>`.
 
 .. pp:param:: warpx.gamma_boost
-    :type: `float`
+    :type: ``float``
 
     The Lorentz factor of the boosted frame in which the simulation is run. (The corresponding Lorentz transformation is assumed to be along :pp:param:`warpx.boost_direction`.)
     For more practical guidance on setting up boosted-frame simulations, refer to the :ref:`FAQ: What do I need to know about using the boosted frame? <faq_boosted_frame>`.
@@ -202,24 +202,24 @@ Overall simulation parameters
     (The direction ``y`` cannot be used in 2D simulations.)
 
 .. pp:param:: warpx.random_seed
-    :type: `string` or `int` > 0
+    :type: ``string`` or ``int`` > 0
     :optional:
 
     If provided ``warpx.random_seed = random``, the random seed will be determined
-    using `std::random_device` and `std::clock()`,
+    using ``std::random_device`` and ``std::clock()``,
     thus every simulation run produces different random numbers.
-    If provided ``warpx.random_seed = n``, and it is required that `n > 0`,
-    the random seed for each MPI rank is `(mpi_rank+1) * n`,
-    where `mpi_rank` starts from 0.
-    `n = 1` and ``warpx.random_seed = default``
+    If provided ``warpx.random_seed = n``, and it is required that ``n > 0``,
+    the random seed for each MPI rank is ``(mpi_rank+1) * n``,
+    where ``mpi_rank`` starts from 0.
+    ``n = 1`` and ``warpx.random_seed = default``
     produce the default random seed.
     Note that when GPU threading is used,
     one should not expect to obtain the same random numbers,
     even if a fixed :pp:param:`warpx.random_seed` is provided.
 
 .. pp:param:: algo.evolve_scheme
-    :type: `string`
-    :default: `explicit`
+    :type: ``string``
+    :default: ``explicit``
 
     Specifies the evolve scheme used by WarpX.
 
@@ -230,7 +230,7 @@ Overall simulation parameters
       - **Time-biasing parameter:**
         The fields (:math:`\textbf{E}` & :math:`\textbf{B}`) used to advance the system are computed at time :math:`t^{n+\theta}`: :math:`\mathbf{E}^{n+\theta}=\left(1-\theta\right)\mathbf{E}^n + \theta\mathbf{E}^{n+1}`, where :math:`\theta\in[0.5,1.0]`.
 
-        - ``implicit_evolve.theta`` (`float`, default: 0.5)
+        - ``implicit_evolve.theta`` (``float``, default: 0.5)
         - :math:`\theta = 0.5`: Exact energy conservation.
         - :math:`\theta = 1.0`: Maximal damping of high-k modes.
 
@@ -249,65 +249,65 @@ Overall simulation parameters
         - Practical limits on :math:`\Delta t` set by solver efficiency, number of particle cell crossings, and physics resolution.
 
       - **Nonlinear solvers:**
-        Advancing the implicit system in time requires solving a nonlinear system. The nonlinear solver options are `picard` and `newton`.
+        Advancing the implicit system in time requires solving a nonlinear system. The nonlinear solver options are ``picard`` and ``newton``.
 
-        - ``implicit_evolve.nonlinear_solver`` (`string`, default: None)
+        - ``implicit_evolve.nonlinear_solver`` (``string``, default: None)
 
         - ``implicit_evolve.nonlinear_solver = picard``: Use a Picard iteration method. Requires small time steps; often non-convergent for large time steps.
 
-          - ``picard.verbose`` (`bool`, default: true)
-          - ``picard.require_convergence`` (`bool`, default: true)
-          - ``picard.maximum_iterations`` (`int`, default: 100)
-          - ``picard.relative_tolerance`` (`float`, default: 1.0e-6)
-          - ``picard.absolute_tolerance`` (`float`, default: 0.0)
-          - ``picard.diagnostic_file`` (`string`, default: None)
-          - ``picard.diagnostic_interval`` (`int`, default: 1)
+          - ``picard.verbose`` (``bool``, default: true)
+          - ``picard.require_convergence`` (``bool``, default: true)
+          - ``picard.maximum_iterations`` (``int``, default: 100)
+          - ``picard.relative_tolerance`` (``float``, default: 1.0e-6)
+          - ``picard.absolute_tolerance`` (``float``, default: 0.0)
+          - ``picard.diagnostic_file`` (``string``, default: None)
+          - ``picard.diagnostic_interval`` (``int``, default: 1)
 
         - ``implicit_evolve.nonlinear_solver = newton``: Use a PS-JFNK method. Required for large time steps, but efficiency often relies on preconditioning and/or using ``implicit_evolve.use_mass_matrices_jacobian = true``.
 
-          - ``newton.verbose`` (`bool`, default: true)
-          - ``newton.require_convergence`` (`bool`, default: true)
-          - ``newton.maximum_iterations`` (`int`, default: 100)
-          - ``newton.relative_tolerance`` (`float`, default: 1.0e-6)
-          - ``newton.absolute_tolerance`` (`float`, default: 0.0)
-          - ``newton.diagnostic_file`` (`string`, default: None)
-          - ``newton.diagnostic_interval`` (`int`, default: 1)
+          - ``newton.verbose`` (``bool``, default: true)
+          - ``newton.require_convergence`` (``bool``, default: true)
+          - ``newton.maximum_iterations`` (``int``, default: 100)
+          - ``newton.relative_tolerance`` (``float``, default: 1.0e-6)
+          - ``newton.absolute_tolerance`` (``float``, default: 0.0)
+          - ``newton.diagnostic_file`` (``string``, default: None)
+          - ``newton.diagnostic_interval`` (``int``, default: 1)
 
           - The PS-JFNK solver uses GMRES to solve the linear system at each nonlinear iteration:
 
-          - ``gmres.verbose_int`` (`int`, default: 2)
-          - ``gmres.restart_length`` (`int`, default: 30)
-          - ``gmres.maximum_iterations`` (`int`, default: 1000)
-          - ``gmres.relative_tolerance`` (`float`, default: 1.0e-4)
-          - ``gmres.absolute_tolerance`` (`float`, default: 0.0)
+          - ``gmres.verbose_int`` (``int``, default: 2)
+          - ``gmres.restart_length`` (``int``, default: 30)
+          - ``gmres.maximum_iterations`` (``int``, default: 1000)
+          - ``gmres.relative_tolerance`` (``float``, default: 1.0e-4)
+          - ``gmres.absolute_tolerance`` (``float``, default: 0.0)
 
       - **PS-JFNK solver specific options:**
         The PS-JFNK solver (``implicit_evolve.nonlinear_solver = newton``) has a variety of additional parameters and options.
 
         - At each iteration in the PS-JFNK process, each particle is self-consistently updated for fixed :math:`\textbf{E}` and :math:`\textbf{B}` on the grid using a Picard method. The options for this Picard solve are set by:
 
-          - ``implicit_evolve.max_particle_iterations`` (`integer`, default: 21)
-          - ``implicit_evolve.particle_tolerance`` (`float`, default: 1.e-10)
-          - ``implicit_evolve.particle_suborbits`` (`bool`, default: false)
-          - ``implicit_evolve.print_unconverged_particle_details`` (`bool`, default: false)
+          - ``implicit_evolve.max_particle_iterations`` (``integer``, default: 21)
+          - ``implicit_evolve.particle_tolerance`` (``float``, default: 1.e-10)
+          - ``implicit_evolve.particle_suborbits`` (``bool``, default: false)
+          - ``implicit_evolve.print_unconverged_particle_details`` (``bool``, default: false)
 
-        - ``implicit_evolve.use_mass_matrices_jacobian`` (`bool`, default: false).
-          When `true`, the plasma current density is computed using the mass matrices during the linear stage of PS-JFNK, replacing direct particle calculations. This can enable large speed ups for simulations with many particles.
+        - ``implicit_evolve.use_mass_matrices_jacobian`` (``bool``, default: false).
+          When ``true``, the plasma current density is computed using the mass matrices during the linear stage of PS-JFNK, replacing direct particle calculations. This can enable large speed ups for simulations with many particles.
 
-          - ``implicit_evolve.skip_particle_picard_init`` (`bool`, default: false).
-            When `true` and ``implicit_evolve.use_mass_matrices_jacobian = true``, the full Picard update of the particles is skipped on the initial Newton step, and only a single iteration is performed.
+          - ``implicit_evolve.skip_particle_picard_init`` (``bool``, default: false).
+            When ``true`` and ``implicit_evolve.use_mass_matrices_jacobian = true``, the full Picard update of the particles is skipped on the initial Newton step, and only a single iteration is performed.
             This can enhance the overall efficiency of the Newton solver.
             Default is true if ``implicit_evolve.particle_suborbits = true``.
 
-        - ``implicit_evolve.use_mass_matrices_pc`` (`bool`, default: false).
-          When `true`, the plasma response is captured in the preconditioner.
+        - ``implicit_evolve.use_mass_matrices_pc`` (``bool``, default: false).
+          When ``true``, the plasma response is captured in the preconditioner.
           Requires use of a preconditioner (``jacobian.pc_type = pc_curl_curl_mlmg``, ``pc_petsc``, or ``pc_jacobi``).
 
-        - ``implicit_evolve.mass_matrices_pc_width`` (`integer`, default: 0).
+        - ``implicit_evolve.mass_matrices_pc_width`` (``integer``, default: 0).
           If using ``jacobian.pc_type = pc_petsc``, this parameter specifies the width of the mass matrices included in the preconditioner.
           In most cases, a width of 1 is sufficient for good GMRES performance.
 
-        - ``jacobian.pc_type`` (`string`, default: None). A preconditioner can be used to minimize the number of linear GMRES iterations. There are two options:
+        - ``jacobian.pc_type`` (``string``, default: None). A preconditioner can be used to minimize the number of linear GMRES iterations. There are two options:
 
           - ``jacobian.pc_type = pc_curl_curl_mlmg``: Use the AMReX MLMG solver for the curl curl formulation of Maxwell's equations. This preconditioner solves the following equation:
 
@@ -320,21 +320,21 @@ Overall simulation parameters
               - Default: :math:`\boldsymbol\beta = \mathbb{I}`, giving implicit Maxwell equations, suitable for time steps that under-resolve light waves (:math:`c\Delta t > 1/\sqrt{\left(\sum_i1/\Delta x_i^2\right)}`).
               - ``implicit_evolve.use_mass_matrices_pc = true``: :math:`\boldsymbol\beta` also includes plasma response via the diagonal mass matrices, enabling time steps that under-resolve the plasma period (:math:`\omega_{pe}\Delta t > 1`).
 
-            - ``pc_curl_curl_mlmg.verbose`` (`bool`, default: true)
-            - ``pc_curl_curl_mlmg.bottom_verbose`` (`bool`, default: false)
-            - ``pc_curl_curl_mlmg.agglomeration`` (`bool`, default: true)
-            - ``pc_curl_curl_mlmg.consolidation`` (`bool`, default: true)
-            - ``pc_curl_curl_mlmg.max_iter`` (`int`, default: 10)
-            - ``pc_curl_curl_mlmg.max_coarsening_level`` (`int`, default: 30)
-            - ``pc_curl_curl_mlmg.relative_tolerance`` (`float`, default: 1.0e-4)
-            - ``pc_curl_curl_mlmg.absolute_tolerance`` (`float`, default: 1.0e-16)
+            - ``pc_curl_curl_mlmg.verbose`` (``bool``, default: true)
+            - ``pc_curl_curl_mlmg.bottom_verbose`` (``bool``, default: false)
+            - ``pc_curl_curl_mlmg.agglomeration`` (``bool``, default: true)
+            - ``pc_curl_curl_mlmg.consolidation`` (``bool``, default: true)
+            - ``pc_curl_curl_mlmg.max_iter`` (``int``, default: 10)
+            - ``pc_curl_curl_mlmg.max_coarsening_level`` (``int``, default: 30)
+            - ``pc_curl_curl_mlmg.relative_tolerance`` (``float``, default: 1.0e-4)
+            - ``pc_curl_curl_mlmg.absolute_tolerance`` (``float``, default: 1.0e-16)
 
           - ``jacobian.pc_type = pc_jacobi``: Use the Point-Jacobi method. This preconditioner only captures the plasma response via the diagonal mass matrices.
 
-            - ``pc_jacobi.verbose`` (`bool`, default: true)
-            - ``pc_jacobi.max_iter`` (`int`, default: 10)
-            - ``pc_jacobi.relative_tolerance`` (`float`, default: 1.0e-4)
-            - ``pc_jacobi.absolute_tolerance`` (`float`, default: 1.0e-16)
+            - ``pc_jacobi.verbose`` (``bool``, default: true)
+            - ``pc_jacobi.max_iter`` (``int``, default: 10)
+            - ``pc_jacobi.relative_tolerance`` (``float``, default: 1.0e-4)
+            - ``pc_jacobi.absolute_tolerance`` (``float``, default: 1.0e-16)
 
       - **References:** (WarpX includes relativistic extensions not discussed in references.)
 
@@ -360,8 +360,8 @@ Overall simulation parameters
 .. _param-electrostatic-pic:
 
 .. pp:param:: warpx.do_electrostatic
-    :type: `string`
-    :default: `none`
+    :type: ``string``
+    :default: ``none``
     :optional:
 
     Specifies the electrostatic mode. When turned on, instead of updating
@@ -375,8 +375,8 @@ Overall simulation parameters
     of each scheme.
 
 .. pp:param:: warpx.poisson_solver
-    :type: `string`
-    :default: `multigrid`
+    :type: ``string``
+    :default: ``multigrid``
     :optional:
 
     * ``multigrid``: Poisson's equation is solved using an iterative multigrid (MLMG) solver.
@@ -400,7 +400,7 @@ Overall simulation parameters
         In electromagnetic mode, this solver can be used to initialize the species' self fields
         (``<species_name>.initialize_self_fields=1``) provided that the field BCs are PML (``boundary.field_lo,hi = PML``).
 
-          * ``warpx.use_2d_slices_fft_solver`` (`bool`) optional (default: 0): Select the type of Integrated Green Function solver.
+          * ``warpx.use_2d_slices_fft_solver`` (``bool``) optional (default: 0): Select the type of Integrated Green Function solver.
             If 0, solve Poisson equation in full 3D geometry.
             If 1, solve Poisson equation in a quasi 3D geometry, neglecting the :math:`z` derivatives in the Laplacian of the Poisson equation.
             In practice, in this case, the code performs many 2D Poisson solves on all :math:`(x,y)` slices, each slice at a given :math:`z`.
@@ -408,7 +408,7 @@ Overall simulation parameters
             As a consequence, this solver does not need to do an FFT along the :math:`z` direction,
             and instead uses only transverse FFTs (along :math:`x` and :math:`y`) at each :math:`z` position (or :math:`z` "slice").
 
-          * ``ablastr.nprocs_igf_fft`` (`int`) optional (default: number of MPI ranks): Number of MPI ranks used to parallelize the FFT solver.
+          * ``ablastr.nprocs_igf_fft`` (``int``) optional (default: number of MPI ranks): Number of MPI ranks used to parallelize the FFT solver.
             This can be less or equal than then number of MPI ranks that are used to run the overall simulation.
             It can be useful if the auxiliary simulation boxes fit within a single process, so to avoid extra communications.
             The auxiliary boxes are extended boxes in real and spectral space that are used to perform the necessary FFTs.
@@ -416,7 +416,7 @@ Overall simulation parameters
             The extended simulation box size in spectral space is :math:`n_x, 2n_y-1, 2n_z-1` with the 3D solver, :math:`n_x, 2n_y-1, n_z` with the 2D solver.
 
 .. pp:param:: warpx.self_fields_required_precision
-    :type: `float`
+    :type: ``float``
     :default: 1.e-11
 
     The relative precision with which the electrostatic space-charge fields should
@@ -428,7 +428,7 @@ Overall simulation parameters
     is also used as the default for ``magnetostatic_solver_required_precision``.
 
 .. pp:param:: warpx.self_fields_absolute_tolerance
-    :type: `float`
+    :type: ``float``
     :default: 0.0
 
     The absolute tolerance with which the space-charge fields should be
@@ -442,7 +442,7 @@ Overall simulation parameters
     is also used as the default for ``magnetostatic_solver_absolute_tolerance``.
 
 .. pp:param:: warpx.self_fields_max_iters
-    :type: `integer`
+    :type: ``integer``
     :default: 200
 
     Maximum number of iterations used for MLMG solver for space-charge
@@ -453,7 +453,7 @@ Overall simulation parameters
     is also used as the default for ``magnetostatic_solver_max_iters``.
 
 .. pp:param:: warpx.self_fields_verbosity
-    :type: `integer`
+    :type: ``integer``
     :default: 2
 
     The verbosity used for MLMG solver for space-charge fields calculation. Currently
@@ -462,7 +462,7 @@ Overall simulation parameters
     is also used as the default for ``magnetostatic_solver_verbosity``.
 
 .. pp:param:: warpx.magnetostatic_solver_required_precision
-    :type: `float`
+    :type: ``float``
     :default: value of ``self_fields_required_precision``
 
     The relative precision with which the magnetostatic (vector Poisson) fields should
@@ -471,7 +471,7 @@ Overall simulation parameters
     than for the electrostatic solver.
 
 .. pp:param:: warpx.magnetostatic_solver_absolute_tolerance
-    :type: `float`
+    :type: ``float``
     :default: value of ``self_fields_absolute_tolerance``
 
     The absolute tolerance with which the magnetostatic fields should be
@@ -480,7 +480,7 @@ Overall simulation parameters
     than for the electrostatic solver.
 
 .. pp:param:: warpx.magnetostatic_solver_max_iters
-    :type: `integer`
+    :type: ``integer``
     :default: value of ``self_fields_max_iters``
 
     Maximum number of iterations used for the magnetostatic (vector Poisson) MLMG solver
@@ -489,7 +489,7 @@ Overall simulation parameters
     than for the electrostatic solver.
 
 .. pp:param:: warpx.magnetostatic_solver_verbosity
-    :type: `integer`
+    :type: ``integer``
     :default: value of ``self_fields_verbosity``
 
     The verbosity used for the magnetostatic MLMG solver when using
@@ -535,19 +535,19 @@ Allowed signal names are documented in the `C++ standard <https://en.cppreferenc
 We follow the same naming, but remove the ``SIG`` prefix, e.g., the WarpX signal configuration name for ``SIGINT`` is ``INT``.
 
 .. pp:param:: warpx.break_signals
-    :type: array of `string`, separated by spaces
+    :type: array of ``string``, separated by spaces
     :optional:
 
     A list of signal names or numbers that the simulation should
     handle by cleanly terminating at the next timestep
 
 .. pp:param:: warpx.checkpoint_signals
-    :type: array of `string`, separated by spaces
+    :type: array of ``string``, separated by spaces
     :optional:
 
     A list of signal names or numbers that the simulation should
     handle by outputting a checkpoint at the next timestep. A
-    diagnostic of type `checkpoint` must be configured.
+    diagnostic of type ``checkpoint`` must be configured.
 
 .. note::
 
@@ -589,12 +589,12 @@ Setting up the field mesh
 -------------------------
 
 .. pp:param:: amr.n_cell
-    :type: `2 integers in 2D`, `3 integers in 3D`
+    :type: ``2 integers in 2D``, ``3 integers in 3D``
 
     The number of grid points along each direction (on the **coarsest level**)
 
 .. pp:param:: amr.max_level
-    :type: `integer`
+    :type: ``integer``
     :default: ``0``
 
     When using mesh refinement, the number of refinement levels that will be used.
@@ -602,21 +602,21 @@ Setting up the field mesh
     Use 0 in order to disable mesh refinement.
 
 .. pp:param:: amr.ref_ratio
-    :type: `integer` per refined level
+    :type: ``integer`` per refined level
     :default: ``2``
 
     When using mesh refinement, this is the refinement ratio per level.
     With this option, all directions are fined by the same ratio.
 
 .. pp:param:: amr.ref_ratio_vect
-    :type: `3 integers for x,y,z per refined level`
+    :type: ``3 integers for x,y,z per refined level``
 
     When using mesh refinement, this can be used to set the refinement ratio per direction and level, relative to the previous level.
 
     Example: for three levels, a value of ``2 2 4 8 8 16`` refines the first level by 2-fold in x and y and 4-fold in z compared to the coarsest level (level 0/mother grid); compared to the first level, the second level is refined 8-fold in x and y and 16-fold in z.
 
 .. pp:param:: geometry.dims
-    :type: `string`
+    :type: ``string``
 
     The dimensions of the simulation geometry.
     Supported values are ``1``, ``2``, ``3``, ``RZ``, ``RCYLINDER``, and ``RSPHERE``.
@@ -632,7 +632,7 @@ Setting up the field mesh
     If you installed WarpX from a :ref:`package manager <install-methods>`, then pick the right executable by name.
 
 .. pp:param:: warpx.n_rz_azimuthal_modes
-    :type: `integer`
+    :type: ``integer``
     :default: 1
 
     When using the RZ version, this is the number of azimuthal modes.
@@ -642,7 +642,7 @@ Setting up the field mesh
     :link_aliases:
         geometry.prob_lo
         geometry.prob_hi
-    :type: `2 floats in 2D`, `3 floats in 3D`
+    :type: ``2 floats in 2D``, ``3 floats in 3D``
     :unit: meters
 
     The extent of the full simulation box. This box is rectangular, and thus its
@@ -651,7 +651,7 @@ Setting up the field mesh
     (or r with cylindrical) and the last is z.
 
 .. pp:param:: warpx.do_moving_window
-    :type: `integer`
+    :type: ``integer``
     :default: 0
 
     Whether to use a moving window for the simulation
@@ -662,19 +662,19 @@ Setting up the field mesh
     The direction of the moving window.
 
 .. pp:param:: warpx.moving_window_v
-    :type: `float`
+    :type: ``float``
 
     The speed of moving window, in units of the speed of light
     (i.e. use ``1.0`` for a moving window that moves exactly at the speed of light)
 
 .. pp:param:: warpx.start_moving_window_step
-    :type: `integer`
+    :type: ``integer``
     :default: 0
 
     The timestep at which the moving window starts.
 
 .. pp:param:: warpx.end_moving_window_step
-    :type: `integer`
+    :type: ``integer``
     :default: ``-1`` for false
 
     The timestep at which the moving window ends.
@@ -683,7 +683,7 @@ Setting up the field mesh
     :link_aliases:
         warpx.fine_tag_lo
         warpx.fine_tag_hi
-    :type: `2 floats in 2D`, `3 floats in 3D`
+    :type: ``2 floats in 2D``, ``3 floats in 3D``
     :unit: meters
     :optional:
 
@@ -692,18 +692,18 @@ Setting up the field mesh
     of the lower corner (:pp:param:`warpx.fine_tag_lo`) and upper corner (:pp:param:`warpx.fine_tag_hi`).
 
 .. pp:param:: warpx.ref_patch_function(x,y,z)
-    :type: `string`
+    :type: ``string``
     :optional:
 
-    A function of `x`, `y`, `z` that defines the extent of the refined patch when
+    A function of ``x``, ``y``, ``z`` that defines the extent of the refined patch when
     using static mesh refinement with :pp:param:`amr.max_level`>0. Note that the function can be used
     to define distinct regions for refinement, however, the refined regions should be such that
     the pml layer surrounding the patches should not overlap. For this reason, when defining
     distinct patches, please ensure that they are sufficiently separated.
 
 .. pp:param:: warpx.refine_plasma
-    :type: `integer`
-    :default: `0`
+    :type: ``integer``
+    :default: ``0``
     :optional:
 
     Increase the number of macro-particles that are injected "ahead" of a mesh
@@ -713,7 +713,7 @@ Setting up the field mesh
     to moving window plasma injection, and requires a single refined level.
 
 .. pp:param:: warpx.n_current_deposition_buffer
-    :type: `integer`
+    :type: ``integer``
 
     When using mesh refinement: the particles that are located inside
     a refinement patch, but within ``n_current_deposition_buffer`` cells of
@@ -725,7 +725,7 @@ Setting up the field mesh
     enough to hold the particle shape, on the fine grid
 
 .. pp:param:: warpx.n_field_gather_buffer
-    :type: `integer`
+    :type: ``integer``
     :optional:
 
     Default: ``warpx.n_field_gather_buffer = n_current_deposition_buffer + 1`` (one cell larger than ``n_current_deposition_buffer`` on the fine grid).
@@ -735,21 +735,21 @@ Setting up the field mesh
     See the section :ref:`Mesh refinement <theory-amr>` for more details.
 
 .. pp:param:: warpx.do_single_precision_comms
-    :type: `integer`
+    :type: ``integer``
     :default: 0
 
     Perform MPI communications for field guard regions in single precision.
     Only meaningful for ``WarpX_PRECISION=DOUBLE``.
 
 .. pp:param:: particles.deposit_on_main_grid
-    :type: `list of strings`
+    :type: ``list of strings``
 
     When using mesh refinement: the particle species whose name are included
     in the list will deposit their charge/current directly on the main grid
     (i.e. the coarsest level), even if they are inside a refinement patch.
 
 .. pp:param:: particles.gather_from_main_grid
-    :type: `list of strings`
+    :type: ``list of strings``
 
     When using mesh refinement: the particle species whose name are included
     in the list will gather their fields from the main grid
@@ -765,8 +765,8 @@ Domain Boundary Conditions
         boundary.field_lo,hi
         boundary.field_lo
         boundary.field_hi
-    :type: `2 strings` for 2D, `3 strings` for 3D
-    :default: `pml`
+    :type: ``2 strings`` for 2D, ``3 strings`` for 3D
+    :default: ``pml``
 
     Boundary conditions applied to fields at the lower and upper domain boundaries.
     Options are:
@@ -780,7 +780,7 @@ Domain Boundary Conditions
 
     * ``damped``: This is the recommended option in the moving direction when using the spectral solver with moving window (currently only supported along z). This boundary condition applies a damping factor to the electric and magnetic fields in the outer half of the guard cells, using a sine squared profile. As the spectral solver is by nature periodic, the damping prevents fields from wrapping around to the other end of the domain when the periodicity is not desired. This boundary condition is only valid when using the spectral solver.
 
-    * ``pec``: This option can be used to set a Perfect Electric Conductor at the simulation boundary. Please see the :ref:`PEC theory section <theory-bc-pec>` for more details. Note that PEC boundary is invalid at `r=0` for RZ, RCYLINDER, and RSPHERE. Please use ``none`` option. This boundary condition does not work with the spectral solver.
+    * ``pec``: This option can be used to set a Perfect Electric Conductor at the simulation boundary. Please see the :ref:`PEC theory section <theory-bc-pec>` for more details. Note that PEC boundary is invalid at ``r=0`` for RZ, RCYLINDER, and RSPHERE. Please use ``none`` option. This boundary condition does not work with the spectral solver.
       There is the additional input parameter ``particles.crop_on_PEC_boundary`` which sets whether particle trajectories are cropped when particles cross PEC boundaries, defaulting to false.
 
     * ``pmc``: This option can be used to set a Perfect Magnetic Conductor at the simulation boundary. Please see the :ref:`PEC theory section <theory-bc-pmc>` for more details. This is equivalent to ``Neumann``. This boundary condition does not work with the spectral solver.
@@ -817,7 +817,7 @@ Domain Boundary Conditions
 
       * ``insulator.Ex_z_hi(x,y,t)``, ``insulator.Ey_z_hi(x,y,t)``, ``insulator.Bx_z_hi(x,y,t)``, ``insulator.By_z_hi(x,y,t)``: expressions of the tangential field values for the upper z boundary
 
-    * ``none``: No boundary condition is applied to the fields with the electromagnetic solver. This option must be used for the lower boundary, `r=0`, with RZ, RCYLINDER, and RSPHERE.
+    * ``none``: No boundary condition is applied to the fields with the electromagnetic solver. This option must be used for the lower boundary, ``r=0``, with RZ, RCYLINDER, and RSPHERE.
 
     * ``neumann``: For the electrostatic multigrid solver, a Neumann boundary condition (with gradient of the potential equal to 0) will be applied on the specified boundary.
 
@@ -833,7 +833,7 @@ Domain Boundary Conditions
         boundary.potential_hi_x
         boundary.potential_hi_y
         boundary.potential_hi_z
-    :default: `0`
+    :default: ``0``
 
     Gives the value of the electric potential, in Volts, at the boundaries, for ``pec`` boundaries. With electrostatic solvers
     (i.e., with ``warpx.do_electrostatic = ...``), this is used in order to compute the potential
@@ -845,8 +845,8 @@ Domain Boundary Conditions
     :link_aliases:
         boundary.particle_lo
         boundary.particle_hi
-    :type: `2 strings` for 2D, `3 strings` for 3D
-    :default: `absorbing`
+    :type: ``2 strings`` for 2D, ``3 strings`` for 3D
+    :default: ``absorbing``
 
     Options are:
 
@@ -868,15 +868,15 @@ Domain Boundary Conditions
       This should not be used in any other cases.
 
 .. pp:param:: boundary.reflect_all_velocities
-    :type: `bool`
-    :default: `false`
+    :type: ``bool``
+    :default: ``false``
     :optional:
 
     For a reflecting boundary condition, this flags whether the sign of only the normal velocity is changed or all velocities.
 
 .. pp:param:: boundary.verboncoeur_axis_correction
-    :type: `bool`
-    :default: `true`
+    :type: ``bool``
+    :default: ``true``
     :optional:
 
     Whether to apply the Verboncoeur correction on the charge and current density on axis when using RZ, RCYLINDER, or RSPHERE.
@@ -889,54 +889,54 @@ Additional PML parameters
 -------------------------
 
 .. pp:param:: warpx.pml_ncell
-    :type: `int`
+    :type: ``int``
     :default: 10
 
     The depth of the PML, in number of cells.
 
 .. pp:param:: do_similar_dm_pml
-    :type: `int`
+    :type: ``int``
     :default: 1
 
-    Whether or not to use an amrex::DistributionMapping for the PML grids that is `similar` to the mother grids, meaning that the
+    Whether or not to use an amrex::DistributionMapping for the PML grids that is *similar* to the mother grids, meaning that the
     mapping will be computed to minimize the communication costs between the PML and the mother grids.
 
 .. pp:param:: warpx.pml_delta
-    :type: `int`
+    :type: ``int``
     :default: 10
 
     The characteristic depth, in number of cells, over which
     the absorption coefficients of the PML increases.
 
 .. pp:param:: warpx.do_pml_in_domain
-    :type: `int`
+    :type: ``int``
     :default: 0
 
     Whether to create the PML inside the simulation area or outside. If inside,
     it allows the user to propagate particles in PML and to use extended PML
 
 .. pp:param:: warpx.pml_has_particles
-    :type: `int`
+    :type: ``int``
     :default: 0
 
     Whether to propagate particles in PML or not. Can only be done if PML are in simulation domain,
-    i.e. if `warpx.do_pml_in_domain = 1`.
+    i.e. if ``warpx.do_pml_in_domain = 1``.
 
 .. pp:param:: warpx.do_pml_j_damping
-    :type: `int`
+    :type: ``int``
     :default: 0
 
     Whether to damp current in PML. Can only be used if particles are propagated in PML,
-    i.e. if `warpx.pml_has_particles = 1`.
+    i.e. if ``warpx.pml_has_particles = 1``.
 
 .. pp:param:: warpx.v_particle_pml
-    :type: `float`
+    :type: ``float``
     :default: 1
 
-    When ``warpx.do_pml_j_damping = 1``, the assumed velocity of the particles to be absorbed in the PML, in units of the speed of light `c`.
+    When ``warpx.do_pml_j_damping = 1``, the assumed velocity of the particles to be absorbed in the PML, in units of the speed of light ``c``.
 
 .. pp:param:: warpx.do_pml_dive_cleaning
-    :type: `bool`
+    :type: ``bool``
 
     Whether to use divergence cleaning for E in the PML region.
     The value must match :pp:param:`warpx.do_pml_divb_cleaning` (either both false or both true).
@@ -944,7 +944,7 @@ Additional PML parameters
     This option is implemented only for the Cartesian PSATD solver; it is turned on by default in this case.
 
 .. pp:param:: warpx.do_pml_divb_cleaning
-    :type: `bool`
+    :type: ``bool``
 
     Whether to use divergence cleaning for B in the PML region.
     The value must match :pp:param:`warpx.do_pml_dive_cleaning` (either both false or both true).
@@ -962,9 +962,9 @@ In WarpX, the embedded boundary can be defined in either of two ways:
         In that case, you will need to set the following parameter in the input file.
 
         .. pp:param:: warpx.eb_implicit_function
-            :type: `string`
+            :type: ``string``
 
-            A function of `x`, `y`, `z` that defines the surface of the embedded
+            A function of ``x``, ``y``, ``z`` that defines the surface of the embedded
             boundary. That surface lies where the function value is 0 ;
             the physics simulation area is where the function value is negative ;
             the interior of the embedded boundary is where the function value is positive.
@@ -973,7 +973,7 @@ In WarpX, the embedded boundary can be defined in either of two ways:
         In that case, you will need to set the following parameters in the input file.
 
         .. pp:param:: eb2.stl_file
-            :type: `string`
+            :type: ``string``
 
             The path to an `STL file <https://en.wikipedia.org/wiki/STL_(file_format)>`__.
             In addition, you also need to set ``eb2.geom_type = stl``, in order for the file to be read by WarpX.
@@ -983,10 +983,10 @@ Whether the embedded boundary is defined with an analytical function or an STL f
 additionally define the electric potential at the embedded boundary with an analytical function:
 
 .. pp:param:: warpx.eb_potential(x,y,z,t)
-    :type: `string`
+    :type: ``string``
 
     Gives the value of the electric potential, in Volts, at the surface of the embedded boundary,
-    as a function of  `x`, `y`, `z` and `t`. With electrostatic solvers (i.e., with
+    as a function of  ``x``, ``y``, ``z`` and ``t``. With electrostatic solvers (i.e., with
     ``warpx.do_electrostatic = ...``), this is used in order to compute the potential
     in the simulation volume at each timestep. When using other solvers (e.g. Maxwell solver),
     setting this variable will trigger an electrostatic solve at ``t=0``, to compute the initial
@@ -1017,38 +1017,38 @@ using the temperature parameter ``theta`` for any direction in which their momen
 The parameters affecting this region are as follows:
 
 .. pp:param:: particle_thermalizer.normal
-    :type: `string`
+    :type: ``string``
 
     The normal direction describing the thermalizer region. Allowed values are ``x``, ``y``, or ``z`` (case-insensitive). Along with the ``start`` and ``stop`` parameters below, this specifies the region in space where particles will be thermalized.
     This parameter is optional. If not specified, the thermalizer will not be applied.
 
 .. pp:param:: particle_thermalizer.species
-    :type: `list of strings`
+    :type: ``list of strings``
     :optional:
 
     Names of the species to which the thermalizer is applied. If not specified, the thermalizer
     is applied to all species.
 
 .. pp:param:: particle_thermalizer.start
-    :type: `float`
+    :type: ``float``
 
     Starting coordinate (in SI units) of the thermalization region along the specified normal direction.
     This parameter is required if the thermalizer is enabled.
 
 .. pp:param:: particle_thermalizer.end
-    :type: `float`
+    :type: ``float``
 
     Ending coordinate (in SI units) of the thermalization region along the specified normal direction.
     This parameter is required if the thermalizer is enabled.
 
 .. pp:param:: particle_thermalizer.momentum_threshold
-    :type: `float`
+    :type: ``float``
 
     Momentum threshold used by the thermalizer. In each direction, if a particle's normalized momentum component (e.g. :math:`\gamma \beta_x`) is above this threshold, that component will be thermalized.
     This parameter is required if the thermalizer is enabled.
 
 .. pp:param:: particle_thermalizer.theta
-    :type: `float`
+    :type: ``float``
 
     Dimensionless temperature parameter (k*T/m/c^2) used to sample the thermalized particle velocities.
     This parameter is required if the thermalizer is enabled. For the selected particles, if the
@@ -1070,8 +1070,8 @@ Distribution across MPI ranks and parallelization
 -------------------------------------------------
 
 .. pp:param:: warpx.numprocs
-    :type: `2 ints` for 2D, `3 ints` for 3D
-    :default: `none`
+    :type: ``2 ints`` for 2D, ``3 ints`` for 3D
+    :default: ``none``
     :optional:
 
     This optional parameter can be used to control the domain decomposition on the
@@ -1081,8 +1081,8 @@ Distribution across MPI ranks and parallelization
     specified, the product of the numbers must be equal to the number of MPI processes.
 
 .. pp:param:: amr.max_grid_size
-    :type: `integer`
-    :default: `128`
+    :type: ``integer``
+    :default: ``128``
     :optional:
 
     Maximum allowable size of each **subdomain**
@@ -1100,8 +1100,8 @@ Distribution across MPI ranks and parallelization
     of the coarsest level, but also to any of the finer level.
 
 .. pp:param:: algo.load_balance_intervals
-    :type: `string`
-    :default: `0`
+    :type: ``string``
+    :default: ``0``
     :optional:
 
     Using the `Time intervals`_ syntax, this string defines the timesteps at which
@@ -1117,8 +1117,8 @@ Distribution across MPI ranks and parallelization
     (see ``max_grid_size``).
 
 .. pp:param:: algo.load_balance_efficiency_ratio_threshold
-    :type: `float`
-    :default: `1.1`
+    :type: ``float``
+    :default: ``1.1``
     :optional:
 
     Controls whether to adopt a proposed distribution mapping computed during a load balance.
@@ -1137,24 +1137,24 @@ Distribution across MPI ranks and parallelization
     adopted if the proposed efficiency were greater than ``0.9``).
 
 .. pp:param:: algo.load_balance_with_sfc
-    :type: `0` or `1`
-    :default: `0`
+    :type: ``0`` or ``1``
+    :default: ``0``
     :optional:
 
-    If this is `1`: use a Space-Filling Curve (SFC) algorithm in order to
+    If this is ``1``: use a Space-Filling Curve (SFC) algorithm in order to
     perform load-balancing of the simulation.
-    If this is `0`: the Knapsack algorithm is used instead.
+    If this is ``0``: the Knapsack algorithm is used instead.
 
 .. pp:param:: algo.load_balance_knapsack_factor
-    :type: `float`
-    :default: `1.24`
+    :type: ``float``
+    :default: ``1.24``
     :optional:
 
     Controls the maximum number of boxes that can be assigned to a rank during
     load balance when using the 'knapsack' policy for update of the distribution
     mapping; the maximum is
-    `load_balance_knapsack_factor*(average number of boxes per rank)`.
-    For example, if there are 4 boxes per rank and `load_balance_knapsack_factor=2`,
+    ``load_balance_knapsack_factor*(average number of boxes per rank)``.
+    For example, if there are 4 boxes per rank and ``load_balance_knapsack_factor=2``,
     no more than 8 boxes can be assigned to any rank.
 
 .. pp:param:: algo.load_balance_costs_update
@@ -1162,7 +1162,7 @@ Distribution across MPI ranks and parallelization
     :default: ``timers``
     :optional:
 
-    If this is `heuristic`: load balance costs are updated according to a measure of
+    If this is ``heuristic``: load balance costs are updated according to a measure of
     particles and cells assigned to each box of the domain.  The cost :math:`c` is
     computed as
 
@@ -1176,16 +1176,16 @@ Distribution across MPI ranks and parallelization
     :math:`n_{\text{cell}}` is the number of cells on the box, and
     :math:`w_{\text{cell}}` is the cell cost weight factor (controlled by :pp:param:`algo.costs_heuristic_cells_wt`).
 
-    If this is `timers`: costs are updated according to in-code timers.
+    If this is ``timers``: costs are updated according to in-code timers.
 
 .. pp:param:: algo.costs_heuristic_particles_wt
-    :type: `float`
+    :type: ``float``
     :optional:
 
-    Particle weight factor used in `Heuristic` strategy for costs update; if running on GPU,
+    Particle weight factor used in ``Heuristic`` strategy for costs update; if running on GPU,
     the particle weight is set to a value determined from single-GPU tests on Summit,
     depending on the choice of solver (FDTD or PSATD) and order of the particle shape.
-    If running on CPU, the default value is `0.9`. If running on GPU, the default value is
+    If running on CPU, the default value is ``0.9``. If running on GPU, the default value is
 
     +----------+-----------------------+
     |          | Particle shape factor |
@@ -1198,13 +1198,13 @@ Distribution across MPI ranks and parallelization
     +----------+-------+-------+-------+
 
 .. pp:param:: algo.costs_heuristic_cells_wt
-    :type: `float`
+    :type: ``float``
     :optional:
 
-    Cell weight factor used in `Heuristic` strategy for costs update; if running on GPU,
+    Cell weight factor used in ``Heuristic`` strategy for costs update; if running on GPU,
     the cell weight is set to a value determined from single-GPU tests on Summit,
     depending on the choice of solver (FDTD or PSATD) and order of the particle shape.
-    If running on CPU, the default value is `0.1`. If running on GPU, the default value is
+    If running on CPU, the default value is ``0.1``. If running on GPU, the default value is
 
     +----------+-----------------------+
     |          | Particle shape factor |
@@ -1217,15 +1217,15 @@ Distribution across MPI ranks and parallelization
     +----------+-------+-------+-------+
 
 .. pp:param:: warpx.do_dynamic_scheduling
-    :type: `0` or `1`
-    :default: `1`
+    :type: ``0`` or ``1``
+    :default: ``1``
     :optional:
 
     Whether to activate OpenMP dynamic scheduling.
 
 .. pp:param:: warpx.roundrobin_sfc
-    :type: `0` or `1`
-    :default: `0`
+    :type: ``0`` or ``1``
+    :default: ``0``
     :optional:
 
     Whether to use AMReX's RRSFS strategy for making DistributionMapping to
@@ -1236,7 +1236,7 @@ Distribution across MPI ranks and parallelization
     process.
 
 .. pp:param:: warpx.split_high_density_boxes
-    :type: `bool`
+    :type: ``bool``
     :default: false
     :optional:
 
@@ -1244,7 +1244,7 @@ Distribution across MPI ranks and parallelization
     improve the potential for load balancing.
 
 .. pp:param:: warpx.split_high_density_boxes_threshold
-    :type: `float`
+    :type: ``float``
     :default: 1.1
     :optional:
 
@@ -1253,7 +1253,7 @@ Distribution across MPI ranks and parallelization
     multiplied by this factor, we try to split this Box into smaller ones.
 
 .. pp:param:: warpx.split_high_density_boxes_min_box_size
-    :type: `integer`
+    :type: ``integer``
     :default: 8
     :optional:
 
@@ -1267,42 +1267,42 @@ Particle initialization
 -----------------------
 
 .. pp:param:: particles.species_names
-    :type: `strings`, separated by spaces
+    :type: ``strings``, separated by spaces
 
     The name of each species. This is then used in the rest of the input deck ;
-    in this documentation we use `<species_name>` as a placeholder.
+    in this documentation we use ``<species_name>`` as a placeholder.
 
 .. pp:param:: particles.use_fdtd_nci_corr
-    :type: `0` or `1`
-    :default: `0`
+    :type: ``0`` or ``1``
+    :default: ``0``
     :optional:
 
     Whether to activate the FDTD Numerical Cherenkov Instability corrector.
     Not currently available in the RZ, RCYLINDER, and RSPHERE configuration.
 
 .. pp:param:: particles.rigid_injected_species
-    :type: `strings`, separated by spaces
+    :type: ``strings``, separated by spaces
 
     List of species injected using the rigid injection method. The rigid injection
     method is useful when injecting a relativistic particle beam in boosted-frame
     simulations; see the :ref:`input-output section <boosted_frame-io>` for more details.
-    For species injected using this method, particles are translated along the `+z`
+    For species injected using this method, particles are translated along the ``+z``
     axis with constant velocity as long as their ``z`` coordinate verifies
     ``z<zinject_plane``. When ``z>zinject_plane``,
     particles are pushed in a standard way, using the specified pusher.
     (see the parameter :pp:param:`<species_name>.zinject_plane` below)
 
 .. pp:param:: particles.do_tiling
-    :type: `bool`
-    :default: `false` if WarpX is compiled for GPUs, `true` otherwise
+    :type: ``bool``
+    :default: ``false`` if WarpX is compiled for GPUs, ``true`` otherwise
     :optional:
 
     Controls whether tiling ('cache blocking') transformation is used for particles.
     Tiling should be on when using OpenMP and off when using GPUs.
 
 .. pp:param:: <species_name>.species_type
-    :type: `string`
-    :default: `unspecified`
+    :type: ``string``
+    :default: ``unspecified``
     :optional:
 
     Type of physical species.
@@ -1322,20 +1322,20 @@ Particle initialization
     If ``mass`` and/or ``charge`` are nonetheless specified, they will override the pre-defined values for that ``species_type``.
 
 .. pp:param:: <species_name>.charge
-    :type: `float`
-    :default: `NaN`
+    :type: ``float``
+    :default: ``NaN``
     :optional:
 
-    The charge of one `physical` particle of this species.
+    The charge of one *physical* particle of this species.
     If ``species_type`` is specified, the charge will be set to the physical value and ``charge`` is optional.
     When ``<species_name>.do_field_ionization = 1``, the physical particle charge is equal to ``ionization_initial_level * charge``, so latter parameter should be equal to q_e (which is defined in WarpX as the elementary charge in coulombs).
 
 .. pp:param:: <species_name>.mass
-    :type: `float`
-    :default: `NaN`
+    :type: ``float``
+    :default: ``NaN``
     :optional:
 
-    The mass of one `physical` particle of this species.
+    The mass of one *physical* particle of this species.
     If ``species_type`` is specified, the mass will be set to the physical value and ``mass`` is optional.
     ``mass`` must be strictly positive. For massless species, use :pp:param:`<species_name>.species_type`. The only allowed massless species type is ``photon``.
 
@@ -1351,7 +1351,7 @@ Particle initialization
         <species_name>.xmax
         <species_name>.ymax
         <species_name>.zmax
-    :type: `float`
+    :type: ``float``
     :default: unlimited
     :optional:
 
@@ -1375,7 +1375,7 @@ Particle initialization
     Note that if a moving window is used, the bulk velocity of all of the sources must be the same since it is used when updating the window.
 
 .. pp:param:: <species_name>.injection_style
-    :type: `string`
+    :type: ``string``
     :default: ``none``
 
     Determines how the (macro-)particles will be injected in the simulation.
@@ -1392,28 +1392,28 @@ Particle initialization
     * ``SingleParticle``: Inject a single macroparticle.
       This requires the additional parameters:
 
-      * ``<species_name>.single_particle_pos`` (`3 doubles`, particle 3D position [meter])
+      * ``<species_name>.single_particle_pos`` (``3 doubles``, particle 3D position [meter])
 
-      * ``<species_name>.single_particle_u`` (`3 doubles`, particle 3D normalized momentum, i.e. :math:`\gamma \beta`)
+      * ``<species_name>.single_particle_u`` (``3 doubles``, particle 3D normalized momentum, i.e. :math:`\gamma \beta`)
 
-      * ``<species_name>.single_particle_weight`` ( `double`, macroparticle weight, i.e. number of physical particles it represents)
+      * ``<species_name>.single_particle_weight`` ( ``double``, macroparticle weight, i.e. number of physical particles it represents)
 
     * ``MultipleParticles``: Inject multiple macroparticles.
       This requires the additional parameters:
 
-      * ``<species_name>.multiple_particles_pos_x`` (list of `doubles`, X positions of the particles [meter])
+      * ``<species_name>.multiple_particles_pos_x`` (list of ``doubles``, X positions of the particles [meter])
 
-      * ``<species_name>.multiple_particles_pos_y`` (list of `doubles`, Y positions of the particles [meter])
+      * ``<species_name>.multiple_particles_pos_y`` (list of ``doubles``, Y positions of the particles [meter])
 
-      * ``<species_name>.multiple_particles_pos_z`` (list of `doubles`, Z positions of the particles [meter])
+      * ``<species_name>.multiple_particles_pos_z`` (list of ``doubles``, Z positions of the particles [meter])
 
-      * ``<species_name>.multiple_particles_ux`` (list of `doubles`, X normalized momenta of the particles, i.e. :math:`\gamma \beta_x`)
+      * ``<species_name>.multiple_particles_ux`` (list of ``doubles``, X normalized momenta of the particles, i.e. :math:`\gamma \beta_x`)
 
-      * ``<species_name>.multiple_particles_uy`` (list of `doubles`, Y normalized momenta of the particles, i.e. :math:`\gamma \beta_y`)
+      * ``<species_name>.multiple_particles_uy`` (list of ``doubles``, Y normalized momenta of the particles, i.e. :math:`\gamma \beta_y`)
 
-      * ``<species_name>.multiple_particles_uz`` (list of `doubles`, Z normalized momenta of the particles, i.e. :math:`\gamma \beta_z`)
+      * ``<species_name>.multiple_particles_uz`` (list of ``doubles``, Z normalized momenta of the particles, i.e. :math:`\gamma \beta_z`)
 
-      * ``<species_name>.multiple_particles_weight`` (list of `doubles`, macroparticle weights, i.e. number of physical particles each represents)
+      * ``<species_name>.multiple_particles_weight`` (list of ``doubles``, macroparticle weights, i.e. number of physical particles each represents)
 
     * ``gaussian_beam``: Inject particle beam with gaussian distribution in
       space in all directions. This requires additional parameters:
@@ -1427,9 +1427,9 @@ Particle initialization
 
       * ``<species_name>.npart`` (number of macroparticles in the beam),
 
-      * ``<species_name>.x/y/z_m`` (average position in `x/y/z`),
+      * ``<species_name>.x/y/z_m`` (average position in ``x/y/z``),
 
-      * ``<species_name>.x/y/z_rms`` (standard deviation in `x/y/z`),
+      * ``<species_name>.x/y/z_rms`` (standard deviation in ``x/y/z``),
 
       There are additional optional parameters:
 
@@ -1459,35 +1459,35 @@ Particle initialization
 
           \sigma_{x,y}(z) &= \sigma^*_{x,y} \sqrt{1 + \left( \frac{z - z^*}{\beta^*_{x,y}} \right)^2}
 
-      * ``<species_name>.do_gaussian_beam_rotation`` (`bool`, optional) the positions of the beam particles are rotated around the beam centroid.
+      * ``<species_name>.do_gaussian_beam_rotation`` (``bool``, optional) the positions of the beam particles are rotated around the beam centroid.
 
       If ``do_gaussian_beam_rotation = 1`` then the user needs to specify:
 
-          * ``<species_name>.gaussian_beam_rotation_axis``: (list of 3 `doubles`) axis around which the rotation takes place
+          * ``<species_name>.gaussian_beam_rotation_axis``: (list of 3 ``doubles``) axis around which the rotation takes place
 
-          * ``<species_name>.gaussian_beam_rotation_angle``: (`double`) angle of rotation around the specified axis, in radians.
+          * ``<species_name>.gaussian_beam_rotation_angle``: (``double``) angle of rotation around the specified axis, in radians.
 
-      * ``<species_name>.do_gaussian_beam_rotation_momenta`` (`bool`, optional) the momenta of the beam particles are also rotated using the same transformation applied to their positions. The rotation is the same as that for the positions. Momenta cannot be rotated independently; position rotation must be enabled first.
+      * ``<species_name>.do_gaussian_beam_rotation_momenta`` (``bool``, optional) the momenta of the beam particles are also rotated using the same transformation applied to their positions. The rotation is the same as that for the positions. Momenta cannot be rotated independently; position rotation must be enabled first.
 
-      Note that the other beam parameters (e.g. ``<species_name>.x/y/z_rms``, etc.) are used in the initialization process `before` performing the rotation.
+      Note that the other beam parameters (e.g. ``<species_name>.x/y/z_rms``, etc.) are used in the initialization process *before* performing the rotation.
       Therefore, the user should define the beam size, cuts, and focal distance for the beam pre-rotation, hence aligned to the Cartesian axes.
 
     * ``external_file``: Inject macroparticles with properties (mass, charge, position, and momentum - :math:`\gamma \beta m c`) read from an external openPMD file.
       With it users can specify the additional arguments:
 
-      * ``<species_name>.injection_file`` (`string`) openPMD file name and
+      * ``<species_name>.injection_file`` (``string``) openPMD file name and
 
-      * :pp:param:`<species_name>.charge` (`double`) optional (default is read from openPMD file) when set this will be the charge of the physical particle represented by the injected macroparticles.
+      * :pp:param:`<species_name>.charge` (``double``) optional (default is read from openPMD file) when set this will be the charge of the physical particle represented by the injected macroparticles.
 
-      * :pp:param:`<species_name>.mass` (`double`) optional (default is read from openPMD file) when set this will be the charge of the physical particle represented by the injected macroparticles.
+      * :pp:param:`<species_name>.mass` (``double``) optional (default is read from openPMD file) when set this will be the charge of the physical particle represented by the injected macroparticles.
 
-      * ``<species_name>.z_shift`` (`double`) optional (default is no shift) when set this value will be added to the longitudinal, ``z``, position of the particles.
+      * ``<species_name>.z_shift`` (``double``) optional (default is no shift) when set this value will be added to the longitudinal, ``z``, position of the particles.
 
-      * ``<species_name>.impose_t_lab_from_file`` (`bool`) optional (default is false) only read if warpx.gamma_boost > 1., it allows to set t_lab for the Lorentz Transform as being the time stored in the openPMD file.
+      * ``<species_name>.impose_t_lab_from_file`` (``bool``) optional (default is false) only read if warpx.gamma_boost > 1., it allows to set t_lab for the Lorentz Transform as being the time stored in the openPMD file.
 
       Warning: ``q_tot!=0`` is not supported with the ``external_file`` injection style. If a value is provided, it is ignored and no re-scaling is done.
-      The external file must include the species ``openPMD::Record`` labeled ``position`` and ``momentum`` (`double` arrays), with dimensionality and units set via ``openPMD::setUnitDimension`` and ``setUnitSI``.
-      If the external file also contains ``openPMD::Records`` for ``mass`` and ``charge`` (constant `double` scalars) then the species will use these, unless overwritten in the input file (see :pp:param:`<species_name>.mass`, :pp:param:`<species_name>.charge` or :pp:param:`<species_name>.species_type`).
+      The external file must include the species ``openPMD::Record`` labeled ``position`` and ``momentum`` (``double`` arrays), with dimensionality and units set via ``openPMD::setUnitDimension`` and ``setUnitSI``.
+      If the external file also contains ``openPMD::Records`` for ``mass`` and ``charge`` (constant ``double`` scalars) then the species will use these, unless overwritten in the input file (see :pp:param:`<species_name>.mass`, :pp:param:`<species_name>.charge` or :pp:param:`<species_name>.species_type`).
       The ``external_file`` option is currently implemented for 2D, 3D and RZ geometries, with record components in the cartesian coordinates ``(x,y,z)`` for 3D and RZ, and ``(x,z)`` for 2D.
       For more information on the `openPMD format <https://github.com/openPMD>`__ and how to build WarpX with it, please visit :ref:`the install section <install-build-cmake>`.
       See `this file <https://github.com/BLAST-WarpX/warpx/blob/development/Examples/Tests/gaussian_beam/inputs_test_3d_focusing_gaussian_beam_from_openpmd_prepare.py>`__
@@ -1499,26 +1499,26 @@ Particle initialization
 
       * :pp:param:`<species_name>.flux_profile` (see the description of this parameter further below)
 
-      * ``<species_name>.inject_from_embedded_boundary`` (`0` or `1`, default `0` ; whether to inject from the embedded boundary or from a user-specified plane.
+      * ``<species_name>.inject_from_embedded_boundary`` (``0`` or ``1``, default ``0`` ; whether to inject from the embedded boundary or from a user-specified plane.
         When injecting from the embedded boundary, the momentum distribution specified by the user along ``z`` (see e.g. ``uz_m``, ``uz_th`` below) is interpreted
         as the momentum distribution along the local normal to the embedded boundary.)
 
-      * ``<species_name>.surface_flux_pos`` (only used when injecting from a plane, `double`, location of the injection plane [meter])
+      * ``<species_name>.surface_flux_pos`` (only used when injecting from a plane, ``double``, location of the injection plane [meter])
 
-      * ``<species_name>.flux_normal_axis`` (only used when injecting from a plane, `x`, `y`, or `z` for 3D, `x` or `z` for 2D, or `r`, `t`, or `z` for RZ, or `r` for RCYLINDER and RSPHERE. When `flux_normal_axis` is `r` or `t`, the `x` and `y` components of the user-specified momentum distribution are interpreted as the `r` and `t` components respectively)
+      * ``<species_name>.flux_normal_axis`` (only used when injecting from a plane, ``x``, ``y``, or ``z`` for 3D, ``x`` or ``z`` for 2D, or ``r``, ``t``, or ``z`` for RZ, or ``r`` for RCYLINDER and RSPHERE. When ``flux_normal_axis`` is ``r`` or ``t``, the ``x`` and ``y`` components of the user-specified momentum distribution are interpreted as the ``r`` and ``t`` components respectively)
 
-      * ``<species_name>.flux_direction`` (only used when injecting from a plane, `-1` or `+1`, direction of flux relative to the plane)
+      * ``<species_name>.flux_direction`` (only used when injecting from a plane, ``-1`` or ``+1``, direction of flux relative to the plane)
 
-      * ``<species_name>.num_particles_per_cell`` (`double`)
+      * ``<species_name>.num_particles_per_cell`` (``double``)
 
-      * ``<species_name>.flux_tmin`` (`double`, Optional time at which the flux will be turned on. Ignored when negative.)
+      * ``<species_name>.flux_tmin`` (``double``, Optional time at which the flux will be turned on. Ignored when negative.)
 
-      * ``<species_name>.flux_tmax`` (`double`, Optional time at which the flux will be turned off. Ignored when negative.)
+      * ``<species_name>.flux_tmax`` (``double``, Optional time at which the flux will be turned off. Ignored when negative.)
 
     * ``none``: Do not inject macro-particles (for example, in a simulation that starts with neutral, ionizable atoms, one may want to create the electrons species -- where ionized electrons can be stored later on -- without injecting electron macro-particles).
 
 .. pp:param:: <species_name>.num_particles_per_cell_each_dim
-    :type: `3 integers in 3D, RZ, RSPHERE, 2 integers in 2D and RCYLINDER`
+    :type: ``3 integers in 3D, RZ, RSPHERE, 2 integers in 2D and RCYLINDER``
 
     With the NUniformPerCell injection style, this specifies the number of particles along each axis
     within a cell. For RZ, the three axis are radius, theta, and z and that the recommended
@@ -1527,16 +1527,16 @@ Particle initialization
     For RSPHERE, the three axis are radius, theta, and phi, and for RCYLINDER, the two axis are radius and theta.
 
 .. pp:param:: <species_name>.random_theta
-    :type: `bool`
-    :default: `1`
+    :type: ``bool``
+    :default: ``1``
     :optional:
 
     When using RZ or RCYLINDER geometry, whether to randomize the azimuthal position of particles.
     This is used when ``<species_name>.injection_style = NUniformPerCell``.
 
 .. pp:param:: <species_name>.do_splitting
-    :type: `bool`
-    :default: `0`
+    :type: ``bool``
+    :default: ``0``
     :optional:
 
     Split particles of the species when crossing the boundary from a lower
@@ -1545,21 +1545,21 @@ Particle initialization
     Currently implemented on CPU only.
 
 .. pp:param:: <species_name>.do_continuous_injection
-    :type: `0` or `1`
+    :type: ``0`` or ``1``
 
     Whether to inject particles during the simulation, and not only at
     initialization. This can be required with a moving window and/or when
     running in a boosted frame.
 
 .. pp:param:: <species_name>.initialize_self_fields
-    :type: `0` or `1`
+    :type: ``0`` or ``1``
 
     Whether to calculate the space-charge fields associated with this species
     at the beginning of the simulation.
     The fields are calculated for the mean gamma of the species.
 
 .. pp:param:: <species_name>.self_fields_required_precision
-    :type: `float`
+    :type: ``float``
     :default: 1.e-11
 
     The relative precision with which the initial space-charge fields should
@@ -1570,7 +1570,7 @@ Particle initialization
     relaxed precision requirement through ``self_fields_required_precision``.
 
 .. pp:param:: <species_name>.self_fields_absolute_tolerance
-    :type: `float`
+    :type: ``float``
     :default: 0.0
 
     The absolute tolerance with which the space-charge fields should be
@@ -1583,7 +1583,7 @@ Particle initialization
     value.
 
 .. pp:param:: <species_name>.self_fields_max_iters
-    :type: `integer`
+    :type: ``integer``
     :default: 200
 
     Maximum number of iterations used for MLMG solver for initial space-charge
@@ -1591,7 +1591,7 @@ Particle initialization
     ``self_fields_required_precision``, this parameter may be increased.
 
 .. pp:param:: <species_name>.profile
-    :type: `string`
+    :type: ``string``
 
     Density profile for this species. The options are:
 
@@ -1622,7 +1622,7 @@ Particle initialization
       openPMD data are loaded and cached as needed.
 
 .. pp:param:: <species_name>.flux_profile
-    :type: `string`
+    :type: ``string``
 
     Defines the expression of the flux, when using ``<species_name>.injection_style=NFluxPerCell``
 
@@ -1634,22 +1634,22 @@ Particle initialization
       mathematical expression for the flux of the species.
 
 .. pp:param:: <species_name>.density_min
-    :type: `float`
-    :default: `0.`
+    :type: ``float``
+    :default: ``0.``
     :optional:
 
     Minimum plasma density. No particle is injected where the density is below this value.
 
 .. pp:param:: <species_name>.density_max
-    :type: `float`
-    :default: `infinity`
+    :type: ``float``
+    :default: ``infinity``
     :optional:
 
-    Maximum plasma density. The density at each point is the minimum between the value given in the profile, and `density_max`.
+    Maximum plasma density. The density at each point is the minimum between the value given in the profile, and ``density_max``.
 
 .. pp:param:: <species_name>.radial_numpercell_power
-    :type: `float`
-    :default: `0`
+    :type: ``float``
+    :default: ``0``
     :optional:
 
     With cylindrical and spherical geometry, specifies the radial power scaling of the number of particles per cell.
@@ -1661,9 +1661,9 @@ Particle initialization
     The particle weights are set accordingly depending on the power and on the specified density profile.
 
 .. pp:param:: <species_name>.momentum_distribution_type
-    :type: `string`
+    :type: ``string``
 
-    Distribution of the normalized momentum (`u=p/mc`) for this species. The options are:
+    Distribution of the normalized momentum (``u=p/mc``) for this species. The options are:
 
     * ``at_rest``: Particles are initialized with zero momentum.
 
@@ -1760,7 +1760,7 @@ Particle initialization
       * ``<species_name>.momentum_function_uz_th(x,y,z)``: standard deviation of :math:`u_{z}`
 
 .. pp:param:: <species_name>.theta_distribution_type
-    :type: `string`
+    :type: ``string``
     :default: ``constant``
     :optional:
 
@@ -1772,7 +1772,7 @@ Particle initialization
     * If ``parser``, use a spatially-dependent analytic parser function, given by the required parameter ``<species_name>.theta_function(x,y,z)``.
 
 .. pp:param:: <species_name>.beta_distribution_type
-    :type: `string`
+    :type: ``string``
     :default: ``constant``
     :optional:
 
@@ -1784,14 +1784,14 @@ Particle initialization
     * If ``parser``, use a spatially-dependent analytic parser function, given by the required parameter ``<species_name>.beta_function(x,y,z)``.
 
 .. pp:param:: <species_name>.zinject_plane
-    :type: `float`
+    :type: ``float``
 
     Only read if  ``<species_name>`` is in :pp:param:`particles.rigid_injected_species`.
     Injection plane when using the rigid injection method.
     See :pp:param:`particles.rigid_injected_species` above.
 
 .. pp:param:: <species_name>.rigid_advance
-    :type: `string` or `bool`
+    :type: ``string`` or ``bool``
     :default: ``vzbar``
 
     Only read if ``<species_name>`` is in :pp:param:`particles.rigid_injected_species`.
@@ -1805,46 +1805,46 @@ Particle initialization
     * ``v``: each particle's velocity :math:`{\bf v}`, including transverse components
 
 .. pp:param:: <species_name>.do_backward_propagation
-    :type: `bool`
+    :type: ``bool``
 
     Inject a backward-propagating beam to reduce the effect of charge-separation
     fields when running in the boosted frame. See examples.
 
 .. pp:param:: <species_name>.split_type
-    :type: `int`
-    :default: `0`
+    :type: ``int``
+    :default: ``0``
     :optional:
 
-    Splitting technique. When `0`, particles are split along the simulation
-    axes (4 particles in 2D, 6 particles in 3D). When `1`, particles are split
+    Splitting technique. When ``0``, particles are split along the simulation
+    axes (4 particles in 2D, 6 particles in 3D). When ``1``, particles are split
     along the diagonals (4 particles in 2D, 8 particles in 3D).
 
 .. pp:param:: <species_name>.do_not_deposit
-    :type: `0` or `1`
-    :default: `0`
+    :type: ``0`` or ``1``
+    :default: ``0``
     :optional:
 
-    If `1` is given, both charge deposition and current deposition will
+    If ``1`` is given, both charge deposition and current deposition will
     not be done, thus that species does not contribute to the fields.
 
 .. pp:param:: <species_name>.do_not_gather
-    :type: `0` or `1`
-    :default: `0`
+    :type: ``0`` or ``1``
+    :default: ``0``
     :optional:
 
-    If `1` is given, field gather from grids will not be done,
+    If ``1`` is given, field gather from grids will not be done,
     thus that species will not be affected by the field on grids.
 
 .. pp:param:: <species_name>.do_not_push
-    :type: `0` or `1`
-    :default: `0`
+    :type: ``0`` or ``1``
+    :default: ``0``
     :optional:
 
-    If `1` is given, this species will not be pushed
+    If ``1`` is given, this species will not be pushed
     by any pusher during the simulation.
 
 .. pp:param:: <species_name>.addIntegerAttributes
-    :type: list of `string`
+    :type: list of ``string``
 
     User-defined integer particle attribute for species, ``species_name``.
     These integer attributes will be initialized with user-defined functions
@@ -1852,7 +1852,7 @@ Particle initialization
     If the user-defined integer attribute is ``<int_attrib_name>`` then the
     following required parameter must be specified to initialize the attribute.
 
-    * ``<species_name>.attribute.<int_attrib_name>(x,y,z,ux,uy,uz,t)`` (`string`)
+    * ``<species_name>.attribute.<int_attrib_name>(x,y,z,ux,uy,uz,t)`` (``string``)
         ``t`` represents the physical time in seconds during the simulation.
         ``x``, ``y``, ``z`` represent particle positions in the unit of meter.
         ``ux``, ``uy``, ``uz`` represent the particle momenta in the unit of
@@ -1866,7 +1866,7 @@ Particle initialization
         are assigned a value of ``1``.
 
 .. pp:param:: <species_name>.addRealAttributes
-    :type: list of `string`
+    :type: list of ``string``
 
     User-defined real particle attribute for species, ``species_name``.
     These real attributes will be initialized with user-defined functions
@@ -1874,7 +1874,7 @@ Particle initialization
     If the user-defined real attribute is ``<real_attrib_name>`` then the
     following required parameter must be specified to initialize the attribute.
 
-    * ``<species_name>.attribute.<real_attrib_name>(x,y,z,ux,uy,uz,t)`` (`string`)
+    * ``<species_name>.attribute.<real_attrib_name>(x,y,z,ux,uy,uz,t)`` (``string``)
         ``t`` represents the physical time in seconds during the simulation.
         ``x``, ``y``, ``z`` represent particle positions in the unit of meter.
         ``ux``, ``uy``, ``uz`` represent the particle momenta in the unit of
@@ -1893,14 +1893,14 @@ Particle initialization
         <species_name>.save_particles_at_yhi
         <species_name>.save_particles_at_zhi
         <species_name>.save_particles_at_eb
-    :type: `0` or `1`
-    :default: `0`
+    :type: ``0`` or ``1``
+    :default: ``0``
     :optional:
 
-    If `1` particles of this species will be copied to the scraped particle
+    If ``1`` particles of this species will be copied to the scraped particle
     buffer for the specified boundary if they leave the simulation domain in
     the specified direction. **If USE_EB=TRUE** the ``save_particles_at_eb``
-    flag can be set to `1` to also save particle data for the particles of this
+    flag can be set to ``1`` to also save particle data for the particles of this
     species that impact the embedded boundary.
     The scraped particle buffer can be used to track particle fluxes out of the
     simulation.
@@ -1923,15 +1923,15 @@ Particle initialization
        call ``clear_buffer()``.
 
 .. pp:param:: <species_name>.do_field_ionization
-    :type: `0` or `1`
-    :default: `0`
+    :type: ``0`` or ``1``
+    :default: ``0``
     :optional:
 
     Do field ionization for this species (using the ADK theory).
 
 .. pp:param:: <species_name>.do_adk_correction
-    :type: `0` or `1`
-    :default: `0`
+    :type: ``0`` or ``1``
+    :default: ``0``
     :optional:
 
     Whether to apply the correction to the ADK theory proposed by Zhang, Lan and Lu in `Q. Zhang et al. (Phys. Rev. A 90, 043410, 2014) <https://doi.org/10.1103/PhysRevA.90.043410>`__.
@@ -1939,34 +1939,34 @@ Particle initialization
     Currently, this is only implemented for Hydrogen, although Argon is also available in the same reference.
 
 .. pp:param:: <species_name>.physical_element
-    :type: `string`
+    :type: ``string``
 
-    Only read if `do_field_ionization = 1`. Symbol of chemical element for
+    Only read if ``do_field_ionization = 1``. Symbol of chemical element for
     this species. Example: for Helium, use ``physical_element = He``.
     All the elements up to atomic number Z=100 (Fermium) are supported.
 
 .. pp:param:: <species_name>.ionization_product_species
-    :type: `string`
+    :type: ``string``
 
-    Only read if `do_field_ionization = 1`. Name of species in which ionized
+    Only read if ``do_field_ionization = 1``. Name of species in which ionized
     electrons are stored. This species must be created as a regular species
     in the input file (in particular, it must be in :pp:param:`particles.species_names`).
 
 .. pp:param:: <species_name>.ionization_initial_level
-    :type: `int`
-    :default: `0`
+    :type: ``int``
+    :default: ``0``
     :optional:
 
-    Only read if `do_field_ionization = 1`. Initial ionization level of the
+    Only read if ``do_field_ionization = 1``. Initial ionization level of the
     species (must be smaller than the atomic number of chemical element given
-    in `physical_element`).
+    in ``physical_element``).
 
 .. pp:param:: <species_name>.do_resampling
-    :type: `0` or `1`
-    :default: `0`
+    :type: ``0`` or ``1``
+    :default: ``0``
     :optional:
 
-    If `1` resampling is performed for this species. This means that the number of macroparticles
+    If ``1`` resampling is performed for this species. This means that the number of macroparticles
     will be reduced at specific timesteps while preserving the distribution function as much as
     possible (details depend on the chosen resampling algorithm).
     This can be useful in situations with continuous creation of particles (e.g. with ionization
@@ -1974,8 +1974,8 @@ Particle initialization
     perform resampling.
 
 .. pp:param:: <species_name>.resampling_algorithm
-    :type: `string`
-    :default: `leveling_thinning`
+    :type: ``string``
+    :default: ``leveling_thinning``
     :optional:
 
     The algorithm used for resampling:
@@ -1983,7 +1983,7 @@ Particle initialization
     * ``leveling_thinning`` This algorithm is defined in :cite:t:`param-MuravievCPC2021`.
       It has one parameter:
 
-        * ``<species_name>.resampling_algorithm_target_ratio`` (`float`) optional (default `1.5`)
+        * ``<species_name>.resampling_algorithm_target_ratio`` (``float``) optional (default ``1.5``)
             This **roughly** corresponds to the ratio between the number of particles before and
             after resampling.
 
@@ -1991,44 +1991,44 @@ Particle initialization
       cells and merged, similar to the approach described in :cite:t:`param-Vranic2015`.
       It has three parameters:
 
-        * ``<species_name>.resampling_algorithm_delta_ur`` (`float`)
+        * ``<species_name>.resampling_algorithm_delta_ur`` (``float``)
             The width of momentum cells used in clustering particles, in m/s.
 
-        * ``<species_name>.resampling_algorithm_n_theta`` (`int`)
+        * ``<species_name>.resampling_algorithm_n_theta`` (``int``)
             The number of cell divisions to use in the :math:`\theta` direction
             when clustering the particle velocities.
 
-        * ``<species_name>.resampling_algorithm_n_phi`` (`int`)
+        * ``<species_name>.resampling_algorithm_n_phi`` (``int``)
             The number of cell divisions to use in the :math:`\phi` direction
             when clustering the particle velocities.
 
 .. pp:param:: <species_name>.resampling_min_ppc
-    :type: `int`
-    :default: `1`
+    :type: ``int``
+    :default: ``1``
     :optional:
 
     Resampling is not performed in cells with a number of macroparticles strictly smaller
     than this parameter.
 
 .. pp:param:: <species_name>.resampling_trigger_intervals
-    :type: `string`
-    :default: `0`
+    :type: ``string``
+    :default: ``0``
     :optional:
 
     Using the `Time intervals`_ syntax, this string defines timesteps at which resampling is
     performed.
 
 .. pp:param:: <species_name>.resampling_trigger_max_avg_ppc
-    :type: `float`
-    :default: `infinity`
+    :type: ``float``
+    :default: ``infinity``
     :optional:
 
     Resampling is performed every time the number of macroparticles per cell of the species
     averaged over the whole simulation domain exceeds this parameter.
 
 .. pp:param:: <species_name>.do_temperature_deposition
-    :type: `boolean`
-    :default: `false`
+    :type: ``boolean``
+    :default: ``false``
     :optional:
 
     When running with Ohm's Law Hybrid Solver, this will enable temperature deposition
@@ -2036,8 +2036,8 @@ Particle initialization
     This is required when using the electron energy solver with electron-ion temperature relaxation.
 
 .. pp:param:: <species>.do_qed_virtual_photons
-    :type: `boolean`
-    :default: `false`
+    :type: ``boolean``
+    :default: ``false``
     :optional:
 
     Create a population of virtual photons associated with ``<species>``.
@@ -2049,11 +2049,11 @@ Particle initialization
     The momentum of the virtual photons is parallel to that of the parent particle.
     This feature also requires the following input parameters:
 
-      * ``<species>.qed_virtual_photon_species_name`` (`string`) name of the virtual photon species associated with the current lepton species.
+      * ``<species>.qed_virtual_photon_species_name`` (``string``) name of the virtual photon species associated with the current lepton species.
 
-      * ``<virtual_photon_species>.qed_virtual_photons_min_energy`` (`float`, in Joules) minimum energy of the virtual photons
+      * ``<virtual_photon_species>.qed_virtual_photons_min_energy`` (``float``, in Joules) minimum energy of the virtual photons
 
-      * ``<virtual_photon_species>.qed_virtual_photons_multiplier`` (`int`), sampling factor for the virtual photons.
+      * ``<virtual_photon_species>.qed_virtual_photons_multiplier`` (``int``), sampling factor for the virtual photons.
         A sampling factor of ``f`` means that the number of virtual photons is multiplied by ``f``, while their weights are divided by ``f``.
 
     The virtual photons can undergo collisions via the linear Breit-Wheeler or linear Compton processes.
@@ -2062,8 +2062,8 @@ Particle initialization
     It requires WarpX to be compiled with ``WarpX_QED=ON`` (CMake) or ``QED=TRUE`` (GNU Make).
 
 .. pp:param:: <species>.qed_virtual_photons_do_beam_size_effect
-    :type: `boolean`
-    :default: `false`
+    :type: ``boolean``
+    :default: ``false``
     :optional:
 
     Applies the beam size effect on the virtual photons.
@@ -2077,11 +2077,11 @@ Cold Relativistic Fluid initialization
 --------------------------------------
 
 .. pp:param:: fluids.species_names
-    :type: `strings`, separated by spaces
+    :type: ``strings``, separated by spaces
 
     Defines the names of each fluid species. It is a required input to create and evolve fluid species using the cold relativistic fluid equations.
     Most of the parameters described in the section "Particle initialization" can also be used to initialize fluid properties (e.g. initial density distribution).
-    For fluid-specific inputs we use `<fluid_species_name>` as a placeholder. Also see external fields
+    For fluid-specific inputs we use ``<fluid_species_name>`` as a placeholder. Also see external fields
     for how to specify these for fluids as the function names differ.
 
 .. _running-cpp-parameters-laser:
@@ -2090,14 +2090,14 @@ Laser initialization
 --------------------
 
 .. pp:param:: lasers.names
-    :type: list of `string`
+    :type: list of ``string``
 
     Name of each laser. This is then used in the rest of the input deck ;
-    in this documentation we use `<laser_name>` as a placeholder. The parameters below
+    in this documentation we use ``<laser_name>`` as a placeholder. The parameters below
     must be provided for each laser pulse.
 
 .. pp:param:: <laser_name>.position
-    :type: `3 floats in 3D and 2D`
+    :type: ``3 floats in 3D and 2D``
     :unit: meters
 
     The coordinates of one of the point of the antenna that will emit the laser.
@@ -2120,7 +2120,7 @@ Laser initialization
     in this case, the laser antenna will be moving, in the boosted frame.
 
 .. pp:param:: <laser_name>.polarization
-    :type: `3 floats in 3D and 2D`
+    :type: ``3 floats in 3D and 2D``
 
     The coordinates of a vector that points in the direction of polarization of
     the laser. The norm of this vector is unimportant, only its direction matters.
@@ -2130,7 +2130,7 @@ Laser initialization
         the polarization can be orthogonal to the plane of the simulation).
 
 .. pp:param:: <laser_name>.direction
-    :type: `3 floats in 3D`
+    :type: ``3 floats in 3D``
 
     The coordinates of a vector that points in the propagation direction of
     the laser. The norm of this vector is unimportant, only its direction matters.
@@ -2143,7 +2143,7 @@ Laser initialization
         be parallel to :pp:param:`warpx.boost_direction`, for now.
 
 .. pp:param:: <laser_name>.e_max
-    :type: `float`
+    :type: ``float``
     :unit: V/m
 
     Peak amplitude of the laser field, in the focal plane.
@@ -2160,7 +2160,7 @@ Laser initialization
     perform the conversion to the boosted frame.
 
 .. pp:param:: <laser_name>.a0
-    :type: `float`
+    :type: ``float``
     :comment: dimensionless
 
     Peak normalized amplitude of the laser field, in the focal plane (given in the lab frame, just as ``e_max`` above).
@@ -2168,7 +2168,7 @@ Laser initialization
     Either ``a0`` or ``e_max`` must be specified.
 
 .. pp:param:: <laser_name>.wavelength
-    :type: `float`
+    :type: ``float``
     :unit: meters
 
     The wavelength of the laser in vacuum.
@@ -2178,7 +2178,7 @@ Laser initialization
     to automatically perform the conversion to the boosted frame.
 
 .. pp:param:: <laser_name>.profile
-    :type: `string`
+    :type: ``string``
 
     The spatio-temporal shape of the laser. The options that are currently
     implemented are:
@@ -2197,13 +2197,13 @@ Laser initialization
       function, they still have to be specified as they are used for numerical purposes.
     - ``"from_file"``: the electric field of the laser is read from an external file. Currently both
       the `lasy <https://lasydoc.readthedocs.io/en/latest/>`_ format as well as a custom binary format are supported. It requires to provide
-      the name of the file to load setting the additional parameter ``<laser_name>.binary_file_name`` or ``<laser_name>.lasy_file_name`` (`string`).
-      It accepts an optional parameter ``<laser_name>.time_chunk_size`` (`int`), supported for both lasy and binary files;
+      the name of the file to load setting the additional parameter ``<laser_name>.binary_file_name`` or ``<laser_name>.lasy_file_name`` (``string``).
+      It accepts an optional parameter ``<laser_name>.time_chunk_size`` (``int``), supported for both lasy and binary files;
       this allows to read only time_chunk_size timesteps from the file. New timesteps are read as soon as they are needed.
 
       The default value is automatically set to the number of timesteps contained in the file
       (i.e. only one read is performed at the beginning of the simulation).
-      It also accepts the optional parameter ``<laser_name>.delay`` (`float`; in seconds), which allows
+      It also accepts the optional parameter ``<laser_name>.delay`` (``float``; in seconds), which allows
       delaying (``delay > 0``) or anticipating (``delay < 0``) the laser by the specified amount of time.
 
       Details about the usage of the lasy format: lasy can produce either 3D Cartesian files or RZ files.
@@ -2232,7 +2232,7 @@ Laser initialization
       A binary file can be generated from Python, see an example at ``Examples/Tests/laser_injection_from_file``
 
 .. pp:param:: <laser_name>.profile_t_peak
-    :type: `float`
+    :type: ``float``
     :unit: seconds
 
     The time at which the laser reaches its peak intensity, at the position
@@ -2243,7 +2243,7 @@ Laser initialization
     to automatically perform the conversion to the boosted frame.
 
 .. pp:param:: <laser_name>.profile_duration
-    :type: `float`
+    :type: ``float``
     :unit: seconds
 
     The duration of the laser pulse for the ``"gaussian"`` profile, defined as :math:`\tau` below:
@@ -2261,7 +2261,7 @@ Laser initialization
     to automatically perform the conversion to the boosted frame.
 
 .. pp:param:: <laser_name>.profile_waist
-    :type: `float`
+    :type: ``float``
     :unit: meters
 
     The waist of the transverse Gaussian :math:`w_0`, i.e. defined such that the electric field of the
@@ -2272,7 +2272,7 @@ Laser initialization
         E(\boldsymbol{x},t) \propto \exp\left( -\frac{\boldsymbol{x}_\perp^2}{w_0^2} \right)
 
 .. pp:param:: <laser_name>.profile_focal_distance
-    :type: `float`
+    :type: ``float``
     :unit: meters
 
     The distance from ``laser_position`` to the focal plane.
@@ -2285,44 +2285,44 @@ Laser initialization
     to automatically perform the conversion to the boosted frame.
 
 .. pp:param:: <laser_name>.phi0
-    :type: `float`
+    :type: ``float``
     :unit: radians
-    :default: `0.`
+    :default: ``0.``
     :optional:
 
     The Carrier Envelope Phase, i.e. the phase of the laser oscillation, at the
     position where the laser envelope is maximum (only used for the ``"gaussian"`` profile)
 
 .. pp:param:: <laser_name>.stc_direction
-    :type: `3 floats`
-    :default: `1. 0. 0.`
+    :type: ``3 floats``
+    :default: ``1. 0. 0.``
     :optional:
 
     Direction of laser spatio-temporal couplings.
     See definition in :cite:t:`param-AkturkOE2004`.
 
 .. pp:param:: <laser_name>.zeta
-    :type: `float`
+    :type: ``float``
     :unit: meters.seconds
-    :default: `0.`
+    :default: ``0.``
     :optional:
 
     Spatial chirp at focus in direction :pp:param:`<laser_name>.stc_direction`. See definition in
     :cite:t:`param-AkturkOE2004`.
 
 .. pp:param:: <laser_name>.beta
-    :type: `float`
+    :type: ``float``
     :unit: seconds
-    :default: `0.`
+    :default: ``0.``
     :optional:
 
     Angular dispersion (or angular chirp) at focus in direction :pp:param:`<laser_name>.stc_direction`.
     See definition in :cite:t:`param-AkturkOE2004`.
 
 .. pp:param:: <laser_name>.phi2
-    :type: `float`
+    :type: ``float``
     :unit: seconds**2
-    :default: `0.`
+    :default: ``0.``
     :optional:
 
     The amount of temporal chirp :math:`\phi^{(2)}` at focus (in the lab frame). Namely, a wave packet
@@ -2346,8 +2346,8 @@ Laser initialization
     See also the definition in :cite:t:`param-AkturkOE2004`.
 
 .. pp:param:: <laser_name>.do_continuous_injection
-    :type: `0` or `1`
-    :default: `0`
+    :type: ``0`` or ``1``
+    :default: ``0``
     :optional:
 
     Whether or not to use continuous injection.
@@ -2356,13 +2356,13 @@ Laser initialization
     frame), use this so that the laser antenna is injected when it reaches
     the box boundary. If running in a boosted frame, this requires the
     boost direction, moving window direction and laser propagation direction
-    to be along `z`. If not running in a boosted frame, this requires the
-    moving window and laser propagation directions to be the same (`x`, `y`
-    or `z`)
+    to be along ``z``. If not running in a boosted frame, this requires the
+    moving window and laser propagation directions to be the same (``x``, ``y``
+    or ``z``)
 
 .. pp:param:: <laser_name>.min_particles_per_mode
-    :type: `int`
-    :default: `4`
+    :type: ``int``
+    :default: ``4``
     :optional:
 
     When using the RZ version, this specifies the minimum number of particles
@@ -2370,8 +2370,8 @@ Laser initialization
     the number of spokes given by min_particles_per_mode*(warpx.n_rz_azimuthal_modes-1).
 
 .. pp:param:: lasers.deposit_on_main_grid
-    :type: `int`
-    :default: `0`
+    :type: ``int``
+    :default: ``0``
     :optional:
 
     When using mesh refinement, whether the antenna that emits the laser
@@ -2379,32 +2379,32 @@ Laser initialization
     on the higher mesh-refinement levels.
 
 .. pp:param:: warpx.num_mirrors
-    :type: `int`
-    :default: `0`
+    :type: ``int``
+    :default: ``0``
     :optional:
 
     Users can input perfect mirror condition inside the simulation domain.
     The number of mirrors is given by :pp:param:`warpx.num_mirrors`. The mirrors are
-    orthogonal to the `z` direction. The following parameters are required
+    orthogonal to the ``z`` direction. The following parameters are required
     when :pp:param:`warpx.num_mirrors` is >0.
 
 .. pp:param:: warpx.mirror_z
-    :type: list of `float`
+    :type: list of ``float``
     :comment: required if ``warpx.num_mirrors>0``
 
     ``z`` location of the front of the mirrors.
 
 .. pp:param:: warpx.mirror_z_width
-    :type: list of `float`
+    :type: list of ``float``
     :comment: required if ``warpx.num_mirrors>0``
 
     ``z`` width of the mirrors.
 
 .. pp:param:: warpx.mirror_z_npoints
-    :type: list of `int`
+    :type: list of ``int``
     :comment: required if ``warpx.num_mirrors>0``
 
-    In the boosted frame, depending on `gamma_boost`, :pp:param:`warpx.mirror_z_width`
+    In the boosted frame, depending on ``gamma_boost``, :pp:param:`warpx.mirror_z_width`
     can be smaller than the cell size, so that the mirror would not work. This
     parameter is the minimum number of points for the mirror. If
     ``mirror_z_width < dz/cell_size``, the upper bound of the mirror is increased
@@ -2441,10 +2441,10 @@ are applied to the grid directly. In particular, these fields can be seen in the
     magnetic field for each of the three components on the grid.
     Constants required in the expression can be set using ``my_constants``.
     For example, if ``warpx.Bx_external_grid_function(x,y,z)=Bo*x + delta*(y + z)``
-    then the constants `Bo` and `delta` required in the above equation
+    then the constants ``Bo`` and ``delta`` required in the above equation
     can be set using ``my_constants.Bo=`` and ``my_constants.delta=`` in the
     input file. For a two-dimensional simulation, it is assumed that the first dimension
-    is `x` and the second dimension is `z`, and the value of `y` is set to zero.
+    is ``x`` and the second dimension is ``z``, and the value of ``y`` is set to zero.
     Note that the current implementation of the parser for external B-field
     does not work with RZ and the code will abort with an error message.
 
@@ -2476,11 +2476,11 @@ are applied to the grid directly. In particular, these fields can be seen in the
     electric field for each of the three components on the grid.
     Constants required in the expression can be set using ``my_constants``.
     For example, if ``warpx.Ex_external_grid_function(x,y,z)=Eo*x + delta*(y + z)``
-    then the constants `Bo` and `delta` required in the above equation
+    then the constants ``Bo`` and ``delta`` required in the above equation
     can be set using ``my_constants.Eo=`` and ``my_constants.delta=`` in the
     input file. For a two-dimensional simulation, it is assumed that the first
-    dimension is `x` and the second dimension is `z`,
-    and the value of `y` is set to zero.
+    dimension is ``x`` and the second dimension is ``z``,
+    and the value of ``y`` is set to zero.
     Note that the current implementation of the parser for external E-field
     does not work with RZ and the code will abort with an error message.
 
@@ -2499,7 +2499,7 @@ are applied to the grid directly. In particular, these fields can be seen in the
     :link_aliases:
         warpx.E_external_grid
         warpx.B_external_grid
-    :type: list of `3 floats`
+    :type: list of ``3 floats``
 
     required when ``warpx.E_ext_grid_init_style="constant"``
     and when ``warpx.B_ext_grid_init_style="constant"``, respectively.
@@ -2702,7 +2702,7 @@ Accelerator Lattice
 ^^^^^^^^^^^^^^^^^^^
 
 Several accelerator lattice elements can be defined as described below.
-The elements are defined relative to the `z` axis and in the lab frame, starting at `z = 0`.
+The elements are defined relative to the ``z`` axis and in the lab frame, starting at ``z = 0``.
 They are described using a simplified MAD like syntax.
 Note that elements of the same type cannot overlap each other.
 
@@ -2731,7 +2731,7 @@ Note that elements of the same type cannot overlap each other.
             * ``<element_name>.ds`` (``float``, in meters) the segment length
 
         * ``quad`` for a hard edged quadrupole.
-          This applies a quadrupole field that is uniform within the `z` extent of the element with a sharp cut off at the ends.
+          This applies a quadrupole field that is uniform within the ``z`` extent of the element with a sharp cut off at the ends.
           This uses residence corrections, with the field scaled by the amount of time within the element for particles entering
           or leaving it, to increase the accuracy.
           This requires these additional parameters:
@@ -2739,13 +2739,13 @@ Note that elements of the same type cannot overlap each other.
             * ``<element_name>.ds`` (``float``, in meters) the segment length
 
             * ``<element_name>.dEdx`` (``float``, in volts/meter^2) optional (default: 0.) the electric quadrupole field gradient
-              The field applied to the particles will be `Ex = dEdx*x` and `Ey = -dEdx*y`.
+              The field applied to the particles will be ``Ex = dEdx*x`` and ``Ey = -dEdx*y``.
 
             * ``<element_name>.dBdx`` (``float``, in Tesla/meter) optional (default: 0.) the magnetic quadrupole field gradient
-              The field applied to the particles will be `Bx = dBdx*y` and `By = dBdx*x`.
+              The field applied to the particles will be ``Bx = dBdx*y`` and ``By = dBdx*x``.
 
         * ``plasmalens`` for a field modeling a plasma lens
-          This applies a radially directed plasma lens field that is uniform within the `z` extent of the element with
+          This applies a radially directed plasma lens field that is uniform within the ``z`` extent of the element with
           a sharp cut off at the ends.
           This uses residence corrections, with the field scaled by the amount of time within the element for particles entering
           or leaving it, to increase the accuracy.
@@ -2754,10 +2754,10 @@ Note that elements of the same type cannot overlap each other.
             * ``<element_name>.ds`` (``float``, in meters) the segment length
 
             * ``<element_name>.dEdx`` (``float``, in volts/meter^2) optional (default: 0.) the electric field gradient
-              The field applied to the particles will be `Ex = dEdx*x` and `Ey = dEdx*y`.
+              The field applied to the particles will be ``Ex = dEdx*x`` and ``Ey = dEdx*y``.
 
             * ``<element_name>.dBdx`` (``float``, in Tesla/meter) optional (default: 0.) the magnetic field gradient
-              The field applied to the particles will be `Bx = dBdx*y` and `By = -dBdx*x`.
+              The field applied to the particles will be ``Bx = dBdx*y`` and ``By = -dBdx*x``.
 
         * ``line`` a sub-lattice (line) of elements to append to the lattice.
 
@@ -2777,14 +2777,14 @@ WarpX provides several particle collision models, using varying degrees of appro
 Details about the collision models can be found in the :ref:`theory section <multiphysics-collisions>`.
 
 .. pp:param:: collisions.collision_names
-    :type: `strings`, separated by spaces
+    :type: ``strings``, separated by spaces
 
     The name of each collision type.
     This is then used in the rest of the input deck;
     in this documentation we use ``<collision_name>`` as a placeholder.
 
 .. pp:param:: <collision_name>.type
-    :type: `string`
+    :type: ``string``
     :optional:
 
     The type of collision. The types implemented are:
@@ -2828,7 +2828,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
       of a single electron in a strong electromagnetic field.
 
 .. pp:param:: <collision_name>.species
-    :type: `strings`
+    :type: ``strings``
 
     If using ``dsmc``, ``pairwisecoulomb``, ``nuclearfusion``, or ``bremsstrahlung``, this should be the name(s) of the species,
     between which the collision will be considered. (Provide only one name for intra-species collisions.)
@@ -2841,7 +2841,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
 
 
 .. pp:param:: <collision_name>.product_species
-    :type: `strings`
+    :type: ``strings``
 
     Only for ``dsmc``, ``linear_breit_wheeler``, ``nuclearfusion``, and ``bremsstrahlung``.
     The name(s) of the species in which to add the new macroparticles created by the reaction.
@@ -2852,7 +2852,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
     If using ``linear_compton``, these should be two species: first, a photon species, and second, a lepton species, in this exact order.
 
 .. pp:param:: <collision_name>.ndt_supercycle
-    :type: `int`
+    :type: ``int``
     :optional:
 
     Execute collision once every ``ndt_supercycle`` PIC time steps.
@@ -2860,7 +2860,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
     Must be >= 1. Mutually exclusive with ``ndt_subcycle``. Default is 1.
 
 .. pp:param:: <collision_name>.ndt_subcycle
-    :type: `int`
+    :type: ``int``
     :optional:
 
     Execute collision ``ndt_subcycle`` times per PIC time step.
@@ -2869,7 +2869,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
     Useful when a large PIC time step is desired but collisions require finer time resolution.
 
 .. pp:param:: <collision_name>.CoulombLog
-    :type: `float`
+    :type: ``float``
     :optional:
 
     Only for ``pairwisecoulomb``. A provided fixed Coulomb logarithm of the
@@ -2884,7 +2884,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
     :cite:t:`param-PerezPOP2012`.
 
 .. pp:param:: <collision_name>.use_global_debye_length
-    :type: `bool`
+    :type: ``bool``
     :optional:
 
     Only for ``pairwisecoulomb``. When set, the Debye length used in the Coulomb log
@@ -2894,7 +2894,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
     is specified, this Debye length is not used.
 
 .. pp:param:: <collision_name>.event_multiplier
-    :type: `float`
+    :type: ``float``
     :optional:
 
     Only for ``nuclearfusion``, ``linear_breit_wheeler``, and ``linear_compton``.
@@ -2909,7 +2909,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
     The default value of ``event_multiplier`` is 1.
 
 .. pp:param:: <collision_name>.probability_threshold
-    :type: `float`
+    :type: ``float``
     :optional:
 
     Only for ``nuclearfusion``, ``linear_breit_wheeler``, and ``linear_compton``.
@@ -2921,7 +2921,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
     which WarpX reduces the event multiplier.
 
 .. pp:param:: <collision_name>.probability_target_value
-    :type: `float`
+    :type: ``float``
     :optional:
 
     Only for ``nuclearfusion``, ``linear_breit_wheeler``, and ``linear_compton``.
@@ -2930,7 +2930,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
     that collisions such that the probability approches ``probability_target_value``.
 
 .. pp:param:: <collision_name>.scattering_angle_model
-    :type: `string`
+    :type: ``string``
     :default: ``isotropic``
     :optional:
 
@@ -2940,7 +2940,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
     With ``forward``, the scattering angle is set to zero, i.e. the products are emitted in the same direction as the reactant.
 
 .. pp:param:: <collision_name>.background_density
-    :type: `float`
+    :type: ``float``
 
     Only for ``background_mcc`` and ``background_stopping``. The density of the background in :math:`m^{-3}`.
     Can also provide ``<collision_name>.background_density(x,y,z,t)`` using the parser
@@ -2949,14 +2949,14 @@ Details about the collision models can be found in the :ref:`theory section <mul
     must also be provided to calculate the maximum collision probability.
 
 .. pp:param:: <collision_name>.background_temperature
-    :type: `float`
+    :type: ``float``
 
     Only for ``background_mcc`` and ``background_stopping``. The temperature of the background in Kelvin.
     Can also provide ``<collision_name>.background_temperature(x,y,z,t)`` using the parser
     initialization style for spatially and temporally varying temperature.
 
 .. pp:param:: <collision_name>.background_mass
-    :type: `float`
+    :type: ``float``
     :optional:
 
     Only for ``background_mcc`` and ``background_stopping``. The mass of the background gas in kg.
@@ -2966,13 +2966,13 @@ Details about the collision models can be found in the :ref:`theory section <mul
     ``background_type`` set to ``ions``, the mass must be given.
 
 .. pp:param:: <collision_name>.background_charge_state
-    :type: `float`
+    :type: ``float``
 
     Only for ``background_stopping``, where it is required when ``background_type`` is set to ``ions``.
     This specifies the charge state of the background ions.
 
 .. pp:param:: <collision_name>.background_type
-    :type: `string`
+    :type: ``string``
 
     Only for ``background_stopping``, where it is required, the type of the background.
     The possible values are ``electrons`` and ``ions``. When ``electrons``, equation 14.12 from Goldston and Rutherford is used.
@@ -3003,7 +3003,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
     where :math:`\beta` is the term on the r.h.s except :math:`W_b`.
 
 .. pp:param:: <collision_name>.scattering_processes
-    :type: `strings` separated by spaces
+    :type: ``strings`` separated by spaces
 
     Only for ``dsmc`` and ``background_mcc``. The scattering processes that should be
     included. Available options are ``elastic``, ``excitationX``, ``forward``, ``back``, ``twoproduct_reaction`` and ``charge_exchange``
@@ -3015,7 +3015,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
     ``<scattering_process>`` as a placeholder going forward.
 
 .. pp:param:: <collision_name>.<scattering_process>_cross_section
-    :type: `string`
+    :type: ``string``
 
     Only for ``dsmc`` and ``background_mcc``. Path to the file containing cross-section data
     for the given scattering processes. The cross-section file must have exactly
@@ -3024,50 +3024,50 @@ Details about the collision models can be found in the :ref:`theory section <mul
     represent the kinetic energy of the colliding particles in the center-of-mass frame.
 
 .. pp:param:: <collision_name>.<scattering_process>_energy
-    :type: `float`
+    :type: ``float``
 
     Only for ``dsmc`` and ``background_mcc``. If the scattering process is either
     ``excitationX``, ``ionization`` or ``twoproduct_reaction``, the energy cost of that process must be given in eV.
 
 .. pp:param:: <collision_name>.ionization_species
-    :type: `float`
+    :type: ``float``
 
     Only for ``background_mcc``. If the scattering process is ``ionization`` the
     produced species must also be given. For example if argon properties is used
     for the background gas, a species of argon ions should be specified here.
 
 .. pp:param:: <collision_name>.ionization_target_species
-    :type: `string`
+    :type: ``string``
 
     Only for ``dsmc`` with impact ionization. This specifies which one of the
     colliding particles is ionized.
 
 .. pp:param:: <collision_name>.Z
-    :type: `integer`
+    :type: ``integer``
 
     Only for ``bremsstrahlung``. The atomic number of the target ion species.
     Currently, only the values 1, 2, 5, 6 are supported.
 
 .. pp:param:: <collision_name>.multiplier
-    :type: `float`
+    :type: ``float``
 
     Only for ``bremsstrahlung``. Multiplier for the collision probability.
     Any resulting photons will have the electron weight divided the multiplier.
     The default is 1. This must be greater than or equal to 1.
 
 .. pp:param:: <collision_name>.create_photons
-    :type: `integer`
+    :type: ``integer``
 
     Only for ``bremsstrahlung``. Whether photons will be created, defaults to 1 (true).
 
 .. pp:param:: <collision_name>.koT1_cut
-    :type: `float`
+    :type: ``float``
 
     Only for ``bremsstrahlung``. Minimum energy of the photons created.
     This is relative to the electron energy, defaulting to 1.e-4.
 
 .. pp:param:: collisions.correct_energy_momentum
-    :type: `bool`
+    :type: ``bool``
     :default: 0
     :optional:
 
@@ -3078,7 +3078,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
     This uses the algorithm described in https://doi.org/10.1016/j.jcp.2025.113927.
 
 .. pp:param:: collisions.energy_fraction
-    :type: `float`
+    :type: ``float``
     :default: 0.05
     :optional:
 
@@ -3086,7 +3086,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
     This parameter is the fraction of the relative energy in the COM frame that is used in the correction.
 
 .. pp:param:: collisions.energy_fraction_max
-    :type: `float`
+    :type: ``float``
     :default: 0.5
     :optional:
 
@@ -3094,7 +3094,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
     This parameter is the fraction of the total relative energy in the COM frame of all pairs that is used in the correction.
 
 .. pp:param:: collisions.beta_weight_exponent
-    :type: `float`
+    :type: ``float``
     :default: 1.
     :optional:
 
@@ -3112,25 +3112,25 @@ Details about the collision models can be found in the :ref:`theory section <mul
     formulation is intrinsically energy-conserving when combined with MCC collisions, as shown in `Angus et al., J. Comput. Phys. 456, 2022 <https://doi.org/10.1016/j.jcp.2022.111030>`__.
 
 .. pp:param:: <collision_name>.correct_energy_momentum
-    :type: `bool`
+    :type: ``bool``
     :optional:
 
     For pairwisecoulomb collisions, override the parameter :pp:param:`collisions.correct_energy_momentum` for the specific collision.
 
 .. pp:param:: <collision_name>.energy_fraction
-    :type: `float`
+    :type: ``float``
     :optional:
 
     For pairwisecoulomb collisions, override the parameter :pp:param:`collisions.energy_fraction` for the specific collision.
 
 .. pp:param:: <collision_name>.energy_fraction_max
-    :type: `float`
+    :type: ``float``
     :optional:
 
     For pairwisecoulomb collisions, override the parameter :pp:param:`collisions.energy_fraction_max` for the specific collision.
 
 .. pp:param:: <collision_name>.beta_weight_exponent
-    :type: `float`
+    :type: ``float``
     :optional:
 
     For pairwisecoulomb collisions, override the parameter :pp:param:`collisions.beta_weight_exponent` for the specific collision.
@@ -3146,19 +3146,19 @@ Time step
 ^^^^^^^^^
 
 .. pp:param:: warpx.cfl
-    :type: `float`
-    :default: `0.999`
+    :type: ``float``
+    :default: ``0.999``
     :optional:
 
     The ratio between the actual timestep that is used in the simulation
-    and the Courant-Friedrichs-Lewy (CFL) limit. (e.g. for `warpx.cfl=1`,
+    and the Courant-Friedrichs-Lewy (CFL) limit. (e.g. for ``warpx.cfl=1``,
     the timestep will be exactly equal to the CFL limit.)
-    For some speed v and grid spacing dx, this limits the timestep to `warpx.cfl * dx / v`.
-    When used with the electromagnetic solver, `v` is the speed of light.
-    For the electrostatic solver, `v` is the maximum speed among all particles in the domain.
+    For some speed v and grid spacing dx, this limits the timestep to ``warpx.cfl * dx / v``.
+    When used with the electromagnetic solver, ``v`` is the speed of light.
+    For the electrostatic solver, ``v`` is the maximum speed among all particles in the domain.
 
 .. pp:param:: warpx.const_dt
-    :type: `float`
+    :type: ``float``
 
     Allows direct specification of the time step size, in units of seconds.
     When the electrostatic solver is being used, this must be supplied if not using adaptive timestepping.
@@ -3166,15 +3166,15 @@ Time step
     it is up to the user to ensure that the CFL condition is met.
 
 .. pp:param:: warpx.dt_update_interval
-    :type: `string`
-    :default: `-1`
+    :type: ``string``
+    :default: ``-1``
     :optional:
 
     How many iterations pass between timestep adaptations when using the electrostatic solver.
-    Must be greater than `0` to use adaptive timestepping, or else :pp:param:`warpx.const_dt` must be specified.
+    Must be greater than ``0`` to use adaptive timestepping, or else :pp:param:`warpx.const_dt` must be specified.
 
 .. pp:param:: warpx.max_dt
-    :type: `float`
+    :type: ``float``
     :optional:
 
     The maximum timestep permitted for the electrostatic solver, when using adaptive timestepping.
@@ -3184,7 +3184,7 @@ Filtering
 ^^^^^^^^^
 
 .. pp:param:: warpx.use_filter
-    :type: `0` or `1`
+    :type: ``0`` or ``1``
 
     Whether to use filtering in the simulation.
     With the explicit evolve scheme, the filtering is turned on by default, except for RZ FDTD.
@@ -3199,16 +3199,16 @@ Filtering
        Known bug: filter currently not working with FDTD solver in RZ geometry (see https://github.com/BLAST-WarpX/warpx/issues/1943).
 
 .. pp:param:: warpx.filter_npass_each_dir
-    :type: `3 int`
-    :default: `1 1 1`
+    :type: ``3 int``
+    :default: ``1 1 1``
     :optional:
 
     Number of passes along each direction for the bilinear filter.
     In 2D simulations, only the first two values are read.
 
 .. pp:param:: warpx.use_filter_compensation
-    :type: `0` or `1`
-    :default: `0`
+    :type: ``0`` or ``1``
+    :default: ``0``
 
     Whether to add compensation when applying filtering.
     This is only supported with the RZ spectral solver.
@@ -3217,7 +3217,7 @@ Particle push, charge and current deposition, field gathering
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. pp:param:: algo.current_deposition
-    :type: `string`
+    :type: ``string``
     :optional:
 
     This parameter selects the algorithm for the deposition of the current density.
@@ -3254,7 +3254,7 @@ Particle push, charge and current deposition, field gathering
        decomposition with local FFTs over guard cells is planned but not yet completed.
 
 .. pp:param:: algo.charge_deposition
-    :type: `string`
+    :type: ``string``
     :optional:
 
     The algorithm for the charge density deposition. Available options are:
@@ -3263,7 +3263,7 @@ Particle push, charge and current deposition, field gathering
        the :ref:`particle-in-cell theory section <theory-pic>`.
 
 .. pp:param:: algo.field_gathering
-    :type: `string`
+    :type: ``string``
     :optional:
 
     The algorithm for field gathering. Available options are:
@@ -3277,7 +3277,7 @@ Particle push, charge and current deposition, field gathering
     Default: ``algo.field_gathering = energy-conserving`` with collocated or staggered grids (note that ``energy-conserving`` and ``momentum-conserving`` are equivalent with collocated grids), ``algo.field_gathering = momentum-conserving`` with hybrid grids.
 
 .. pp:param:: algo.particle_pusher
-    :type: `string`
+    :type: ``string``
     :optional:
 
     The algorithm for the particle pusher. Available options are:
@@ -3289,17 +3289,17 @@ Particle push, charge and current deposition, field gathering
     If :pp:param:`algo.particle_pusher` is not specified, ``boris`` is the default.
 
 .. pp:param:: algo.particle_shape
-    :type: `integer`; `1`, `2`, `3`, or `4`
+    :type: ``integer``; ``1``, ``2``, ``3``, or ``4``
 
-    The order of the shape factors (splines) for the macro-particles along all spatial directions: `1` for linear, `2` for quadratic, `3` for cubic, `4` for quartic.
+    The order of the shape factors (splines) for the macro-particles along all spatial directions: ``1`` for linear, ``2`` for quadratic, ``3`` for cubic, ``4`` for quartic.
     Low-order shape factors result in faster simulations, but may lead to more noisy results.
     High-order shape factors are computationally more expensive, but may increase the overall accuracy of the results. For production runs it is generally safer to use high-order shape factors, such as cubic order.
 
     Note that this input parameter is not optional and must always be set in all input files provided that there is at least one particle species (set in input as :pp:param:`particles.species_names`) or one laser species (set in input as :pp:param:`lasers.names`) in the simulation. No default value is provided automatically.
 
 .. pp:param:: particles.max_grid_crossings
-    :type: `integer`
-    :default: `1`
+    :type: ``integer``
+    :default: ``1``
     :optional:
 
     Maximum number of grid crossings the particles can do per time step.
@@ -3311,7 +3311,7 @@ Maxwell solver
 Two families of Maxwell solvers are implemented in WarpX, based on the Finite-Difference Time-Domain method (FDTD) or the Pseudo-Spectral Analytical Time-Domain method (PSATD), respectively.
 
 .. pp:param:: algo.maxwell_solver
-    :type: `string`
+    :type: ``string``
     :optional:
 
     The algorithm for the Maxwell field solver.
@@ -3328,7 +3328,7 @@ Two families of Maxwell solvers are implemented in WarpX, based on the Finite-Di
     If :pp:param:`algo.maxwell_solver` is not specified, ``yee`` is the default.
 
 .. pp:param:: algo.em_solver_medium
-    :type: `string`
+    :type: ``string``
     :optional:
 
     The medium for evaluating the Maxwell solver. Available options are :
@@ -3346,8 +3346,8 @@ Maxwell solver: PSATD method
         psatd.nox
         psatd.noy
         psatd.noz
-    :type: `integer`
-    :default: `16` for all
+    :type: ``integer``
+    :default: ``16`` for all
     :optional:
 
     The order of accuracy of the spatial derivatives, when using the code compiled with a PSATD solver.
@@ -3358,7 +3358,7 @@ Maxwell solver: PSATD method
         psatd.nx_guard
         psatd.ny_guard
         psatd.nz_guard
-    :type: `integer`
+    :type: ``integer``
     :optional:
 
     The number of guard cells to use with PSATD solver.
@@ -3366,7 +3366,7 @@ Maxwell solver: PSATD method
     equal the order of the solver for collocated grids and half the order of the solver for staggered grids.
 
 .. pp:param:: psatd.periodic_single_box_fft
-    :type: `0` or `1`
+    :type: ``0`` or ``1``
     :default: 0
 
     If true, this will *not* incorporate the guard cells into the box over which FFTs are performed.
@@ -3376,8 +3376,8 @@ Maxwell solver: PSATD method
     (for problems with multiple boxes) become exact in the case of the periodic, single-box FFT without guard cells.
 
 .. pp:param:: psatd.current_correction
-    :type: `0` or `1`
-    :default: `1`, with the exceptions mentioned below
+    :type: ``0`` or ``1``
+    :default: ``1``, with the exceptions mentioned below
 
     If true, a current correction scheme in Fourier space is applied in order to guarantee charge conservation.
     The default value is ``psatd.current_correction=1``, unless a charge-conserving current deposition scheme is used (by setting ``algo.current_deposition=esirkepov`` or ``algo.current_deposition=vay``) or unless the ``div(E)`` cleaning scheme is used (by setting ``warpx.do_dive_cleaning=1``).
@@ -3401,7 +3401,7 @@ Maxwell solver: PSATD method
     This option is currently implemented only for the standard PSATD, Galilean PSATD, and averaged Galilean PSATD schemes, while it is not yet available for the PSATD JRhom algorithm.
 
 .. pp:param:: psatd.update_with_rho
-    :type: `0` or `1`
+    :type: ``0`` or ``1``
 
     If true, the update equation for the electric field is expressed in terms of both the current density and the charge density, namely :math:`\widehat{\boldsymbol{J}}^{\,n+1/2}`, :math:`\widehat\rho^{n}`, and :math:`\widehat\rho^{n+1}`.
     If false, instead, the update equation for the electric field is expressed in terms of the current density :math:`\widehat{\boldsymbol{J}}^{\,n+1/2}` only.
@@ -3474,7 +3474,7 @@ Maxwell solver: PSATD method
     Note that the update with and without rho is also supported in RZ geometry.
 
 .. pp:param:: psatd.v_galilean
-    :type: `3 floats`
+    :type: ``3 floats``
     :unit: units of the speed of light
     :default: ``0. 0. 0.``
 
@@ -3484,8 +3484,8 @@ Maxwell solver: PSATD method
     It also requires the use of the direct current deposition algorithm (by setting ``algo.current_deposition = direct``).
 
 .. pp:param:: psatd.use_default_v_galilean
-    :type: `0` or `1`
-    :default: `0`
+    :type: ``0`` or ``1``
+    :default: ``0``
 
     This can be used in boosted-frame simulations only and sets the Galilean velocity along the :math:`z` direction automatically as :math:`v_{G} = -\sqrt{1-1/\gamma^2}`, where :math:`\gamma` is the Lorentz factor of the boosted frame (set by :pp:param:`warpx.gamma_boost`).
     See the section :ref:`Numerical Stability and alternate formulation in a Galilean frame <theory-boostedframe-galilean>` for more information on the Galilean algorithm for boosted-frame simulations.
@@ -3499,7 +3499,7 @@ Maxwell solver: PSATD method
     A non-zero comoving velocity selects the comoving PSATD algorithm, which suppresses the numerical Cherenkov instability (NCI) in boosted-frame simulations, under certain assumptions. This option requires that WarpX is compiled with ``USE_FFT = TRUE``. It also requires the use of direct current deposition (``algo.current_deposition = direct``) and has neither been implemented nor tested with other current deposition schemes.
 
 .. pp:param:: psatd.do_time_averaging
-    :type: `0` or `1`
+    :type: ``0`` or ``1``
     :default: 0
 
     Whether to use an averaged Galilean PSATD algorithm or standard Galilean PSATD.
@@ -3521,7 +3521,7 @@ Maxwell solver: macroscopic media
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. pp:param:: algo.macroscopic_sigma_method
-    :type: `string`
+    :type: ``string``
     :optional:
 
     The algorithm for updating electric field when :pp:param:`algo.em_solver_medium` is macroscopic. Available options are:
@@ -3536,7 +3536,7 @@ Maxwell solver: macroscopic media
         macroscopic.sigma_function(x,y,z)
         macroscopic.epsilon_function(x,y,z)
         macroscopic.mu_function(x,y,z)
-    :type: `string`
+    :type: ``string``
 
     To initialize spatially varying conductivity, permittivity, and permeability, respectively,
     using a mathematical function in the input. Constants required in the
@@ -3548,7 +3548,7 @@ Maxwell solver: macroscopic media
         macroscopic.sigma
         macroscopic.epsilon
         macroscopic.mu
-    :type: `double`
+    :type: ``double``
 
     To initialize a constant conductivity, permittivity, and permeability of the
     computational medium, respectively. The default values are the corresponding values
@@ -3568,7 +3568,7 @@ Maxwell solver: kinetic-fluid hybrid
 
     **Best Practices**
 
-    - *Grid type:* Setting `warpx.grid_type = collocated` is recommended
+    - *Grid type:* Setting ``warpx.grid_type = collocated`` is recommended
     - *Particle shape:* Linear particles (``algo.particle_shape = 1``) are recommended based on :cite:t:`param-Stanier2020`.
 
 .. warning::
@@ -3581,19 +3581,19 @@ Maxwell solver: kinetic-fluid hybrid
     - *Time-dependent A fields:* When using expressions for external vector potentials, time variation must be specified via ``A_time_external_function(t)``, not directly in the ``A[x,y,z]_external_grid_function(x,y,z)`` expressions.
 
 .. pp:param:: hybrid_pic_model.elec_temp
-    :type: `float`
+    :type: ``float``
 
     If :pp:param:`algo.maxwell_solver` is set to ``hybrid``, this sets the electron temperature, in eV, used to calculate
     the electron pressure (see :ref:`here <theory-hybrid-model-elec-temp>`).
 
 .. pp:param:: hybrid_pic_model.n0_ref
-    :type: `float`
+    :type: ``float``
 
     If :pp:param:`algo.maxwell_solver` is set to ``hybrid``, this sets the reference density, in :math:`m^{-3}`, used to calculate
     the electron pressure (see :ref:`here <theory-hybrid-model-elec-temp>`).
 
 .. pp:param:: hybrid_pic_model.gamma
-    :type: `float`
+    :type: ``float``
     :default: ``5/3``
     :optional:
 
@@ -3601,91 +3601,91 @@ Maxwell solver: kinetic-fluid hybrid
     the electron pressure (see :ref:`here <theory-hybrid-model-elec-temp>`).
 
 .. pp:param:: hybrid_pic_model.plasma_resistivity(rho,J)
-    :type: `float` or `str`
+    :type: ``float`` or ``str``
     :default: ``0``
     :optional:
 
     If :pp:param:`algo.maxwell_solver` is set to ``hybrid``, this sets the plasma resistivity in :math:`\Omega m`.
 
 .. pp:param:: hybrid_pic_model.plasma_hyper_resistivity(rho,B)
-    :type: `float` or `str`
+    :type: ``float`` or ``str``
     :default: ``0``
     :optional:
 
     If :pp:param:`algo.maxwell_solver` is set to ``hybrid``, this sets the plasma hyper-resistivity in :math:`\Omega m^3`.
 
 .. pp:param:: hybrid_pic_model.J[x/y/z]_external_grid_function(x,y,z,t)
-    :type: `float` or `str`
+    :type: ``float`` or ``str``
     :default: ``0``
     :optional:
 
     If :pp:param:`algo.maxwell_solver` is set to ``hybrid``, this sets the external current (on the grid) in :math:`A/m^2`.
 
 .. pp:param:: hybrid_pic_model.n_floor
-    :type: `float`
+    :type: ``float``
     :default: ``1``
     :optional:
 
     If :pp:param:`algo.maxwell_solver` is set to ``hybrid``, this sets the plasma density floor, in :math:`m^{-3}`, which is useful since the generalized Ohm's law used to calculate the E-field includes a :math:`1/n` term.
 
 .. pp:param:: hybrid_pic_model.substeps
-    :type: `int`
+    :type: ``int``
     :default: ``10``
     :optional:
 
     If :pp:param:`algo.maxwell_solver` is set to ``hybrid``, this sets the number of sub-steps to take during the B-field update.
 
 .. pp:param:: hybrid_pic_model.holmstrom_vacuum_region
-    :type: `bool`
+    :type: ``bool``
     :default: ``false``
     :optional:
 
     If :pp:param:`algo.maxwell_solver` is set to ``hybrid``, this sets the vacuum region handling of the generalized Ohm's Law to suppress vacuum fluctuations. :cite:t:`param-holmstrom2013handlingvacuumregionshybrid`.
 
 .. pp:param:: hybrid_pic_model.add_external_fields
-    :type: `bool`
+    :type: ``bool``
     :default: ``false``
     :optional:
 
     If :pp:param:`algo.maxwell_solver` is set to ``hybrid``, this sets the hybrid solver to use split external fields defined in external_vector_potential inputs.
 
 .. pp:param:: external_vector_potential.do_diva_cleaning
-    :type: `bool`
+    :type: ``bool``
     :default: ``true``
     :optional:
 
     This enables or disables the divergence cleaner application to the external A fields.
 
 .. pp:param:: external_vector_potential.fields
-    :type: list of `str`
+    :type: list of ``str``
     :default: ``empty``
     :optional:
 
     If :pp:param:`hybrid_pic_model.add_external_fields` is set to ``true``, this adds a list of names for external time varying vector potentials to be added to hybrid solver.
 
 .. pp:param:: external_vector_potential.<field_name>.read_from_file
-    :type: `bool`
+    :type: ``bool``
     :default: ``false``
     :optional:
 
     If :pp:param:`hybrid_pic_model.add_external_fields` is set to ``true``, this flag determines whether to load an external field or use an implicit function to evaluate the time varying field.
 
 .. pp:param:: external_vector_potential.<field_name>.path
-    :type: `str`
+    :type: ``str``
     :default: ``""``
     :optional:
 
     If :pp:param:`external_vector_potential.<field_name>.read_from_file` is set to ``true``, sets the path to an OpenPMD file that can be loaded externally in :math:`weber/m`.
 
 .. pp:param:: external_vector_potential.<field_name>.A[x,y,z]_external_grid_function(x,y,z)
-    :type: `str`
+    :type: ``str``
     :default: ``"0"``
     :optional:
 
     If :pp:param:`external_vector_potential.<field_name>.read_from_file` is set to ``false``, Sets the external vector potential to be populated by an implicit function (on the grid) in :math:`weber/m`.
 
 .. pp:param:: external_vector_potential.<field_name>.A_time_external_grid_function(t)
-    :type: `str`
+    :type: ``str``
     :default: ``"1"``
     :optional:
 
@@ -3696,7 +3696,7 @@ Grid types (collocated, staggered, hybrid)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. pp:param:: warpx.grid_type
-    :type: `string`, ``collocated``, ``staggered`` or ``hybrid``
+    :type: ``string``, ``collocated``, ``staggered`` or ``hybrid``
 
     Whether to use a collocated grid (all fields defined at the cell nodes),
     a staggered grid (fields defined on a Yee grid), or a hybrid grid (fields
@@ -3708,7 +3708,7 @@ Grid types (collocated, staggered, hybrid)
     Default: ``warpx.grid_type = staggered``.
 
 .. pp:param:: interpolation.galerkin_scheme
-    :type: `0` or `1`
+    :type: ``0`` or ``1``
 
     Whether to use a Galerkin scheme when gathering fields to particles.
     When set to ``1``, the interpolation orders used for field-gathering are reduced for certain field components along certain directions.
@@ -3727,7 +3727,7 @@ Grid types (collocated, staggered, hybrid)
         warpx.field_centering_nox
         warpx.field_centering_noy
         warpx.field_centering_noz
-    :type: `integer`
+    :type: ``integer``
     :optional:
 
     The order of interpolation used with staggered or hybrid grids (``warpx.grid_type = staggered`` or ``warpx.grid_type = hybrid``) and momentum-conserving field gathering (``algo.field_gathering = momentum-conserving``) to interpolate the electric and magnetic fields from the cell centers to the cell nodes, before gathering the fields from the cell nodes to the particle positions.
@@ -3740,7 +3740,7 @@ Grid types (collocated, staggered, hybrid)
         warpx.current_centering_noy
         warpx.current_centering_noz
         warpx.current_centering_no<x,y,z>
-    :type: `integer`
+    :type: ``integer``
     :optional:
 
     The order of interpolation used with hybrid grids (``warpx.grid_type = hybrid``) to interpolate the currents from the cell nodes to the cell centers when ``warpx.do_current_centering = 1``, before pushing the Maxwell fields on staggered grids.
@@ -3748,7 +3748,7 @@ Grid types (collocated, staggered, hybrid)
     Default: ``warpx.current_centering_no<x,y,z> = 8`` with hybrid grids (typically necessary to ensure stability in boosted-frame simulations of relativistic plasmas and beams).
 
 .. pp:param:: warpx.do_current_centering
-    :type: `bool`, `0` or `1`
+    :type: ``bool``, ``0`` or ``1``
 
     If true, the current is deposited on a nodal grid and then centered to a staggered grid (Yee grid), using finite-order interpolation.
 
@@ -3758,7 +3758,7 @@ Additional parameters
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. pp:param:: warpx.do_dive_cleaning
-    :type: `0` or `1`
+    :type: ``0`` or ``1``
     :default: 0
 
     Whether to use modified Maxwell equations that progressively eliminate
@@ -3769,28 +3769,28 @@ Additional parameters
     domain, where it can be absorbed.
 
 .. pp:param:: warpx.do_initial_div_cleaning
-    :type: `0` or `1`
+    :type: ``0`` or ``1``
     :default: 0
 
     Whether to use projection method to scrub A/B field divergence in externally
     loaded fields. This is automatically turned on if external/initial B or time varying A fields are loaded.
 
 .. pp:param:: warpx.projection_div_cleaner.rtol
-    :type: `float`
-    :default: `5e-12` when double precision and `5e-5` for single precision
+    :type: ``float``
+    :default: ``5e-12`` when double precision and ``5e-5`` for single precision
     :optional:
 
     Controls the relative tolerance when solving for the projected divergence of the field in the MLMG AMReX solver.
 
 .. pp:param:: warpx.projection_div_cleaner.atol
-    :type: `float`
-    :default: `0`
+    :type: ``float``
+    :default: ``0``
     :optional:
 
     Controls the absolute tolerance when solving for the projected divergence of the field in the MLMG AMReX solver.
 
 .. pp:param:: warpx.do_subcycling
-    :type: `0` or `1`
+    :type: ``0`` or ``1``
     :default: 0
 
     Whether or not to use sub-cycling. Different refinement levels have a
@@ -3807,28 +3807,28 @@ Additional parameters
     https://ieeexplore.ieee.org/document/8659392.
 
 .. pp:param:: warpx.override_sync_intervals
-    :type: `string`
-    :default: `1`
+    :type: ``string``
+    :default: ``1``
     :optional:
 
     Using the `Time intervals`_ syntax, this string defines the timesteps at which
-    synchronization of sources (`rho` and `J`) and fields (`E` and `B`) on grid nodes at box
+    synchronization of sources (``rho`` and ``J``) and fields (``E`` and ``B``) on grid nodes at box
     boundaries is performed. Since the grid nodes at the interface between two neighbor boxes are
     duplicated in both boxes, an instability can occur if they have too different values.
     This option makes sure that they are synchronized periodically.
-    Note that if Perfectly Matched Layers (PML) are used, synchronization of the `E` and `B` fields
+    Note that if Perfectly Matched Layers (PML) are used, synchronization of the ``E`` and ``B`` fields
     is performed at every timestep regardless of this parameter.
 
 .. pp:param:: warpx.do_device_synchronize
-    :type: `bool`
-    :default: `1`
+    :type: ``bool``
+    :default: ``1``
     :optional:
 
     When running in an accelerated platform, whether to call a ``amrex::Gpu::synchronize()`` around profiling regions.
     This allows the profiler to give meaningful timers, but (hardly) slows down the simulation.
 
 .. pp:param:: warpx.sort_intervals
-    :type: `string`
+    :type: ``string``
     :default: s: ``-1`` on CPU; ``4`` on GPU
     :optional:
 
@@ -3838,7 +3838,7 @@ Additional parameters
     It is turned on on GPUs for performance reasons (to improve memory locality).
 
 .. pp:param:: warpx.sort_particles_for_deposition
-    :type: `bool`
+    :type: ``bool``
     :default: ``true`` for the CUDA backend, otherwise ``false``
     :optional:
 
@@ -3848,7 +3848,7 @@ Additional parameters
     ``true`` is recommend for best performance on NVIDIA GPUs, especially if there are many particles per cell.
 
 .. pp:param:: warpx.sort_idx_type
-    :type: list of `int`
+    :type: list of ``int``
     :default: ``0 0 0``
     :optional:
 
@@ -3860,7 +3860,7 @@ Additional parameters
     In 1D, only the first element is read.
 
 .. pp:param:: warpx.sort_bin_size
-    :type: list of `int`
+    :type: list of ``int``
     :default: ``1 1 1``
     :optional:
 
@@ -3868,8 +3868,8 @@ Additional parameters
     In 2D, only the first two elements are read.
 
 .. pp:param:: warpx.do_shared_mem_charge_deposition
-    :type: `bool`
-    :default: `false`
+    :type: ``bool``
+    :default: ``false``
     :optional:
 
     If activated, charge deposition will allocate and use small
@@ -3881,8 +3881,8 @@ Additional parameters
     space available for the temporary buffers.
 
 .. pp:param:: warpx.do_shared_mem_current_deposition
-    :type: `bool`
-    :default: `false`
+    :type: ``bool``
+    :default: ``false``
     :optional:
 
     If activated, current deposition will allocate and use small
@@ -3897,8 +3897,8 @@ Additional parameters
     and HIP, and is only recommended for 3D or 2D.
 
 .. pp:param:: warpx.shared_tilesize
-    :type: list of `int`
-    :default: `6 6 8` in 3D; `14 14` in 2D; `1s` otherwise
+    :type: list of ``int``
+    :default: ``6 6 8`` in 3D; ``14 14`` in 2D; ``1s`` otherwise
     :optional:
 
     Used to tune performance when ``do_shared_mem_current_deposition`` or
@@ -3913,8 +3913,8 @@ Additional parameters
     tuned for the problem.
 
 .. pp:param:: warpx.shared_mem_current_tpb
-    :type: `int`
-    :default: `128`
+    :type: ``int``
+    :default: ``128``
     :optional:
 
     Used to tune performance when ``do_shared_mem_current_deposition`` is
@@ -3964,22 +3964,22 @@ This should be changed in the future.
 In-situ capabilities can be used by turning on Sensei or Ascent (provided they are installed) through the output format, see below.
 
 .. pp:param:: diagnostics.enable
-    :type: `0` or `1`
-    :default: `1`
+    :type: ``0`` or ``1``
+    :default: ``1``
     :optional:
 
     Whether to enable or disable diagnostics. This flag overwrites all other diagnostics input parameters.
 
 .. pp:param:: diagnostics.diags_names
-    :type: list of `string`
-    :default: `empty`
+    :type: list of ``string``
+    :default: ``empty``
     :optional:
 
     Name of each diagnostics.
     example: ``diagnostics.diags_names = diag1 my_second_diag``.
 
 .. pp:param:: <diag_name>.intervals
-    :type: `string`
+    :type: ``string``
 
     Using the `Time intervals`_ syntax, this string defines the timesteps at which data is dumped.
     Use a negative number or 0 to disable data dumping.
@@ -3988,20 +3988,20 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     changed using the parameter :pp:param:`<diag_name>.dump_last_timestep` described below.
 
 .. pp:param:: <diag_name>.dump_last_timestep
-    :type: `bool`
-    :default: `1`
+    :type: ``bool``
+    :default: ``1``
     :optional:
 
-    If this is `1`, the last timestep is dumped regardless of :pp:param:`<diag_name>.intervals`.
+    If this is ``1``, the last timestep is dumped regardless of :pp:param:`<diag_name>.intervals`.
 
 .. pp:param:: <diag_name>.diag_type
-    :type: `string`
+    :type: ``string``
 
     Type of diagnostics. ``Full``, ``BackTransformed``, and ``BoundaryScraping``
     example: ``diag1.diag_type = Full`` or ``diag1.diag_type = BackTransformed``
 
 .. pp:param:: <diag_name>.format
-    :type: `string`
+    :type: ``string``
     :default: ``plotfile``
     :optional:
 
@@ -4021,13 +4021,13 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     example: ``diag1.format = openpmd``.
 
 .. pp:param:: <diag_name>.sensei_config
-    :type: `string`
+    :type: ``string``
 
     Only read if ``<diag_name>.format = sensei``.
     Points to the SENSEI XML file which selects and configures the desired back end.
 
 .. pp:param:: <diag_name>.sensei_pin_mesh
-    :type: `integer`
+    :type: ``integer``
     :default: 0
 
     Only read if ``<diag_name>.format = sensei``.
@@ -4054,7 +4054,7 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     Default: ``f`` (full diagnostics)
 
 .. pp:param:: <diag_name>.buffer_flush_limit_btd
-    :type: `integer`
+    :type: ``integer``
     :default: s to 5
     :optional:
     :comment: only read if ``<diag_name>.diag_type = BackTransformed``
@@ -4118,7 +4118,7 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
         <diag_name>.adios2_engine.parameters.BurstBufferPath="/mnt/bb/username"
 
 .. pp:param:: <diag_name>.fields_to_plot
-    :type: list of `strings`
+    :type: list of ``strings``
     :optional:
 
     Fields written to output.
@@ -4136,14 +4136,14 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     Otherwise, we reconstruct a 2D Cartesian slice of the fields for output at :math:`\theta=0`.
 
 .. pp:param:: <diag_name>.dump_rz_modes
-    :type: `0` or `1`
-    :default: `0`
+    :type: ``0`` or ``1``
+    :default: ``0``
     :optional:
 
     Whether to save all modes when in RZ.  When ``openpmd_backend = openpmd``, this parameter is ignored and all modes are saved.
 
 .. pp:param:: <diag_name>.particle_fields_to_plot
-    :type: list of `strings`
+    :type: list of ``strings``
     :optional:
 
     Names of per-cell diagnostics of particle properties to calculate and output as additional fields.
@@ -4153,7 +4153,7 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     Also, note that this option is only available for ``<diag_name>.diag_type = Full``
 
 .. pp:param:: <diag_name>.particle_fields_species
-    :type: list of `strings`
+    :type: list of ``strings``
     :optional:
 
     Species for which to calculate ``particle_fields_to_plot``.
@@ -4161,15 +4161,15 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     The default is a list of all of the available particle species.
 
 .. pp:param:: <diag_name>.particle_fields.<field_name>.do_average
-    :type: `0` or `1`
-    :default: `1`
+    :type: ``0`` or ``1``
+    :default: ``1``
     :optional:
 
     Whether the diagnostic is an average or a sum. With an average, the sum over the specified function is divided
     by the sum of the particle weights in each cell.
 
 .. pp:param:: <diag_name>.particle_fields.<field_name>(x,y,z,ux,uy,uz)
-   :type: parser `string`
+   :type: parser ``string``
 
    Parser function to be calculated for each particle per cell. The averaged field written is
 
@@ -4178,12 +4178,12 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
       \texttt{<field_name>_<species_name>} = \frac{\sum_{i=1}^N w_i \, f(x_i,y_i,z_i,u_{x,i},u_{y,i},u_{z,i})}{\sum_{i=1}^N w_i}
 
    where :math:`w_i` is the particle weight, :math:`f()` is the parser function, and :math:`(x_i,y_i,z_i)` are particle positions in units of a meter. The sums are over all particles of type ``<species_name>`` in a cell (ignoring the particle shape factor) that satisfy :pp:param:`<diag_name>.particle_fields.<field_name>.filter(x,y,z,ux,uy,uz)`.
-   When :pp:param:`<diag_name>.particle_fields.<field_name>.do_average` is `0`, the division by the sum over particle weights is not done.
+   When :pp:param:`<diag_name>.particle_fields.<field_name>.do_average` is ``0``, the division by the sum over particle weights is not done.
    In 1D or 2D, the particle coordinates will follow the WarpX convention. :math:`(u_{x,i},u_{y,i},u_{z,i})` are components of the particle four-momentum. :math:`u = \gamma v/c`, :math:`\gamma` is the Lorentz factor, :math:`v` is the particle velocity and :math:`c` is the speed of light.
    For photons, we use the standardized momentum :math:`u = p/(m_{e}c)`, where :math:`p` is the momentum of the photon and :math:`m_{e}` the mass of an electron.
 
 .. pp:param:: <diag_name>.particle_fields.<field_name>.filter(x,y,z,ux,uy,uz)
-    :type: parser `string`
+    :type: parser ``string``
     :optional:
 
     Parser function returning a boolean for whether to include a particle in the diagnostic.
@@ -4191,8 +4191,8 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     The function arguments are the same as above.
 
 .. pp:param:: <diag_name>.plot_raw_fields
-    :type: `0` or `1`
-    :default: `0`
+    :type: ``0`` or ``1``
+    :default: ``0``
     :optional:
 
     By default, the fields written in the plot files are averaged on the cell centers.
@@ -4203,8 +4203,8 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     in the yt documentation for more details on how to view raw fields.
 
 .. pp:param:: <diag_name>.plot_raw_fields_guards
-    :type: `0` or `1`
-    :default: `0`
+    :type: ``0`` or ``1``
+    :default: ``0``
     :optional:
 
     Only used when ``<diag_name>.plot_raw_fields = 1``.
@@ -4212,8 +4212,8 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     Only works with ``<diag_name>.format = plotfile``.
 
 .. pp:param:: <diag_name>.coarsening_ratio
-    :type: list of `int`
-    :default: `1 1 1`
+    :type: list of ``int``
+    :default: ``1 1 1``
     :optional:
 
     Reduce size of the selected diagnostic fields output by this ratio in each dimension.
@@ -4224,48 +4224,48 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     dimension must be a multiple of the ``coarsening_ratio`` multiplied by ``numprocs`` in that dimension.
 
 .. pp:param:: <diag_name>.file_prefix
-    :type: `string`
-    :default: `diags/<diag_name>`
+    :type: ``string``
+    :default: ``diags/<diag_name>``
     :optional:
 
     Root for output file names. Supports sub-directories.
 
 .. pp:param:: <diag_name>.file_min_digits
-    :type: `int`
-    :default: `6`
+    :type: ``int``
+    :default: ``6``
     :optional:
 
     The minimum number of digits used for the iteration number appended to the diagnostic file names.
 
 .. pp:param:: <diag_name>.diag_lo
-    :type: list `float`, 1 per dimension
-    :default: `-infinity -infinity -infinity`
+    :type: list ``float``, 1 per dimension
+    :default: ``-infinity -infinity -infinity``
     :optional:
 
     Lower corner of the output fields (if smaller than ``warpx.dom_lo``, then set to ``warpx.dom_lo``). Currently, when the ``diag_lo`` is different from ``warpx.dom_lo``, particle output is disabled.
 
 .. pp:param:: <diag_name>.diag_hi
-    :type: list `float`, 1 per dimension
-    :default: `+infinity +infinity +infinity`
+    :type: list ``float``, 1 per dimension
+    :default: ``+infinity +infinity +infinity``
     :optional:
 
     Higher corner of the output fields (if larger than ``warpx.dom_hi``, then set to ``warpx.dom_hi``). Currently, when the ``diag_hi`` is different from ``warpx.dom_hi``, particle output is disabled.
 
 .. pp:param:: <diag_name>.write_species
-    :type: `0` or `1`
-    :default: `1`
+    :type: ``0`` or ``1``
+    :default: ``1``
     :optional:
 
     Whether to write species output or not. For checkpoint format, always set this parameter to 1.
 
 .. pp:param:: <diag_name>.species
-    :type: list of `string`
+    :type: list of ``string``
     :default: all physical species in the simulation
 
     Which species dumped in this diagnostics.
 
 .. pp:param:: <diag_name>.<species_name>.variables
-    :type: list of `strings` separated by spaces
+    :type: list of ``strings`` separated by spaces
     :optional:
 
     List of particle quantities to write to output.
@@ -4288,38 +4288,38 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     Note that the fields gathered in the same way as during the simulation, and do not include any applied fields.
 
 .. pp:param:: <diag_name>.<species_name>.random_fraction
-    :type: `float`
+    :type: ``float``
     :optional:
 
-    If provided ``<diag_name>.<species_name>.random_fraction = a``, only `a` fraction of the particle data of this species will be dumped randomly in diag ``<diag_name>``, i.e. if `rand() < a`, this particle will be dumped, where `rand()` denotes a random number generator.
-    The value `a` provided should be between 0 and 1.
+    If provided ``<diag_name>.<species_name>.random_fraction = a``, only ``a`` fraction of the particle data of this species will be dumped randomly in diag ``<diag_name>``, i.e. if ``rand() < a``, this particle will be dumped, where ``rand()`` denotes a random number generator.
+    The value ``a`` provided should be between 0 and 1.
 
 .. pp:param:: <diag_name>.<species_name>.uniform_stride
-    :type: `int`
+    :type: ``int``
     :optional:
 
     If provided ``<diag_name>.<species_name>.uniform_stride = n``,
-    every `n` particle of this species will be dumped, selected uniformly.
+    every ``n`` particle of this species will be dumped, selected uniformly.
     The value provided should be an integer greater than or equal to 0.
 
 .. pp:param:: <diag_name>.<species_name>.plot_filter_function(t,x,y,z,ux,uy,uz)
-    :type: `string`
+    :type: ``string``
     :optional:
 
     Users can provide an expression returning a boolean for whether a particle is dumped.
-    `t` represents the physical time in seconds during the simulation.
-    `x, y, z` represent particle positions in the unit of meter.
-    `ux, uy, uz` represent particle momenta in the unit of
+    ``t`` represents the physical time in seconds during the simulation.
+    ``x, y, z`` represent particle positions in the unit of meter.
+    ``ux, uy, uz`` represent particle momenta in the unit of
     :math:`\gamma v/c`, where
     :math:`\gamma` is the Lorentz factor,
     :math:`v/c` is the particle velocity normalized by the speed of light.
-    E.g. If provided `(x>0.0)*(uz<10.0)` only those particles located at
-    positions `x` greater than `0`, and those having momentum `uz` less than 10,
+    E.g. If provided ``(x>0.0)*(uz<10.0)`` only those particles located at
+    positions ``x`` greater than ``0``, and those having momentum ``uz`` less than 10,
     will be dumped.
 
 .. pp:param:: amrex.async_out
-    :type: `0` or `1`
-    :default: `0`
+    :type: ``0`` or ``1``
+    :default: ``0``
     :optional:
 
     Enable asynchronous I/O for AMReX ``plotfile`` output.
@@ -4329,8 +4329,8 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     implementation and may be negligible on a workstation.
 
 .. pp:param:: amrex.async_out_nfiles
-    :type: `int`
-    :default: `64`
+    :type: ``int``
+    :default: ``64``
     :optional:
 
     Maximum number of files to use for asynchronous I/O (default: 64).
@@ -4342,15 +4342,15 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     :link_aliases:
         warpx.field_io_nfiles
         warpx.particle_io_nfiles
-    :type: `int`
-    :default: `1024`
+    :type: ``int``
+    :default: ``1024``
     :optional:
 
     The maximum number of files to use when writing field and particle data to plotfile directories.
 
 .. pp:param:: warpx.mffile_nstreams
-    :type: `int`
-    :default: `4`
+    :type: ``int``
+    :default: ``4``
     :optional:
 
     Limit the number of concurrent readers per file.
@@ -4372,8 +4372,8 @@ We support only field data and related options from the list at `Full Diagnostic
 In addition, ``TimeAveraged`` diagnostic options include:
 
 .. pp:param:: <diag_name>.time_average_mode
-    :type: `string`
-    :default: `none`
+    :type: ``string``
+    :default: ``none``
 
     Describes the operating mode for time averaged field output.
 
@@ -4389,14 +4389,14 @@ In addition, ``TimeAveraged`` diagnostic options include:
         please create additional instances of ``TimeAveraged`` diagnostics.
 
 .. pp:param:: <diag_name>.average_period_steps
-    :type: `int`
+    :type: ``int``
 
     Configures the number of time steps in an averaging period.
     Set this only in the ``dynamic_start`` mode and only if ``average_period_time`` has not already been set.
     Will be ignored in the ``fixed_start`` mode (with warning).
 
 .. pp:param:: <diag_name>.average_period_time
-    :type: `float`
+    :type: ``float``
     :unit: seconds
 
     Configures the time (SI units) in an averaging period.
@@ -4404,7 +4404,7 @@ In addition, ``TimeAveraged`` diagnostic options include:
     Will be ignored in the ``fixed_start`` mode (with warning).
 
 .. pp:param:: <diag_name>.average_start_step
-    :type: `int`
+    :type: ``int``
 
     Configures the time step at which time-averaging begins.
     Set this only in the ``fixed_start`` mode.
@@ -4422,7 +4422,7 @@ BackTransformed Diagnostics
     Additional options for this diagnostic include:
 
 .. pp:param:: <diag_name>.num_snapshots_lab
-    :type: `integer`
+    :type: ``integer``
 
     Only used when :pp:param:`<diag_name>.diag_type` is ``BackTransformed``.
     The number of lab-frame snapshots that will be written.
@@ -4430,7 +4430,7 @@ BackTransformed Diagnostics
     a run-time error occurs if the user attempts to set both ``num_snapshots_lab`` and ``intervals``.
 
 .. pp:param:: <diag_name>.intervals
-    :type: `string`
+    :type: ``string``
     :noindex:
 
     Only used when :pp:param:`<diag_name>.diag_type` is ``BackTransformed``.
@@ -4443,7 +4443,7 @@ BackTransformed Diagnostics
     a run-time error occurs if the user attempts to set both ``num_snapshots_lab`` and ``intervals``.
 
 .. pp:param:: <diag_name>.dt_snapshots_lab
-    :type: `float`
+    :type: ``float``
     :unit: seconds
 
     Only used when :pp:param:`<diag_name>.diag_type` is ``BackTransformed``.
@@ -4451,17 +4451,17 @@ BackTransformed Diagnostics
     time interval is expressed in the laboratory frame).
 
 .. pp:param:: <diag_name>.dz_snapshots_lab
-    :type: `float`
+    :type: ``float``
     :unit: meters
 
     Only used when :pp:param:`<diag_name>.diag_type` is ``BackTransformed``.
     Distance between the lab-frame snapshots (expressed in the laboratory
     frame). ``dt_snapshots_lab`` is then computed by
-    ``dt_snapshots_lab = dz_snapshots_lab/c``. Either `dt_snapshots_lab`
-    or `dz_snapshot_lab` is required.
+    ``dt_snapshots_lab = dz_snapshots_lab/c``. Either ``dt_snapshots_lab``
+    or ``dz_snapshot_lab`` is required.
 
 .. pp:param:: <diag_name>.buffer_size
-    :type: `integer`
+    :type: ``integer``
 
     Only used when :pp:param:`<diag_name>.diag_type` is ``BackTransformed``.
     The default size of the back transformed diagnostic buffers used to generate lab-frame
@@ -4477,8 +4477,8 @@ BackTransformed Diagnostics
     optimum I/O performance.
 
 .. pp:param:: <diag_name>.do_back_transformed_fields
-    :type: `0` or `1`
-    :default: `1`
+    :type: ``0`` or ``1``
+    :default: ``1``
     :optional:
 
     Only used when :pp:param:`<diag_name>.diag_type` is ``BackTransformed``
@@ -4487,8 +4487,8 @@ BackTransformed Diagnostics
     :pp:param:`<diag_name>.do_back_transformed_fields` or :pp:param:`<diag_name>.do_back_transformed_particles` must be 1.
 
 .. pp:param:: <diag_name>.do_back_transformed_particles
-    :type: `0` or `1`
-    :default: `1`
+    :type: ``0`` or ``1``
+    :default: ``1``
     :optional:
 
     Only used when :pp:param:`<diag_name>.diag_type` is ``BackTransformed``
@@ -4514,7 +4514,7 @@ This can be important if a large number of particles are lost, avoiding filling 
 
 In addition to their usual attributes, the saved particles have
    an integer attribute ``stepScraped``, which indicates the PIC iteration at which each particle was absorbed at the boundary,
-   a real attribute ``deltaTimeScraped``, which indicates the time between the time associated to `stepScraped`
+   a real attribute ``deltaTimeScraped``, which indicates the time between the time associated to ``stepScraped``
    and the exact time when each particle hits the boundary,
    a real attribute ``timeScraped``, which indicates the exact time when the paritcle hit the boundary,
    3 real attributes ``nx``, ``ny``, ``nz``, which represents the three components of the normal to the boundary on the point of contact of the particles (not saved if they reach non-EB boundaries)
@@ -4527,10 +4527,10 @@ Reduced Diagnostics
 ^^^^^^^^^^^^^^^^^^^
 
 ``ReducedDiags`` enable users to compute specific reduced quantities, such as particle temperature, energy histograms, or maximum field values, and efficiently save this in-situ analyzed data to files.
-This shifts analysis from post-processing to runtime calculation of reduction operations (average, maximum, ...) and can greatly save disk space when "raw" particle and field outputs from `FullDiagnostics` can be avoided in favor of single values, 1D or 2D data at possibly even higher time resolution.
+This shifts analysis from post-processing to runtime calculation of reduction operations (average, maximum, ...) and can greatly save disk space when "raw" particle and field outputs from ``FullDiagnostics`` can be avoided in favor of single values, 1D or 2D data at possibly even higher time resolution.
 
 .. pp:param:: warpx.reduced_diags_names
-    :type: `strings`, separated by spaces
+    :type: ``strings``, separated by spaces
 
     A list of user-given names for reduced diagnostics.
     By default, these names are also prefixing the names of output files.
@@ -4540,7 +4540,7 @@ This shifts analysis from post-processing to runtime calculation of reduction op
     in this documentation we use ``<reduced_diags_name>`` as a placeholder.
 
 .. pp:param:: <reduced_diags_name>.type
-    :type: `string`
+    :type: ``string``
 
     The type of reduced diagnostics associated with this ``<reduced_diags_name>``.
     For example, ``ParticleEnergy``, ``FieldEnergy``, etc.
@@ -4687,10 +4687,10 @@ This shifts analysis from post-processing to runtime calculation of reduction op
     * ``FieldReduction``
         This type computes an arbitrary reduction of the positions, the current density, and the electromagnetic fields.
 
-        * ``<reduced_diags_name>.reduced_function(x,y,z,Ex,Ey,Ez,Bx,By,Bz,jx,jy,jz)`` (`string`)
+        * ``<reduced_diags_name>.reduced_function(x,y,z,Ex,Ey,Ez,Bx,By,Bz,jx,jy,jz)`` (``string``)
             An analytic function to be reduced must be provided, using the math parser.
 
-        * ``<reduced_diags_name>.reduction_type`` (`string`)
+        * ``<reduced_diags_name>.reduction_type`` (``string``)
             The type of reduction to be performed. It must be either ``Maximum``, ``Minimum`` or
             ``Integral``.
             ``Integral`` computes the spatial integral of the function defined in the parser by
@@ -4792,28 +4792,28 @@ This shifts analysis from post-processing to runtime calculation of reduction op
         This type computes the load balance efficiency, given the present costs
         and distribution mapping. Load balance efficiency is computed as the
         mean cost over all ranks, divided by the maximum cost over all ranks.
-        Until costs are recorded, load balance efficiency is output as `-1`;
+        Until costs are recorded, load balance efficiency is output as ``-1``;
         at earliest, the load balance efficiency can be output starting at step
-        `2`, since costs are not recorded until step `1`.
+        ``2``, since costs are not recorded until step ``1``.
 
     * ``ParticleHistogram``
         This type computes a user defined particle histogram.
 
-        * ``<reduced_diags_name>.species`` (`string`)
+        * ``<reduced_diags_name>.species`` (``string``)
             A species name must be provided,
             such that the diagnostics are done for this species.
 
-        * ``<reduced_diags_name>.histogram_function(t,x,y,z,ux,uy,uz)`` (`string`)
+        * ``<reduced_diags_name>.histogram_function(t,x,y,z,ux,uy,uz)`` (``string``)
             A histogram function must be provided.
-            `t` represents the physical time in seconds during the simulation.
-            `x, y, z` represent particle positions in the unit of meter.
-            `ux, uy, uz` represent the particle momenta in the unit of
+            ``t`` represents the physical time in seconds during the simulation.
+            ``x, y, z`` represent particle positions in the unit of meter.
+            ``ux, uy, uz`` represent the particle momenta in the unit of
             :math:`\gamma v/c`, where
             :math:`\gamma` is the Lorentz factor,
             :math:`v/c` is the particle velocity normalized by the speed of light.
             E.g.
-            ``x`` produces the position (density) distribution in `x`.
-            ``ux`` produces the momentum distribution in `x`,
+            ``x`` produces the position (density) distribution in ``x``.
+            ``ux`` produces the momentum distribution in ``x``,
             ``sqrt(ux*ux+uy*uy+uz*uz)`` produces the speed distribution.
             The default value of the histogram without normalization is
             :math:`f = \sum\limits_{i=1}^N w_i`, where
@@ -4821,13 +4821,13 @@ This shifts analysis from post-processing to runtime calculation of reduction op
             in that bin,
             :math:`w_i` denotes the weight of the ith particle.
 
-        * ``<reduced_diags_name>.bin_number`` (`int` > 0)
+        * ``<reduced_diags_name>.bin_number`` (``int`` > 0)
             This is the number of bins used for the histogram.
 
-        * ``<reduced_diags_name>.bin_max`` (`float`)
+        * ``<reduced_diags_name>.bin_max`` (``float``)
             This is the maximum value of the bins.
 
-        * ``<reduced_diags_name>.bin_min`` (`float`)
+        * ``<reduced_diags_name>.bin_min`` (``float``)
             This is the minimum value of the bins.
 
         * ``<reduced_diags_name>.normalization`` (optional)
@@ -4851,17 +4851,17 @@ This shifts analysis from post-processing to runtime calculation of reduction op
             the macroparticle weight will be used to compute
             the histogram, and no normalization will be done.
 
-        * ``<reduced_diags_name>.filter_function(t,x,y,z,ux,uy,uz)`` (`string`) optional
+        * ``<reduced_diags_name>.filter_function(t,x,y,z,ux,uy,uz)`` (``string``) optional
             Users can provide an expression returning a boolean for whether a particle is taken
             into account when calculating the histogram.
-            `t` represents the physical time in seconds during the simulation.
-            `x, y, z` represent particle positions in the unit of meter.
-            `ux, uy, uz` represent particle momenta in the unit of
+            ``t`` represents the physical time in seconds during the simulation.
+            ``x, y, z`` represent particle positions in the unit of meter.
+            ``ux, uy, uz`` represent particle momenta in the unit of
             :math:`\gamma v/c`, where
             :math:`\gamma` is the Lorentz factor,
             :math:`v/c` is the particle velocity normalized by the speed of light.
-            E.g. If provided `(x>0.0)*(uz<10.0)` only those particles located at
-            positions `x` greater than `0`, and those having momentum `uz` less than 10,
+            E.g. If provided ``(x>0.0)*(uz<10.0)`` only those particles located at
+            positions ``x`` greater than ``0``, and those having momentum ``uz`` less than 10,
             will be taken into account when calculating the histogram.
 
         The output columns are
@@ -4873,58 +4873,58 @@ This shifts analysis from post-processing to runtime calculation of reduction op
     * ``ParticleHistogram2D``
         This type computes a user defined, 2D particle histogram.
 
-        * ``<reduced_diags_name>.species`` (`string`)
+        * ``<reduced_diags_name>.species`` (``string``)
             A species name must be provided,
             such that the diagnostics are done for this species.
 
-        * ``<reduced_diags_name>.file_min_digits`` (`int`) optional (default `6`)
+        * ``<reduced_diags_name>.file_min_digits`` (``int``) optional (default ``6``)
             The minimum number of digits used for the iteration number appended to the diagnostic file names.
 
-        * ``<reduced_diags_name>.histogram_function_abs(t,x,y,z,ux,uy,uz,w)`` (`string`)
+        * ``<reduced_diags_name>.histogram_function_abs(t,x,y,z,ux,uy,uz,w)`` (``string``)
             A histogram function must be provided for the abscissa axis.
-            `t` represents the physical time in seconds during the simulation.
-            `x, y, z` represent particle positions in the unit of meter.
-            `ux, uy, uz` represent the particle velocities in the unit of
+            ``t`` represents the physical time in seconds during the simulation.
+            ``x, y, z`` represent particle positions in the unit of meter.
+            ``ux, uy, uz`` represent the particle velocities in the unit of
             :math:`\gamma v/c`, where
             :math:`\gamma` is the Lorentz factor,
             :math:`v/c` is the particle velocity normalized by the speed of light.
-            `w` represents the weight.
+            ``w`` represents the weight.
 
-        * ``<reduced_diags_name>.histogram_function_ord(t,x,y,z,ux,uy,uz,w)`` (`string`)
+        * ``<reduced_diags_name>.histogram_function_ord(t,x,y,z,ux,uy,uz,w)`` (``string``)
             A histogram function must be provided for the ordinate axis.
 
-        * ``<reduced_diags_name>.bin_number_abs`` (`int` > 0) and ``<reduced_diags_name>.bin_number_ord`` (`int` > 0)
+        * ``<reduced_diags_name>.bin_number_abs`` (``int`` > 0) and ``<reduced_diags_name>.bin_number_ord`` (``int`` > 0)
             These are the number of bins used for the histogram for the abscissa and ordinate axis respectively.
 
-        * ``<reduced_diags_name>.bin_max_abs`` (`float`) and ``<reduced_diags_name>.bin_max_ord`` (`float`)
+        * ``<reduced_diags_name>.bin_max_abs`` (``float``) and ``<reduced_diags_name>.bin_max_ord`` (``float``)
             These are the maximum value of the bins for the abscissa and ordinate axis respectively.
             Particles with values outside of these ranges are discarded.
 
-        * ``<reduced_diags_name>.bin_min_abs`` (`float`) and ``<reduced_diags_name>.bin_min_ord`` (`float`)
+        * ``<reduced_diags_name>.bin_min_abs`` (``float``) and ``<reduced_diags_name>.bin_min_ord`` (``float``)
             These are the minimum value of the bins for the abscissa and ordinate axis respectively.
             Particles with values outside of these ranges are discarded.
 
-        * ``<reduced_diags_name>.filter_function(t,x,y,z,ux,uy,uz,w)`` (`string`) optional
+        * ``<reduced_diags_name>.filter_function(t,x,y,z,ux,uy,uz,w)`` (``string``) optional
             Users can provide an expression returning a boolean for whether a particle is taken
             into account when calculating the histogram.
-            `t` represents the physical time in seconds during the simulation.
-            `x, y, z` represent particle positions in the unit of meter.
-            `ux, uy, uz` represent particle velocities in the unit of
+            ``t`` represents the physical time in seconds during the simulation.
+            ``x, y, z`` represent particle positions in the unit of meter.
+            ``ux, uy, uz`` represent particle velocities in the unit of
             :math:`\gamma v/c`, where
             :math:`\gamma` is the Lorentz factor,
             :math:`v/c` is the particle velocity normalized by the speed of light.
-            `w` represents the weight.
+            ``w`` represents the weight.
 
-        * ``<reduced_diags_name>.value_function(t,x,y,z,ux,uy,uz,w)`` (`string`) optional
+        * ``<reduced_diags_name>.value_function(t,x,y,z,ux,uy,uz,w)`` (``string``) optional
             Users can provide an expression for the weight used to calculate the number of particles
             per cell associated with the selected abscissa and ordinate functions and/or the filter function.
-            `t` represents the physical time in seconds during the simulation.
-            `x, y, z` represent particle positions in the unit of meter.
-            `ux, uy, uz` represent particle velocities in the unit of
+            ``t`` represents the physical time in seconds during the simulation.
+            ``x, y, z`` represent particle positions in the unit of meter.
+            ``ux, uy, uz`` represent particle velocities in the unit of
             :math:`\gamma v/c`, where
             :math:`\gamma` is the Lorentz factor,
             :math:`v/c` is the particle velocity normalized by the speed of light.
-            `w` represents the weight.
+            ``w`` represents the weight.
 
         The output is a ``<reduced_diags_name>`` folder containing a set of openPMD files.
         An example input file and a loading python script of
@@ -5046,16 +5046,16 @@ This shifts analysis from post-processing to runtime calculation of reduction op
         In practice, the above expression of the differential luminosity is evaluated over discrete bins in energy :math:`\mathcal{E}^*`,
         and by summing over macroparticles.
 
-        * ``<reduced_diags_name>.species`` (`list of two strings`)
+        * ``<reduced_diags_name>.species`` (``list of two strings``)
             The names of the two species for which the differential luminosity is computed.
 
-        * ``<reduced_diags_name>.bin_number`` (`int` > 0)
+        * ``<reduced_diags_name>.bin_number`` (``int`` > 0)
             The number of bins in energy :math:`\mathcal{E}^*`
 
-        * ``<reduced_diags_name>.bin_max`` (`float`, in eV)
+        * ``<reduced_diags_name>.bin_max`` (``float``, in eV)
             The minimum value of :math:`\mathcal{E}^*` for which the differential luminosity is computed.
 
-        * ``<reduced_diags_name>.bin_min`` (`float`, in eV)
+        * ``<reduced_diags_name>.bin_min`` (``float``, in eV)
             The maximum value of :math:`\mathcal{E}^*` for which the differential luminosity is computed.
 
     * ``DifferentialLuminosity2D``
@@ -5074,32 +5074,32 @@ This shifts analysis from post-processing to runtime calculation of reduction op
         are, respectively, the momentum and the energy of a particle of the :math:`i`-th species.
         The 2D differential luminosity is given in units of :math:`\text{m}^{-2}.\text{eV}^{-2}`.
 
-        * ``<reduced_diags_name>.species`` (`list of two strings`)
+        * ``<reduced_diags_name>.species`` (``list of two strings``)
             The names of the two species for which the differential luminosity is computed.
 
-        * ``<reduced_diags_name>.bin_number_1`` (`int` > 0)
+        * ``<reduced_diags_name>.bin_number_1`` (``int`` > 0)
             The number of bins in energy :math:`E_1`
 
-        * ``<reduced_diags_name>.bin_max_1`` (`float`, in eV)
+        * ``<reduced_diags_name>.bin_max_1`` (``float``, in eV)
             The minimum value of :math:`E_1` for which the 2D differential luminosity is computed.
 
-        * ``<reduced_diags_name>.bin_min_1`` (`float`, in eV)
+        * ``<reduced_diags_name>.bin_min_1`` (``float``, in eV)
             The maximum value of :math:`E_2` for which the 2D differential luminosity is compute
 
-        * ``<reduced_diags_name>.bin_number_2`` (`int` > 0)
+        * ``<reduced_diags_name>.bin_number_2`` (``int`` > 0)
             The number of bins in energy :math:`E_2`
 
-        * ``<reduced_diags_name>.bin_max_2`` (`float`, in eV)
+        * ``<reduced_diags_name>.bin_max_2`` (``float``, in eV)
             The minimum value of :math:`E_2` for which the 2D differential luminosity is computed.
 
-        * ``<reduced_diags_name>.bin_min_2`` (`float`, in eV)
+        * ``<reduced_diags_name>.bin_min_2`` (``float``, in eV)
             The minimum value of :math:`E_2` for which the 2D differential luminosity is computed.
 
-        * ``<reduced_diags_name>.file_min_digits`` (`int`) optional (default `6`)
+        * ``<reduced_diags_name>.file_min_digits`` (``int``) optional (default ``6``)
             The minimum number of digits used for the iteration number appended to the diagnostic file names.
 
         The output is a ``<reduced_diags_name>`` folder containing a set of openPMD files.
-        The values of the diagnostic are stored in a record labeled `d2L_dE1_dE2`.
+        The values of the diagnostic are stored in a record labeled ``d2L_dE1_dE2``.
         An example input file and a loading python script of
         using the DifferentialLuminosity2D reduced diagnostics
         are given in ``Examples/Tests/diff_lumi_diag/``.
@@ -5108,31 +5108,31 @@ This shifts analysis from post-processing to runtime calculation of reduction op
         This type outputs the simulation's physical timestep (in seconds) at each mesh refinement level.
 
 .. pp:param:: reduced_diags.intervals
-    :type: `string`
+    :type: ``string``
 
     Using the `Time intervals`_ syntax, this string defines the timesteps at which reduced
     diagnostics are written to the file.
     This can also be specified for the specific diagnostic by setting ``<reduced_diags_name>.intervals``.
 
 .. pp:param:: reduced_diags.path
-    :type: `string`
-    :default: `./diags/reducedfiles/`
+    :type: ``string``
+    :default: ``./diags/reducedfiles/``
     :optional:
 
     The path where the output file will be stored.
     This can also be specified for the specific diagnostic by setting ``<reduced_diags_name>.path``.
 
 .. pp:param:: reduced_diags.extension
-    :type: `string`
-    :default: `txt`
+    :type: ``string``
+    :default: ``txt``
     :optional:
 
     The extension of the output file (the suffix).
     This can also be specified for the specific diagnostic by setting ``<reduced_diags_name>.extension``.
 
 .. pp:param:: reduced_diags.separator
-    :type: `string`
-    :default: a `whitespace`
+    :type: ``string``
+    :default: a ``whitespace``
     :optional:
 
     The separator between row values in the output file.
@@ -5140,8 +5140,8 @@ This shifts analysis from post-processing to runtime calculation of reduction op
     This can also be specified for the specific diagnostic by setting ``<reduced_diags_name>.separator``.
 
 .. pp:param:: reduced_diags.precision
-    :type: `integer`
-    :default: `14`
+    :type: ``integer``
+    :default: ``14``
     :optional:
 
     The precision used when writing out the data to the text files.
@@ -5160,31 +5160,31 @@ Nonlinear Compton scattering
 This process is also known more generically as Quantum Synchrotron emission.
 
 .. pp:param:: qed_qs.photon_creation_energy_threshold
-    :type: `float`
-    :default: `2`
+    :type: ``float``
+    :default: ``2``
     :optional:
 
     Energy threshold for photon particle creation in units of :math:`m_e c^2`.
 
 .. pp:param:: <species_name>.do_qed_quantum_sync
-    :type: `int`
-    :default: `0`
+    :type: ``int``
+    :default: ``0``
     :optional:
 
     Enables Quantum synchrotron emission for this species.
     Quantum synchrotron lookup table should be either generated or loaded from disk to enable
     this process (see "Lookup tables for QED modules" section below).
-    `<species>` must be either an electron or a positron species.
+    ``<species>`` must be either an electron or a positron species.
 
 .. pp:param:: <species_name>.qed_quantum_sync_phot_product_species
-    :type: `string`
+    :type: ``string``
 
     If an electron or a positron species has the Quantum synchrotron process, a photon product species must be specified
     (the name of an existing photon species must be provided)
 
 .. pp:param:: <species_name>.do_classical_radiation_reaction
-    :type: `int`
-    :default: `0`
+    :type: ``int``
+    :default: ``0``
     :optional:
 
     Enables Radiation Reaction (or Radiation Friction) for the species. Species
@@ -5199,23 +5199,23 @@ Nonlinear Breit-Wheeler
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 .. pp:param:: <species_name>.do_qed_breit_wheeler
-    :type: `int`
-    :default: `0`
+    :type: ``int``
+    :default: ``0``
     :optional:
 
     Enables non-linear Breit-Wheeler process for this species.
     Breit-Wheeler lookup table should be either generated or loaded from disk to enable
     this process (see "Lookup tables for QED modules" section below).
-    `<species>` must be a photon species (i.e., a species with :pp:param:`<species_name>.species_type` set to `photon`)
+    ``<species>`` must be a photon species (i.e., a species with :pp:param:`<species_name>.species_type` set to ``photon``)
 
 .. pp:param:: <species_name>.qed_breit_wheeler_ele_product_species
-    :type: `string`
+    :type: ``string``
 
     If a photon species has the Breit-Wheeler process, an electron product species must be specified
     (the name of an existing electron species must be provided)
 
 .. pp:param:: <species_name>.qed_breit_wheeler_pos_product_species
-    :type: `string`
+    :type: ``string``
 
     If a photon species has the Breit-Wheeler process, a positron product species must be specified
     (the name of an existing positron species must be provided).
@@ -5229,7 +5229,7 @@ The lookup tables can be pre-generated using a standalone tool (see :ref:`qed to
 Alternatively, one can use the low-resolution builtin tables or generate them on the fly at the beginning of the simulation.
 
 .. pp:param:: qed_qs.lookup_table_mode
-    :type: `string`
+    :type: ``string``
 
     There are three options to prepare the lookup table required by the nonlinear Compton Scattering (or Quantum Synchrotron) module:
 
@@ -5240,35 +5240,35 @@ Alternatively, one can use the low-resolution builtin tables or generate them on
       All the following parameters must be specified (table 1 is used to evolve the optical depth
       of the particles, while table 2 is used for photon emission):
 
-        * ``qed_qs.tab_dndt_chi_min`` (`float`): minimum chi parameter for lookup table 1 (
+        * ``qed_qs.tab_dndt_chi_min`` (``float``): minimum chi parameter for lookup table 1 (
           used for the evolution of the optical depth of electrons and positrons)
 
-        * ``qed_qs.tab_dndt_chi_max`` (`float`): maximum chi parameter for lookup table 1
+        * ``qed_qs.tab_dndt_chi_max`` (``float``): maximum chi parameter for lookup table 1
 
-        * ``qed_qs.tab_dndt_how_many`` (`int`): number of points to be used for lookup table 1
+        * ``qed_qs.tab_dndt_how_many`` (``int``): number of points to be used for lookup table 1
 
-        * ``qed_qs.tab_em_chi_min`` (`float`): minimum chi parameter for lookup table 2 (
+        * ``qed_qs.tab_em_chi_min`` (``float``): minimum chi parameter for lookup table 2 (
           used for photon emission)
 
-        * ``qed_qs.tab_em_chi_max`` (`float`): maximum chi parameter for lookup table 2
+        * ``qed_qs.tab_em_chi_max`` (``float``): maximum chi parameter for lookup table 2
 
-        * ``qed_qs.tab_em_chi_how_many`` (`int`): number of points to be used for chi axis in lookup table 2
+        * ``qed_qs.tab_em_chi_how_many`` (``int``): number of points to be used for chi axis in lookup table 2
 
-        * ``qed_qs.tab_em_frac_how_many`` (`int`): number of points to be used for the second axis in lookup table 2
+        * ``qed_qs.tab_em_frac_how_many`` (``int``): number of points to be used for the second axis in lookup table 2
           (the second axis is the ratio between the quantum parameter of the photon and the
           quantum parameter of the charged particle).
 
-        * ``qed_qs.tab_em_frac_min`` (`float`): minimum value to be considered for the second axis of lookup table 2
+        * ``qed_qs.tab_em_frac_min`` (``float``): minimum value to be considered for the second axis of lookup table 2
 
-        * ``qed_qs.save_table_in`` (`string`): where to save the lookup table
+        * ``qed_qs.save_table_in`` (``string``): where to save the lookup table
 
     * ``load``: a lookup table is loaded from a pre-generated binary file. This can be a table generated by a previous run or using the standalone tool.
       The following parameter must be specified:
 
-        * ``qed_qs.load_table_from`` (`string`): name of the lookup table file to read from.
+        * ``qed_qs.load_table_from`` (``string``): name of the lookup table file to read from.
 
 .. pp:param:: qed_bw.lookup_table_mode
-    :type: `string`
+    :type: ``string``
 
     There are three options to prepare the lookup table required by the Breit-Wheeler module:
 
@@ -5279,39 +5279,39 @@ Alternatively, one can use the low-resolution builtin tables or generate them on
       All the following parameters must be specified (table 1 is used to evolve the optical depth
       of the photons, while table 2 is used for pair generation):
 
-        * ``qed_bw.tab_dndt_chi_min`` (`float`): minimum chi parameter for lookup table 1 (
+        * ``qed_bw.tab_dndt_chi_min`` (``float``): minimum chi parameter for lookup table 1 (
           used for the evolution of the optical depth of the photons)
 
-        * ``qed_bw.tab_dndt_chi_max`` (`float`): maximum chi parameter for lookup table 1
+        * ``qed_bw.tab_dndt_chi_max`` (``float``): maximum chi parameter for lookup table 1
 
-        * ``qed_bw.tab_dndt_how_many`` (`int`): number of points to be used for lookup table 1
+        * ``qed_bw.tab_dndt_how_many`` (``int``): number of points to be used for lookup table 1
 
-        * ``qed_bw.tab_pair_chi_min`` (`float`): minimum chi parameter for lookup table 2 (
+        * ``qed_bw.tab_pair_chi_min`` (``float``): minimum chi parameter for lookup table 2 (
           used for pair generation)
 
-        * ``qed_bw.tab_pair_chi_max`` (`float`): maximum chi parameter for lookup table 2
+        * ``qed_bw.tab_pair_chi_max`` (``float``): maximum chi parameter for lookup table 2
 
-        * ``qed_bw.tab_pair_chi_how_many`` (`int`): number of points to be used for chi axis in lookup table 2
+        * ``qed_bw.tab_pair_chi_how_many`` (``int``): number of points to be used for chi axis in lookup table 2
 
-        * ``qed_bw.tab_pair_frac_how_many`` (`int`): number of points to be used for the second axis in lookup table 2
+        * ``qed_bw.tab_pair_frac_how_many`` (``int``): number of points to be used for the second axis in lookup table 2
           (the second axis is the ratio between the quantum parameter of the less energetic particle of the pair and the
           quantum parameter of the photon).
 
-        * ``qed_bw.save_table_in`` (`string`): where to save the lookup table
+        * ``qed_bw.save_table_in`` (``string``): where to save the lookup table
 
     * ``load``: a lookup table is loaded from a pre-generated binary file. This can be a table generated by a previous run or using the standalone tool.
       The following parameter must be specified:
 
-        * ``qed_bw.load_table_from`` (`string`): name of the lookup table file to read from.
+        * ``qed_bw.load_table_from`` (``string``): name of the lookup table file to read from.
 
 .. pp:param:: qed_qs.chi_min
-    :type: `float`
+    :type: ``float``
     :comment: minimum chi parameter to be considered by the Quantum Synchrotron engine
 
     (suggested value : 0.001)
 
 .. pp:param:: qed_bw.chi_min
-    :type: `float`
+    :type: ``float``
     :comment: minimum chi parameter to be considered by the Breit-Wheeler engine
 
     (suggested value : 0.01)
@@ -5321,8 +5321,8 @@ Schwinger process
 ^^^^^^^^^^^^^^^^^
 
 .. pp:param:: warpx.do_qed_schwinger
-    :type: `bool`
-    :default: `0`
+    :type: ``bool``
+    :default: ``0``
     :optional:
 
     If this is 1, Schwinger electron-positron pairs can be generated in vacuum in the cells where the EM field is high enough.
@@ -5334,19 +5334,19 @@ Schwinger process
     coordinates or single precision.
 
 .. pp:param:: qed_schwinger.ele_product_species
-    :type: `string`
+    :type: ``string``
 
     If Schwinger process is activated, an electron product species must be specified
     (the name of an existing electron species must be provided).
 
 .. pp:param:: qed_schwinger.pos_product_species
-    :type: `string`
+    :type: ``string``
 
     If Schwinger process is activated, a positron product species must be specified
     (the name of an existing positron species must be provided).
 
 .. pp:param:: qed_schwinger.y_size
-    :type: `float`
+    :type: ``float``
     :unit: meters
 
     If Schwinger process is activated with ``DIM=2D``, a transverse size must be specified.
@@ -5365,7 +5365,7 @@ Schwinger process
         qed_schwinger.xmin,ymin,zmin
         qed_schwinger.xmax,ymax,zmax
         qed_schwinger.xmin,ymin,zmin,xmax,ymax,zmax
-    :type: `float`
+    :type: ``float``
     :default: unlimited
     :optional:
 
@@ -5374,8 +5374,8 @@ Schwinger process
     The same is applicable in the other directions.
 
 .. pp:param:: qed_schwinger.threshold_poisson_gaussian
-    :type: `integer`
-    :default: `25`
+    :type: ``integer``
+    :default: ``25``
     :optional:
 
     If the expected number of physical pairs created in a cell at a given timestep is smaller than this threshold,
@@ -5385,7 +5385,7 @@ Schwinger process
     per timestep per species (with a weight corresponding to the number of physical pairs created).
 
 .. pp:param:: warpx.use_hybrid_QED
-    :type: `bool`
+    :type: ``bool``
     :default: 0
 
     Will use the Hybrid QED Maxwell solver when pushing fields: a QED correction is added to the
@@ -5395,7 +5395,7 @@ Schwinger process
     This feature does not require to compile with ``-DWarpX_QED=ON``.
 
 .. pp:param:: warpx.quantum_xi
-    :type: `float`
+    :type: ``float``
     :default: 1.3050122.e-52
 
     Overwrites the actual quantum parameter used in Maxwell's QED equations. Assigning a
@@ -5410,17 +5410,17 @@ WarpX supports checkpoints/restart via AMReX.
 The checkpoint capability can be turned with regular diagnostics: ``<diag_name>.format = checkpoint``.
 
 .. pp:param:: amr.restart
-    :type: `string`
+    :type: ``string``
 
     Name of the checkpoint file to restart from. Returns an error if the folder does not exist
     or if it is not properly formatted.
 
 .. pp:param:: warpx.write_diagnostics_on_restart
-    :type: `bool`
-    :default: `false`
+    :type: ``bool``
+    :default: ``false``
     :optional:
 
-    When `true`, write the diagnostics after restart at the time of the restart.
+    When ``true``, write the diagnostics after restart at the time of the restart.
 
 
 .. _running-cpp-parameters-test-debug:
@@ -5437,7 +5437,7 @@ When developing, testing and :ref:`debugging WarpX <debugging_warpx>`, the follo
     Controls how much information is printed to the terminal, when running WarpX.
 
 .. pp:param:: warpx.limit_verbose_step
-    :type: `bool`
+    :type: ``bool``
     :default: false
 
     If set to true, the information normally printed to the terminal at every time step
@@ -5478,23 +5478,23 @@ When developing, testing and :ref:`debugging WarpX <debugging_warpx>`, the follo
     This will slow down the run.
 
 .. pp:param:: warpx.serialize_initial_conditions
-    :type: `0` or `1`
-    :default: `0`
+    :type: ``0`` or ``1``
+    :default: ``0``
     :optional:
 
     Serialize the initial conditions for reproducible testing, e.g, in our continuous integration tests.
     Mainly whether or not to use OpenMP threading for particle initialization.
 
 .. pp:param:: warpx.safe_guard_cells
-    :type: `0` or `1`
-    :default: `0`
+    :type: ``0`` or ``1``
+    :default: ``0``
     :optional:
 
     Run in safe mode, exchanging more guard cells, and more often in the PIC loop (for debugging).
 
 .. pp:param:: ablastr.fillboundary_always_sync
-    :type: `0` or `1`
-    :default: `0`
+    :type: ``0`` or ``1``
+    :default: ``0``
     :optional:
 
     Run all ``FillBoundary`` operations on ``MultiFab`` to force-synchronize shared nodal points.


### PR DESCRIPTION
- double backticks for verbatim
- asterix for emphasis
- follow-up to #6773

[Preview.](https://warpx--6774.org.readthedocs.build/en/6774/usage/parameters.html#simulation-time)