### PR TITLE
Fix optical length update when `collisions.split_momentum_push = 1`

### DIFF
--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -93,7 +93,7 @@ PhotonParticleContainer::PushPX (WarpXParIter& pti,
                                  int lev, int gather_lev,
                                  amrex::Real dt, ScaleFields /*scaleFields*/, SubcyclingHalf subcycling_half,
                                  PositionPushType position_push_type,
-                                 MomentumPushType /*momentum_push_type*/)
+                                 MomentumPushType momentum_push_type)
 {
     // Get inverse cell size on gather_lev
     const amrex::XDim3 dinv = WarpX::InvCellSize(std::max(gather_lev,0));
@@ -121,6 +121,8 @@ PhotonParticleContainer::PushPX (WarpXParIter& pti,
 #ifdef WARPX_QED
     BreitWheelerEvolveOpticalDepth evolve_opt;
     amrex::ParticleReal* AMREX_RESTRICT p_optical_depth_BW = nullptr;
+    const amrex::Real qed_dt =
+        (momentum_push_type == MomentumPushType::Full) ? dt : amrex::Real(0.5) * dt;
     const bool local_has_breit_wheeler = has_breit_wheeler();
     if (local_has_breit_wheeler) {
         evolve_opt = m_shr_p_bw_engine->build_evolve_functor();
@@ -224,7 +226,7 @@ PhotonParticleContainer::PushPX (WarpXParIter& pti,
             [[maybe_unused]] auto dt_tmp = dt;
             if constexpr (qed_control == has_qed) {
                 evolve_opt(ux[i], uy[i], uz[i], Exp, Eyp, Ezp, Bxp, Byp, Bzp,
-                           dt, p_optical_depth_BW[i]);
+                           qed_dt, p_optical_depth_BW[i]);
             }
 #else
             amrex::ignore_unused(qed_control);

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -224,6 +224,7 @@ PhotonParticleContainer::PushPX (WarpXParIter& pti,
             [[maybe_unused]] auto *uy_tmp = uy;
             [[maybe_unused]] auto *uz_tmp = uz;
             [[maybe_unused]] auto dt_tmp = dt;
+            [[maybe_unused]] auto qed_dt_tmp = qed_dt;
             if constexpr (qed_control == has_qed) {
                 evolve_opt(ux[i], uy[i], uz[i], Exp, Eyp, Ezp, Bxp, Byp, Bzp,
                            qed_dt, p_optical_depth_BW[i]);

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -95,6 +95,8 @@ PhotonParticleContainer::PushPX (WarpXParIter& pti,
                                  PositionPushType position_push_type,
                                  MomentumPushType momentum_push_type)
 {
+    amrex::ignore_unused(momentum_push_type);
+
     // Get inverse cell size on gather_lev
     const amrex::XDim3 dinv = WarpX::InvCellSize(std::max(gather_lev,0));
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1151,7 +1151,7 @@ PhysicalParticleContainer::SplitParticles (int lev)
 
     amrex::Vector<amrex::Vector<ParticleReal>> attr;
     attr.push_back(wp);
-    const amrex::Vector<amrex::Vector<int>> attr_int;
+    const amrex::Vector<amrex::Vector<int>> attr_int{};
     pctmp_split.AddNParticles(lev,
                               np_split_to_add,
                               xp,
@@ -1557,6 +1557,7 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
         [[maybe_unused]] auto foo_local_has_quantum_sync = local_has_quantum_sync;
         [[maybe_unused]] auto *foo_podq = p_optical_depth_QSR;
         [[maybe_unused]] const auto& foo_evolve_opt = evolve_opt; // have to do all these for nvcc
+        [[maybe_unused]] auto foo_qed_dt = qed_dt;
         if constexpr (qed_control == has_qed) {
             if (local_has_quantum_sync) {
                 evolve_opt(ux[ip], uy[ip], uz[ip],

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1447,6 +1447,8 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
     const auto do_sync = m_do_qed_quantum_sync;
     amrex::Real t_chi_max = 0.0;
     if (do_sync) { t_chi_max = m_shr_p_qs_engine->get_minimum_chi_part(); }
+    const amrex::Real qed_dt =
+        (momentum_push_type == MomentumPushType::Full) ? dt : amrex::Real(0.5) * dt;
 
     QuantumSynchrotronEvolveOpticalDepth evolve_opt;
     amrex::ParticleReal* AMREX_RESTRICT p_optical_depth_QSR = nullptr;
@@ -1559,7 +1561,7 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
             if (local_has_quantum_sync) {
                 evolve_opt(ux[ip], uy[ip], uz[ip],
                            Exp, Eyp, Ezp,Bxp, Byp, Bzp,
-                           dt, p_optical_depth_QSR[ip]);
+                           qed_dt, p_optical_depth_QSR[ip]);
             }
         }
 #else


### PR DESCRIPTION
If  collisions are performed in the middle of the momentum push (`collisions.split_momentum_push = 1`), then particles are advanced through two `PushPX` calls per timestep: `FirstHalf` and `SecondHalf`, each correponding to `0.5*dt`.

Before this PR, the QED optical-depth evolution was performed in each call using the full timestep `dt`, so quantum synchrotron and Breit-Wheeler optical depths were incorrectly advanced by `2*dt` per timestep.

This could make QED events occur too often when QED processes were used together with split-push collisions.

This PR uses `0.5*dt` for QED optical-depth evolution during split momentum pushes, while keeping `dt` for the standard full momentum push.

Note that this behavior could only be observed if both these conditions were true:
* collisions exist: `collisions.collision_names` is not empty
* (nonlinear/strong) QED species exist, i.e. `<species>.do_qed_quantum_sync=1`, or `<species>.do_qed_breit_wheeler=1`.

There is no test that satisfies the combination as of now.
We will add one in a follow-up PR. 

Thanks to @pkicsiny !