### PR TITLE
WarpX.H: reorder inclusions

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -27,7 +27,6 @@
 #include "Particles/ParticleBoundaryBuffer_fwd.H"
 #include "Particles/MultiParticleContainer_fwd.H"
 #include "Particles/WarpXParticleContainer_fwd.H"
-#include "Particles/ParticleThermalizer/ParticleThermalizer.H"
 #include "Fluids/MultiFluidContainer_fwd.H"
 #include "Fluids/WarpXFluidContainer_fwd.H"
 
@@ -45,6 +44,7 @@
 #include "FieldSolver/ImplicitSolvers/WarpXSolverVec.H"
 #include "Filter/BilinearFilter.H"
 #include "Parallelization/GuardCellManager.H"
+#include "Particles/ParticleThermalizer/ParticleThermalizer.H"
 #include "Utils/Parser/IntervalsParser.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/export.H"

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -19,25 +19,26 @@
 #include "EmbeddedBoundary/WarpXFaceInfoBox_fwd.H"
 #include "FieldSolver/ElectrostaticSolvers/ElectrostaticSolver_fwd.H"
 #include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver_fwd.H"
-#include "FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties_fwd.H"
 #include "FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel_fwd.H"
+#include "FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties_fwd.H"
 #include "FieldSolver/ImplicitSolvers/ImplicitSolver_fwd.H"
 #include "Filter/NCIGodfreyFilter_fwd.H"
-#include "Initialization/ExternalField_fwd.H"
-#include "Particles/ParticleBoundaryBuffer_fwd.H"
-#include "Particles/MultiParticleContainer_fwd.H"
-#include "Particles/WarpXParticleContainer_fwd.H"
 #include "Fluids/MultiFluidContainer_fwd.H"
 #include "Fluids/WarpXFluidContainer_fwd.H"
+#include "Initialization/ExternalField_fwd.H"
+#include "Particles/MultiParticleContainer_fwd.H"
+#include "Particles/ParticleBoundaryBuffer_fwd.H"
+#include "Particles/WarpXParticleContainer_fwd.H"
 
 #ifdef WARPX_USE_FFT
 #   ifdef WARPX_DIM_RZ
-#       include "FieldSolver/SpectralSolver/SpectralSolverRZ_fwd.H"
 #       include "BoundaryConditions/PML_RZ_fwd.H"
+#       include "FieldSolver/SpectralSolver/SpectralSolverRZ_fwd.H"
 #   else
 #       include "FieldSolver/SpectralSolver/SpectralSolver_fwd.H"
 #   endif
 #endif
+
 #include "AcceleratorLattice/AcceleratorLattice.H"
 #include "Fields.H"
 #include "FieldSolver/MagnetostaticSolver/MagnetostaticSolver.H"
@@ -45,12 +46,15 @@
 #include "Filter/BilinearFilter.H"
 #include "Parallelization/GuardCellManager.H"
 #include "Particles/ParticleThermalizer/ParticleThermalizer.H"
+#include "Utils/export.H"
 #include "Utils/Parser/IntervalsParser.H"
 #include "Utils/WarpXAlgorithmSelection.H"
-#include "Utils/export.H"
 
 #include <ablastr/fields/MultiFabRegister.H>
 #include <ablastr/utils/Enums.H>
+
+#include <AMReX_BaseFwd.H>
+#include <AMReX_AmrCoreFwd.H>
 
 #include <AMReX.H>
 #include <AMReX_AmrCore.H>
@@ -67,9 +71,6 @@
 #include <AMReX_RealBox.H>
 #include <AMReX_RealVect.H>
 #include <AMReX_Vector.H>
-
-#include <AMReX_BaseFwd.H>
-#include <AMReX_AmrCoreFwd.H>
 
 #include <array>
 #include <iostream>


### PR DESCRIPTION
This PR reorders the inclusions in the `WarpX.H` header, following the convention :

- WarpX forward declaration headers
- WarpX headers
- ablastr headers
- AMReX forward declaration headers
- AMReX headers
- STL headers

each group is in alphabetical order, except for:
```
#ifdef WARPX_USE_FFT
#   ifdef WARPX_DIM_RZ
#       include "BoundaryConditions/PML_RZ_fwd.H"
#       include "FieldSolver/SpectralSolver/SpectralSolverRZ_fwd.H"
#   else
#       include "FieldSolver/SpectralSolver/SpectralSolver_fwd.H"
#   endif
#endif
```
which is placed at the end of the WarpX forward declaration headers section.