### PR TITLE
[WIP]Set build_coarse_level_by_coarsening to False

### DIFF
--- a/Source/EmbeddedBoundary/WarpXInitEB.cpp
+++ b/Source/EmbeddedBoundary/WarpXInitEB.cpp
@@ -97,7 +97,7 @@ WarpX::InitEB ()
          // number (e.g., maxLevel()+20) for multigrid solvers.  Because the coarse
          // level has only 1/8 of the cells on the fine level, the memory usage should
          // not be an issue.
-        amrex::EB2::Build(gshop, Geom(maxLevel()), maxLevel(), maxLevel()+20);
+        amrex::EB2::Build(gshop, Geom(maxLevel()), maxLevel(), maxLevel()+20, 4, false);
     } else {
         amrex::ParmParse pp_eb2("eb2");
         if (!pp_eb2.contains("geom_type")) {

--- a/Source/EmbeddedBoundary/WarpXInitEB.cpp
+++ b/Source/EmbeddedBoundary/WarpXInitEB.cpp
@@ -105,7 +105,7 @@ WarpX::InitEB ()
             pp_eb2.add("geom_type", geom_type); // use all_regular by default
         }
         // See the comment above on amrex::EB2::Build for the hard-wired number 20.
-        amrex::EB2::Build(Geom(maxLevel()), maxLevel(), maxLevel()+20);
+        amrex::EB2::Build(Geom(maxLevel()), maxLevel(), maxLevel()+20, 4, false);
     }
 #endif
 }


### PR DESCRIPTION
Problem: we have a simulation with EB geometry specified via an STL file that runs without any issues without MR. However, once MR is enabled, we get the following error message:

```amrex::Abort::4::Failed to build required coarse EB level 1 !!! SIGABRT```

 @WeiqunZhang suggested setting `build_coarse_level_by_coarsening = false`.

Action items: 

- [ ] check whether this change breaks any CI tests;
- [ ] discuss further.