### PR TITLE
Add new time step size limiters

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3196,6 +3196,12 @@ Time step
     When specified, :pp:param:`warpx.const_dt` must not also be specified.
     The time step size is updated using the limits specified by :pp:param:`warpx.cfl`, :pp:param:`warpx.max_omegap_dt`, and :pp:param:`warpx.max_omegac_dt`.
 
+.. pp:param:: warpx.dt_update_diagnostic_file
+    :type: ``string``
+    :optional:
+
+    When adaptive timestepping is activated, information about the new time step and the simulation conditions are output to the file specified by this parameter.
+
 .. pp:param:: warpx.max_omegap_dt
     :type: ``float``
     :optional:

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3188,26 +3188,28 @@ Time step
 
 .. pp:param:: warpx.dt_update_interval
     :type: ``string``
-    :default: ``-1``
     :optional:
 
-    How many iterations pass between timestep adaptations when using the explicit electrostatic or theta-implicit solver.
-    Must be greater than ``0`` to use adaptive timestepping, or else :pp:param:`warpx.const_dt` must be specified.
+    This controls adaptive timestepping, where the time step size is updated based on the conditions of the simulation, and only applies when using the explicit electrostatic or theta-implicit solvers.
+    This specifies time step intervals when the time step size is updated.
+    The value must be greater than ``0``.
+    When specified, :pp:param:`warpx.const_dt` must not also be specified.
+    The time step size is updated using the limits specified by :pp:param:`warpx.cfl`, :pp:param:`warpx.max_omegap_dt`, and :pp:param:`warpx.max_omegac_dt`.
 
 .. pp:param:: warpx.max_omegap_dt
     :type: ``float``
     :optional:
 
-    The time step size is limited to be less than the value specified divided by the global plasma frequency.
-    The application is this limit is controlled by :pp:param:`warpx.dt_update_interval`, and is only applied when using the explicit electrostatic or theta-implicit solver..
+    With adaptive timestepping, the time step size is limited to be less than or equal to the value specified divided by the global plasma frequency.
+    The application of this limit is controlled by :pp:param:`warpx.dt_update_interval`, and is only applied when using the explicit electrostatic or theta-implicit solver..
 
 .. pp:param:: warpx.max_omegac_dt
     :type: ``float``
     :optional:
 
-    The time step size is limited to be less than the value specified divided by the maximum cyclotron frequency.
-    Note that the maximum B field is calculated from using only the constant applied B field (as set by :pp:param:`particles.B_external_particle`) and the B-field grid data.
-    The application is this limit is controlled by :pp:param:`warpx.dt_update_interval`, and is only applied when using the explicit electrostatic or theta-implicit solver..
+    With adaptive timestepping, the time step size is limited to be less than or equal to the value specified divided by the maximum cyclotron frequency.
+    Note that the maximum B-field is calculated from using only the constant applied B field (as set by :pp:param:`particles.B_external_particle`) and the B-field grid data.
+    The application of this limit is controlled by :pp:param:`warpx.dt_update_interval`, and is only applied when using the explicit electrostatic or theta-implicit solver..
 
 .. pp:param:: warpx.max_dt
     :type: ``float``

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3191,14 +3191,29 @@ Time step
     :default: ``-1``
     :optional:
 
-    How many iterations pass between timestep adaptations when using the electrostatic solver.
+    How many iterations pass between timestep adaptations when using the explicit electrostatic or theta-implicit solver.
     Must be greater than ``0`` to use adaptive timestepping, or else :pp:param:`warpx.const_dt` must be specified.
+
+.. pp:param:: warpx.max_omegap_dt
+    :type: ``float``
+    :optional:
+
+    The time step size is limited to be less than the value specified divided by the global plasma frequency.
+    The application is this limit is controlled by :pp:param:`warpx.dt_update_interval`, and is only applied when using the explicit electrostatic or theta-implicit solver..
+
+.. pp:param:: warpx.max_omegac_dt
+    :type: ``float``
+    :optional:
+
+    The time step size is limited to be less than the value specified divided by the maximum cyclotron frequency.
+    Note that the maximum B field is calculated from using only the constant applied B field (as set by :pp:param:`particles.B_external_particle`) and the B-field grid data.
+    The application is this limit is controlled by :pp:param:`warpx.dt_update_interval`, and is only applied when using the explicit electrostatic or theta-implicit solver..
 
 .. pp:param:: warpx.max_dt
     :type: ``float``
     :optional:
 
-    The maximum timestep permitted for the electrostatic solver, when using adaptive timestepping.
+    The maximum timestep permitted when using adaptive timestepping.
     If supplied, also sets the initial timestep for these simulations, before the first timestep update.
 
 Filtering

--- a/Examples/Tests/electrostatic_sphere/inputs_test_3d_electrostatic_sphere_adaptive
+++ b/Examples/Tests/electrostatic_sphere/inputs_test_3d_electrostatic_sphere_adaptive
@@ -1,6 +1,9 @@
 stop_time = 60e-6
 warpx.cfl = 0.2
 warpx.dt_update_interval = 10
