### PR TITLE
Fix NaN handling in electrostatic_sphere_eb MR analysis

### DIFF
--- a/Examples/Tests/electrostatic_sphere_eb/analysis_rz_mr.py
+++ b/Examples/Tests/electrostatic_sphere_eb/analysis_rz_mr.py
@@ -26,7 +26,7 @@ fn = sys.argv[1]
 def find_first_non_zero_from_bottom_left(matrix):
     for i in range(matrix.shape[0]):
         for j in range(matrix.shape[1]):
-            if (matrix[i][j] != 0) and (matrix[i][j] != np.nan):
+            if (matrix[i][j] != 0) and (not np.isnan(matrix[i][j])):
                 return (i, j)
     return i, j
 
@@ -34,7 +34,7 @@ def find_first_non_zero_from_bottom_left(matrix):
 def find_first_non_zero_from_upper_right(matrix):
     for i in range(matrix.shape[0] - 1, -1, -1):
         for j in range(matrix.shape[1] - 1, -1, -1):
-            if (matrix[i][j] != 0) and (matrix[i][j] != np.nan):
+            if (matrix[i][j] != 0) and (not np.isnan(matrix[i][j])):
                 return (i, j)
     return i, j
 


### PR DESCRIPTION
## Summary

In IEEE floats, `np.nan != np.nan` is _always_ `True`, so the old code was buggy:
NaN is never equal to anything, _including itself_.

## Original Description - Spotted by @zippylab

The find_first_non_zero_from_bottom_left/upper_right helper functions used ``matrix[i][j] != np.nan`` to skip NaN values.  Per IEEE 754, NaN != NaN is always True, so this check never filtered out NaN cells.

On GPU platforms where openpmd outputs NaN for cells outside the refined patch (rather than zero), the analysis selected NaN regions as valid data, producing ``nan`` errors for level 1 and failing the assertion.

Fix: replace ``!= np.nan`` with ``not np.isnan()``.

With the fix, level 1 errors on A100 GPU are 0.029% (phi) and 0.083% (Er), well within the 0.4% tolerance.

## X-ref

Isolated from #6801