### PR TITLE
binary collision energy conservation, sort by weight

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3101,7 +3101,8 @@ Details about the collision models can be found in the :ref:`theory section <mul
     :default: 0
     :optional:
 
-    For pairwisecoulomb collisions, whether to correct the energy and momentum after the collisions so that they are conserved.
+    Only for ``pairwisecoulomb`` collisions, whether to correct the energy and momentum after the collisions so that they are conserved.
+    This can be set for each collision using :pp:param:`<collision_name>.correct_energy_momentum`.
     In binary collisions, if the weights of the colliding particles are not the same, the collision does not
     exactly conserve energy and momentum. When this option is on, after the collisions, small modifications are made to the
     particle momentum so that the energy and momentum are exactly conserved in each cell.
@@ -3112,7 +3113,8 @@ Details about the collision models can be found in the :ref:`theory section <mul
     :default: 0.05
     :optional:
 
-    For pairwisecoulomb collisions, when correcting the energy and momentum conservation, the energy correction is applied to pairs of particles in their center of momentum frame.
+    Only for ``pairwisecoulomb`` collisions, with :pp:param:`collisions.correct_energy_momentum` set, the energy correction is applied to pairs of particles in their center of momentum frame.
+    This can be set for each collision using :pp:param:`<collision_name>.energy_fraction`.
     This parameter is the fraction of the relative energy in the COM frame that is used in the correction.
 
 .. pp:param:: collisions.energy_fraction_max
@@ -3120,7 +3122,8 @@ Details about the collision models can be found in the :ref:`theory section <mul
     :default: 0.5
     :optional:
 
-    For pairwisecoulomb collisions, when correcting the energy and momentum conservation, the energy correction is applied to pairs of particles in their center of momentum frame.
+    Only for ``pairwisecoulomb`` collisions, with :pp:param:`collisions.correct_energy_momentum` set, the energy correction is applied to pairs of particles in their center of momentum frame.
+    This can be set for each collision using :pp:param:`<collision_name>.energy_fraction_max`.
     This parameter is the fraction of the total relative energy in the COM frame of all pairs that is used in the correction.
 
 .. pp:param:: collisions.beta_weight_exponent
@@ -3128,8 +3131,17 @@ Details about the collision models can be found in the :ref:`theory section <mul
     :default: 1.
     :optional:
 
-    For pairwisecoulomb collisions, when correcting the energy and momentum conservation, this parameter controls the exponent used on the particle weight when distributing the momentum correction.
+    Only for ``pairwisecoulomb`` collisions, with :pp:param:`collisions.correct_energy_momentum` set, this parameter controls the exponent used on the particle weight when distributing the momentum correction.
+    This can be set for each collision using :pp:param:`<collision_name>.beta_weight_exponent`.
     With a value greater than 1, it will distribute more of the correction to particles with higher weights.
+
+.. pp:param:: collisions.energy_correction_sort_by_weight
+    :type: ``bool``
+    :default: 0
+    :optional:
+
+    Only for ``pairwisecoulomb`` collisions, with :pp:param:`collisions.correct_energy_momentum` set, specifies whether the particles are sorted by weight when the energy correction is applied.
+    When the particles have a range of weights, sorting improves the correction by applying more of it to the heavier weighted particles, which has a proportionately smaller effect on their momenta, and typically reduces the number of particles that the correction is applied to.
 
 .. pp:param:: collisions.split_momentum_push
     :type: ``bool``
@@ -3140,30 +3152,6 @@ Details about the collision models can be found in the :ref:`theory section <mul
     This improves energy conservation, as demonstrated in (`Vay et al., Phys. Rev. E 111, 2025 <https://doi.org/10.1103/PhysRevE.111.025306>`__).
     This is only implemented for the explicit evolve scheme and is not available for the implicit evolve schemes, because the implicit
     formulation is intrinsically energy-conserving when combined with MCC collisions, as shown in `Angus et al., J. Comput. Phys. 456, 2022 <https://doi.org/10.1016/j.jcp.2022.111030>`__.
