### PR TITLE
Add link to WarpX logo in documentation

### DIFF
--- a/Docs/source/acknowledge_us.rst
+++ b/Docs/source/acknowledge_us.rst
@@ -13,10 +13,12 @@ In presentations
 For your presentations, you can find a WarpX acknowledgment slide `here <https://docs.google.com/presentation/d/1irVUyGKc-1vaQbJN7HgdBpPGQICfD5ci_maOu6noypk/edit?usp=sharing>`__.
 Feel free to use it to acknowledge WarpX in your presentation.
 
+WarpX logos in various image formats and color schemes are available in `this folder <https://drive.google.com/drive/folders/1ohWRIybrMfpHLbIeQa7qr9LL8OWheCHB>`__ and can be featured on slides when acknowledging WarpX.
+
 .. _acknowledge_warpx_generic:
 
-Acknowledgement Sentence
-************************
+Acknowledgment in publications
+******************************
 
 Please add the following acknowledgement sentence to your publications, it helps contributors keep in touch with the community and promote the project.
 

--- a/Docs/source/acknowledge_us.rst
+++ b/Docs/source/acknowledge_us.rst
@@ -17,8 +17,8 @@ WarpX logos in various image formats and color schemes are available in `this fo
 
 .. _acknowledge_warpx_generic:
 
-Acknowledgment in publications
-******************************
+Acknowledgement Sentence
+************************
 
 Please add the following acknowledgement sentence to your publications, it helps contributors keep in touch with the community and promote the project.
 


### PR DESCRIPTION
This adds a link to the WarpX logo in the documentation (see https://warpx--6814.org.readthedocs.build/en/6814/acknowledge_us.html#in-presentations)

<img width="728" height="321" alt="Screenshot 2026-04-28 at 9 09 57 AM" src="https://github.com/user-attachments/assets/9065a4eb-30f6-449f-81c3-468680196638" />