+warpx.dt_update_diagnostic_file = diags/reducedfiles/dt_updates.txt
+warpx.max_omegap_dt = 0.2
+warpx.max_omegac_dt = 0.2
 warpx.max_dt = 1.5e-6
 amr.n_cell = 64 64 64
 amr.max_level = 0

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -113,51 +113,33 @@ WarpX::ComputeDt ()
 }
 
 /**
- * Determine the simulation timestep from the maximum speed of all particles
- * Sets timestep so that a particle can only cross cfl*dx cells per timestep.
+ * Used to determine the simulation timestep from the maximum speed of all particles
+ * Timestep will be set so that a particle can cross at most cfl*dx cells per timestep.
  */
-std::optional<amrex::Real>
-WarpX::DtLimitFromParticleSpeeds ()
+amrex::Real
+WarpX::ParticleGridSpeedMax ()
 {
     const amrex::Real* dx = geom[max_level].CellSize();
     const amrex::Real dx_min = minDim(dx);
 
     const amrex::ParticleReal max_v = mypc->maxParticleVelocity();
 
-    if (max_v > 0.) {
-        return cfl * dx_min / max_v;
-    } else {
-        return std::nullopt;
-    }
-
+    return max_v/dx_min;
 }
 
-std::optional<amrex::Real>
-WarpX::DtLimitFromPlasmaFrequency ()
+amrex::Real
+WarpX::GlobalPlasmaFrequencyMax ()
 {
-    if (!m_max_omegap_dt.has_value()) {
-        return std::nullopt;
-    }
-
     const std::unique_ptr<amrex::MultiFab> global_plasma_frequency = mypc->GetGlobalPlasmaFrequency(0);
     const amrex::Real global_plasma_frequency_max = global_plasma_frequency->max(0);
-
-    if (global_plasma_frequency_max > 0.) {
-        return m_max_omegap_dt.value()/global_plasma_frequency_max;
-    } else {
-        return std::nullopt;
-    }
+    return global_plasma_frequency_max;
 }
 
-std::optional<amrex::Real>
-WarpX::DtLimitFromCyclotronFrequency ()
+amrex::Real
+WarpX::GlobalCyclotronFrequencyMax ()
 {
     using ablastr::fields::Direction;
     using warpx::fields::FieldType;
-
-    if (!m_max_omegac_dt.has_value()) {
-        return std::nullopt;
-    }
 
     const amrex::ParmParse pp_particles("particles");
     amrex::Vector<amrex::Real> B_external_particle(3, 0.);
@@ -247,32 +229,34 @@ WarpX::DtLimitFromCyclotronFrequency ()
         }
     }
 
-    if (omegac_max > 0.) {
-        return m_max_omegac_dt.value()/omegac_max;
-    } else {
-        return std::nullopt;
-    }
+    return omegac_max;
 }
 
 void
 WarpX::ApplyDtLimiters ()
 {
-    std::optional<amrex::Real> speed_limit = DtLimitFromParticleSpeeds();
-    std::optional<amrex::Real> opmegap_limit = DtLimitFromPlasmaFrequency();
-    std::optional<amrex::Real> opmegac_limit = DtLimitFromCyclotronFrequency();
+    amrex::Real vmax_o_dx = ParticleGridSpeedMax();
+    amrex::Real omegap_max = m_max_omegap_dt.has_value() ? GlobalPlasmaFrequencyMax() : 0.;
+    amrex::Real omegac_max = m_max_omegac_dt.has_value() ? GlobalCyclotronFrequencyMax() : 0.;
 
-    if (!speed_limit.has_value() &&
-        !opmegap_limit.has_value() &&
-        !opmegac_limit.has_value()) {
+    if (vmax_o_dx == 0. &&
+        (!m_max_omegap_dt.has_value() || omegap_max == 0.) &&
+        (!m_max_omegac_dt.has_value() || omegac_max == 0.)) {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_max_dt.has_value(),
                                          "No valid time step size limit found, warpx.max_dt must be specified");
     }
 
     amrex::Real dt_new = std::numeric_limits<amrex::Real>::max();
 
-    if (speed_limit.has_value()) { dt_new = std::min(dt_new, speed_limit.value()); }
-    if (opmegap_limit.has_value()) { dt_new = std::min(dt_new, opmegap_limit.value()); }
-    if (opmegac_limit.has_value()) { dt_new = std::min(dt_new, opmegac_limit.value()); }
+    if (vmax_o_dx > 0.) {
+        dt_new = std::min(dt_new, cfl/vmax_o_dx);
+    }
+    if (m_max_omegap_dt.has_value() && omegap_max > 0.) {
+        dt_new = std::min(dt_new, m_max_omegap_dt.value()/omegap_max);
+    }
+    if (m_max_omegac_dt.has_value() && omegac_max > 0.) {
+        dt_new = std::min(dt_new, m_max_omegac_dt.value()/omegac_max);
+    }
 
     if (m_max_dt.has_value()) {
         dt_new = std::min(dt_new, m_max_dt.value());
@@ -285,4 +269,69 @@ WarpX::ApplyDtLimiters ()
         dt[lev] = dt[lev+1] * refRatio(lev)[0];
     }
 
+    // Write diagnostics if requested
+    if (amrex::ParallelDescriptor::IOProcessor()
+        && !m_dt_update_diagnostic_file.empty()
+        && !amrex::FileExists(m_dt_update_diagnostic_file)) {
+
+        std::filesystem::path const diagnostic_path(m_dt_update_diagnostic_file);
+        std::filesystem::path const diagnostic_dir = diagnostic_path.parent_path();
+        if (!diagnostic_dir.empty()) {
+            std::filesystem::create_directories(diagnostic_dir);
+        }
+
+        std::ofstream diagnostic_file{m_dt_update_diagnostic_file, std::ofstream::out | std::ofstream::trunc};
+        if (!diagnostic_file.is_open()) {
+            amrex::Abort("Failed to open file: " + m_dt_update_diagnostic_file);
+        }
+
+        int c = 0;
+        diagnostic_file << "#";
+        diagnostic_file << "[" << c++ << "]step()";
+        diagnostic_file << " ";
+        diagnostic_file << "[" << c++ << "]time(s)";
+        diagnostic_file << " ";
+        diagnostic_file << "[" << c++ << "]new_dt";
+        diagnostic_file << " ";
+        diagnostic_file << "[" << c++ << "]vmax_dt";
+        if (m_max_omegap_dt.has_value()) {
+            diagnostic_file << " ";
+            diagnostic_file << "[" << c++ << "]omegap_dt";
+        }
+        if (m_max_omegac_dt.has_value()) {
+            diagnostic_file << " ";
+            diagnostic_file << "[" << c++ << "]omegac_dt";
+        }
+        diagnostic_file << "\n";
+        diagnostic_file.close();
+    }
+
+    if (amrex::ParallelDescriptor::IOProcessor()
+        && !m_dt_update_diagnostic_file.empty()) {
+
+        std::ofstream diagnostic_file{m_dt_update_diagnostic_file, std::ofstream::out | std::ofstream::app};
+        if (!diagnostic_file.is_open()) {
+            amrex::Abort("Failed to open file: " + m_dt_update_diagnostic_file);
+        }
+
+        diagnostic_file << std::setprecision(14);
+        diagnostic_file << istep[0] + 1;
+        diagnostic_file << " ";
+        diagnostic_file << t_new[0];
+        diagnostic_file << " ";
+        diagnostic_file << dt_new;
+        diagnostic_file << " ";
+        diagnostic_file << vmax_o_dx*dt_new;
+
+        if (m_max_omegap_dt.has_value()) {
+            diagnostic_file << " ";
+            diagnostic_file << omegap_max*dt_new;
+        }
+        if (m_max_omegac_dt.has_value()) {
+            diagnostic_file << " ";
+            diagnostic_file << omegac_max*dt_new;
+        }
+        diagnostic_file << "\n";
+        diagnostic_file.close();
+    }
 }

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -15,15 +15,19 @@
 #   include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianNodalAlgorithm.H"
 #   include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H"
 #endif
