### PR TITLE
fix update timestep print message

### DIFF
--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -225,7 +225,7 @@ WarpX::GlobalCyclotronFrequencyMax ()
     {
         const WarpXParticleContainer& pc = mypc->GetParticleContainer(i);
         if (pc.getMass() > 0.) {
-            const amrex::Real pc_omegac = pc.getCharge()*B_max/pc.getMass();
+            const amrex::Real pc_omegac = std::abs(pc.getCharge())*B_max/pc.getMass();
             omegac_max = std::max(omegac_max, pc_omegac);
         }
     }

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -194,7 +194,7 @@ WarpX::Evolve (int numsteps)
 
         // Update the timestep for solvers that support adaptive timestepping
         // (electrostatic and theta-implicit EM), provided const_dt is not specified.
-        if (m_dt_update_interval.contains(step+1) || step == 0) {
+        if (m_dt_update_interval.contains(step+1) || (step == 0 && m_max_dt.has_value())) {
             SynchronizeVelocityWithPosition();
             ApplyDtLimiters();
             if (verbose_step) {

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -194,11 +194,13 @@ WarpX::Evolve (int numsteps)
 
         // Update the timestep for solvers that support adaptive timestepping
         // (electrostatic and theta-implicit EM), provided const_dt is not specified.
-        if (m_dt_update_interval.contains(step+1)) {
+        if (m_dt_update_interval.contains(step+1) || step == 0) {
             SynchronizeVelocityWithPosition();
             ApplyDtLimiters();
             if (verbose_step) {
-                amrex::Print() << Utils::TextMsg::Info("updating timestep to dt = " + std::to_string(dt[0]));
+                std::ostringstream oss;
+                oss << "updating timestep to DT = " << std::scientific << std::setprecision(6) << dt[0];
+                amrex::Print() << Utils::TextMsg::Info(oss.str());
             }
         }
 


### PR DESCRIPTION
This PR fixes a bug and a print issues introduced in PR #6840. When `ApplyDtLimiters()` is called, the updated time step is printed using:
`amrex::Print() << Utils::TextMsg::Info("updating timestep to dt = " + std::to_string(dt[0]));`

I find that the print looks like:
`--- INFO : updating timestep to dt = 0.000000`.

This PR instead uses
```
std::ostringstream oss;
oss << "updating timestep to DT = " << std::scientific << std::setprecision(6) << dt[0];
amrex::Print() << Utils::TextMsg::Info(oss.str());
```
Which looks like
`--- INFO    : updating timestep to DT = 1.000000e-12`

The bug fixed in this PR is that the absolute value of the charge should be used when computing the maximum cyclotron frequency.

It was also commented in PR #6840 that `ApplyDtLimiters()` is not applied at step 0, resulting in the time step set by the CFL for light waves. This PR also adds the call to `ApplyDtLimiters()` at step = 0.
