### PR TITLE
Fix anonymous hyperlink mismatch

### DIFF
--- a/Docs/source/acknowledge_us.rst
+++ b/Docs/source/acknowledge_us.rst
@@ -207,7 +207,7 @@ If your project uses a specific algorithm or component, please consider citing t
 - Hedlof R, Barnes D, Groenewald R, Necas A, Smith T, Lau C, Brandt S, Zhang W, Eckert Z, Hooper R.
   **Verification of an energy-conserving semi-implicit electrostatic particle-in-cell scheme for modeling high-density plasma at scale**.
   Physics of Plasmas 33, 053902, 2026.
-  `DOI:10.1063/5.0315721 < https://doi.org/10.1063/5.0315721>`__
+  `DOI:10.1063/5.0315721 <https://doi.org/10.1063/5.0315721>`__
 
 - Lehe R, Haseeb M, Angus J, Grote D, Groenewald R, Formenti A, Huebl A, Deslippe J, Vay JL.
   **An Efficient GPU Parallelization Strategy for Binary Collisions in Particle-In-Cell Plasma Simulations**.


### PR DESCRIPTION
## Overview

Fix the following documentation build error:
```
building [html]: targets for 145 source files that are out of date
updating environment: [new config] 145 added, 0 changed, 0 removed
<unknown>:22: SyntaxWarning: invalid escape sequence '\,'
reading sources... [100%] usage/workflows/stl_geometry_preparation
/home/edoardo/src/warpx/Docs/source/acknowledge_us.rst:: ERROR: Anonymous hyperlink mismatch: 1 references but 0 targets.
```

<p align="center">
<img width="700" alt="Screenshot from 2026-05-19 11-55-02" src="https://github.com/user-attachments/assets/2d57dd8a-6baf-4c67-8066-190ff96370e7" />
</p>

## Notes

Seen in https://app.readthedocs.org/projects/warpx/builds/32758974/, originally from https://github.com/BLAST-WarpX/warpx/pull/6871.