### PR TITLE
implicit restart bug fix

### DIFF
--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -421,7 +421,7 @@ WarpX::InitFromCheckpoint ()
     mypc->Restart(restart_chkfile);
 
     if (m_implicit_solver) {
-        m_implicit_solver->Define(this, restart_chkfile.empty());
+        m_implicit_solver->Define(this, /*from_restart=*/true);
         m_implicit_solver->CreateParticleAttributes();
     }
 


### PR DESCRIPTION
This PR fixes a bug introduced in PR #6784. The `from_restart` flag passed to `m_implicit->Define()` should be `true` when called from `WarpX::InitFromCheckpoint()`.