### PR TITLE
Add relative permittivity (epsilon_r) to Ampere's law

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -184,6 +184,21 @@ Overall simulation parameters
     Name of a file that WarpX writes to archive the used inputs.
     The context of this file will contain an exact copy of all explicitly and implicitly used inputs parameters, including those :ref:`extended and overwritten from the command line <usage_run>`.
 
+.. pp:param:: warpx.epsilon_r
+    :type: `float`
+    :default: ``1.0``
+
+    Relative permittivity applied uniformly to Ampere's law in the FDTD solver.
+    Setting this to a value greater than ``1.0`` scales the ``curl(B)`` and ``J`` terms in the E-field update by ``1/epsilon_r``, effectively reducing the EM wave propagation speed to ``c/sqrt(epsilon_r)`` and relaxing the CFL condition.
+    Faraday's law and the particle pusher are not modified.
+    Must be ``>= 1.0``.
+    Only supported with the explicit FDTD solver (``algo.evolve_scheme = explicit``).
+
+    .. warning::
+        This approximation is only valid when the plasma frequency
+        and particle velocities are much smaller than ``c/sqrt(epsilon_r)``.
+        Use with care and verify that results are physically consistent.
+
 .. pp:param:: warpx.gamma_boost
     :type: `float`
 

--- a/Examples/Tests/CMakeLists.txt
+++ b/Examples/Tests/CMakeLists.txt
@@ -2,6 +2,7 @@
 #
 
 add_subdirectory(accelerator_lattice)
+add_subdirectory(epsilon_r)
 add_subdirectory(boosted_diags)
 add_subdirectory(boundaries)
 add_subdirectory(btd_rz)

--- a/Examples/Tests/epsilon_r/CMakeLists.txt
+++ b/Examples/Tests/epsilon_r/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Add tests (alphabetical order) ##############################################
+#
+
+add_warpx_test(
+    test_1d_epsilon_r  # name
+    1  # dims
+    2  # nprocs
+    inputs_test_1d_epsilon_r  # inputs
+    OFF  # analysis
+    OFF  # checksum
+    OFF  # dependency
+)

--- a/Examples/Tests/epsilon_r/analysis_default_regression.py
+++ b/Examples/Tests/epsilon_r/analysis_default_regression.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import sys
+
+import yt
+
+sys.path.insert(1, "../Regression/Checksum/")
+from checksumAPI import evaluate_checksum
+from openpmd_viewer import OpenPMDTimeSeries
+
+
+def main(args):
+    # parse test name from test directory
+    test_name = os.path.split(os.getcwd())[1]
+    if "_restart" in test_name:
+        # use original test's checksums
+        test_name = test_name.replace("_restart", "")
+    # TODO check environment and reset tolerance (portable, machine precision)
+    # compare checksums
+    evaluate_checksum(
+        test_name=test_name,
+        output_file=args.path,
+        output_format=args.format,
+        rtol=args.rtol,
+        do_fields=args.do_fields,
+        do_particles=args.do_particles,
+    )
+
+
+if __name__ == "__main__":
+    # define parser
+    parser = argparse.ArgumentParser()
+    # add arguments: output path
+    parser.add_argument(
+        "--path",
+        help="path to output file(s)",
+        type=str,
+    )
+    # add arguments: relative tolerance
+    # Identify whether the test is a restart test,
+    # if it is, use a 1e-12 tolerance for the restart checksum analysis
+    test_name = os.path.split(os.getcwd())[1]
+    default_tolerance = 1e-12 if "_restart" in test_name else 1e-9
+    parser.add_argument(
+        "--rtol",
+        help="relative tolerance to compare checksums",
+        type=float,
+        required=False,
+        default=default_tolerance,
+    )
+    # add arguments: skip fields
+    parser.add_argument(
+        "--skip-fields",
+        help="skip fields when comparing checksums",
+        action="store_true",
+        dest="skip_fields",
+    )
+    # add arguments: skip particles
+    parser.add_argument(
+        "--skip-particles",
+        help="skip particles when comparing checksums",
+        action="store_true",
+        dest="skip_particles",
+    )
+    # parse arguments
+    args = parser.parse_args()
+    # set args.format automatically
+    try:
+        yt.load(args.path)
+    except Exception:
+        try:
+            OpenPMDTimeSeries(args.path)
+        except Exception:
+            print("Could not open the file as a plotfile or an openPMD time series")
+        else:
+            args.format = "openpmd"
+    else:
+        args.format = "plotfile"
+    # set args.do_fields (not parsed, based on args.skip_fields)
+    args.do_fields = False if args.skip_fields else True
+    # set args.do_particles (not parsed, based on args.skip_particles)
+    args.do_particles = False if args.skip_particles else True
+    # execute main function
+    main(args)

