### PR TITLE
Only do pairwise energy conservation if there are two or more particles

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -760,6 +760,10 @@ public:
 
                         index_type const cell_start_1 = cell_offsets_1[i_cell];
                         index_type const cell_stop_1  = cell_offsets_1[i_cell+1];
+
+                        // No correction needed if there is only one particle in the cell
+                        if ( cell_stop_1 - cell_start_1 <= 1 ) { return; }
+
                         amrex::ParticleReal deltaEp1 = -KE_in_each_cell[i_cell];
 
                         if (deltaEp1 != 0.) {
@@ -1423,7 +1427,7 @@ public:
 
                             bool correction1_failed = false;
                             bool correction2_failed = false;
-                            if (deltaEp1 != 0.) {
+                            if (deltaEp1 != 0. && cell_stop_1 - cell_start_1 > 1) {
                                 // Adjust species 1 particles to absorb deltaEp1.
                                 correction1_failed =
                                      ParticleUtils::ModifyEnergyPairwise(u1x, u1y, u1z, w1, indices_1,
@@ -1431,7 +1435,7 @@ public:
                                                                          energy_fraction, energy_fraction_max, deltaEp1);
                             }
 
-                            if (deltaEp2 != 0.) {
+                            if (deltaEp2 != 0. && cell_stop_2 - cell_start_2 > 1) {
                                 // Adjust species 2 particles to absorb deltaEp2.
                                 correction2_failed =
                                      ParticleUtils::ModifyEnergyPairwise(u2x, u2y, u2z, w2, indices_2,

--- a/Source/Utils/ParticleUtils.H
+++ b/Source/Utils/ParticleUtils.H
@@ -417,6 +417,7 @@ namespace ParticleUtils {
         T_index i1 = cell_start;
         bool correction_failed = false;
         bool deltaE_is_zero = false;
+        int Erel_negative_count = 0;
         while (!deltaE_is_zero && !correction_failed && loop_count <= max_loop_count) {
 
             T_index i2 = i1 + 1;
@@ -459,7 +460,20 @@ namespace ParticleUtils {
             const amrex::ParticleReal pztot = wpmp1*uz1 + wpmp2*uz2;
             const amrex::ParticleReal Ecm = std::sqrt(Etot*Etot - (pxtot*pxtot + pytot*pytot + pztot*pztot)*c2);
             const amrex::ParticleReal Erel = Ecm - wpmp1*c2 - wpmp2*c2;
-            if (Erel <= 0.0) { continue; }
+            if (Erel <= 0.0) {
+                // This checks for the unlikely case where the Erel is negative for all
+                // pairs of particles
+                Erel_negative_count++;
+                if (Erel_negative_count >= numCell) {
+                    correction_failed = true;
+                    break;
+                }
+                continue;
+            } else {
+                // Reset the counter since the next time through the loop
+                // might use difference pairs of particles
+                Erel_negative_count = 0;
+            }
 
             // Set the amount of energy change for this pair based on the
             // relative energy in the center of momentum.


### PR DESCRIPTION
With unequally weight particles in binary collisions, the particle momenta are adjusted to exactly conserve energy and momentum. The adjustment for energy conservation is done pairwise (within each species). This PR adds a check that there are at least two particles in the cell before calling the routine that does the energy correction. Without this check, an infinite loop can arise since due to round off, the relative energy can be negative.

Also, a check is added for the unlikely case where the relative energy is negative for all pairs of particles.