### PR TITLE
do not deposit/gather neutrals by default.

### DIFF
--- a/Source/Diagnostics/ParticleIO.cpp
+++ b/Source/Diagnostics/ParticleIO.cpp
@@ -114,7 +114,7 @@ RigidInjectedParticleContainer::WriteHeader (std::ostream& os) const
 void
 PhysicalParticleContainer::ReadHeader (std::istream& is)
 {
-    is >> charge >> m_mass;
+    is >> m_charge >> m_mass;
     ablastr::utils::text::goto_next_line(is);
 }
 
@@ -122,7 +122,7 @@ void
 PhysicalParticleContainer::WriteHeader (std::ostream& os) const
 {
     // no need to write species_id
-    os << charge << " " << m_mass << "\n";
+    os << m_charge << " " << m_mass << "\n";
 }
 
 void

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -83,7 +83,7 @@ LaserParticleContainer::LaserParticleContainer (AmrCore* amr_core, int ispecies,
     : WarpXParticleContainer(amr_core, ispecies),
       m_laser_name{name}
 {
-    charge = 1.0;
+    m_charge = 1.0;
     m_mass = std::numeric_limits<Real>::max();
 
     const ParmParse pp_laser_name(m_laser_name);

--- a/Source/Particles/ParticleCreation/AddParticles.cpp
+++ b/Source/Particles/ParticleCreation/AddParticles.cpp
@@ -403,7 +403,7 @@ PhysicalParticleContainer::AddGaussianBeam (PlasmaInjector const& plasma_injecto
         // compute the weight from N_tot if the user specified npart_real = N_tot
         // compute the weight from q_tot if the user specified q_tot
         // note that npart is the number of macroparticles
-        const amrex::Real weight_3d = (N_tot > 0._rt) ? (N_tot / npart) : (q_tot / (npart*charge));
+        const amrex::Real weight_3d = (N_tot > 0._rt) ? (N_tot / npart) : (q_tot / (npart*m_charge));
         for (long i = 0; i < npart; ++i) {
 #if defined(WARPX_DIM_3D) || defined(WARPX_DIM_RZ)
             const amrex::Real weight = weight_3d;

--- a/Source/Particles/PhotonParticleContainer.H
+++ b/Source/Particles/PhotonParticleContainer.H
@@ -113,6 +113,7 @@ public:
                                  amrex::Real const /*dt*/,
                                  amrex::Real const /*relative_time*/,
                                  PushType /*push_type*/) override {}
+
 };
 
 #endif // #ifndef WARPX_PhotonParticleContainer_H_

--- a/Source/Particles/PhotonParticleContainer.H
+++ b/Source/Particles/PhotonParticleContainer.H
@@ -113,7 +113,6 @@ public:
                                  amrex::Real const /*dt*/,
                                  amrex::Real const /*relative_time*/,
                                  PushType /*push_type*/) override {}
-
 };
 
 #endif // #ifndef WARPX_PhotonParticleContainer_H_

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -215,13 +215,13 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     // Initialize splitting
     pp_species_name.query("do_splitting", do_splitting);
     pp_species_name.query("split_type", split_type);
+    pp_species_name.query("do_not_deposit", do_not_deposit);
+    pp_species_name.query("do_not_gather", do_not_gather);
     pp_species_name.query("do_not_push", do_not_push);
+
     if (m_charge == 0._prt) {
         do_not_deposit = true;
         do_not_gather = true;
-    } else {
-        pp_species_name.query("do_not_deposit", do_not_deposit);
-        pp_species_name.query("do_not_gather", do_not_gather);
     }
 
     pp_species_name.query("do_continuous_injection", do_continuous_injection);

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -150,7 +150,7 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     for (auto const& plasma_injector : plasma_injectors) {
         // For now, use the last value for charge and mass that is found.
         // A check could be added for consistency of multiple values, but it'll probably never be needed
-        charge_from_source |= plasma_injector->queryCharge(charge);
+        charge_from_source |= plasma_injector->queryCharge(m_charge);
         mass_from_source |= plasma_injector->queryMass(m_mass);
     }
 
@@ -161,12 +161,12 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(physical_species_from_string,
             physical_species_s + " does not exist!");
         physical_species = physical_species_from_string.value();
-        charge = species::get_charge( physical_species );
+        m_charge = species::get_charge( physical_species );
         m_mass = species::get_mass( physical_species );
     }
 
     // parse charge and mass (overriding values above)