--- a/Examples/Tests/epsilon_r/inputs_test_1d_epsilon_r
+++ b/Examples/Tests/epsilon_r/inputs_test_1d_epsilon_r
@@ -1,0 +1,133 @@
+#################################
+########## CONSTANTS ############
+#################################
+
+###   characteristic plasma values
+my_constants.n0 = 1.e23    # plasma density [1/m^3]
+my_constants.T0 = 1.       # plasma temperature [eV]
+my_constants.R0 = 1.5e-2   # plasma radius [m]
+my_constants.I0 = 200.e3   # pinch current [Amps]
+
+my_constants.AD = 2.01410  # atomic mass deuterium
+my_constants.mD = AD*m_u - m_e   # deuterium mass [kg]
+
+###   derived characteristic pinch values
+my_constants.B0 = mu0*I0/(2*pi*R0)  # B at r=R0 [Tesla]
+my_constants.PB0 = B0^2/(2.0*mu0)   # B pressure at r=R0
+my_constants.rho0 = AD*m_u*n0       # mass density [kg/m^3]
+my_constants.u0 = sqrt(PB0/rho0)    # implosion speed [m/s]
+my_constants.t0 = R0/u0             # implosion time [s]
+
+###   simulation parameters
+my_constants.tsim      = 220.e-9       # sim time = 1.35*t0 [s]
+my_constants.rise_time = t0/20.0       # current rise time [s]
+my_constants.Nppc_z    = 200            # particles per cell per dim
+
+#################################
+####### GENERAL PARAMETERS ######
+#################################
+stop_time = tsim
+max_step = 50
+amr.n_cell        = 1312
+amr.max_grid_size = 32
+amr.blocking_factor = 32
+amr.max_level     = 0
+geometry.dims     = 1
+geometry.prob_lo  = 0.0
+geometry.prob_hi  = 1.54e-2
+
+#################################
+####### Boundary condition ######
+#################################
+boundary.field_lo = pmc
+boundary.field_hi = pec_insulator
+boundary.particle_lo = reflecting
+boundary.particle_hi = absorbing
+
+insulator.area_z_hi(x,y) = 1.0
+insulator.Bx_z_hi(x,y,t) = min(t/rise_time,1)*B0
+
+#################################
+############ NUMERICS ###########
+#################################
+warpx.serialize_initial_conditions = 1
+warpx.verbose = 1
+warpx.limit_verbose_step = false
+warpx.epsilon_r           = 100.0
+warpx.cfl                = 0.9
+warpx.use_filter         = 2
+
+algo.maxwell_solver     = Yee
+algo.evolve_scheme      = explicit
+algo.particle_pusher    = "higuera"
+algo.particle_shape     = 3
+algo.current_deposition = "villasenor"
+
+collisions.split_momentum_push = 0  # not implemented with Higuera-Cary pusher
+
+#################################
+############ PLASMA #############
+#################################
+particles.species_names = electrons deuterium
+
+electrons.charge = -q_e
+electrons.mass = m_e
+electrons.injection_style = "NUniformPerCell"
+electrons.num_particles_per_cell_each_dim = Nppc_z
+electrons.profile = constant
+electrons.density = n0
+electrons.zmax = R0
+electrons.momentum_distribution_type = "gaussian"
+electrons.ux_th = sqrt(T0*q_e/m_e)/clight
+electrons.uy_th = sqrt(T0*q_e/m_e)/clight
+electrons.uz_th = sqrt(T0*q_e/m_e)/clight
+
+deuterium.charge = q_e
+deuterium.mass = mD
+deuterium.injection_style = "NUniformPerCell"
+deuterium.num_particles_per_cell_each_dim = Nppc_z
+deuterium.profile = constant
+deuterium.density = n0
+deuterium.zmax = R0
+deuterium.momentum_distribution_type = "gaussian"
+deuterium.ux_th = sqrt(T0*q_e/mD)/clight
+deuterium.uy_th = sqrt(T0*q_e/mD)/clight
+deuterium.uz_th = sqrt(T0*q_e/mD)/clight
+
+###   Diagnostics
+diagnostics.diags_names = diag1
+diag1.intervals = 50
+diag1.diag_type = Full
+diag1.fields_to_plot = Ex Ey Ez Bx By Bz jx jy jz rho divE
+diag1.electrons.variables = z w ux uy uz
+diag1.deuterium.variables = z w ux uy uz
+
+###   reduced diagnostics
+warpx.reduced_diags_names = particle_energy field_energy poynting_flux
+
+particle_energy.type = ParticleEnergy
+particle_energy.intervals = 1
+particle_energy.precision = 18
+particle_energy.path = diags/reduced_files/
+
+field_energy.type = FieldEnergy
+field_energy.intervals = 1
+field_energy.precision = 18
+field_energy.path = diags/reduced_files/
+
+poynting_flux.type = FieldPoyntingFlux
+poynting_flux.intervals = 1
+poynting_flux.precision = 18
+poynting_flux.path = diags/reduced_files/
+
+#################################
+############ COLLISION ##########
+#################################
+collisions.collision_names = collision1 collision2 collision3
+
+collision1.species = electrons electrons
+collision2.species = deuterium deuterium
+collision3.species = electrons deuterium
+collision1.CoulombLog = 10.0
+collision2.CoulombLog = 10.0
+collision3.CoulombLog = 10.0

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -28,6 +28,7 @@
 #include <AMReX_Vector.H>
 
 #include <algorithm>
