### PR TITLE
In AddPlasma, fix for radial_numpercell_power

### DIFF
--- a/Source/Particles/ParticleCreation/AddParticles.cpp
+++ b/Source/Particles/ParticleCreation/AddParticles.cpp
@@ -1174,11 +1174,13 @@ PhysicalParticleContainer::AddPlasma (PlasmaInjector& plasma_injector, int lev, 
                 // Update the weight based on the specified power.
                 // The coefficient ensures that the correct density distribution is obtained.
                 const amrex::Real coeff = 2._rt*MathConst::pi/(1._rt + radial_numpercell_power)
-                        *(rmax - std::pow(rmax, -radial_numpercell_power)*std::pow(rmin, 1._rt + radial_numpercell_power));
+                        *(rmax - std::pow(rmax, -radial_numpercell_power)*std::pow(rmin, 1._rt + radial_numpercell_power))*
+                        (rmax/(rmax - rmin));
                 weight *= coeff*std::pow(xb/rmax, 1._rt - radial_numpercell_power);
 #elif defined(WARPX_DIM_RSPHERE)
                 const amrex::Real coeff = 4._rt*MathConst::pi/(1._rt + radial_numpercell_power)
-                        *(rmax*rmax - std::pow(rmax, 1._rt - radial_numpercell_power )*std::pow(rmin, 1._rt + radial_numpercell_power));
+                        *(rmax*rmax - std::pow(rmax, 1._rt - radial_numpercell_power )*std::pow(rmin, 1._rt + radial_numpercell_power))*
+                        (rmax/(rmax - rmin));
                 weight *= coeff*std::pow(xb/rmax, 2._rt - radial_numpercell_power);
 #endif
                 pa[PIdx::w ][ip] = weight;
@@ -1696,7 +1698,8 @@ PhysicalParticleContainer::AddPlasmaFlux (PlasmaInjector const& plasma_injector,
                     // Update the weight based on the specified power.
                     // The coefficient ensures that the correct density distribution is obtained.
                     const amrex::Real coeff = 2._rt*MathConst::pi/(1._rt + radial_numpercell_power)
-                        *(rmax - std::pow(rmax, -radial_numpercell_power)*std::pow(rmin, 1._rt + radial_numpercell_power));
+                        *(rmax - std::pow(rmax, -radial_numpercell_power)*std::pow(rmin, 1._rt + radial_numpercell_power))*
+                        (rmax/(rmax - rmin));
                     t_weight *= coeff*std::pow(radial_position/rmax, 1._rt - radial_numpercell_power);
                 }
 
@@ -1713,7 +1716,8 @@ PhysicalParticleContainer::AddPlasmaFlux (PlasmaInjector const& plasma_injector,
                     // Update the weight based on the specified power.
                     // The coefficient ensures that the correct density distribution is obtained.
                     const amrex::Real coeff = 4._rt*MathConst::pi/(1._rt + radial_numpercell_power)
-                        *(rmax*rmax - std::pow(rmax, 1._rt - radial_numpercell_power)*std::pow(rmin, 1._rt + radial_numpercell_power));
+                        *(rmax*rmax - std::pow(rmax, 1._rt - radial_numpercell_power)*std::pow(rmin, 1._rt + radial_numpercell_power))*
+                        (rmax/(rmax - rmin));
                     t_weight *= coeff*std::pow(radial_position/rmax, 2._rt - radial_numpercell_power);
                 }
                 const amrex::Real weight = t_weight;


### PR DESCRIPTION
In `AddPlasma` and `AddPlasmaFlux`, when in a radial geometry, the radial variation of the particle weight can be adjusted by the input parameter `radial_numpercell_power`.  The particle distribution and weights are adjusted accordingly. Though, when the minimum radius, `rmin`, is greater than zero, the weights of the particles was not correct. The weights did not account for the fact that the particles before the transformation are generated only in the range `rmin` to `rmax` whereas the existing formula assumed that particles were created in the range 0 to `rmax` (before transformation). The result is that fewer particles are generated than the weight is accounting for. Multiplying the weights by the factor `rmax/(rmax - rmin)` accounts for this difference.

This addresses the issue raised in #6798.