### PR TITLE
automatically turn on ADIOS_ASYNC_WRITE

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatOpenPMD.cpp
@@ -66,6 +66,12 @@ FlushFormatOpenPMD::FlushFormatOpenPMD (const std::string& diag_name)
         }
 
         pp_diag_name.query("buffer_flush_limit_btd", m_NumAggBTDBufferToFlush);
+
+#ifdef _WIN32
+        _putenv_s("OPENPMD_ADIOS2_ASYNC_WRITE", "1");
+#else
+        setenv("OPENPMD_ADIOS2_ASYNC_WRITE", "1", 1);
+#endif
     }
 
     //


### PR DESCRIPTION
When using BTD, force the env OPENPMD_ADIOS2_ASYNC_WRITE so openPMD will set the flag to ADIOS. 
This is for improving the I/O performance. 