### PR TITLE
Rotate angles to zero for binary collisions

### DIFF
--- a/Regression/Checksum/benchmarks_json/test_rz_deuterium_tritium_fusion.json
+++ b/Regression/Checksum/benchmarks_json/test_rz_deuterium_tritium_fusion.json
@@ -2,8 +2,35 @@
   "lev=0": {
     "rho": 0.0
   },
+  "deuterium_1": {
+    "particle_momentum_x": 1.8380502673870074e-13,
+    "particle_momentum_y": 1.838077030110447e-13,
+    "particle_momentum_z": 0.0,
+    "particle_position_x": 40960820.819756225,
+    "particle_position_y": 81917585.14722733,
+    "particle_theta": 16088876.600180998,
+    "particle_weight": 3217.05534430885
+  },
+  "helium4_1": {
+    "particle_momentum_x": 1.742190043218134e-15,
+    "particle_momentum_y": 1.7434154868580314e-15,
+    "particle_momentum_z": 1.7416808085277619e-15,
+    "particle_position_x": 151717.6322938956,
+    "particle_position_y": 323159.91320638114,
+    "particle_theta": 60097.3216171957,
+    "particle_weight": 1.6042654155587774e-27
+  },
+  "neutron_2": {
+    "particle_momentum_x": 1.5301473527433558e-15,
+    "particle_momentum_y": 1.5320931716871473e-15,
+    "particle_momentum_z": 1.5414745293242394e-15,
+    "particle_position_x": 137023.16351803095,
+    "particle_position_y": 289593.93777875253,
+    "particle_theta": 53608.15061371827,
+    "particle_weight": 2.077108962199761e+19
+  },
   "tritium_1": {
-    "particle_momentum_x": 1.837709854338228e-13,
+    "particle_momentum_x": 1.8377098543382284e-13,
     "particle_momentum_y": 1.83853636964543e-13,
     "particle_momentum_z": 0.0,
     "particle_position_x": 40960705.186219126,
@@ -20,23 +47,23 @@
     "particle_theta": 161101.0699641934,
     "particle_weight": 3.2188020868421784e+29
   },