-    const bool charge_is_specified = utils::parser::queryWithParser(pp_species_name, "charge", charge);
+    const bool charge_is_specified = utils::parser::queryWithParser(pp_species_name, "charge", m_charge);
     const bool mass_is_specified = utils::parser::queryWithParser(pp_species_name, "mass", m_mass);
 
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE (
@@ -215,9 +215,14 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     // Initialize splitting
     pp_species_name.query("do_splitting", do_splitting);
     pp_species_name.query("split_type", split_type);
-    pp_species_name.query("do_not_deposit", do_not_deposit);
-    pp_species_name.query("do_not_gather", do_not_gather);
     pp_species_name.query("do_not_push", do_not_push);
+    if (m_charge == 0.) {
+        do_not_deposit = true;
+        do_not_gather = true;
+    } else {
+        pp_species_name.query("do_not_deposit", do_not_deposit);
+        pp_species_name.query("do_not_gather", do_not_gather);
+    }
 
     pp_species_name.query("do_continuous_injection", do_continuous_injection);
     pp_species_name.query("initialize_self_fields", initialize_self_fields);
@@ -1244,7 +1249,7 @@ PhysicalParticleContainer::PushP (int lev, Real dt,
             }
 
             // Loop over the particles and update their momentum
-            const amrex::ParticleReal q = this->charge;
+            const amrex::ParticleReal q = this->m_charge;
             const amrex::ParticleReal mass = this->m_mass;
 
             const auto pusher_algo = WarpX::particle_pusher_algo;
@@ -1438,7 +1443,7 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
     }
 
     // local copies for device lambda capture
-    const amrex::ParticleReal q = this->charge;
+    const amrex::ParticleReal q = this->m_charge;
     const amrex::ParticleReal mass = this->m_mass;
 
     const auto pusher_algo = WarpX::particle_pusher_algo;
