### PR TITLE
Update documentation on dimensionality

### DIFF
--- a/Docs/source/developers/dimensionality.rst
+++ b/Docs/source/developers/dimensionality.rst
@@ -4,20 +4,21 @@ Dimensionality
 ==============
 
 This section describes the handling of dimensionality in WarpX.
+The velocity space is always three-dimensional: regardless of the dimensionality of the configuration space (position space), particles always carry three velocity (or momentum) components.
 
 Build Options
 -------------
 
-===============  ==========================
-Dimensions       CMake Option
-===============  ==========================
-**3D3V**         ``WarpX_DIMS=3`` (default)
-**2D3V**         ``WarpX_DIMS=2``
-**1D3V**         ``WarpX_DIMS=1``
-**RZ3V**         ``WarpX_DIMS=RZ``
-**RCYLINDER3V**  ``WarpX_DIMS=RCYLINDER``
-**RSPHERE3V**    ``WarpX_DIMS=RSPHERE``
-===============  ==========================
+==============  ==========================
+Dimensions      CMake Option
+==============  ==========================
+**3D**          ``WarpX_DIMS=3`` (default)
+**2D**          ``WarpX_DIMS=2``
+**1D**          ``WarpX_DIMS=1``
+**RZ**          ``WarpX_DIMS=RZ``
+**RCYLINDER**   ``WarpX_DIMS=RCYLINDER``
+**RSPHERE**     ``WarpX_DIMS=RSPHERE``
+==============  ==========================
 
 Note that one can :ref:`build multiple WarpX dimensions at once <install-build-options>` via ``-DWarpX_DIMS="1;2;3;RZ;RCYLINDER;RSPHERE"``.
 
@@ -29,7 +30,7 @@ Defines
 Depending on the build variant of WarpX, the following preprocessor macros will be set:
 
 =========================  ===========  ===========  ===========  ===========  ===========  ===========
-Macro                      3D3V         2D3V         1D3V         RZ3V         RCYLINDER3V  RSPHERE3V
+Macro                      3D           2D           1D           RZ           RCYLINDER    RSPHERE
 =========================  ===========  ===========  ===========  ===========  ===========  ===========
 ``AMREX_SPACEDIM``         ``3``        ``2``        ``1``        ``2``        ``1``        ``1``
 ``WARPX_DIM_3D``           **defined**  *undefined*  *undefined*  *undefined*  *undefined*  *undefined*
@@ -44,7 +45,7 @@ Macro                      3D3V         2D3V         1D3V         RZ3V         R
 At the same time, the following conventions will apply:
 
 ====================  ===========  ===========  ===========  ===========  ===============  ==============
-**Convention**        **3D3V**     **2D3V**     **1D3V**     **RZ3V**     **RCYLINDER3V**  **RSPHERE3V**
+**Convention**        **3D**       **2D**       **1D**       **RZ**       **RCYLINDER**    **RSPHERE**
 --------------------  -----------  -----------  -----------  -----------  ---------------  --------------
 *Fields*
 ------------------------------------------------------------------------  ---------------  --------------
@@ -63,5 +64,5 @@ Please see the following sections for particle SoA details.
 Conventions
 -----------
 
-In 2D3V, we assume that the position of a particle in ``y`` is equal to ``0``.
-In 1D3V, we assume that the position of a particle in ``x`` and ``y`` is equal to ``0``.
+In 2D, we assume that the position of a particle in ``y`` is equal to ``0``.
+In 1D, we assume that the position of a particle in ``x`` and ``y`` is equal to ``0``.


### PR DESCRIPTION
## Overview

Update the documentation section on dimensionality, as discussed during the developers meeting of May 19, 2026:

- Add a one-line comment to explain the velocity dimensionality.
- Drop the `3V` suffix from variables that happen to be build options.

## Related PRs

- #1020

## Notes

The separate question of why we use `RCYLINDER` or `RSPHERE` in a table column labeled "dimensions", in my opinion, remains open and valid, but it brings back to https://github.com/BLAST-WarpX/warpx/issues/5946.