-  "deuterium_1": {
-    "particle_momentum_x": 1.8380502673870074e-13,
-    "particle_momentum_y": 1.838077030110447e-13,
-    "particle_momentum_z": 0.0,
-    "particle_position_x": 40960820.819756225,
-    "particle_position_y": 81917585.14722733,
-    "particle_theta": 16088876.600180998,
-    "particle_weight": 3217.05534430885
+  "helium4_2": {
+    "particle_momentum_x": 1.5301473527433558e-15,
+    "particle_momentum_y": 1.5320931716871473e-15,
+    "particle_momentum_z": 1.7604115480202394e-15,
+    "particle_position_x": 137023.16351803095,
+    "particle_position_y": 289593.93777875253,
+    "particle_theta": 53608.15061371827,
+    "particle_weight": 2.077108962199761e+19
   },
-  "helium4_1": {
-    "particle_momentum_x": 1.8694661748712878e-15,
-    "particle_momentum_y": 1.8568012232575533e-15,
-    "particle_momentum_z": 1.7026981126836896e-15,
+  "neutron_1": {
+    "particle_momentum_x": 1.742190043218134e-15,
+    "particle_momentum_y": 1.7434154868580314e-15,
+    "particle_momentum_z": 1.7416808085277619e-15,
     "particle_position_x": 151717.6322938956,
     "particle_position_y": 323159.91320638114,
     "particle_theta": 60097.3216171957,
-    "particle_weight": 1.604265415558155e-27
+    "particle_weight": 1.6042654155587774e-27
   },
   "deuterium_2": {
     "particle_momentum_x": 0.0,
@@ -46,32 +73,5 @@
     "particle_position_y": 8191851.890824943,
     "particle_theta": 1607074.8178639775,
     "particle_weight": 3.187610961626956e+29
-  },
-  "neutron_2": {
-    "particle_momentum_x": 1.5336220546124197e-15,
-    "particle_momentum_y": 1.5315901467166076e-15,
-    "particle_momentum_z": 1.5414745293242394e-15,
-    "particle_position_x": 137023.16351803095,
-    "particle_position_y": 289593.93777875253,
-    "particle_theta": 53608.15061371827,
-    "particle_weight": 2.077108962199761e+19
-  },
-  "neutron_1": {
-    "particle_momentum_x": 1.7128747929803067e-15,
-    "particle_momentum_y": 1.7143543209992252e-15,
-    "particle_momentum_z": 1.7026981126836896e-15,
-    "particle_position_x": 151717.6322938956,
-    "particle_position_y": 323159.91320638114,
-    "particle_theta": 60097.3216171957,
-    "particle_weight": 1.604265415558155e-27
-  },
-  "helium4_2": {
-    "particle_momentum_x": 1.5336220546124197e-15,
-    "particle_momentum_y": 1.5315901467166076e-15,
-    "particle_momentum_z": 1.7604115480202394e-15,
-    "particle_position_x": 137023.16351803095,
-    "particle_position_y": 289593.93777875253,
-    "particle_theta": 53608.15061371827,
-    "particle_weight": 2.077108962199761e+19
   }
 }

--- a/Source/Particles/Collision/BinaryCollision/Bremsstrahlung/BremsstrahlungFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/Bremsstrahlung/BremsstrahlungFunc.H
@@ -118,11 +118,6 @@ public:
 
             index_type pair_index = cell_start_pair + coll_idx;
 
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-            amrex::ParticleReal * const AMREX_RESTRICT theta1 = soa_1.m_rdata[PIdx::theta];
-            amrex::ParticleReal * const AMREX_RESTRICT theta2 = soa_2.m_rdata[PIdx::theta];
-#endif
-
             index_type i1 = I1s + coll_idx;
             index_type const i2 = I2s + coll_idx;
             // we will start from collision number = coll_idx and then add
@@ -132,21 +127,6 @@ public:
             for (index_type k = coll_idx; k < max_N; k += min_N)
             {
 
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-                /* In RZ and RCYLINDER geometry, macroparticles can collide with other macroparticles
-                 * in the same *cylindrical* cell. For this reason, collisions between macroparticles
-                 * are actually not local in space. In this case, the underlying assumption is that
-                 * particles within the same cylindrical cell represent a cylindrically-symmetry
-                 * momentum distribution function. Therefore, here, we temporarily rotate the
-                 * momentum of one of the macroparticles in agreement with this cylindrical symmetry.
-                 * (This is technically only valid if we use only the m=0 azimuthal mode in the simulation;
-                 * there is a corresponding assert statement at initialization.) */
-                amrex::ParticleReal const theta = theta2[I2[i2]]-theta1[I1[i1]];
-                amrex::ParticleReal const u1xbuf = u1x[I1[i1]];
-                u1x[I1[i1]] = u1xbuf*std::cos(theta) - u1y[I1[i1]]*std::sin(theta);
-                u1y[I1[i1]] = u1xbuf*std::sin(theta) + u1y[I1[i1]]*std::cos(theta);
-#endif
-
                 BremsstrahlungEvent(
                     u1x[ I1[i1] ], u1y[ I1[i1] ], u1z[ I1[i1] ],
                     u2x[ I2[i2] ], u2y[ I2[i2] ], u2z[ I2[i2] ],
@@ -154,12 +134,6 @@ public:
                     n1, n2, dt, static_cast<int>(pair_index), p_mask,
                     p_pair_reaction_weight, p_product_data,
                     engine);
-
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-                amrex::ParticleReal const u1xbuf_new = u1x[I1[i1]];
-                u1x[I1[i1]] = u1xbuf_new*std::cos(-theta) - u1y[I1[i1]]*std::sin(-theta);
-                u1y[I1[i1]] = u1xbuf_new*std::sin(-theta) + u1y[I1[i1]]*std::cos(-theta);
-#endif
 
                 p_pair_indices_1[pair_index] = I1[i1];
                 p_pair_indices_2[pair_index] = I2[i2];

--- a/Source/Particles/Collision/BinaryCollision/Coulomb/ElasticCollisionPerez.H
+++ b/Source/Particles/Collision/BinaryCollision/Coulomb/ElasticCollisionPerez.H
@@ -90,11 +90,6 @@ void ElasticCollisionPerez (
     // set max cross section based on mfp = atomic spacing
     const T_PR sigma_max = T_PR(1.0) / (maxn * rmin);
 
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-    T_PR * const AMREX_RESTRICT theta1 = soa_1.m_rdata[PIdx::theta];
-    T_PR * const AMREX_RESTRICT theta2 = soa_2.m_rdata[PIdx::theta];
-#endif
-
     // call UpdateMomentumPerezElastic()
     {
       T_index i1 = I1s + coll_idx;
@@ -104,20 +99,6 @@ void ElasticCollisionPerez (
       // stride (smaller set size) until we do all collisions (larger set size)
       for (T_index k = coll_idx; k < max_N; k += min_N)
       {
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-          /* In RZ and RCYLINDER geometry, macroparticles can collide with other macroparticles
-           * in the same *cylindrical* cell. For this reason, collisions between macroparticles
-           * are actually not local in space. In this case, the underlying assumption is that
-           * particles within the same cylindrical cell represent a cylindrically-symmetry
-           * momentum distribution function. Therefore, here, we temporarily rotate the
-           * momentum of one of the macroparticles in agreement with this cylindrical symmetry.
-           * (This is technically only valid if we use only the m=0 azimuthal mode in the simulation;
-           * there is a corresponding assert statement at initialization.) */
-          T_PR const theta = theta2[I2[i2]]-theta1[I1[i1]];
-          T_PR const u1xbuf = u1x[I1[i1]];
-          u1x[I1[i1]] = u1xbuf*std::cos(theta) - u1y[I1[i1]]*std::sin(theta);
-          u1y[I1[i1]] = u1xbuf*std::sin(theta) + u1y[I1[i1]]*std::cos(theta);
-#endif
 
           // Compute the effective density n12 used to compute the normalized
           // transport mean free path (s12) in UpdateMomentumPerezElastic().
@@ -136,12 +117,6 @@ void ElasticCollisionPerez (
               u2x[ I2[i2] ], u2y[ I2[i2] ], u2z[ I2[i2] ],
               q1, m1, w1[ I1[i1] ], q2, m2, w2[ I2[i2] ],
               n12, sigma_max, L, bmax, dt, engine );
-
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-          T_PR const u1xbuf_new = u1x[I1[i1]];
-          u1x[I1[i1]] = u1xbuf_new*std::cos(-theta) - u1y[I1[i1]]*std::sin(-theta);
-          u1y[I1[i1]] = u1xbuf_new*std::sin(-theta) + u1y[I1[i1]]*std::cos(-theta);
-#endif
 
           if (max_N == NI1) {
             i1 += min_N;

--- a/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.H
@@ -132,10 +132,6 @@ public:
             const auto multiplier_ratio = static_cast<int>(
                 m_isSameSpecies ? min_N + max_N - 1 : min_N);
 
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-            amrex::ParticleReal * const AMREX_RESTRICT theta1 = soa_1.m_rdata[PIdx::theta];
-            amrex::ParticleReal * const AMREX_RESTRICT theta2 = soa_2.m_rdata[PIdx::theta];
-#endif
             index_type i1 = I1s + coll_idx;
             index_type i2 = I2s + coll_idx;
             // we will start from collision number = coll_idx and then add
@@ -149,22 +145,6 @@ public:
                     p_mask[pair_index] = false;
                 } else {
 
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-                    /* In RZ and RCYLINDER geometry, macroparticles can collide with other macroparticles
-                    * in the same *cylindrical* cell. For this reason, collisions between macroparticles
-                    * are actually not local in space. In this case, the underlying assumption is that
-                    * particles within the same cylindrical cell represent a cylindrically-symmetry
-                    * momentum distribution function. Therefore, here, we temporarily rotate the
-                    * momentum of one of the macroparticles in agreement with this cylindrical symmetry.
-                    * (This is technically only valid if we use only the m=0 azimuthal mode in the simulation;
-                    * there is a corresponding assert statement at initialization.)
-                    */
-                    amrex::ParticleReal const theta = theta2[I2[i2]]-theta1[I1[i1]];
-                    amrex::ParticleReal const u1xbuf = u1x[I1[i1]];
-                    u1x[I1[i1]] = u1xbuf*std::cos(theta) - u1y[I1[i1]]*std::sin(theta);
-                    u1y[I1[i1]] = u1xbuf*std::sin(theta) + u1y[I1[i1]]*std::cos(theta);
-#endif
-
                     const int max_process_count = 4; // Pre-defined value, for performance reasons
                     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
                         (m_process_count < max_process_count), "Too many scattering processes in DSMC routine (hardcoded to only allow 4). Update the max_process_count value in source code to allow more scattering processes."
@@ -176,13 +156,6 @@ public:
                         dt, dV, static_cast<int>(pair_index), p_mask,
                         p_pair_reaction_weight, multiplier_ratio,
                         m_process_count, m_scattering_processes_data, engine);
-
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-                    /* Undo the earlier velocity rotation. */
-                    amrex::ParticleReal const u1xbuf_new = u1x[I1[i1]];
-                    u1x[I1[i1]] = u1xbuf_new*std::cos(-theta) - u1y[I1[i1]]*std::sin(-theta);
-                    u1y[I1[i1]] = u1xbuf_new*std::sin(-theta) + u1y[I1[i1]]*std::cos(-theta);
-#endif
 
                     // Remove pair reaction weight from the colliding particles' weights
                     if (p_mask[pair_index]) {

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -264,25 +264,6 @@ public:
                 auto& uy1 = soa_products_data[1].m_rdata[PIdx::uy][slot1_idx];
                 auto& uz1 = soa_products_data[1].m_rdata[PIdx::uz][slot1_idx];
 
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-                /* In RZ and RCYLINDER geometry, macroparticles can collide with other macroparticles
-                * in the same *cylindrical* cell. For this reason, collisions between macroparticles
-                * are actually not local in space. In this case, the underlying assumption is that
-                * particles within the same cylindrical cell represent a cylindrically-symmetry
-                * momentum distribution function. Therefore, here, we temporarily rotate the
-                * momentum of one of the macroparticles in agreement with this cylindrical symmetry.
-                * (This is technically only valid if we use only the m=0 azimuthal mode in the simulation;
-                * there is a corresponding assert statement at initialization.)
-                */
-                amrex::ParticleReal const theta = (
-                    soa_products_data[1].m_rdata[PIdx::theta][slot1_idx]
-                    - soa_products_data[0].m_rdata[PIdx::theta][slot0_idx]
-                );
-                amrex::ParticleReal const ux0buf = ux0;
-                ux0 = ux0buf*std::cos(theta) - uy0*std::sin(theta);
-                uy0 = ux0buf*std::sin(theta) + uy0*std::cos(theta);
-#endif
-
                 // for simplicity (for now) we assume non-relativistic particles
                 // and simply calculate the center-of-momentum velocity from the
                 // rest masses
@@ -331,12 +312,6 @@ public:
                 uy1 += uCOM_y;
                 uz1 += uCOM_z;
 
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-                /* Undo the earlier velocity rotation. */
-                amrex::ParticleReal const ux0buf_new = ux0;
-                ux0 = ux0buf_new*std::cos(-theta) - uy0*std::sin(-theta);
-                uy0 = ux0buf_new*std::sin(-theta) + uy0*std::cos(-theta);
-#endif
             }
 
             // Next perform all product-producing collisions

--- a/Source/Particles/Collision/BinaryCollision/LinearBreitWheeler/LinearBreitWheelerCollisionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/LinearBreitWheeler/LinearBreitWheelerCollisionFunc.H
@@ -176,10 +176,6 @@ public:
             const auto multiplier_ratio = static_cast<int>(
                 m_isSameSpecies ? min_N + max_N - 1 : min_N);
 
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-            amrex::ParticleReal * const AMREX_RESTRICT theta1 = soa_1.m_rdata[PIdx::theta];
-            amrex::ParticleReal * const AMREX_RESTRICT theta2 = soa_2.m_rdata[PIdx::theta];
-#endif
             index_type i1 = I1s + coll_idx;
             index_type i2 = I2s + coll_idx;
             // we will start from collision number = coll_idx and then add
@@ -193,20 +189,6 @@ public:
                     p_mask[pair_index] = false;
                 }
                 else {
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-                    /* In RZ and RCYLINDER geometry, macroparticles can collide with other macroparticles
-                     * in the same *cylindrical* cell. For this reason, collisions between macroparticles
-                     * are actually not local in space. In this case, the underlying assumption is that
-                     * particles within the same cylindrical cell represent a cylindrically-symmetry
-                     * momentum distribution function. Therefore, here, we temporarily rotate the
-                     * momentum of one of the macroparticles in agreement with this cylindrical symmetry.
-                     * (This is technically only valid if we use only the m=0 azimuthal mode in the simulation;
-                     * there is a corresponding assert statement at initialization.) */
-                    amrex::ParticleReal const theta = theta2[I2[i2]]-theta1[I1[i1]];
-                    amrex::ParticleReal const u1xbuf = u1x[I1[i1]];
-                    u1x[I1[i1]] = u1xbuf*std::cos(theta) - u1y[I1[i1]]*std::sin(theta);
-                    u1y[I1[i1]] = u1xbuf*std::sin(theta) + u1y[I1[i1]]*std::cos(theta);
-#endif
                     SingleLinearBreitWheelerCollisionEvent(
                         u1x[ I1[i1] ], u1y[ I1[i1] ], u1z[ I1[i1] ],
                         u2x[ I2[i2] ], u2y[ I2[i2] ], u2z[ I2[i2] ],
@@ -216,11 +198,6 @@ public:
                         m_probability_threshold,
                         m_probability_target_value,
                         engine);
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-                    amrex::ParticleReal const u1xbuf_new = u1x[I1[i1]];
-                    u1x[I1[i1]] = u1xbuf_new*std::cos(-theta) - u1y[I1[i1]]*std::sin(-theta);
-                    u1y[I1[i1]] = u1xbuf_new*std::sin(-theta) + u1y[I1[i1]]*std::cos(-theta);
-#endif
                     // Remove pair reaction weight from the colliding particles' weights
                     if (p_mask[pair_index]) {
                         BinaryCollisionUtils::remove_weight_from_colliding_particle(

--- a/Source/Particles/Collision/BinaryCollision/LinearCompton/LinearComptonCollisionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/LinearCompton/LinearComptonCollisionFunc.H
@@ -172,10 +172,6 @@ public:
             const auto multiplier_ratio = static_cast<int>(
                 m_isSameSpecies ? min_N + max_N - 1 : min_N);
 
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-            amrex::ParticleReal * const AMREX_RESTRICT theta1 = soa_1.m_rdata[PIdx::theta];
-            amrex::ParticleReal * const AMREX_RESTRICT theta2 = soa_2.m_rdata[PIdx::theta];
-#endif
             index_type i1 = I1s + coll_idx;
             index_type i2 = I2s + coll_idx;
             // we will start from collision number = coll_idx and then add
@@ -189,20 +185,6 @@ public:
                     p_mask[pair_index] = false;
                 }
                 else {
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-                    /* In RZ and RCYLINDER geometry, macroparticles can collide with other macroparticles
-                     * in the same *cylindrical* cell. For this reason, collisions between macroparticles
-                     * are actually not local in space. In this case, the underlying assumption is that
-                     * particles within the same cylindrical cell represent a cylindrically-symmetry
-                     * momentum distribution function. Therefore, here, we temporarily rotate the
-                     * momentum of one of the macroparticles in agreement with this cylindrical symmetry.
-                     * (This is technically only valid if we use only the m=0 azimuthal mode in the simulation;
-                     * there is a corresponding assert statement at initialization.) */
-                    amrex::ParticleReal const theta = theta2[I2[i2]]-theta1[I1[i1]];
-                    amrex::ParticleReal const u1xbuf = u1x[I1[i1]];
-                    u1x[I1[i1]] = u1xbuf*std::cos(theta) - u1y[I1[i1]]*std::sin(theta);
-                    u1y[I1[i1]] = u1xbuf*std::sin(theta) + u1y[I1[i1]]*std::cos(theta);
-#endif
                     SingleLinearComptonCollisionEvent(
                         u1x[ I1[i1] ], u1y[ I1[i1] ], u1z[ I1[i1] ],
                         u2x[ I2[i2] ], u2y[ I2[i2] ], u2z[ I2[i2] ],
@@ -212,11 +194,6 @@ public:
                         m_probability_threshold,
                         m_probability_target_value,
                         engine);
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-                    amrex::ParticleReal const u1xbuf_new = u1x[I1[i1]];
-                    u1x[I1[i1]] = u1xbuf_new*std::cos(-theta) - u1y[I1[i1]]*std::sin(-theta);
-                    u1y[I1[i1]] = u1xbuf_new*std::sin(-theta) + u1y[I1[i1]]*std::cos(-theta);
-#endif
                     // Remove pair reaction weight from the colliding particles' weights
                     if (p_mask[pair_index]) {
                         BinaryCollisionUtils::remove_weight_from_colliding_particle(

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
@@ -166,10 +166,6 @@ public:
             const auto multiplier_ratio = static_cast<int>(
                 m_isSameSpecies ? min_N + max_N - 1 : min_N);
 
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-            amrex::ParticleReal * const AMREX_RESTRICT theta1 = soa_1.m_rdata[PIdx::theta];
-            amrex::ParticleReal * const AMREX_RESTRICT theta2 = soa_2.m_rdata[PIdx::theta];
-#endif
             index_type i1 = I1s + coll_idx;
             index_type i2 = I2s + coll_idx;
             // we will start from collision number = coll_idx and then add
@@ -185,21 +181,6 @@ public:
                 }
                 else {
 
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-                    /* In RZ and RCYLINDER geometry, macroparticles can collide with other macroparticles
-                     * in the same *cylindrical* cell. For this reason, collisions between macroparticles
-                     * are actually not local in space. In this case, the underlying assumption is that
-                     * particles within the same cylindrical cell represent a cylindrically-symmetry
-                     * momentum distribution function. Therefore, here, we temporarily rotate the
-                     * momentum of one of the macroparticles in agreement with this cylindrical symmetry.
-                     * (This is technically only valid if we use only the m=0 azimuthal mode in the simulation;
-                     * there is a corresponding assert statement at initialization.) */
-                    amrex::ParticleReal const theta = theta2[I2[i2]]-theta1[I1[i1]];
-                    amrex::ParticleReal const u1xbuf = u1x[I1[i1]];
-                    u1x[I1[i1]] = u1xbuf*std::cos(theta) - u1y[I1[i1]]*std::sin(theta);
-                    u1y[I1[i1]] = u1xbuf*std::sin(theta) + u1y[I1[i1]]*std::cos(theta);
-#endif
-
                     SingleNuclearFusionEvent(
                         u1x[ I1[i1] ], u1y[ I1[i1] ], u1z[ I1[i1] ],
                         u2x[ I2[i2] ], u2y[ I2[i2] ], u2z[ I2[i2] ],
@@ -209,12 +190,6 @@ public:
                         m_probability_threshold,
                         m_probability_target_value,
                         m_fusion_type, engine);
-
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-                    amrex::ParticleReal const u1xbuf_new = u1x[I1[i1]];
-                    u1x[I1[i1]] = u1xbuf_new*std::cos(-theta) - u1y[I1[i1]]*std::sin(-theta);
-                    u1y[I1[i1]] = u1xbuf_new*std::sin(-theta) + u1y[I1[i1]]*std::cos(-theta);
-#endif
 
                     // Remove pair reaction weight from the colliding particles' weights
                     if (p_mask[pair_index]) {

--- a/Source/Particles/Collision/CollisionHandler.cpp
+++ b/Source/Particles/Collision/CollisionHandler.cpp
@@ -127,7 +127,7 @@ void CollisionHandler::doCollisions ( int step, amrex::Real cur_time, amrex::Rea
      * the momentum of the macroparticles to the common frame, to the x-axis.
      * (This is only valid if we use only the m=0 azimuthal mode in the simulation;
      * there is a corresponding assert statement at initialization.) */
-    mypc->MapMomentumToXAxis(/*forward*/true);
+    mypc->TransformMomentumToCurvilinear(/*forward*/true);
 #endif
 
 #ifdef WARPX_QED
@@ -164,7 +164,7 @@ void CollisionHandler::doCollisions ( int step, amrex::Real cur_time, amrex::Rea
 
 #if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
     // Undo the rotation above
-    mypc->MapMomentumToXAxis(/*forward*/false);
+    mypc->TransformMomentumToCurvilinear(/*forward*/false);
 #endif
 
 }

--- a/Source/Particles/Collision/CollisionHandler.cpp
+++ b/Source/Particles/Collision/CollisionHandler.cpp
@@ -119,7 +119,8 @@ void CollisionHandler::doCollisions ( int step, amrex::Real cur_time, amrex::Rea
 
 #if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
     /* In RZ and RCYLINDER geometry, macroparticles can collide with other macroparticles
-     * in the same *cylindrical* cell. For this reason, collisions between macroparticles
+     * in the same *cylindrical* cell, or in RSPHERE the same *spherical* shell.
+     * For this reason, collisions between macroparticles
      * are actually not local in space. In this case, the underlying assumption is that
      * particles within the same cylindrical cell represent a cylindrically-symmetry
      * momentum distribution function. Therefore, here, we temporarily rotate the

--- a/Source/Particles/Collision/CollisionHandler.cpp
+++ b/Source/Particles/Collision/CollisionHandler.cpp
@@ -116,6 +116,19 @@ CollisionHandler::CollisionHandler(MultiParticleContainer const * const mypc)
  */
 void CollisionHandler::doCollisions ( int step, amrex::Real cur_time, amrex::Real dt, MultiParticleContainer* mypc)
 {
+
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+    /* In RZ and RCYLINDER geometry, macroparticles can collide with other macroparticles
+     * in the same *cylindrical* cell. For this reason, collisions between macroparticles
+     * are actually not local in space. In this case, the underlying assumption is that
+     * particles within the same cylindrical cell represent a cylindrically-symmetry
+     * momentum distribution function. Therefore, here, we temporarily rotate the
+     * momentum of the macroparticles to theta = 0.
+     * (This is technically only valid if we use only the m=0 azimuthal mode in the simulation;
+     * there is a corresponding assert statement at initialization.) */
+    mypc->RotateParticleAnglesByTheta(-1.);
+#endif
+
 #ifdef WARPX_QED
     // For QED incoherent processes (e.g. Bethe-Heitler, Landau-Lifschitz), the process is mediated by virtual photons.
     // The virtual photons are newly generated here and participate in the collisions.
@@ -147,5 +160,10 @@ void CollisionHandler::doCollisions ( int step, amrex::Real cur_time, amrex::Rea
             }
         }
     }
+
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+    // Undo the rotation above
+    mypc->RotateParticleAnglesByTheta(+1.);
+#endif
 
 }

--- a/Source/Particles/Collision/CollisionHandler.cpp
+++ b/Source/Particles/Collision/CollisionHandler.cpp
@@ -124,7 +124,7 @@ void CollisionHandler::doCollisions ( int step, amrex::Real cur_time, amrex::Rea
      * near each other. This would violate the underlying assumptions that particles within the
      * same cylindrical or spherical cell represent a cylindrically- or spherically-symmetric
      * momentum distribution function and are spatially local. Therefore, we temporarily rotate
-     * the momentum of the macroparticles to the common frame, to the x-axis.
+     * the momentum of the macroparticles to the curvilinear frame, equivalent to the x-axis.
      * (This is only valid if we use only the m=0 azimuthal mode in the simulation;
      * there is a corresponding assert statement at initialization.) */
     mypc->TransformMomentumToCurvilinear(/*forward*/true);

--- a/Source/Particles/Collision/CollisionHandler.cpp
+++ b/Source/Particles/Collision/CollisionHandler.cpp
@@ -120,14 +120,14 @@ void CollisionHandler::doCollisions ( int step, amrex::Real cur_time, amrex::Rea
 #if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
     /* In RZ and RCYLINDER geometry, macroparticles can collide with other macroparticles
      * in the same *cylindrical* cell, or in RSPHERE the same *spherical* shell.
-     * For this reason, collisions between macroparticles
-     * are actually not local in space. In this case, the underlying assumption is that
-     * particles within the same cylindrical cell represent a cylindrically-symmetry
-     * momentum distribution function. Therefore, here, we temporarily rotate the
-     * momentum of the macroparticles to theta = 0.
-     * (This is technically only valid if we use only the m=0 azimuthal mode in the simulation;
+     * Because of this, the colliding macroparticles would not nessecarily be spatially
+     * near each other. This would violate the underlying assumptions that particles within the
+     * same cylindrical or spherical cell represent a cylindrically- or spherically-symmetric
+     * momentum distribution function and are spatially local. Therefore, we temporarily rotate
+     * the momentum of the macroparticles to the common frame, to the x-axis.
+     * (This is only valid if we use only the m=0 azimuthal mode in the simulation;
      * there is a corresponding assert statement at initialization.) */
-    mypc->RotateParticleAnglesByTheta(-1.);
+    mypc->MapMomentumToXAxis(/*forward*/true);
 #endif
 
 #ifdef WARPX_QED
@@ -164,7 +164,7 @@ void CollisionHandler::doCollisions ( int step, amrex::Real cur_time, amrex::Rea
 
 #if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
     // Undo the rotation above
-    mypc->RotateParticleAnglesByTheta(+1.);
+    mypc->MapMomentumToXAxis(/*forward*/false);
 #endif
 
 }

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -94,7 +94,7 @@ public:
 
     amrex::ParticleReal maxParticleVelocity();
 
-    void MapMomentumToXAxis (bool forward);
+    void TransformMomentumToCurvilinear (bool forward);
 
     void AllocData ();
 

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -94,7 +94,7 @@ public:
 
     amrex::ParticleReal maxParticleVelocity();
 
-    void MapMomentumToXAxis (amrex::ParticleReal sign);
+    void MapMomentumToXAxis (bool forward);
 
     void AllocData ();
 

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -94,7 +94,7 @@ public:
 
     amrex::ParticleReal maxParticleVelocity();
 
-    void RotateParticleAnglesByTheta (amrex::ParticleReal sign);
+    void MapMomentumToXAxis (amrex::ParticleReal sign);
 
     void AllocData ();
 

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -94,6 +94,8 @@ public:
 
     amrex::ParticleReal maxParticleVelocity();
 
+    void RotateParticleAnglesByTheta (amrex::ParticleReal sign);
+
     void AllocData ();
 
     void InitData ();

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -422,9 +422,9 @@ MultiParticleContainer::maxParticleVelocity() {
 }
 
 void
-MultiParticleContainer::MapMomentumToXAxis (amrex::ParticleReal sign) {
+MultiParticleContainer::MapMomentumToXAxis (bool forward) {
     for (const auto &pc : allcontainers) {
-        pc->MapMomentumToXAxis(sign);
+        pc->MapMomentumToXAxis(forward);
     }
 }
 

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -422,6 +422,13 @@ MultiParticleContainer::maxParticleVelocity() {
 }
 
 void
+MultiParticleContainer::RotateParticleAnglesByTheta (amrex::ParticleReal sign) {
+    for (const auto &pc : allcontainers) {
+        pc->RotateParticleAnglesByTheta(sign);
+    }
+}
+
+void
 MultiParticleContainer::AllocData ()
 {
     for (auto& pc : allcontainers) {

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -422,9 +422,9 @@ MultiParticleContainer::maxParticleVelocity() {
 }
 
 void
-MultiParticleContainer::RotateParticleAnglesByTheta (amrex::ParticleReal sign) {
+MultiParticleContainer::MapMomentumToXAxis (amrex::ParticleReal sign) {
     for (const auto &pc : allcontainers) {
-        pc->RotateParticleAnglesByTheta(sign);
+        pc->MapMomentumToXAxis(sign);
     }
 }
 

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -422,9 +422,9 @@ MultiParticleContainer::maxParticleVelocity() {
 }
 
 void
-MultiParticleContainer::MapMomentumToXAxis (bool forward) {
+MultiParticleContainer::TransformMomentumToCurvilinear (bool forward) {
     for (const auto &pc : allcontainers) {
-        pc->MapMomentumToXAxis(forward);
+        pc->TransformMomentumToCurvilinear(forward);
     }
 }
 

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -462,15 +462,16 @@ public:
     amrex::ParticleReal maxParticleVelocity(bool local = false);
 
     /**
-     * \brief Map the momentum of the particles to and from the X-axis, i.e. theta = 0
+     * \brief Map the momentum of the particles to and from the curvilinear frame.
+     *        This is equivalent to mapping to the X-axis, i.e. theta = 0
      *        cylinderical and theta = phi = 0 for spherical. This mapping is used
      *        for binary collisions to put the colliding particles in a spatially local
      *        frame.
      *
-     * \param[in] forward When true, maps to the X-axis, when false maps from the X-axis
+     * \param[in] forward When true, maps to the frame, when false maps from the frame
      *            to the original location
      */
-    void MapMomentumToXAxis (bool forward);
+    void TransformMomentumToCurvilinear (bool forward);
 
     /**
      * \brief Adds n particles to the simulation

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -461,6 +461,8 @@ public:
 
     amrex::ParticleReal maxParticleVelocity(bool local = false);
 
+    void RotateParticleAnglesByTheta (amrex::ParticleReal sign);
+
     /**
      * \brief Adds n particles to the simulation
      *

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -461,7 +461,16 @@ public:
 
     amrex::ParticleReal maxParticleVelocity(bool local = false);
 
-    void RotateParticleAnglesByTheta (amrex::ParticleReal sign);
+    /**
+     * \brief Map the momentum of the particles to and from the X-axis, i.e. theta = 0
+     *        cylinderical and theta = phi = 0 for spherical. This mapping is used
+     *        for binary collisions to put the colliding particles in a spatially local
+     *        frame.
+     *
+     * \param[in] forward When true, maps to the X-axis, when false maps from the X-axis
+     *            to the original location
+     */
+    void MapMomentumToXAxis (bool forward);
 
     /**
      * \brief Adds n particles to the simulation

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2411,14 +2411,14 @@ WarpXParticleContainer::RotateParticleAnglesByTheta ([[maybe_unused]]amrex::Part
                 // Loop over the particles, rotating to theta = phi = 0
                 amrex::ParallelFor(pti.numParticles(),
                     [=] AMREX_GPU_DEVICE (long i) {
-                        const amrex::ParticleReal phi = phi_data[i];
                         const amrex::ParticleReal theta = theta_data[i];
+                        const amrex::ParticleReal phi = phi_data[i];
                         const amrex::ParticleReal uxsave = ux[i];
                         const amrex::ParticleReal uysave = uy[i];
                         const amrex::ParticleReal uzsave = uz[i];
-                        ux[i] = uxsave*std::cos(theta)*std::cos(phi) + uysave*std::sin(theta)*std::cos(phi) - uzsave*std::sin(phi);
+                        ux[i] = +uxsave*std::cos(theta)*std::cos(phi) + uysave*std::sin(theta)*std::cos(phi) + uzsave*std::sin(phi);
                         uy[i] = -uxsave*std::sin(theta) + uysave*std::cos(theta);
-                        uz[i] = uxsave*std::cos(theta)*std::sin(phi) + uysave*std::sin(theta)*std::sin(phi) + uzsave*std::cos(phi);
+                        uz[i] = -uxsave*std::cos(theta)*std::sin(phi) - uysave*std::sin(theta)*std::sin(phi) + uzsave*std::cos(phi);
                     }
                 );
 
@@ -2427,14 +2427,14 @@ WarpXParticleContainer::RotateParticleAnglesByTheta ([[maybe_unused]]amrex::Part
                 // Loop over the particles, rotating from zero to theta and phi
                 amrex::ParallelFor(pti.numParticles(),
                     [=] AMREX_GPU_DEVICE (long i) {
-                        const amrex::ParticleReal phi = phi_data[i];
                         const amrex::ParticleReal theta = theta_data[i];
+                        const amrex::ParticleReal phi = phi_data[i];
                         const amrex::ParticleReal uxsave = ux[i];
                         const amrex::ParticleReal uysave = uy[i];
                         const amrex::ParticleReal uzsave = uz[i];
-                        ux[i] = uxsave*std::cos(theta)*std::cos(phi) - uysave*std::sin(theta) + uzsave*std::cos(theta)*std::sin(phi);
-                        uy[i] = uxsave*std::sin(theta)*std::cos(phi) + uysave*std::cos(theta) + uzsave*std::sin(theta)*std::sin(phi);
-                        uz[i] = -uxsave*std::sin(phi) + uzsave*std::cos(phi);
+                        ux[i] = +uxsave*std::cos(theta)*std::cos(phi) - uysave*std::sin(theta) - uzsave*std::cos(theta)*std::sin(phi);
+                        uy[i] = +uxsave*std::sin(theta)*std::cos(phi) + uysave*std::cos(theta) - uzsave*std::sin(theta)*std::sin(phi);
+                        uz[i] = +uxsave*std::sin(phi) + uzsave*std::cos(phi);
                     }
                 );
 

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2366,7 +2366,7 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleVelocity(bool local) {
 }
 
 void
-WarpXParticleContainer::MapMomentumToXAxis ([[maybe_unused]]bool forward)
+WarpXParticleContainer::TransformMomentumToCurvilinear ([[maybe_unused]]bool forward)
 {
 #if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
     using namespace amrex::literals;

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2366,6 +2366,45 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleVelocity(bool local) {
 }
 
 void
+WarpXParticleContainer::RotateParticleAnglesByTheta ([[maybe_unused]]amrex::ParticleReal sign)
+{
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
+    using namespace amrex::literals;
+
+    const int nLevels = finestLevel();
+    for (int lev = 0; lev <= nLevels; ++lev) {
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    {
+        for (WarpXParIter pti(*this, lev); pti.isValid(); ++pti)
+        {
+
+            // momenta are stored as a struct of array, in `attribs`
+            auto& attribs = pti.GetAttribs();
+            amrex::ParticleReal * AMREX_RESTRICT ux = attribs[PIdx::ux].dataPtr();
+            amrex::ParticleReal * AMREX_RESTRICT uy = attribs[PIdx::uy].dataPtr();
+            amrex::ParticleReal * AMREX_RESTRICT theta_data = attribs[PIdx::theta].dataPtr();
+
+            // Loop over the particles, rotating their velocities by theta
+            amrex::ParallelFor(pti.numParticles(),
+                [=] AMREX_GPU_DEVICE (long i) {
+                    const amrex::ParticleReal theta_sign = sign < 0. ? -1._prt : +1._prt;
+                    const amrex::ParticleReal theta = theta_sign*theta_data[i];
+                    const amrex::ParticleReal uxsave = ux[i];
+                    ux[i] = uxsave*std::cos(theta) - uy[i]*std::sin(theta);
+                    uy[i] = uxsave*std::sin(theta) + uy[i]*std::cos(theta);
+
+                }
+            );
+        }
+    }
+    }
+#endif
+}
+
+void
 WarpXParticleContainer::PushX (amrex::Real dt)
 {
     const int nLevels = finestLevel();

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2366,7 +2366,7 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleVelocity(bool local) {
 }
 
 void
-WarpXParticleContainer::RotateParticleAnglesByTheta ([[maybe_unused]]amrex::ParticleReal sign)
+WarpXParticleContainer::MapMomentumToXAxis ([[maybe_unused]]bool forward)
 {
 #if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
     using namespace amrex::literals;
@@ -2392,7 +2392,7 @@ WarpXParticleContainer::RotateParticleAnglesByTheta ([[maybe_unused]]amrex::Part
             // Loop over the particles, rotating their velocities by theta
             amrex::ParallelFor(pti.numParticles(),
                 [=] AMREX_GPU_DEVICE (long i) {
-                    const amrex::ParticleReal theta_sign = sign < 0. ? -1._prt : +1._prt;
+                    const amrex::ParticleReal theta_sign = forward ? -1._prt : +1._prt;
                     const amrex::ParticleReal theta = theta_sign*theta_data[i];
                     const amrex::ParticleReal uxsave = ux[i];
                     const amrex::ParticleReal uysave = uy[i];
@@ -2406,7 +2406,7 @@ WarpXParticleContainer::RotateParticleAnglesByTheta ([[maybe_unused]]amrex::Part
             amrex::ParticleReal * AMREX_RESTRICT uz = attribs[PIdx::uz].dataPtr();
             amrex::ParticleReal * AMREX_RESTRICT phi_data = attribs[PIdx::phi].dataPtr();
 
-            if (sign < 0.) {
+            if (forward) {
 
                 // Loop over the particles, rotating to theta = phi = 0
                 amrex::ParallelFor(pti.numParticles(),

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2368,7 +2368,7 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleVelocity(bool local) {
 void
 WarpXParticleContainer::RotateParticleAnglesByTheta ([[maybe_unused]]amrex::ParticleReal sign)
 {
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
     using namespace amrex::literals;
 
     const int nLevels = finestLevel();
@@ -2387,17 +2387,59 @@ WarpXParticleContainer::RotateParticleAnglesByTheta ([[maybe_unused]]amrex::Part
             amrex::ParticleReal * AMREX_RESTRICT uy = attribs[PIdx::uy].dataPtr();
             amrex::ParticleReal * AMREX_RESTRICT theta_data = attribs[PIdx::theta].dataPtr();
 
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
+
             // Loop over the particles, rotating their velocities by theta
             amrex::ParallelFor(pti.numParticles(),
                 [=] AMREX_GPU_DEVICE (long i) {
                     const amrex::ParticleReal theta_sign = sign < 0. ? -1._prt : +1._prt;
                     const amrex::ParticleReal theta = theta_sign*theta_data[i];
                     const amrex::ParticleReal uxsave = ux[i];
-                    ux[i] = uxsave*std::cos(theta) - uy[i]*std::sin(theta);
-                    uy[i] = uxsave*std::sin(theta) + uy[i]*std::cos(theta);
-
+                    const amrex::ParticleReal uysave = uy[i];
+                    ux[i] = uxsave*std::cos(theta) - uysave*std::sin(theta);
+                    uy[i] = uxsave*std::sin(theta) + uysave*std::cos(theta);
                 }
             );
+
+#elif defined(WARPX_DIM_RSPHERE)
+
+            amrex::ParticleReal * AMREX_RESTRICT uz = attribs[PIdx::uy].dataPtr();
+            amrex::ParticleReal * AMREX_RESTRICT phi_data = attribs[PIdx::phi].dataPtr();
+
+            if (sign < 0.) {
+
+                // Loop over the particles, rotating to theta = phi = 0
+                amrex::ParallelFor(pti.numParticles(),
+                    [=] AMREX_GPU_DEVICE (long i) {
+                        const amrex::ParticleReal phi = phi_data[i];
+                        const amrex::ParticleReal theta = theta_data[i];
+                        const amrex::ParticleReal uxsave = ux[i];
+                        const amrex::ParticleReal uysave = uy[i];
+                        const amrex::ParticleReal uzsave = uz[i];
+                        ux[i] = uxsave*std::cos(theta)*std::cos(phi) + uysave*std::sin(theta)*std::cos(phi) - uzsave*std::sin(phi);
+                        uy[i] = -uxsave*std::sin(theta) + uysave*std::cos(theta);
+                        uz[i] = uxsave*std::cos(theta)*std::sin(phi) + uysave*std::sin(theta)*std::sin(phi) + uzsave*std::cos(phi);
+                    }
+                );
+
+            } else {
+
+                // Loop over the particles, rotating from zero to theta and phi
+                amrex::ParallelFor(pti.numParticles(),
+                    [=] AMREX_GPU_DEVICE (long i) {
+                        const amrex::ParticleReal phi = phi_data[i];
+                        const amrex::ParticleReal theta = theta_data[i];
+                        const amrex::ParticleReal uxsave = ux[i];
+                        const amrex::ParticleReal uysave = uy[i];
+                        const amrex::ParticleReal uzsave = uz[i];
+                        ux[i] = uxsave*std::cos(theta)*std::cos(phi) - uysave*std::sin(theta) + uzsave*std::cos(theta)*std::sin(phi);
+                        uy[i] = uxsave*std::sin(theta)*std::cos(phi) + uysave*std::cos(theta) + uzsave*std::sin(theta)*std::sin(phi);
+                        uz[i] = -uxsave*std::sin(phi) + uzsave*std::cos(phi);
+                    }
+                );
+
+            }
+#endif
         }
     }
     }

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2403,7 +2403,7 @@ WarpXParticleContainer::RotateParticleAnglesByTheta ([[maybe_unused]]amrex::Part
 
 #elif defined(WARPX_DIM_RSPHERE)
 
-            amrex::ParticleReal * AMREX_RESTRICT uz = attribs[PIdx::uy].dataPtr();
+            amrex::ParticleReal * AMREX_RESTRICT uz = attribs[PIdx::uz].dataPtr();
             amrex::ParticleReal * AMREX_RESTRICT phi_data = attribs[PIdx::phi].dataPtr();
 
             if (sign < 0.) {


### PR DESCRIPTION
In binary collision in radial geometries, the particle momenta are rotated to a common angle before the collisions so that the particles are spatially local (rather than spread out in angle). Currently, this rotation is done within each of the separate collision kernels. This PR pulls this rotation out of those kernels, rotating all particles to the common angle theta = 0 before any collisions and rotating back afterward. This offers several advantages, reducing code duplication, and reducing effort (since species that participate in multiple collisions have their momenta adjusted only once instead of in each collision).

A side note, the CI test `test_rz_collision` is a fairly weak test since it fully passes whether or not the rotation is done. A suggestion is to reduce the tolerance to 1.e-35. Without the rotation, the error in the momentum is ~1.e-22, below the current tolerance of 1.e-15.