### PR TITLE
Include laser containers in `GetParticleContainerFromName`

### DIFF
--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -403,11 +403,12 @@ MultiParticleContainer::ReadParameters ()
 WarpXParticleContainer&
 MultiParticleContainer::GetParticleContainerFromName (const std::string& name) const
 {
-    auto it = std::find(species_names.begin(), species_names.end(), name);
+    auto species_and_lasers_names = GetSpeciesAndLasersNames();
+    auto it = std::find(species_and_lasers_names.begin(), species_and_lasers_names.end(), name);
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        it != species_names.end(),
+        it != species_and_lasers_names.end(),
         "unknown species name");
-    const auto i = static_cast<int>(std::distance(species_names.begin(), it));
+    const auto i = static_cast<int>(std::distance(species_and_lasers_names.begin(), it));
     return *allcontainers[i];
 }
 


### PR DESCRIPTION
Currently only non-laser species particle containers can be accessed via `GetParticleContainerFromName`; this PR fixes that. This is specifically needed for a current use case at TAE where the laser particles are injected via Python and their velocities are modified from a Python callback to capture a desired antenna current waveform.