+#include <cmath>
 #include <memory>
 
 /**
@@ -74,23 +75,29 @@ WarpX::ComputeDt ()
         deltat = cfl * minDim(dx) / PhysConst::c;
     } else {
         // Computation of dt for FDTD algorithm
+        amrex::Real const sqrt_epsilon_r = std::sqrt(WarpX::epsilon_r);
 #if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
         // - In RZ geometry
         if (electromagnetic_solver_id == ElectromagneticSolverAlgo::Yee) {
-            deltat = cfl * CylindricalYeeAlgorithm::ComputeMaxDt(dx,  n_rz_azimuthal_modes);
+            deltat = cfl * CylindricalYeeAlgorithm::ComputeMaxDt(dx,  n_rz_azimuthal_modes)
+                   * sqrt_epsilon_r;
 #elif defined(WARPX_DIM_RSPHERE)
         // - In RZ geometry
         if (electromagnetic_solver_id == ElectromagneticSolverAlgo::Yee) {
-            deltat = cfl * SphericalYeeAlgorithm::ComputeMaxDt(dx);
+            deltat = cfl * SphericalYeeAlgorithm::ComputeMaxDt(dx)
+                   * sqrt_epsilon_r;
 #else
         // - In Cartesian geometry
         if (grid_type == GridType::Collocated) {
-            deltat = cfl * CartesianNodalAlgorithm::ComputeMaxDt(dx);
+            deltat = cfl * CartesianNodalAlgorithm::ComputeMaxDt(dx)
+                   * sqrt_epsilon_r;
         } else if (electromagnetic_solver_id == ElectromagneticSolverAlgo::Yee
                     || electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT) {
-            deltat = cfl * CartesianYeeAlgorithm::ComputeMaxDt(dx);
+            deltat = cfl * CartesianYeeAlgorithm::ComputeMaxDt(dx)
+                   * sqrt_epsilon_r;
         } else if (electromagnetic_solver_id == ElectromagneticSolverAlgo::CKC) {
-            deltat = cfl * CartesianCKCAlgorithm::ComputeMaxDt(dx);
+            deltat = cfl * CartesianCKCAlgorithm::ComputeMaxDt(dx)
+                   * sqrt_epsilon_r;
 #endif
         } else {
             WARPX_ABORT_WITH_MESSAGE("ComputeDt: Unknown algorithm");

--- a/Source/FieldSolver/FiniteDifferenceSolver/ApplySilverMuellerBoundary.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/ApplySilverMuellerBoundary.cpp
@@ -12,6 +12,7 @@
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
+#include "WarpX.H"
 
 #include <AMReX.H>
 #include <AMReX_Array4.H>
@@ -27,6 +28,7 @@
 #include <AMReX_REAL.H>
 
 #include <array>
+#include <cmath>
 #include <memory>
 
 using namespace amrex;
@@ -59,15 +61,16 @@ void FiniteDifferenceSolver::ApplySilverMuellerBoundary (
 
 #if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
     // Calculate relevant coefficients
-    amrex::Real const cdt = PhysConst::c*dt;
+    amrex::Real const c_eff = PhysConst::c / std::sqrt(WarpX::epsilon_r);
+    amrex::Real const cdt = c_eff*dt;
     amrex::Real const cdt_over_dr = cdt*m_h_stencil_coefs_r[0];
     amrex::Real const coef1_r = (1._rt - cdt_over_dr)/(1._rt + cdt_over_dr);
-    amrex::Real const coef2_r = 2._rt*cdt_over_dr/(1._rt + cdt_over_dr) / PhysConst::c;
-    amrex::Real const coef3_r = cdt/(1._rt + cdt_over_dr) / PhysConst::c;
+    amrex::Real const coef2_r = 2._rt*cdt_over_dr/(1._rt + cdt_over_dr) / c_eff;
+    amrex::Real const coef3_r = cdt/(1._rt + cdt_over_dr) / c_eff;
 #if defined(WARPX_DIM_RZ)
     amrex::Real const cdt_over_dz = cdt*m_h_stencil_coefs_z[0];
     amrex::Real const coef1_z = (1._rt - cdt_over_dz)/(1._rt + cdt_over_dz);
-    amrex::Real const coef2_z = 2._rt*cdt_over_dz/(1._rt + cdt_over_dz) / PhysConst::c;
+    amrex::Real const coef2_z = 2._rt*cdt_over_dz/(1._rt + cdt_over_dz) / c_eff;
 #endif
 
 #if !defined(WARPX_DIM_RSPHERE)
@@ -216,19 +219,20 @@ void FiniteDifferenceSolver::ApplySilverMuellerBoundary (
 #else
 
     // Calculate relevant coefficients
+    amrex::Real const c_eff = PhysConst::c / std::sqrt(WarpX::epsilon_r);
 #if (defined WARPX_DIM_3D || WARPX_DIM_XZ)
-    amrex::Real const cdt_over_dx = PhysConst::c*dt*m_h_stencil_coefs_x[0];
+    amrex::Real const cdt_over_dx = c_eff*dt*m_h_stencil_coefs_x[0];
     amrex::Real const coef1_x = (1._rt - cdt_over_dx)/(1._rt + cdt_over_dx);
-    amrex::Real const coef2_x = 2._rt*cdt_over_dx/(1._rt + cdt_over_dx) / PhysConst::c;
+    amrex::Real const coef2_x = 2._rt*cdt_over_dx/(1._rt + cdt_over_dx) / c_eff;
 #endif
 #ifdef WARPX_DIM_3D
-    amrex::Real const cdt_over_dy = PhysConst::c*dt*m_h_stencil_coefs_y[0];
+    amrex::Real const cdt_over_dy = c_eff*dt*m_h_stencil_coefs_y[0];
     amrex::Real const coef1_y = (1._rt - cdt_over_dy)/(1._rt + cdt_over_dy);
-    amrex::Real const coef2_y = 2._rt*cdt_over_dy/(1._rt + cdt_over_dy) / PhysConst::c;
+    amrex::Real const coef2_y = 2._rt*cdt_over_dy/(1._rt + cdt_over_dy) / c_eff;
 #endif
-    amrex::Real const cdt_over_dz = PhysConst::c*dt*m_h_stencil_coefs_z[0];
+    amrex::Real const cdt_over_dz = c_eff*dt*m_h_stencil_coefs_z[0];
     amrex::Real const coef1_z = (1._rt - cdt_over_dz)/(1._rt + cdt_over_dz);
-    amrex::Real const coef2_z = 2._rt*cdt_over_dz/(1._rt + cdt_over_dz) / PhysConst::c;
+    amrex::Real const coef2_z = 2._rt*cdt_over_dz/(1._rt + cdt_over_dz) / c_eff;
 
 #if (defined WARPX_DIM_3D || WARPX_DIM_XZ)
     bool const apply_lo_x = (field_boundary_lo[0] == FieldBoundaryType::Absorbing_SilverMueller);

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
@@ -117,7 +117,7 @@ void FiniteDifferenceSolver::EvolveECartesian (
     int lev, amrex::Real const dt ) {
 
     amrex::LayoutData<amrex::Real>* cost = WarpX::getCosts(lev);
-    Real constexpr c2 = PhysConst::c * PhysConst::c;
+    Real const c2 = PhysConst::c * PhysConst::c / WarpX::epsilon_r;
 
     // Loop through the grids, and over the tiles within each grid
 #ifdef AMREX_USE_OMP
@@ -293,7 +293,7 @@ void FiniteDifferenceSolver::EvolveECylindrical (
         Box const& tet  = mfi.tilebox(Efield[1]->ixType().toIntVect());
         Box const& tez  = mfi.tilebox(Efield[2]->ixType().toIntVect());
 
-        Real const c2 = PhysConst::c * PhysConst::c;
+        Real const c2 = PhysConst::c * PhysConst::c / WarpX::epsilon_r;
 
         // Loop over the cells and update the fields
         amrex::ParallelFor(ter, tet, tez,
@@ -503,7 +503,7 @@ void FiniteDifferenceSolver::EvolveESpherical (
         Box const& tet  = mfi.tilebox(Efield[1]->ixType().toIntVect());
         Box const& tep  = mfi.tilebox(Efield[2]->ixType().toIntVect());
 
-        Real const c2 = PhysConst::c * PhysConst::c;
+        Real const c2 = PhysConst::c * PhysConst::c / WarpX::epsilon_r;
 
         // Loop over the cells and update the fields
         amrex::ParallelFor(ter, tet, tep,

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveEPML.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveEPML.cpp
@@ -19,6 +19,7 @@
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
+#include "WarpX.H"
 
 #include <AMReX.H>
 #include <AMReX_Array4.H>
@@ -110,7 +111,7 @@ void FiniteDifferenceSolver::EvolveEPMLCartesian (
     MultiSigmaBox const& sigba,
     amrex::Real const dt, bool pml_has_particles ) {
 
-    Real constexpr c2 = PhysConst::c * PhysConst::c;
+    Real const c2 = PhysConst::c * PhysConst::c / WarpX::epsilon_r;
 
     // Loop through the grids, and over the tiles within each grid
 #ifdef AMREX_USE_OMP
@@ -240,7 +241,7 @@ void FiniteDifferenceSolver::EvolveEPMLCartesian (
             int const y_lo = 0;
             int const z_lo = sigba[mfi].sigma[1].lo();
 #endif
-            const Real mu_c2_dt = (PhysConst::mu0*PhysConst::c*PhysConst::c) * dt;
+            const Real mu_c2_dt = (PhysConst::mu0 * PhysConst::c * PhysConst::c / WarpX::epsilon_r) * dt;
 
             amrex::ParallelFor( tex, tey, tez,
                 [=] AMREX_GPU_DEVICE (int i, int j, int k) {

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveG.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveG.cpp
@@ -14,6 +14,8 @@
 #endif
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
+#include "Utils/WarpXConst.H"
+#include "WarpX.H"
 
 #include <AMReX.H>
 #include <AMReX_Array4.H>
@@ -73,7 +75,7 @@ void FiniteDifferenceSolver::EvolveGCartesian (
     amrex::Real const dt)
 {
 
-    amrex::Real constexpr c2 = PhysConst::c * PhysConst::c;
+    amrex::Real const c2 = PhysConst::c * PhysConst::c / WarpX::epsilon_r;
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())

--- a/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/MacroscopicEvolveE.cpp
@@ -10,6 +10,7 @@
 #include "MacroscopicProperties/MacroscopicProperties.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
+#include "WarpX.H"
 
 #include <ablastr/coarsen/sample.H>
 
@@ -126,6 +127,8 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
 #endif
     for ( MFIter mfi(*Efield[0], TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
 
+        amrex::Real const inv_epsilon_r = 1.0_rt / WarpX::epsilon_r;
+
         // Extract field data for this grid/tile
         Array4<Real> const& Ex = Efield[0]->array(mfi);
         Array4<Real> const& Ey = Efield[1]->array(mfi);
@@ -184,7 +187,8 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
             amrex::Real const epsilon_interp = ablastr::coarsen::sample::Interp(eps_arr, epsilon_stag,
                                                                                 Ex_stag, macro_cr, i, j, k, scomp);
             const amrex::Real alpha = T_MacroAlgo::alpha( sigma_interp, epsilon_interp, dt);
-            const amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
+            const amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt)
+                                   * inv_epsilon_r;
             Ex(i, j, k) = alpha * Ex(i, j, k)
                         + beta * ( - T_Algo::DownwardDz(Hy, coefs_z, n_coefs_z, i, j, k,0)
                                     + T_Algo::DownwardDy(Hz, coefs_y, n_coefs_y, i, j, k,0)
@@ -204,7 +208,8 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
             amrex::Real const epsilon_interp = ablastr::coarsen::sample::Interp(eps_arr, epsilon_stag,
                                                                                 Ey_stag, macro_cr, i, j, k, scomp);
             const amrex::Real alpha = T_MacroAlgo::alpha( sigma_interp, epsilon_interp, dt);
-            const amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
+            const amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt)
+                                   * inv_epsilon_r;
 
             Ey(i, j, k) = alpha * Ey(i, j, k)
                         + beta * ( - T_Algo::DownwardDx(Hz, coefs_x, n_coefs_x, i, j, k,0)
@@ -225,7 +230,8 @@ void FiniteDifferenceSolver::MacroscopicEvolveECartesian (
             amrex::Real const epsilon_interp = ablastr::coarsen::sample::Interp(eps_arr, epsilon_stag,
                                                                                 Ez_stag, macro_cr, i, j, k, scomp);
             const amrex::Real alpha = T_MacroAlgo::alpha( sigma_interp, epsilon_interp, dt);
-            const amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt);
+            const amrex::Real beta = T_MacroAlgo::beta( sigma_interp, epsilon_interp, dt)
+                                   * inv_epsilon_r;
 
             Ez(i, j, k) = alpha * Ez(i, j, k)
                         + beta * ( - T_Algo::DownwardDy(Hx, coefs_y, n_coefs_y, i, j, k,0)

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -311,6 +311,12 @@ public:
     //! If true, the initial conditions from random number generators are serialized (useful for reproducible testing with OpenMP)
     static bool serialize_initial_conditions;
 
+    //! Relative permittivity applied to Ampere's law (default 1.0, no modification).
+    //! Scales the curl(B) and J terms in the E-field update by 1/epsilon_r,
+    //! effectively reducing the EM wave speed to c/sqrt(epsilon_r).
+    //! Set via warpx.epsilon_r.
+    static amrex::Real epsilon_r;
+
     //! Lorentz factor of the boosted frame in which a boosted-frame simulation is run
     static amrex::Real gamma_boost;
     //! Beta value corresponding to the Lorentz factor of the boosted frame of the simulation

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -114,6 +114,8 @@ bool WarpX::fft_do_time_averaging = false;
 amrex::IntVect WarpX::m_fill_guards_fields  = amrex::IntVect(0);
 amrex::IntVect WarpX::m_fill_guards_current = amrex::IntVect(0);
 
+Real WarpX::epsilon_r = 1._rt;
+
 Real WarpX::gamma_boost = 1._rt;
 Real WarpX::beta_boost = 0._rt;
 Vector<int> WarpX::boost_direction = {0,0,0};
@@ -692,6 +694,31 @@ WarpX::ReadParameters ()
                                          "Subcycling method 1 only works for 2 levels.");
 
         ReadBoostedFrameParameters(gamma_boost, beta_boost, boost_direction);
+
+        // Relative permittivity for Ampere's law
+        {
+            utils::parser::queryWithParser(pp_warpx, "epsilon_r", epsilon_r);
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(epsilon_r >= 1.0,
+                "warpx.epsilon_r must be >= 1.0");
+            if (epsilon_r > 1.0) {
+                WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                    evolve_scheme == EvolveScheme::Explicit,
+                    "warpx.epsilon_r > 1 is only supported "
+                    "with the explicit FDTD solver (algo.evolve_scheme = explicit).");
+                WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                    electromagnetic_solver_id != ElectromagneticSolverAlgo::PSATD,
+                    "warpx.epsilon_r > 1 is not supported "
+                    "with the PSATD spectral solver. Use an explicit FDTD solver (Yee or CKC).");
+                WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                    electromagnetic_solver_id != ElectromagneticSolverAlgo::HybridPIC,
+                    "warpx.epsilon_r > 1 is not supported "
+                    "with the HybridPIC solver.");
+                amrex::Print() << "\n*** Relative permittivity in Ampere's law enabled ***\n"
+                               << "    epsilon_r = " << epsilon_r << "\n"
+                               << "    effective wave speed = " << PhysConst::c / std::sqrt(epsilon_r)
+                               << " m/s (physical c = " << PhysConst::c << " m/s)\n\n";
+            }
+        }
 
         // queryWithParser returns 1 if argument zmax_plasma_to_compute_max_step is
         // specified by the user, 0 otherwise.


### PR DESCRIPTION
## Summary

This PR adds a `warpx.epsilon_r` parameter that introduces a uniform relative permittivity into Ampere's law, scaling the `curl(B)` and `J` terms by `1/epsilon_r`. This effectively reduces the EM wave propagation speed to `c/sqrt(epsilon_r)` and relaxes the CFL condition for explicit FDTD simulations.

Faraday's law and the particle pusher are **not** modified.

Issue #6769. Supersedes #6725.

## Motivation

In high-density plasma simulations (e.g., Z-pinch, dense fusion targets), the light-wave CFL constraint can be orders of magnitude more restrictive than needed by the plasma dynamics. This feature allows users to relax the CFL by a factor of `sqrt(epsilon_r)` while keeping the explicit FDTD solver.

## Changes from #6725

PR #6725 implemented this as a "reduced speed of light" by globally replacing `PhysConst::c` with a modified `WarpX::c_light` across 14 files. Per reviewer feedback, this PR reframes the approach as **adding a relative permittivity to Ampere's law**, which:

- Does not redefine or shadow any physical constant
- Confines modifications to the Ampere equation and related routines only
- Is physically equivalent: setting `epsilon_r = N²` gives the same result as `c → c/N`

## Physics

Standard Ampere's law:

$$\frac{\partial \mathbf{E}}{\partial t} = c^2 \nabla \times \mathbf{B} - \frac{\mathbf{J}}{\epsilon_0}$$

With `warpx.epsilon_r`:

$$\frac{\partial \mathbf{E}}{\partial t} = \frac{c^2}{\epsilon_r} \nabla \times \mathbf{B} - \frac{\mathbf{J}}{\epsilon_0 \, \epsilon_r}$$

Faraday's law $\partial \mathbf{B}/\partial t = -\nabla \times \mathbf{E}$ is unchanged.

## Implementation

| File | Change |
|------|--------|
| `WarpX.H` / `WarpX.cpp` | Declare, initialize, and parse `epsilon_r` with safeguards |
| `EvolveE.cpp` | `c2 → c2 / epsilon_r` (Cartesian, Cylindrical, Spherical) |
| `EvolveEPML.cpp` | `c2 → c2 / epsilon_r`, `mu_c2_dt` scaled |
| `EvolveG.cpp` | `c2 → c2 / epsilon_r` (div cleaning) |
| `MacroscopicEvolveE.cpp` | `beta → beta / epsilon_r` |
| `WarpXComputeDt.cpp` | `dt *= sqrt(epsilon_r)` |
| `ApplySilverMuellerBoundary.cpp` | `c → c / sqrt(epsilon_r)` for ABC impedance matching |
| `parameters.rst` | Document `warpx.epsilon_r` |
| `Examples/Tests/epsilon_r/` | 1D Z-pinch test case |

## Safeguards

- `epsilon_r >= 1.0` enforced at runtime
- Only allowed with `algo.evolve_scheme = explicit`
- Rejected for PSATD and HybridPIC solvers
- Informational message printed when `epsilon_r > 1`

## Test

A lightweight 1D Z-pinch test (`test_1d_epsilon_r`) with `epsilon_r = 100.0` verifies that the parameter is parsed, the CFL is relaxed by a factor of 10, and the simulation runs correctly.