+#include "Fields.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/Parser/ParserUtils.H"
 
+#include <ablastr/coarsen/sample.H>
+
 #include <AMReX.H>
 #include <AMReX_Geometry.H>
 #include <AMReX_IntVect.H>
+#include <AMReX_MFIter.H>
 #include <AMReX_Print.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Vector.H>
@@ -149,6 +153,7 @@ std::optional<amrex::Real>
 WarpX::DtLimitFromCyclotronFrequency ()
 {
     using ablastr::fields::Direction;
+    using warpx::fields::FieldType;
 
     if (!m_max_omegac_dt.has_value()) {
         return std::nullopt;
@@ -158,19 +163,77 @@ WarpX::DtLimitFromCyclotronFrequency ()
     amrex::Vector<amrex::Real> B_external_particle(3, 0.);
     utils::parser::queryArrWithParser(pp_particles, "B_external_particle", B_external_particle);
 
-    amrex::MultiFab const & Bx = *m_fields.get("Bfield_fp", Direction{0}, 0);
-    amrex::MultiFab const & By = *m_fields.get("Bfield_fp", Direction{1}, 0);
-    amrex::MultiFab const & Bz = *m_fields.get("Bfield_fp", Direction{2}, 0);
+    amrex::Real Bx_external = B_external_particle[0];
+    amrex::Real By_external = B_external_particle[1];
+    amrex::Real Bz_external = B_external_particle[2];
 
     amrex::Real B_max = 0.;
 
-    B_max = std::max(B_max, Bx.norm0(0));
-    B_max = std::max(B_max, By.norm0(0));
-    B_max = std::max(B_max, Bz.norm0(0));
+    // loop over refinement levels
+    for (int lev = 0; lev <= finestLevel(); ++lev)
+    {
+        // get MultiFab data at lev
+        const amrex::MultiFab & Bx = *m_fields.get(FieldType::Bfield_aux, Direction{0}, lev);
+        const amrex::MultiFab & By = *m_fields.get(FieldType::Bfield_aux, Direction{1}, lev);
+        const amrex::MultiFab & Bz = *m_fields.get(FieldType::Bfield_aux, Direction{2}, lev);
 
-    B_max = std::max(B_max, std::abs(B_external_particle[0]));
-    B_max = std::max(B_max, std::abs(B_external_particle[1]));
-    B_max = std::max(B_max, std::abs(B_external_particle[2]));
+        // Prepare interpolation of field components to cell center
+        // The arrays below store the index type (staggering) of each MultiFab, with the third
+        // component set to zero in the two-dimensional case.
+        auto Bxtype = amrex::GpuArray<int,3>{0, 0, 0};
+        auto Bytype = amrex::GpuArray<int,3>{0, 0, 0};
+        auto Bztype = amrex::GpuArray<int,3>{0, 0, 0};
+        for (int i = 0; i < AMREX_SPACEDIM; ++i){
+            Bxtype[i] = Bx.ixType()[i];
+            Bytype[i] = By.ixType()[i];
+            Bztype[i] = Bz.ixType()[i];
+        }
+
+        // General preparation of interpolation and reduction operations
+        const amrex::GpuArray<int,3> cellCenteredtype{0,0,0};
+        const amrex::GpuArray<int,3> reduction_coarsening_ratio{1,1,1};
+        constexpr int reduction_comp = 0;
+
+        amrex::ReduceOps<amrex::ReduceOpMax> reduce_op;
+        amrex::ReduceData<amrex::Real> reduce_data(reduce_op);
+        using ReduceTuple = typename decltype(reduce_data)::Type;
+
+        // MFIter loop to interpolate fields to cell center and get maximum value
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+        for (amrex::MFIter mfi(Bx, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+        {
+            // Make the box cell centered in preparation for the interpolation (and to avoid
+            // including ghost cells in the calculation)
+            const amrex::Box & box = enclosedCells(mfi.nodaltilebox());
+            const auto& arrBx = Bx[mfi].array();
+            const auto& arrBy = By[mfi].array();
+            const auto& arrBz = Bz[mfi].array();
+
+            reduce_op.eval(box, reduce_data,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
+            {
+                const amrex::Real Bx_interp = ablastr::coarsen::sample::Interp(arrBx, Bxtype, cellCenteredtype,
+                                                                               reduction_coarsening_ratio, i, j, k, reduction_comp);
+                const amrex::Real By_interp = ablastr::coarsen::sample::Interp(arrBy, Bytype, cellCenteredtype,
+                                                                               reduction_coarsening_ratio, i, j, k, reduction_comp);
+                const amrex::Real Bz_interp = ablastr::coarsen::sample::Interp(arrBz, Bztype, cellCenteredtype,
+                                                                               reduction_coarsening_ratio, i, j, k, reduction_comp);
+                return {amrex::Math::powi<2>(Bx_interp + Bx_external) +
+                        amrex::Math::powi<2>(By_interp + By_external) +
+                        amrex::Math::powi<2>(Bz_interp + Bz_external)};
+            });
+        }
+
+        amrex::Real hv_Bsq = amrex::get<0>(reduce_data.value()); // highest value of |B|**2
+
+        B_max = std::max(B_max, std::sqrt(hv_Bsq));
+
+    }
+
+    // MPI reduce
+    amrex::ParallelDescriptor::ReduceRealMax({B_max});
 
     amrex::Real omegac_max = 0.;
 

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -111,32 +111,70 @@ WarpX::ComputeDt ()
  * Determine the simulation timestep from the maximum speed of all particles
  * Sets timestep so that a particle can only cross cfl*dx cells per timestep.
  */
-void
-WarpX::UpdateDtFromParticleSpeeds ()
+std::optional<amrex::Real>
+WarpX::DtLimitFromParticleSpeeds ()
 {
     const amrex::Real* dx = geom[max_level].CellSize();
     const amrex::Real dx_min = minDim(dx);
 
     const amrex::ParticleReal max_v = mypc->maxParticleVelocity();
-    amrex::Real deltat_new = 0.;
 
-    // Protections from overly-large timesteps
-    if (max_v == 0) {
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_max_dt.has_value(), "Particles at rest and no constant or maximum timestep specified. Aborting.");
-        deltat_new = m_max_dt.value();
+    if (max_v > 0.) {
+        return cfl * dx_min / max_v;
     } else {
-        deltat_new = cfl * dx_min / max_v;
+        return std::nullopt;
     }
 
-    // Restrict to be less than user-specified maximum timestep, if present
-    if (m_max_dt.has_value()) {
-        deltat_new = std::min(deltat_new, m_max_dt.value());
+}
+
+std::optional<amrex::Real>
+WarpX::DtLimitFromPlasmaFrequency ()
+{
+    if (!m_max_omegap_dt.has_value()) {
+        return std::nullopt;
     }
+
+    const std::unique_ptr<amrex::MultiFab> global_plasma_frequency = mypc->GetGlobalPlasmaFrequency(0);
+    const amrex::Real global_plasma_frequency_max = global_plasma_frequency->max(0);
+
+    if (global_plasma_frequency_max > 0.) {
+        return m_max_omegap_dt.value()/global_plasma_frequency_max;
+    } else {
+        return std::nullopt;
+    }
+}
+
+std::optional<amrex::Real>
+WarpX::DtLimitFromCyclotronFrequency ()
+{
+    return std::nullopt;
+}
+
+void
+WarpX::ApplyDtLimiters ()
+{
+    std::optional<amrex::Real> speed_limit = DtLimitFromParticleSpeeds();
+    std::optional<amrex::Real> opmegap_limit = DtLimitFromPlasmaFrequency();
+    std::optional<amrex::Real> opmegac_limit = DtLimitFromCyclotronFrequency();
+
+    amrex::Real dt_new = std::numeric_limits<amrex::Real>::max();
+    if (!speed_limit.has_value() &&
+        !opmegap_limit.has_value() &&
+        !opmegac_limit.has_value()) {
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_max_dt.has_value(),
+                                         "No valid time step size limit found, max_dt must be specified");
+        dt_new = m_max_dt.value();
+    }
+
+    if (speed_limit.has_value()) { dt_new = std::min(dt_new, speed_limit.value()); }
+    if (opmegap_limit.has_value()) { dt_new = std::min(dt_new, opmegap_limit.value()); }
+    if (opmegac_limit.has_value()) { dt_new = std::min(dt_new, opmegac_limit.value()); }
 
     // Update dt
-    dt[max_level] = deltat_new;
+    dt[max_level] = dt_new;
 
     for (int lev = max_level-1; lev >= 0; --lev) {
         dt[lev] = dt[lev+1] * refRatio(lev)[0];
     }
+
 }

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -177,7 +177,7 @@ WarpX::DtLimitFromCyclotronFrequency ()
     const int n_containers = mypc->nContainers();
     for (int i = 0; i < n_containers; i++)
     {
-        WarpXParticleContainer& pc = mypc->GetParticleContainer(i);
+        const WarpXParticleContainer& pc = mypc->GetParticleContainer(i);
         if (pc.getMass() > 0.) {
             const amrex::Real pc_omegac = pc.getCharge()*B_max/pc.getMass();
             omegac_max = std::max(omegac_max, pc_omegac);

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -34,6 +34,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <filesystem>
 
 /**
  * Compute the minimum of array x, where x has dimension AMREX_SPACEDIM

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -19,6 +19,7 @@
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
+#include "Utils/Parser/ParserUtils.H"
 
 #include <AMReX.H>
 #include <AMReX_Geometry.H>
@@ -147,7 +148,47 @@ WarpX::DtLimitFromPlasmaFrequency ()
 std::optional<amrex::Real>
 WarpX::DtLimitFromCyclotronFrequency ()
 {
-    return std::nullopt;
+    using ablastr::fields::Direction;
+
+    if (!m_max_omegac_dt.has_value()) {
+        return std::nullopt;
+    }
+
+    const amrex::ParmParse pp_particles("particles");
+    amrex::Vector<amrex::Real> B_external_particle(3, 0.);
+    utils::parser::queryArrWithParser(pp_particles, "B_external_particle", B_external_particle);
+
+    amrex::MultiFab const & Bx = *m_fields.get("Bfield_fp", Direction{0}, 0);
+    amrex::MultiFab const & By = *m_fields.get("Bfield_fp", Direction{1}, 0);
+    amrex::MultiFab const & Bz = *m_fields.get("Bfield_fp", Direction{2}, 0);
+
+    amrex::Real B_max = 0.;
+
+    B_max = std::max(B_max, Bx.norm0(0));
+    B_max = std::max(B_max, By.norm0(0));
+    B_max = std::max(B_max, Bz.norm0(0));
+
+    B_max = std::max(B_max, std::abs(B_external_particle[0]));
+    B_max = std::max(B_max, std::abs(B_external_particle[1]));
+    B_max = std::max(B_max, std::abs(B_external_particle[2]));
+
+    amrex::Real omegac_max = 0.;
+
+    const int n_containers = mypc->nContainers();
+    for (int i = 0; i < n_containers; i++)
+    {
+        WarpXParticleContainer& pc = mypc->GetParticleContainer(i);
+        if (pc.getMass() > 0.) {
+            const amrex::Real pc_omegac = pc.getCharge()*B_max/pc.getMass();
+            omegac_max = std::max(omegac_max, pc_omegac);
+        }
+    }
+
+    if (omegac_max > 0.) {
+        return m_max_omegac_dt.value()/omegac_max;
+    } else {
+        return std::nullopt;
+    }
 }
 
 void

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -199,11 +199,12 @@ WarpX::ApplyDtLimiters ()
     std::optional<amrex::Real> opmegac_limit = DtLimitFromCyclotronFrequency();
 
     amrex::Real dt_new = std::numeric_limits<amrex::Real>::max();
+
     if (!speed_limit.has_value() &&
         !opmegap_limit.has_value() &&
         !opmegac_limit.has_value()) {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_max_dt.has_value(),
-                                         "No valid time step size limit found, max_dt must be specified");
+                                         "No valid time step size limit found, warpx.max_dt must be specified");
         dt_new = m_max_dt.value();
     }
 

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -236,26 +236,30 @@ WarpX::GlobalCyclotronFrequencyMax ()
 void
 WarpX::ApplyDtLimiters ()
 {
-    amrex::Real vmax_o_dx = ParticleGridSpeedMax();
-    amrex::Real omegap_max = m_max_omegap_dt.has_value() ? GlobalPlasmaFrequencyMax() : 0.;
-    amrex::Real omegac_max = m_max_omegac_dt.has_value() ? GlobalCyclotronFrequencyMax() : 0.;
+    using namespace amrex::literals;
 
-    if (vmax_o_dx == 0. &&
-        (!m_max_omegap_dt.has_value() || omegap_max == 0.) &&
-        (!m_max_omegac_dt.has_value() || omegac_max == 0.)) {
+    // Calculate limiting values from the simulation conditions
+    const amrex::Real vmax_o_dx = ParticleGridSpeedMax();
+    const amrex::Real omegap_max = m_max_omegap_dt.has_value() ? GlobalPlasmaFrequencyMax() : 0._rt;
+    const amrex::Real omegac_max = m_max_omegac_dt.has_value() ? GlobalCyclotronFrequencyMax() : 0._rt;
+
+    // Ensure that a valid time step value exists, either from the simulation conditions or from max_dt
+    if (vmax_o_dx == 0._rt &&
+        (!m_max_omegap_dt.has_value() || omegap_max == 0._rt) &&
+        (!m_max_omegac_dt.has_value() || omegac_max == 0._rt)) {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_max_dt.has_value(),
                                          "No valid time step size limit found, warpx.max_dt must be specified");
     }
 
     amrex::Real dt_new = std::numeric_limits<amrex::Real>::max();
 
-    if (vmax_o_dx > 0.) {
+    if (vmax_o_dx > 0._rt) {
         dt_new = std::min(dt_new, cfl/vmax_o_dx);
     }
-    if (m_max_omegap_dt.has_value() && omegap_max > 0.) {
+    if (m_max_omegap_dt.has_value() && omegap_max > 0._rt) {
         dt_new = std::min(dt_new, m_max_omegap_dt.value()/omegap_max);
     }
-    if (m_max_omegac_dt.has_value() && omegac_max > 0.) {
+    if (m_max_omegac_dt.has_value() && omegac_max > 0._rt) {
         dt_new = std::min(dt_new, m_max_omegac_dt.value()/omegac_max);
     }
 

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -163,9 +163,9 @@ WarpX::DtLimitFromCyclotronFrequency ()
     amrex::Vector<amrex::Real> B_external_particle(3, 0.);
     utils::parser::queryArrWithParser(pp_particles, "B_external_particle", B_external_particle);
 
-    amrex::Real Bx_external = B_external_particle[0];
-    amrex::Real By_external = B_external_particle[1];
-    amrex::Real Bz_external = B_external_particle[2];
+    const amrex::Real Bx_external = B_external_particle[0];
+    const amrex::Real By_external = B_external_particle[1];
+    const amrex::Real Bz_external = B_external_particle[2];
 
     amrex::Real B_max = 0.;
 
@@ -226,7 +226,7 @@ WarpX::DtLimitFromCyclotronFrequency ()
             });
         }
 
-        amrex::Real hv_Bsq = amrex::get<0>(reduce_data.value()); // highest value of |B|**2
+        const amrex::Real hv_Bsq = amrex::get<0>(reduce_data.value()); // highest value of |B|**2
 
         B_max = std::max(B_max, std::sqrt(hv_Bsq));
 

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -261,19 +261,22 @@ WarpX::ApplyDtLimiters ()
     std::optional<amrex::Real> opmegap_limit = DtLimitFromPlasmaFrequency();
     std::optional<amrex::Real> opmegac_limit = DtLimitFromCyclotronFrequency();
 
-    amrex::Real dt_new = std::numeric_limits<amrex::Real>::max();
-
     if (!speed_limit.has_value() &&
         !opmegap_limit.has_value() &&
         !opmegac_limit.has_value()) {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_max_dt.has_value(),
                                          "No valid time step size limit found, warpx.max_dt must be specified");
-        dt_new = m_max_dt.value();
     }
+
+    amrex::Real dt_new = std::numeric_limits<amrex::Real>::max();
 
     if (speed_limit.has_value()) { dt_new = std::min(dt_new, speed_limit.value()); }
     if (opmegap_limit.has_value()) { dt_new = std::min(dt_new, opmegap_limit.value()); }
     if (opmegac_limit.has_value()) { dt_new = std::min(dt_new, opmegac_limit.value()); }
+
+    if (m_max_dt.has_value()) {
+        dt_new = std::min(dt_new, m_max_dt.value());
+    }
 
     // Update dt
     dt[max_level] = dt_new;

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -195,11 +195,11 @@ WarpX::Evolve (int numsteps)
         // Update the timestep for solvers that support adaptive timestepping
         // (electrostatic and theta-implicit EM), provided const_dt is not specified.
         if (m_dt_update_interval.contains(step+1)) {
-            if (verbose_step) {
-                amrex::Print() << Utils::TextMsg::Info("updating timestep");
-            }
             SynchronizeVelocityWithPosition();
-            UpdateDtFromParticleSpeeds();
+            ApplyDtLimiters();
+            if (verbose_step) {
+                amrex::Print() << Utils::TextMsg::Info("updating timestep to dt = " + std::to_string(dt[0]));
+            }
         }
 
         // If position and velocity are synchronized, push velocity backward one half step

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -196,6 +196,7 @@ public:
 
     std::unique_ptr<amrex::MultiFab> GetChargeDensity(int lev, bool local = false);
 
+    std::unique_ptr<amrex::MultiFab> GetGlobalPlasmaFrequency (int lev);
     void GenerateGlobalDebyeLength ();
 
     void doFieldIonization (int lev,

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -731,6 +731,7 @@ MultiParticleContainer::GetGlobalPlasmaFrequency (int lev)
                 });
         }
     }
+    return global_plasma_frequency;
 }
 
 void

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -693,6 +693,46 @@ MultiParticleContainer::GetChargeDensity (int lev, bool local)
     return rho;
 }
 
+std::unique_ptr<amrex::MultiFab>
+MultiParticleContainer::GetGlobalPlasmaFrequency (int lev)
+{
+    WarpX & warpx = WarpX::GetInstance();
+
+    amrex::BoxArray const & ba = warpx.boxArray(lev);
+    amrex::DistributionMapping const & dmap = warpx.DistributionMap(lev);
+    int const ncomps = 1;
+    const amrex::IntVect ng = amrex::IntVect::TheZeroVector();
+    auto global_plasma_frequency = std::make_unique<amrex::MultiFab>(ba, dmap, ncomps, ng);
+    global_plasma_frequency->setVal(amrex::Real(0.0));
+
+    for (auto& pc : allcontainers) {
+
+        if (pc->getMass() == 0. || pc->getCharge() == 0.) {
+            continue;
+        }
+
+        std::unique_ptr<amrex::MultiFab> plasma_frequency = pc->GetPlasmaFrequency(lev);
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+        for (amrex::MFIter mfi(*global_plasma_frequency, TilingIfNotGPU()); mfi.isValid(); ++mfi )
+        {
+            const amrex::Box box = mfi.tilebox();
+
+            amrex::Array4<amrex::Real> const& omegap_array = plasma_frequency->array(mfi);
+            amrex::Array4<amrex::Real> const& global_omegap_array = global_plasma_frequency->array(mfi);
+
+            amrex::ParallelFor(box,
+                [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    amrex::Real const omegap = omegap_array(i,j,k);
+                    amrex::Real const global_omegap = global_omegap_array(i,j,k);
+                    global_omegap_array(i,j,k) = std::sqrt(global_omegap*global_omegap + omegap*omegap);
+                });
+        }
+    }
+}
+
 void
 MultiParticleContainer::GenerateGlobalDebyeLength ()
 {

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -696,7 +696,7 @@ MultiParticleContainer::GetChargeDensity (int lev, bool local)
 std::unique_ptr<amrex::MultiFab>
 MultiParticleContainer::GetGlobalPlasmaFrequency (int lev)
 {
-    WarpX & warpx = WarpX::GetInstance();
+    const WarpX & warpx = WarpX::GetInstance();
 
     amrex::BoxArray const & ba = warpx.boxArray(lev);
     amrex::DistributionMapping const & dmap = warpx.DistributionMap(lev);

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -400,6 +400,7 @@ public:
     void DepositNumberDensity (amrex::MultiFab* number_density, int lev);
     std::unique_ptr<amrex::MultiFab> GetNumberDensity (int lev);
 
+    std::unique_ptr<amrex::MultiFab> GetPlasmaFrequency (int lev);
     std::unique_ptr<amrex::MultiFab> GetDebyeLength (int lev);
 
     void DepositMassMatrices (WarpXParIter& pti,

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2113,6 +2113,51 @@ WarpXParticleContainer::GetNumberDensity (int lev)
 }
 
 std::unique_ptr<amrex::MultiFab>
+WarpXParticleContainer::GetPlasmaFrequency (int lev)
+{
+
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_mass*charge != 0.,
+        "The plasma frequency can not be calculated for a massless or neutral species.");
+
+    std::unique_ptr<amrex::MultiFab> number_density = GetNumberDensity(lev);
+
+    amrex::BoxArray const & ba = number_density->boxArray();
+    amrex::DistributionMapping const & dm = number_density->DistributionMap();
+    int const ncomps = 1;
+    int const ng = 0;
+    auto plasma_frequency = std::make_unique<amrex::MultiFab>(ba, dm, ncomps, ng);
+
+    amrex::Real const rmass = (amrex::Real)(m_mass);
+    amrex::Real const rcharge = (amrex::Real)(charge);
+    amrex::Real const Aconst = rcharge*rcharge/(rmass*PhysConst::epsilon_0);
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (amrex::MFIter mfi(*plasma_frequency, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const amrex::Box& box = mfi.tilebox();
+
+        amrex::Array4<amrex::Real> const& num_array = number_density->array(mfi);
+        amrex::Array4<amrex::Real> const& omegap_array = plasma_frequency->array(mfi);
+
+        amrex::ParallelFor(box,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+
+                amrex::Real const N = num_array(i,j,k);
+
+                // plasma frequency squared
+                amrex::Real const ompegap_sq = Aconst*N;
+
+                omegap_array(i,j,k) = std::sqrt(ompegap_sq);
+
+            });
+    }
+
+    return plasma_frequency;
+}
+
+std::unique_ptr<amrex::MultiFab>
 WarpXParticleContainer::GetDebyeLength (int lev)
 {
 

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2127,8 +2127,8 @@ WarpXParticleContainer::GetPlasmaFrequency (int lev)
     int const ng = 0;
     auto plasma_frequency = std::make_unique<amrex::MultiFab>(ba, dm, ncomps, ng);
 
-    amrex::Real const rmass = (amrex::Real)(m_mass);
-    amrex::Real const rcharge = (amrex::Real)(charge);
+    auto const rmass = (amrex::Real)(m_mass);
+    auto const rcharge = (amrex::Real)(charge);
     amrex::Real const Aconst = rcharge*rcharge/(rmass*PhysConst::epsilon_0);
 
 #ifdef AMREX_USE_OMP

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -422,10 +422,12 @@ public:
     void ComputeDt ();
 
     /**
-     * Determine the simulation timestep from the maximum speed of all particles
-     * Sets timestep so that a particle can only cross cfl*dx cells per timestep.
+     * Determine the simulation timestep from the time step limiters
      */
-    void UpdateDtFromParticleSpeeds ();
+    std::optional<amrex::Real> DtLimitFromParticleSpeeds ();
+    std::optional<amrex::Real> DtLimitFromPlasmaFrequency ();
+    std::optional<amrex::Real> DtLimitFromCyclotronFrequency ();
+    void ApplyDtLimiters ();
 
     /** Print main PIC parameters to stdout */
     void PrintMainPICparameters ();
@@ -1282,6 +1284,8 @@ private:
     // Timestepping parameters
     std::optional<amrex::Real> m_const_dt;
     std::optional<amrex::Real> m_max_dt;
+    std::optional<amrex::Real> m_max_omegap_dt;
+    std::optional<amrex::Real> m_max_omegac_dt;
 
     // whether to use subcycling
     bool m_do_subcycling = false;

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -424,9 +424,9 @@ public:
     /**
      * Determine the simulation timestep from the time step limiters
      */
-    std::optional<amrex::Real> DtLimitFromParticleSpeeds ();
-    std::optional<amrex::Real> DtLimitFromPlasmaFrequency ();
-    std::optional<amrex::Real> DtLimitFromCyclotronFrequency ();
+    amrex::Real ParticleGridSpeedMax ();
+    amrex::Real GlobalPlasmaFrequencyMax ();
+    amrex::Real GlobalCyclotronFrequencyMax ();
     void ApplyDtLimiters ();
 
     /** Print main PIC parameters to stdout */
@@ -1166,6 +1166,7 @@ private:
     amrex::Vector<amrex::Real> t_old;
     amrex::Vector<amrex::Real> dt;
     utils::parser::IntervalsParser m_dt_update_interval = utils::parser::IntervalsParser{}; // How often to update the timestep when using adaptive timestepping
+    std::string m_dt_update_diagnostic_file;
 
     bool m_safe_guard_cells = false;
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -802,6 +802,7 @@ WarpX::ReadParameters ()
         pp_warpx.queryarr("dt_update_interval", dt_interval_vec);
         m_dt_update_interval = utils::parser::IntervalsParser(dt_interval_vec);
         if (m_dt_update_interval.isActivated()) {
+            pp_warpx.query("dt_update_diagnostic_file", m_dt_update_diagnostic_file);
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 !m_const_dt.has_value(),
                 "warpx.const_dt and warpx.dt_update_interval cannot be defined simultaneously."

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -796,6 +796,8 @@ WarpX::ReadParameters ()
         // Read timestepping options
         utils::parser::queryWithParser(pp_warpx, "const_dt", m_const_dt);
         utils::parser::queryWithParser(pp_warpx, "max_dt", m_max_dt);
+        utils::parser::queryWithParser(pp_warpx, "max_omegap_dt", m_max_omegap_dt);
+        utils::parser::queryWithParser(pp_warpx, "max_omegac_dt", m_max_omegac_dt);
         std::vector<std::string> dt_interval_vec = {"-1"};
         pp_warpx.queryarr("dt_update_interval", dt_interval_vec);
         m_dt_update_interval = utils::parser::IntervalsParser(dt_interval_vec);
@@ -803,6 +805,14 @@ WarpX::ReadParameters ()
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 !m_const_dt.has_value(),
                 "warpx.const_dt and warpx.dt_update_interval cannot be defined simultaneously."
+            );
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                !m_max_omegap_dt.has_value() || m_max_omegap_dt > 0.,
+                "The max_omegap_dt must be greater than zero"
+            );
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                !m_max_omegac_dt.has_value() || m_max_omegac_dt > 0.,
+                "The max_omegac_dt must be greater than zero"
             );
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 (electromagnetic_solver_id == ElectromagneticSolverAlgo::None ||


### PR DESCRIPTION
This add time step limiters based on the plasma frequency and cyclotron frequency. This is in addition to the existing limiter based on the particle speed and controlled by the parameter `warpx.dt_update_interval`. This adds two new input parameters `warpx.max_omegap_dt` and `warpx.max_omegac_dt` for the plasma and cyclotron frequency limits.

For this PR, when calculating the cyclotron frequency, only the B-field MultiFabs and the constant external fields are used when finding the maximum B-field. This ignores the rest of the external fields due to the complication or cost required to include them. If required, a later PR could include them, perhaps by fetching the B-field for the particles (which could be expensive) or by calculating the external B-fields at the grid locations, which would be complicated.

Also, currently, for the initial time steps the `warpx.max_dt` or `warpx.cfl` with speed `c` is used. It would be better to apply the limiters initially rather that requiring the user to specify the initial step. This can be done in this PR or a separate PR.

Todo:
- [x] Add CI test
- [x] Add documentation