### PR TITLE
[WIP] clang-tidy CI test : enable performance-enum-size check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -45,7 +45,6 @@ Checks: '
         -modernize-use-starts-ends-with,
     mpi-*,
     performance-*,
-        -performance-enum-size,
     portability-*,
     readability-*,
         -readability-avoid-nested-conditional-operator,
@@ -90,7 +89,6 @@ HeaderFilterRegex: 'Source[a-z_A-Z0-9\/]+\.H$'
 
 # TODO Consider enabling the following checks:
 # -bugprone-unused-local-non-trivial-variable
-# -performance-enum-size
 # -readability-container-contains
 # -readability-redundant-inline-specifier
 # -readability-redundant-member-init


### PR DESCRIPTION
This PR enables the following check in `clang-tidy` CI test :
- [performance-enum-size](https://releases.llvm.org/18.1.1/tools/clang/tools/extra/docs/clang-tidy/checks/performance/enum-size.html)
From the description :
> Recommends the smallest possible underlying type for an enum or enum class based on the range of its enumerators. Analyzes the values of the enumerators in an enum or enum class, including signed values, to recommend the smallest possible underlying type that can represent all the values of the enum.

This check was introduced in `clang-tidy` v18, and we temporarily disabled it when we switched from `clang-tidy` v17 to `clang-tidy` v18 to enable the switch to C++20 ( https://github.com/BLAST-WarpX/warpx/pull/6606 ). However, per se, the check only requires C++ 11.