@@ -1576,12 +1581,12 @@ PhysicalParticleContainer::InitIonizationModule ()
 {
     if (!do_field_ionization) { return; }
     const ParmParse pp_species_name(species_name);
-    if (charge != PhysConst::q_e){
+    if (m_charge != PhysConst::q_e){
         ablastr::warn_manager::WMRecordWarning("Species",
             "charge != q_e for ionizable species '" +
             species_name + "':" +
             "overriding user value and setting charge = q_e.");
-        charge = PhysConst::q_e;
+        m_charge = PhysConst::q_e;
     }
     utils::parser::queryWithParser(pp_species_name, "do_adk_correction", do_adk_correction);
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -221,7 +221,9 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
 
     if (m_charge == 0._prt) {
         do_not_deposit = true;
-        do_not_gather = true;
+        if (m_mass > 0._prt) {
+            do_not_gather = true;
+        }
     }
 
     pp_species_name.query("do_continuous_injection", do_continuous_injection);

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -216,7 +216,7 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     pp_species_name.query("do_splitting", do_splitting);
     pp_species_name.query("split_type", split_type);
     pp_species_name.query("do_not_push", do_not_push);
-    if (m_charge == 0.) {
+    if (m_charge == 0._prt) {
         do_not_deposit = true;
         do_not_gather = true;
     } else {

--- a/Source/Particles/Pusher/ImplicitPushPX.cpp
+++ b/Source/Particles/Pusher/ImplicitPushPX.cpp
@@ -520,7 +520,7 @@ PhysicalParticleContainer::ImplicitPushXP (WarpXParIter & pti,
     }
 
     // Loop over the particles and update their momentum
-    const amrex::ParticleReal q = this->charge;
+    const amrex::ParticleReal q = this->m_charge;
     const amrex::ParticleReal mass = this->m_mass;
 
     const auto pusher_algo = WarpX::particle_pusher_algo;
@@ -878,7 +878,7 @@ PhysicalParticleContainer::ImplicitPushXPSubOrbits (WarpXParIter& pti,
     }
 
     // Loop over the particles and update their momentum
-    const amrex::ParticleReal q = this->charge;
+    const amrex::ParticleReal q = this->m_charge;
     const amrex::ParticleReal mass = this->m_mass;
 
     const auto pusher_algo = WarpX::particle_pusher_algo;

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -393,7 +393,7 @@ RigidInjectedParticleContainer::PushP (int lev, Real dt,
             ParticleReal* const AMREX_RESTRICT uz_save = uzp_save.dataPtr();
 
             // Loop over the particles and update their momentum
-            const amrex::ParticleReal q = this->charge;
+            const amrex::ParticleReal q = this->m_charge;
             const amrex::ParticleReal mass = this->m_mass;
 
             const auto pusher_algo = WarpX::particle_pusher_algo;

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -559,7 +559,7 @@ public:
         return m_do_back_transformed_particles;
     }
 
-    amrex::ParticleReal getCharge () const {return charge;}
+    amrex::ParticleReal getCharge () const {return m_charge;}
 
     amrex::ParticleReal getMass () const {return m_mass;}
 
@@ -633,7 +633,7 @@ public:
 protected:
     int species_id;
 
-    amrex::ParticleReal charge;
+    amrex::ParticleReal m_charge;
     amrex::ParticleReal m_mass;
     PhysicalSpecies physical_species = PhysicalSpecies::unspecified;
 

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -447,7 +447,7 @@ WarpXParticleContainer::DepositCurrent (WarpXParIter& pti,
 
     const amrex::XDim3 dinv = WarpX::InvCellSize(std::max(depos_lev,0));
 
-    const amrex::ParticleReal q = this->charge;
+    const amrex::ParticleReal q = this->m_charge;
 
     ABLASTR_PROFILE_VAR_NS("WarpXParticleContainer::DepositCurrent::Sorting", blp_sort);
     ABLASTR_PROFILE_VAR_NS("WarpXParticleContainer::DepositCurrent::FindMaxTilesize",
@@ -1016,7 +1016,7 @@ WarpXParticleContainer::DepositMassMatrices (WarpXParIter& pti, const RealVector
 
     const amrex::XDim3 dinv = WarpX::InvCellSize(std::max(depos_lev,0));
 
-    const amrex::ParticleReal qs = this->charge;
+    const amrex::ParticleReal qs = this->m_charge;
     const amrex::ParticleReal mass = this->m_mass;
 
     // Get tile box where current is deposited.
@@ -1555,7 +1555,7 @@ WarpXParticleContainer::DepositCharge (WarpXParIter& pti, RealVector const& wp,
                                   "Particles shape does not fit within tile (CPU) or guard cells (GPU) used for charge deposition");
         amrex::ignore_unused(range); // In case the assertion isn't compiled
 
-        const Real q = this->charge;
+        const Real q = this->m_charge;
 
         ABLASTR_PROFILE_VAR_NS("WarpXParticleContainer::DepositCharge::Sorting", blp_sort);
         ABLASTR_PROFILE_VAR_NS("WarpXParticleContainer::DepositCharge::ChargeDeposition", blp_ppc_chd);
@@ -1780,7 +1780,7 @@ WarpXParticleContainer::DepositCharge (WarpXParIter& pti, RealVector const& wp,
         AMREX_ALWAYS_ASSERT(WarpX::nox == WarpX::noz);
 
         ablastr::particles::deposit_charge<WarpXParticleContainer>(
-                pti, wp, this->charge, ion_lev,
+                pti, wp, this->m_charge, ion_lev,
                 rho, local_rho[thread_num],
                 WarpX::noz, dinv, xyzmin, WarpX::n_rz_azimuthal_modes,
                 ng_rho, depos_lev, ref_ratio,
@@ -2139,7 +2139,7 @@ std::unique_ptr<amrex::MultiFab>
 WarpXParticleContainer::GetPlasmaFrequency (int lev)
 {
 
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_mass*charge != 0.,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_mass*m_charge != 0.,
         "The plasma frequency can not be calculated for a massless or neutral species.");
 
     std::unique_ptr<amrex::MultiFab> number_density = GetNumberDensity(lev);
@@ -2151,7 +2151,7 @@ WarpXParticleContainer::GetPlasmaFrequency (int lev)
     auto plasma_frequency = std::make_unique<amrex::MultiFab>(ba, dm, ncomps, ng);
 
     auto const rmass = (amrex::Real)(m_mass);
-    auto const rcharge = (amrex::Real)(charge);
+    auto const rcharge = (amrex::Real)(m_charge);
     amrex::Real const Aconst = rcharge*rcharge/(rmass*PhysConst::epsilon_0);
 
 #ifdef AMREX_USE_OMP
@@ -2184,7 +2184,7 @@ std::unique_ptr<amrex::MultiFab>
 WarpXParticleContainer::GetDebyeLength (int lev)
 {
 
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_mass*charge != 0.,
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_mass*m_charge != 0.,
         "The Debye length can not be calculated for a massless or neutral species.");
 
     std::unique_ptr<amrex::MultiFab> temperature = GetAverageNGPTemperature(lev);
@@ -2197,7 +2197,7 @@ WarpXParticleContainer::GetDebyeLength (int lev)
     auto debye_length = std::make_unique<amrex::MultiFab>(ba, dm, ncomps, ng);
 
     auto const rmass = static_cast<amrex::Real>(m_mass);
-    auto const rcharge = static_cast<amrex::Real>(charge);
+    auto const rcharge = static_cast<amrex::Real>(m_charge);
     amrex::Real const Aconst = PhysConst::epsilon_0/(rcharge*rcharge);
 
 #ifdef AMREX_USE_OMP
@@ -2304,7 +2304,7 @@ amrex::ParticleReal WarpXParticleContainer::sumParticleWeight (bool local) const
 
 amrex::ParticleReal WarpXParticleContainer::sumParticleCharge (bool local) const {
 
-    return this->sumParticleWeight(local) * this->charge;
+    return this->sumParticleWeight(local) * this->m_charge;
 }
 
 std::array<ParticleReal, 3> WarpXParticleContainer::meanParticleVelocity(bool local) {


### PR DESCRIPTION
Unless the user specifies `do_not_gather = true` and `do_not_deposit = true` at runtime for species with zero charge, the field gather and deposition routines (current and mass matrices) are still performed. This PR changes the default behavior for such species by making `do_not_deposit` default to `true` if `charge == 0.0` and, if `mass > 0.0`, `do_not_gather` default to `true` as well.

This PR additionally makes a variable name change: `charge` --> `m_charge`.