### PR TITLE
runClangTidy.sh : fix typo in instructions on how to set the version of clang-tidy

### DIFF
--- a/Tools/Linter/runClangTidy.sh
+++ b/Tools/Linter/runClangTidy.sh
@@ -57,7 +57,7 @@ echo "This can be overridden by setting the environment"
 echo "variables CLANG, CLANGXX, and CLANGTIDY e.g.: "
 echo "$ export CLANG=clang-17"
 echo "$ export CLANGXX=clang++-17"
-echo "$ export CTIDCLANGTIDYY=clang-tidy-17"
+echo "$ export CLANGTIDY=clang-tidy-17"
 echo "$ ./Tools/Linter/runClangTidy.sh"
 echo
 echo "******************************************************"


### PR DESCRIPTION
The environment variable `CTIDCLANGTIDYY` should be `CLANGTIDY`