-
-.. pp:param:: <collision_name>.correct_energy_momentum
-    :type: ``bool``
-    :optional:
-
-    For pairwisecoulomb collisions, override the parameter :pp:param:`collisions.correct_energy_momentum` for the specific collision.
-
-.. pp:param:: <collision_name>.energy_fraction
-    :type: ``float``
-    :optional:
-
-    For pairwisecoulomb collisions, override the parameter :pp:param:`collisions.energy_fraction` for the specific collision.
-
-.. pp:param:: <collision_name>.energy_fraction_max
-    :type: ``float``
-    :optional:
-
-    For pairwisecoulomb collisions, override the parameter :pp:param:`collisions.energy_fraction_max` for the specific collision.
-
-.. pp:param:: <collision_name>.beta_weight_exponent
-    :type: ``float``
-    :optional:
-
-    For pairwisecoulomb collisions, override the parameter :pp:param:`collisions.beta_weight_exponent` for the specific collision.
 
 .. _running-cpp-parameters-numerics:
 

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3124,7 +3124,9 @@ Details about the collision models can be found in the :ref:`theory section <mul
 
     Only for ``pairwisecoulomb`` collisions, with :pp:param:`collisions.correct_energy_momentum` set, the energy correction is applied to pairs of particles in their center of momentum frame.
     This can be set for each collision using :pp:param:`<collision_name>.energy_fraction_max`.
-    This parameter is the fraction of the total relative energy in the COM frame of all pairs that is used in the correction.
+    This parameter sets the maximum allowed value for :pp:param:`collisions.energy_fraction`.
+    If residual energy error remains after a pass over all particle pairs in a cell, the algorithm increases the effective correction fraction for the next pass based on an estimate of the remaining error.
+    If this computed value exceeds the limit imposed by this parameter, the correction is deemed to have failed and particle velocities in the cell are restored to their pre-collision values.
 
 .. pp:param:: collisions.beta_weight_exponent
     :type: ``float``

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3143,6 +3143,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
     :optional:
 
     Only for ``pairwisecoulomb`` collisions, with :pp:param:`collisions.correct_energy_momentum` set, specifies whether the particles are sorted by weight when the energy correction is applied.
+    This can be set for each collision using :pp:param:`<collision_name>.energy_correction_sort_by_weight`.
     When the particles have a range of weights, sorting improves the correction by applying more of it to the heavier weighted particles, which has a proportionately smaller effect on their momenta, and typically reduces the number of particles that the correction is applied to.
 
 .. pp:param:: collisions.split_momentum_push

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -778,6 +778,9 @@ public:
 
                         if (deltaEp1 != 0.) {
 
+                            // The ignore_unused is needed to fix the error "An extended __device__
+                            // lambda cannot first-capture variable in constexpr-if context"
+                            amrex::ignore_unused(heapSortDecreasing, indices_1, w1);
                             if constexpr (energy_correction_sort_by_weight_control == sort) {
                                 int const numCell1 = (cell_stop_1 - cell_start_1);
                                 heapSortDecreasing(indices_1, w1, cell_start_1, numCell1);
@@ -1448,6 +1451,10 @@ public:
                                 deltaEp1 = w1_sum*KE1_after/Etotdenom*deltaE/numCell1;
                                 deltaEp2 = w2_sum*KE2_after/Etotdenom*deltaE/numCell2;
                             }
+
+                            // The ignore_unused is needed to fix the error "An extended __device__
+                            // lambda cannot first-capture variable in constexpr-if context"
+                            amrex::ignore_unused(heapSortDecreasing);
 
                             bool correction1_failed = false;
                             bool correction2_failed = false;

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -754,6 +754,11 @@ public:
                 amrex::Long* failed_corrections_ptr = failed_corrections.data();
                 amrex::ParticleReal* remaining_energy_ptr = remaining_energy.data();
 
+                // The particles are sorted by weight in decreasing order. This gives more of the correction
+                // to the heavier particles, having a smallar effect on their momenta, and typically
+                // requiring fewer particles to absorb or give off the extra energy.
+                auto heatSortDecreasing = ParticleUtils::HeapSortDecreasing();
+
                 amrex::ParallelFor( n_cells,
                     [=] AMREX_GPU_DEVICE (int i_cell) noexcept
                     {
@@ -767,6 +772,10 @@ public:
                         amrex::ParticleReal deltaEp1 = -KE_in_each_cell[i_cell];
 
                         if (deltaEp1 != 0.) {
+
+                            int const numCell1 = (cell_stop_1 - cell_start_1);
+                            heatSortDecreasing(indices_1, w1, cell_start_1, numCell1);
+
                             // Adjust species 1 particles to absorb deltaEp1.
                             const bool correction_failed =
                                  ParticleUtils::ModifyEnergyPairwise(u1x, u1y, u1z, w1, indices_1,
@@ -1372,6 +1381,11 @@ public:
                 amrex::Long* failed_corrections_ptr = failed_corrections.data();
                 amrex::ParticleReal* remaining_energy_ptr = remaining_energy.data();
 
+                // The particles are sorted by weight in decreasing order. This gives more of the correction
+                // to the heavier particles, having a smallar effect on their momenta, and typically
+                // requiring fewer particles to absorb or give off the extra energy.
+                auto heatSortDecreasing = ParticleUtils::HeapSortDecreasing();
+
                 amrex::ParallelFor( n_cells,
                     [=] AMREX_GPU_DEVICE (int i_cell) noexcept
                     {
@@ -1428,6 +1442,7 @@ public:
                             bool correction1_failed = false;
                             bool correction2_failed = false;
                             if (deltaEp1 != 0. && cell_stop_1 - cell_start_1 > 1) {
+                                heatSortDecreasing(indices_1, w1, cell_start_1, numCell1);
                                 // Adjust species 1 particles to absorb deltaEp1.
                                 correction1_failed =
                                      ParticleUtils::ModifyEnergyPairwise(u1x, u1y, u1z, w1, indices_1,
@@ -1436,6 +1451,7 @@ public:
                             }
 
                             if (deltaEp2 != 0. && cell_stop_2 - cell_start_2 > 1) {
+                                heatSortDecreasing(indices_2, w2, cell_start_2, numCell2);
                                 // Adjust species 2 particles to absorb deltaEp2.
                                 correction2_failed =
                                      ParticleUtils::ModifyEnergyPairwise(u2x, u2y, u2z, w2, indices_2,

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -113,12 +113,14 @@ public:
             // Input parameter set for all pairwise Coulomb collisions
             const amrex::ParmParse pp_collisions("collisions");
             pp_collisions.query("correct_energy_momentum", m_correct_energy_momentum);
+            pp_collisions.query("energy_correction_sort_by_weight", m_energy_correction_sort_by_weight);
             pp_collisions.query("beta_weight_exponent", m_beta_weight_exponent);
             pp_collisions.query("energy_fraction", m_energy_fraction);
             pp_collisions.query("energy_fraction_max", m_energy_fraction_max);
 
             // Input parameter set for this collision
             pp_collision_name.query("correct_energy_momentum", m_correct_energy_momentum);
+            pp_collision_name.query("energy_correction_sort_by_weight", m_energy_correction_sort_by_weight);
             pp_collision_name.query("beta_weight_exponent", m_beta_weight_exponent);
             pp_collision_name.query("energy_fraction", m_energy_fraction);
             pp_collision_name.query("energy_fraction_max", m_energy_fraction_max);
@@ -757,10 +759,13 @@ public:
                 // The particles are sorted by weight in decreasing order. This gives more of the correction
                 // to the heavier particles, having a smallar effect on their momenta, and typically
                 // requiring fewer particles to absorb or give off the extra energy.
-                auto heatSortDecreasing = ParticleUtils::HeapSortDecreasing();
+                const int energy_correction_sort_by_weight_flag = m_energy_correction_sort_by_weight ? sort : no_sort;
+                auto heapSortDecreasing = ParticleUtils::HeapSortDecreasing();
 
-                amrex::ParallelFor( n_cells,
-                    [=] AMREX_GPU_DEVICE (int i_cell) noexcept
+                amrex::ParallelFor(amrex::TypeList<amrex::CompileTimeOptions<no_sort,sort>>{},
+                                   {energy_correction_sort_by_weight_flag},
+                                   n_cells,
+                    [=] AMREX_GPU_DEVICE (int i_cell, auto energy_correction_sort_by_weight_control) noexcept
                     {
 
                         index_type const cell_start_1 = cell_offsets_1[i_cell];
@@ -773,8 +778,10 @@ public:
 
                         if (deltaEp1 != 0.) {
 
-                            int const numCell1 = (cell_stop_1 - cell_start_1);
-                            heatSortDecreasing(indices_1, w1, cell_start_1, numCell1);
+                            if constexpr (energy_correction_sort_by_weight_control == sort) {
+                                int const numCell1 = (cell_stop_1 - cell_start_1);
+                                heapSortDecreasing(indices_1, w1, cell_start_1, numCell1);
+                            }
 
                             // Adjust species 1 particles to absorb deltaEp1.
                             const bool correction_failed =
@@ -1384,10 +1391,13 @@ public:
                 // The particles are sorted by weight in decreasing order. This gives more of the correction
                 // to the heavier particles, having a smallar effect on their momenta, and typically
                 // requiring fewer particles to absorb or give off the extra energy.
-                auto heatSortDecreasing = ParticleUtils::HeapSortDecreasing();
+                const int energy_correction_sort_by_weight_flag = m_energy_correction_sort_by_weight ? sort : no_sort;
+                auto heapSortDecreasing = ParticleUtils::HeapSortDecreasing();
 
-                amrex::ParallelFor( n_cells,
-                    [=] AMREX_GPU_DEVICE (int i_cell) noexcept
+                amrex::ParallelFor(amrex::TypeList<amrex::CompileTimeOptions<no_sort,sort>>{},
+                                   {energy_correction_sort_by_weight_flag},
+                                   n_cells,
+                    [=] AMREX_GPU_DEVICE (int i_cell, auto energy_correction_sort_by_weight_control) noexcept
                     {
                         // The particles from species1 that are in the cell `i_cell` are
                         // given by the `indices_1[cell_start_1:cell_stop_1]`.
@@ -1442,7 +1452,9 @@ public:
                             bool correction1_failed = false;
                             bool correction2_failed = false;
                             if (deltaEp1 != 0. && numCell1 > 1) {
-                                heatSortDecreasing(indices_1, w1, cell_start_1, numCell1);
+                                if constexpr (energy_correction_sort_by_weight_control == sort) {
+                                    heapSortDecreasing(indices_1, w1, cell_start_1, numCell1);
+                                }
                                 // Adjust species 1 particles to absorb deltaEp1.
                                 correction1_failed =
                                      ParticleUtils::ModifyEnergyPairwise(u1x, u1y, u1z, w1, indices_1,
@@ -1451,7 +1463,9 @@ public:
                             }
 
                             if (deltaEp2 != 0. && numCell2 > 1) {
-                                heatSortDecreasing(indices_2, w2, cell_start_2, numCell2);
+                                if constexpr (energy_correction_sort_by_weight_control == sort) {
+                                    heapSortDecreasing(indices_2, w2, cell_start_2, numCell2);
+                                }
                                 // Adjust species 2 particles to absorb deltaEp2.
                                 correction2_failed =
                                      ParticleUtils::ModifyEnergyPairwise(u2x, u2y, u2z, w2, indices_2,
@@ -1505,9 +1519,12 @@ private:
     bool m_have_product_species;
 
     bool m_correct_energy_momentum = false;
+    bool m_energy_correction_sort_by_weight = false;
     amrex::ParticleReal m_beta_weight_exponent = 1.;
     amrex::ParticleReal m_energy_fraction = 0.05;
     amrex::ParticleReal m_energy_fraction_max = 0.5;
+
+    enum energy_correction_sort_by_weight_flags : int { no_sort, sort };
 
     amrex::Vector<std::string> m_product_species;
     // functor that performs collisions within a cell

--- a/Source/Utils/ParticleUtils.H
+++ b/Source/Utils/ParticleUtils.H
@@ -550,6 +550,64 @@ namespace ParticleUtils {
 
         return correction_failed;
     }
+
+    /**
+     * \brief A GPU compartible sort of a index vector vector
+     * based on another GPU vector's values, sorting to decreasing order.
+     * The heap-sort functions below were obtained from
+     * https://www.geeksforgeeks.org/iterative-heap-sort/ and
+     * modified for the current purpose. It achieves the same as
+     * ```
+     * std::sort(
+     *    sorted_indices_data + cell_start, sorted_indices_data + cell_stop,
+     *    [&momentum_bin_number_data](size_t i1, size_t i2) {
+     *        return momentum_bin_number_data[i1] > momentum_bin_number_data[i2];
+     *    }
+     * );
+     * ```
+     * but with support for device execution.
+    */
+    struct HeapSortDecreasing {
+
+        template <typename T_index>
+        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+        void operator() (T_index index_array[], const amrex::ParticleReal bin_array[], const T_index start, const T_index n) const
+        {
+            // sort index_array into a max heap structure
+            for (T_index i = 1; i < n; i++)
+            {
+                auto j = i;
+                // move child through heap if it is less than its parent
+                while (j > 0 && bin_array[index_array[j+start]] < bin_array[index_array[(j - 1)/2 + start]]) {
+                    // swap child and parent until branch is properly ordered
+                    amrex::Swap(index_array[j+start], index_array[(j - 1)/2 + start]);
+                    j = (j - 1) / 2;
+                }
+            }
+
+            for (T_index i = n - 1; i > 0; i--)
+            {
+                // swap value of first (now the smallest value) to the new end point
+                amrex::Swap(index_array[start], index_array[i+start]);
+
+                // remake the max heap
+                T_index j = 0, index;
+                while (j < i) {
+                    index = 2 * j + 1;
+
+                    // if left child is larger than right child, point index variable to right child
+                    if (index + 1 < i && bin_array[index_array[index+start]] > bin_array[index_array[index+1+start]]) {
+                        index++;
+                    }
+                    // if parent is larger than child, swap parent with child having lower value
+                    if (index < i && bin_array[index_array[j+start]] > bin_array[index_array[index+start]]) {
+                        amrex::Swap(index_array[j+start], index_array[index+start]);
+                    }
+                    j = index;
+                }
+            }
+        }
+    };
 }
 
 #endif // WARPX_PARTICLE_UTILS_H_


### PR DESCRIPTION
In the binary collisions when moment conservation is turned on, this PR adds code to sort the particles by weight before applying the energy conservation correction. This sorting shifts more of the correction to the heavier particles - the correction will have a smaller effect on their momenta. Also, since the heavier particles can absorb or give off more energy, this sorting will typically require adjusting fewer particles to apply the correction.

A quick timing test shows that with the sorting, the simulation time is a few percent faster, presumably because of the fewer particles being required for the correction versus the extra time for the sorting.