### PR TITLE
Examples: Remove `particles.do_tiling`

### DIFF
--- a/Examples/Tests/collider_relevant_diags/inputs_test_3d_collider_diagnostics
+++ b/Examples/Tests/collider_relevant_diags/inputs_test_3d_collider_diagnostics
@@ -16,7 +16,6 @@ amr.max_level = 0
 geometry.dims = 3
 geometry.prob_lo = 0 0 0
 geometry.prob_hi =  8 8 8
-particles.do_tiling = 0
 warpx.use_filter = 0
 warpx.abort_on_warning_threshold = high
 

--- a/Examples/Tests/load_external_field/inputs_test_3d_load_external_field_particle_multi_time
+++ b/Examples/Tests/load_external_field/inputs_test_3d_load_external_field_particle_multi_time
@@ -1,7 +1,6 @@
 warpx.abort_on_warning_threshold = medium
 warpx.serialize_initial_conditions = 0
 warpx.do_dynamic_scheduling = 0
-particles.do_tiling = 0
 
 #################################
 ##### TIME-DEPENDENT B (particle loader, MULTI) #####

--- a/Examples/Tests/load_external_field/inputs_test_3d_load_external_field_particle_time
+++ b/Examples/Tests/load_external_field/inputs_test_3d_load_external_field_particle_time
@@ -1,7 +1,6 @@
 warpx.abort_on_warning_threshold = medium
 warpx.serialize_initial_conditions = 0
 warpx.do_dynamic_scheduling = 0
-particles.do_tiling = 0
 
 
 #################################

--- a/Examples/Tests/load_external_field/inputs_test_rz_load_external_field_grid
+++ b/Examples/Tests/load_external_field/inputs_test_rz_load_external_field_grid
@@ -1,7 +1,6 @@
 warpx.abort_on_warning_threshold = medium
 warpx.serialize_initial_conditions = 0
 warpx.do_dynamic_scheduling = 0
-particles.do_tiling = 0
 
 warpx.B_ext_grid_init_style = "read_from_file"
 warpx.read_fields_from_path = "../../../../openPMD-example-datasets/example-femm-thetaMode.h5"

--- a/Examples/Tests/load_external_field/inputs_test_rz_load_external_field_particles
+++ b/Examples/Tests/load_external_field/inputs_test_rz_load_external_field_particles
@@ -1,7 +1,6 @@
 warpx.abort_on_warning_threshold = medium
 warpx.serialize_initial_conditions = 0
 warpx.do_dynamic_scheduling = 0
-particles.do_tiling = 0
 
 particles.B_ext_particle_init_style = "read_from_file"
 particles.read_fields_from_path = "../../../../openPMD-example-datasets/example-femm-thetaMode.h5"

--- a/Examples/Tests/magnetostatic_eb/inputs_test_3d_magnetostatic_eb
+++ b/Examples/Tests/magnetostatic_eb/inputs_test_3d_magnetostatic_eb
@@ -29,7 +29,6 @@ algo.particle_shape = 1
 algo.current_deposition = direct
 
 particles.species_names = beam
-particles.do_tiling = 1
 beam.mass = m_e
 beam.charge = -q_e
 beam.injection_style = nuniformpercell

--- a/Examples/Tests/projection_div_cleaner/inputs_test_rz_projection_div_cleaner
+++ b/Examples/Tests/projection_div_cleaner/inputs_test_rz_projection_div_cleaner
@@ -1,6 +1,5 @@
 warpx.serialize_initial_conditions = 0
 warpx.do_dynamic_scheduling = 0
-particles.do_tiling = 0
 
 warpx.B_ext_grid_init_style = "read_from_file"
 warpx.read_fields_from_path = "../../../../openPMD-example-datasets/example-femm-thetaMode.h5"


### PR DESCRIPTION
Set by default: on for CPU, off for GPU.

If set to on (1) on GPU runs, this asserts.

Isolated from #6801