### PR TITLE
Relax pybind11 version requirement for package managers

### DIFF
--- a/Tools/Release/update_dependencies.py
+++ b/Tools/Release/update_dependencies.py
@@ -150,28 +150,31 @@ def update(args):
                 dependencies_data[f"commit_{repo_name}"] = new_commit_sha
 
         # update version
-        print(f"- old version: {dependencies_data[version_key]}")
-        print(f"- new version: {repo_version_tag}")
-        if dependencies_data[version_key] == repo_version_tag:
-            print("Skipping version update...")
+        if repo_name == "pybind11":
+            print("Skipping version update... (minimum version set manually)")
         else:
-            print("Updating version...")
-            dependencies_data[f"version_{repo_name}"] = repo_version_tag
+            print(f"- old version: {dependencies_data[version_key]}")
+            print(f"- new version: {repo_version_tag}")
+            if dependencies_data[version_key] == repo_version_tag:
+                print("Skipping version update...")
+            else:
+                print("Updating version...")
+                dependencies_data[f"version_{repo_name}"] = repo_version_tag
 
-            # update PICMI version in requirements.txt files manually
-            if repo_name == "picmi":
-                files = [
-                    os.path.join(repo_dir, "requirements.txt"),
-                    os.path.join(repo_dir, "Docs", "requirements.txt"),
-                ]
-                for filename in files:
-                    with open(filename) as f:
-                        lines = f.readlines()
-                    with open(filename, "w") as f:
-                        for line in lines:
-                            if line.startswith("picmistandard=="):
-                                line = f"picmistandard=={repo_version_tag}\n"
-                            f.write(line)
+                # update PICMI version in requirements.txt files manually
+                if repo_name == "picmi":
+                    files = [
+                        os.path.join(repo_dir, "requirements.txt"),
+                        os.path.join(repo_dir, "Docs", "requirements.txt"),
+                    ]
+                    for filename in files:
+                        with open(filename) as f:
+                            lines = f.readlines()
+                        with open(filename, "w") as f:
+                            for line in lines:
+                                if line.startswith("picmistandard=="):
+                                    line = f"picmistandard=={repo_version_tag}\n"
+                                f.write(line)
 
     # write to JSON file with dependencies data
     with open(dependencies_file, "w") as file:

--- a/cmake/dependencies/pybind11.cmake
+++ b/cmake/dependencies/pybind11.cmake
@@ -37,7 +37,7 @@ function(find_pybind11)
             mark_as_advanced(FETCHCONTENT_UPDATES_DISCONNECTED_FETCHEDpybind11)
         endif()
     else()
-        find_package(pybind11 ${pybind11_version} CONFIG REQUIRED)
+        find_package(pybind11 ${pybind11_version_min} CONFIG REQUIRED)
         message(STATUS "pybind11: Found version '${pybind11_VERSION}'")
     endif()
 endfunction()
@@ -55,11 +55,11 @@ set(WarpX_pybind11_repo "https://github.com/pybind/pybind11.git"
 
 # Parse pybind11 version and commit information
 file(READ "${WarpX_SOURCE_DIR}/dependencies.json" dependencies_data)
-string(JSON pybind11_version GET "${dependencies_data}" version_pybind11)
+string(JSON pybind11_version_min GET "${dependencies_data}" version_pybind11_min)
 string(JSON pybind11_commit GET "${dependencies_data}" commit_pybind11)
 
 # Strip "v" prefix from version for find_package
-string(REGEX REPLACE "^v" "" pybind11_version "${pybind11_version}")
+string(REGEX REPLACE "^v" "" pybind11_version_min "${pybind11_version_min}")
 
 set(WarpX_pybind11_branch ${pybind11_commit}
     CACHE STRING

--- a/dependencies.json
+++ b/dependencies.json
@@ -3,7 +3,7 @@
     "version_amrex": "26.04",
     "version_pyamrex": "26.04",
     "version_picsar": "25.06",
-    "version_pybind11": "v3.0.4",
+    "version_pybind11_min": "v3.0.0",
     "version_picmi": "0.34.0",
     "commit_amrex": "7e9ce72d229c5316e46f18fe826dfe2adffe7e17",
     "commit_pyamrex": "1ef54dc9707b8cee69d13c7e3738639bf20f0db2",


### PR DESCRIPTION
## Overview

Fix the issue raised in https://github.com/BLAST-ImpactX/impactx/pull/1419#discussion_r3128341519:

> @EZoni I overlooked something here: You do not want to update the version in `find_package` higher than needed, because that way we cannot build with version `3.0.0`, `3.0.1`, `3.0.2`, and `3.0.3` in package managers anymore - even if those versions are totally fine. (e.g., conda-forge is still to ship `3.0.4`, stands at `3.0.3`. Spack has very good version control, too). So in other words: keep this here on `3.0.0` and below just update the version we download to the latest.

## Related PRs

- https://github.com/BLAST-ImpactX/impactx/pull/1432
- https://github.com/AMReX-Codes/pyamrex/pull/565

## Notes

Please select "Hide whitespace" to review the changes or use `git diff -w`.

