### PR TITLE
Change assert to warning about particle count in RZ

### DIFF
--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -335,12 +335,14 @@ void PlasmaInjector::setupNFluxPerCell (amrex::ParmParse const& pp_species)
 {
     utils::parser::getWithParser(pp_species, source_name, "num_particles_per_cell", num_particles_per_cell_real);
 #ifdef WARPX_DIM_RZ
-    if (WarpX::n_rz_azimuthal_modes > 1) {
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        num_particles_per_cell_real>=2*WarpX::n_rz_azimuthal_modes,
-        "Error: For accurate use of WarpX cylindrical geometry the number "
-        "of particles should be at least two times n_rz_azimuthal_modes "
-        "(Please visit PR#765 for more information.)");
+    if ((WarpX::n_rz_azimuthal_modes > 1) && (num_particles_per_cell_real < 2*WarpX::n_rz_azimuthal_modes)) {
+        ablastr::warn_manager::WMRecordWarning("Species",
+            "Too few particles per cell for cylindrical geometry: got "
+            + std::to_string(num_particles_per_cell_real) + ", but at least "
+            + std::to_string(2*WarpX::n_rz_azimuthal_modes)
+            + " (2 x n_rz_azimuthal_modes) are recommended for accuracy. "
+            "See https://github.com/ECP-WarpX/WarpX/pull/765 for details.",
+            ablastr::warn_manager::WarnPriority::high);
     }
 #endif
 
@@ -450,12 +452,15 @@ void PlasmaInjector::setupNuniformPerCell (amrex::ParmParse const& pp_species)
     }
 
 #if WARPX_DIM_RZ
-    if (WarpX::n_rz_azimuthal_modes > 1) {
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        num_particles_per_cell_each_dim[1]>=2*WarpX::n_rz_azimuthal_modes,
-        "Error: For accurate use of WarpX cylindrical geometry the number "
-        "of particles in the theta direction should be at least two times "
-        "n_rz_azimuthal_modes (Please visit PR#765 for more information.)");
+    if ((WarpX::n_rz_azimuthal_modes > 1) && (num_particles_per_cell_each_dim[1] < 2*WarpX::n_rz_azimuthal_modes)) {
+        ablastr::warn_manager::WMRecordWarning("Species",
+            "Too few particles per cell in the theta direction for cylindrical "
+            "geometry: got "
+            + std::to_string(num_particles_per_cell_each_dim[1]) + ", but at least "
+            + std::to_string(2*WarpX::n_rz_azimuthal_modes)
+            + " (2 x n_rz_azimuthal_modes) are recommended for accuracy. "
+            "See https://github.com/ECP-WarpX/WarpX/pull/765 for details.",
+            ablastr::warn_manager::WarnPriority::high);
     }
 #endif
     // Construct InjectorPosition from InjectorPositionRegular.

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -304,9 +304,11 @@ void PlasmaInjector::setupNRandomPerCell (amrex::ParmParse const& pp_species)
 #if WARPX_DIM_RZ
     if ((WarpX::n_rz_azimuthal_modes > 1) && (num_particles_per_cell < 2*WarpX::n_rz_azimuthal_modes)) {
         ablastr::warn_manager::WMRecordWarning("Species",
-            "For accurate use of WarpX cylindrical geometry the number \n"
-            "of particles should be at least two times n_rz_azimuthal_modes \n"
-            "(Please visit PR#765 for more information.)\n",
+            "Too few particles per cell for cylindrical geometry: got "
+            + std::to_string(num_particles_per_cell) + ", but at least "
+            + std::to_string(2*WarpX::n_rz_azimuthal_modes)
+            + " (2 x n_rz_azimuthal_modes) are recommended for accuracy. "
+            "See https://github.com/ECP-WarpX/WarpX/pull/765 for details.",
             ablastr::warn_manager::WarnPriority::high);
     }
 #endif

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -306,7 +306,8 @@ void PlasmaInjector::setupNRandomPerCell (amrex::ParmParse const& pp_species)
         ablastr::warn_manager::WMRecordWarning("Species",
             "For accurate use of WarpX cylindrical geometry the number \n"
             "of particles should be at least two times n_rz_azimuthal_modes \n"
-            "(Please visit PR#765 for more information.)\n");
+            "(Please visit PR#765 for more information.)\n",
+            ablastr::warn_manager::WarnPriority::high);
     }
 #endif
     // Construct InjectorPosition with InjectorPositionRandom.

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -302,12 +302,11 @@ void PlasmaInjector::setupNRandomPerCell (amrex::ParmParse const& pp_species)
 {
     utils::parser::getWithParser(pp_species, source_name, "num_particles_per_cell", num_particles_per_cell);
 #if WARPX_DIM_RZ
-    if (WarpX::n_rz_azimuthal_modes > 1) {
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        num_particles_per_cell>=2*WarpX::n_rz_azimuthal_modes,
-        "Error: For accurate use of WarpX cylindrical geometry the number "
-        "of particles should be at least two times n_rz_azimuthal_modes "
-        "(Please visit PR#765 for more information.)");
+    if ((WarpX::n_rz_azimuthal_modes > 1) && (num_particles_per_cell < 2*WarpX::n_rz_azimuthal_modes)) {
+        ablastr::warn_manager::WMRecordWarning("Species",
+            "For accurate use of WarpX cylindrical geometry the number \n"
+            "of particles should be at least two times n_rz_azimuthal_modes \n"
+            "(Please visit PR#765 for more information.)\n");
     }
 #endif
     // Construct InjectorPosition with InjectorPositionRandom.


### PR DESCRIPTION
Currently if a user specifies too few particles per cell in RZ with n > 1 azimuthal modes, an error is raised. This really should be a warning since there are use cases where a low particle count is desired.