### PR TITLE
Fix silent failure in analysis_default_regression.py

### DIFF
--- a/Examples/analysis_default_regression.py
+++ b/Examples/analysis_default_regression.py
@@ -32,12 +32,14 @@ def main(args):
 if __name__ == "__main__":
     # define parser
     parser = argparse.ArgumentParser()
+
     # add arguments: output path
     parser.add_argument(
         "--path",
         help="path to output file(s)",
         type=str,
     )
+
     # add arguments: relative tolerance
     # Identify whether the test is a restart test,
     # if it is, use a 1e-12 tolerance for the restart checksum analysis
@@ -50,6 +52,7 @@ if __name__ == "__main__":
         required=False,
         default=default_tolerance,
     )
+
     # add arguments: skip fields
     parser.add_argument(
         "--skip-fields",
@@ -57,6 +60,7 @@ if __name__ == "__main__":
         action="store_true",
         dest="skip_fields",
     )
+
     # add arguments: skip particles
     parser.add_argument(
         "--skip-particles",
@@ -64,23 +68,31 @@ if __name__ == "__main__":
         action="store_true",
         dest="skip_particles",
     )
+
     # parse arguments
     args = parser.parse_args()
+
     # set args.format automatically
+    args.format = None  # default
     try:
         yt.load(args.path)
     except Exception:
         try:
             OpenPMDTimeSeries(args.path)
         except Exception:
-            print("Could not open the file as a plotfile or an openPMD time series")
+            pass  # neither format matched
         else:
             args.format = "openpmd"
     else:
         args.format = "plotfile"
+    if args.format is None:
+        raise ValueError(f"Could not detect format for path: {args.path}")
+
     # set args.do_fields (not parsed, based on args.skip_fields)
     args.do_fields = False if args.skip_fields else True
+
     # set args.do_particles (not parsed, based on args.skip_particles)
     args.do_particles = False if args.skip_particles else True
+
     # execute main function
     main(args)


### PR DESCRIPTION
## Overview

This fixes a silent failure on format detection in analysis_default_regression.py. If both `yt` and `openPMD` attempts fail, the code printed a message but continued execution. Depending on what follows, this could lead to a confusing downstream error or silent misbehavior.

The issue came up in https://github.com/BLAST-WarpX/warpx/pull/6801#discussion_r3148331723 as part of #6801.

## Notes

I added a few empty lines to improve readability as well.