### PR TITLE
Add run time tracer, replacing tiny profiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ option(WarpX_SIMD          "CPU SIMD Acceleration"                      OFF)
 option(WarpX_OPENPMD       "openPMD I/O (HDF5, ADIOS)"                  ON)
 option(WarpX_FASTMATH      "Enable fast-math optimizations"             OFF)
 option(WarpX_FFT           "FFT-based solvers"                          OFF)
+option(WarpX_PROFILE_TRACE "Run time tracing"                           OFF)
 option(WarpX_PYTHON        "Python bindings"                            OFF)
 option(WarpX_SENSEI        "SENSEI in situ diagnostics"                 OFF)
 option(WarpX_QED           "QED support (requires PICSAR)"              ON)
@@ -640,6 +641,10 @@ foreach(D IN LISTS WarpX_DIMS)
     if(ABLASTR_FFT)
         # We need to enable FFT support in ABLASTR for PSATD solver
         target_compile_definitions(ablastr_${SD} PUBLIC ABLASTR_USE_FFT)
+    endif()
+
+    if(WarpX_PROFILE_TRACE)
+        target_compile_definitions(ablastr_${SD} PUBLIC ABLASTER_PROFILE_TRACE)
     endif()
 
     if(WarpX_PYTHON AND pyWarpX_VERSION_INFO)

--- a/Source/ablastr/profiler/ProfilerWrapper.H
+++ b/Source/ablastr/profiler/ProfilerWrapper.H
@@ -8,6 +8,8 @@
 #ifndef ABLASTR_PROFILERWRAPPER_H_
 #define ABLASTR_PROFILERWRAPPER_H_
 
+#ifndef ABLASTER_PROFILE_TRACE
+
 #include <AMReX_BLProfiler.H>
 
 #define ABLASTR_PROFILE(fname) BL_PROFILE(fname)
@@ -17,4 +19,23 @@
 #define ABLASTR_PROFILE_VAR_STOP(vname) BL_PROFILE_VAR_STOP(vname)
 #define ABLASTR_PROFILE_REGION(rname) BL_PROFILE_REGION(rname)
 
+#else
+
+#include <AMReX_ParallelDescriptor.H>
+#include <AMReX_Print.H>
+
+#define _PROFILER_TRACER(name)                                               \
+        if (amrex::ParallelDescriptor::MyProc() == 0) {                      \
+            amrex::Print() << name << "\n";                                  \
+            std::cout.flush();                                               \
+        }
+
+#define ABLASTR_PROFILE(fname) _PROFILER_TRACER(fname)
+#define ABLASTR_PROFILE_VAR(fname, vname) _PROFILER_TRACER(fname)
+#define ABLASTR_PROFILE_VAR_NS(fname, vname) _PROFILER_TRACER(fname)
+#define ABLASTR_PROFILE_VAR_START(vname)
+#define ABLASTR_PROFILE_VAR_STOP(vname)
+#define ABLASTR_PROFILE_REGION(rname) _PROFILER_TRACER(rname)
+
+#endif // ABLASTER_PROFILE_TRACE
 #endif // ABLASTR_PROFILERWRAPPER_H_

--- a/Source/ablastr/profiler/ProfilerWrapper.H
+++ b/Source/ablastr/profiler/ProfilerWrapper.H
@@ -25,9 +25,11 @@
 #include <AMReX_Print.H>
 
 #define _PROFILER_TRACER(name)                                               \
-        if (amrex::ParallelDescriptor::MyProc() == 0) {                      \
-            amrex::Print() << name << "\n";                                  \
-            std::cout.flush();                                               \
+        {                                                                    \
+        amrex::AllPrint() << "[Rank "                                        \
+                          << amrex::ParallelDescriptor::MyProc()             \
+                          << "] " << name << "\n";                           \
+        std::cout.flush();                                                   \
         }
 
 #define ABLASTR_PROFILE(fname) _PROFILER_TRACER(fname)


### PR DESCRIPTION
This is a bit of a hack, but I found this helpful in tracing down a code hang. When setting the cmake option `WarpX_PROFILE_TRACE=ON`, instead of using the AMReX `BL_PROFILE` macro, it is replaced with a print statement, producing a run time trace. This is only intended for debugging since the output will be voluminous.

It would be better if this could be built into BL_PROFILE.