### PR TITLE
[WIP] QED Breit-Wheeler: replace optical depth with per-timestep stochastic sampling

### DIFF
--- a/Docs/source/developers/particles.rst
+++ b/Docs/source/developers/particles.rst
@@ -142,8 +142,6 @@ Attribute name        ``int``/``real``  Description                         Wher
                                                                                        physics is used.
 ``opticalDepthQSR``   ``real``          QED: optical depth of the Quantum-  SoA   RT   Added when PICSAR QED
                                         Synchrotron process                            physics is used.
-``opticalDepthBW``    ``real``          QED: optical depth of the Breit-    SoA   RT   Added when PICSAR QED
-                                        Wheeler process                                physics is used.
 ``x/y/z_n``           ``real``          For implicit solver, the position   SoA   RT   Added when implicit solver
                                         at the start of the time step.                 is used. Not included in diagnostic output.
 ``ux/uy/uz_n``        ``real``          For implicit solver, the momentum   SoA   RT   Added when implicit solver

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -5326,11 +5326,12 @@ Alternatively, one can use the low-resolution builtin tables or generate them on
 
     * ``generate``: a new table is generated on the fly at the beginning of the simulation. This option requires Boost math library
       (version >= 1.66) and the extra compilation flag ``-DWarpX_QED_TABLE_GEN=ON``.
-      All the following parameters must be specified (table 1 is used to evolve the optical depth
-      of the photons, while table 2 is used for pair generation):
+      All the following parameters must be specified (table 1 stores the ``dN/dt`` rate
+      used to sample the per-timestep Breit-Wheeler pair-production probability, while
+      table 2 is used for pair generation):
 
         * ``qed_bw.tab_dndt_chi_min`` (``float``): minimum chi parameter for lookup table 1 (
-          used for the evolution of the optical depth of the photons)
+          used to compute the per-timestep Breit-Wheeler pair-production probability)
 
         * ``qed_bw.tab_dndt_chi_max`` (``float``): maximum chi parameter for lookup table 1
 

--- a/Examples/Tests/qed/analysis_breit_wheeler_core.py
+++ b/Examples/Tests/qed/analysis_breit_wheeler_core.py
@@ -26,8 +26,8 @@ from scipy.constants import c, e, fine_structure, hbar, m_e
 # - The generated particles are emitted in the right direction
 # - Total energy is conserved in each event
 # - The energy distribution of the generated particles is in agreement with theory
-# - The optical depths of the product species are correctly initialized (QED effects are
-#   enabled for product species too).
+# - The optical depths of the product species (used by Quantum Synchrotron emission)
+#   are correctly initialized (QED effects are enabled for product species too).
 #
 # More details on the theoretical formulas used in this script can be found in
 # the Jupyter notebook picsar/src/multi_physics/QED_tests/validation/validation.ipynb
@@ -210,15 +210,15 @@ def check_energy(energy_phot, energy_ele, energy_pos):
     print("  [OK] energy is conserved in each event")
 
 
-def check_opt_depths(phot_data, ele_data, pos_data):
-    data = (phot_data, ele_data, pos_data)
-    for dd in data:
-        # Remove the negative optical depths that correspond to photons that will decay into pairs
-        # at the beginning of the next timestep
-        loc, scale = st.expon.fit(dd["opt"][dd["opt"] > 0])
+def check_opt_depths(ele_data, pos_data):
+    # Photons no longer carry an optical depth: the Breit-Wheeler probability is
+    # sampled stochastically each timestep. Only the (charged) product species
+    # still carry a Quantum-Synchrotron optical depth.
+    for dd in (ele_data, pos_data):
+        loc, scale = st.expon.fit(dd["opt"])
         assert np.abs(loc - 0) < tol_red
         assert np.abs(scale - 1) < tol_red
-    print("  [OK] optical depth distributions are still exponential")
+    print("  [OK] product-species optical depth distributions are exponential")
 
 
 def check_energy_distrib(
@@ -318,6 +318,6 @@ def check(dt, particle_data):
             energy_ele, energy_pos, gamma_phot, chi_phot, n_lost, NNS[idx], idx
         )
 
-        check_opt_depths(phot_data, ele_data, pos_data)
+        check_opt_depths(ele_data, pos_data)
 
         print("*************\n")

--- a/Examples/Tests/qed/analysis_breit_wheeler_opmd.py
+++ b/Examples/Tests/qed/analysis_breit_wheeler_opmd.py
@@ -25,11 +25,11 @@ def main():
     series = io.Series(prefix + "/openpmd_%T.h5", io.Access.read_only)
     data_set_end = series.iterations[2]
 
-    # get simulation time
-    sim_time = data_set_end.time
-    # no particles can be created on the first timestep so we have 2 timesteps in the test case,
-    # with only the second one resulting in particle creation
-    dt = sim_time / 2.0
+    # The Breit-Wheeler pair-production probability is sampled stochastically
+    # at each timestep, so the expected number of pairs after the test's
+    # `max_step` timesteps follows `1 - exp(-dN/dt * sim_time)`. We therefore
+    # use the total simulation time as the effective dt in the analysis.
+    dt = data_set_end.time
 
     # get particle data
     particle_data = {}
@@ -47,11 +47,7 @@ def main():
             io.Mesh_Record_Component.SCALAR
         ][:]
 
-        if is_photon:
-            opt = data_set_end.particles[spec_name]["opticalDepthBW"][
-                io.Mesh_Record_Component.SCALAR
-            ][:]
-        else:
+        if not is_photon:
             opt = data_set_end.particles[spec_name]["opticalDepthQSR"][
                 io.Mesh_Record_Component.SCALAR
             ][:]
@@ -62,7 +58,8 @@ def main():
         data["py"] = py
         data["pz"] = pz
         data["w"] = w
-        data["opt"] = opt
+        if not is_photon:
+            data["opt"] = opt
 
         particle_data[spec_name] = data
 

--- a/Examples/Tests/qed/analysis_breit_wheeler_yt.py
+++ b/Examples/Tests/qed/analysis_breit_wheeler_yt.py
@@ -25,11 +25,11 @@ def main():
     filename_end = sys.argv[1]
     data_set_end = yt.load(filename_end)
 
-    # get simulation time
-    sim_time = data_set_end.current_time.to_value()
-    # no particles can be created on the first timestep so we have 2 timesteps in the test case,
-    # with only the second one resulting in particle creation
-    dt = sim_time / 2.0
+    # The Breit-Wheeler pair-production probability is sampled stochastically
+    # at each timestep, so the expected number of pairs after the test's
+    # `max_step` timesteps follows `1 - exp(-dN/dt * sim_time)`. We therefore
+    # use the total simulation time as the effective dt in the analysis.
+    dt = data_set_end.current_time.to_value()
 
     # get particle data
     all_data_end = data_set_end.all_data()
@@ -45,9 +45,7 @@ def main():
         data["pz"] = all_data_end[spec_name, "particle_momentum_z"].v
         data["w"] = all_data_end[spec_name, "particle_weighting"].v
 
-        if is_photon:
-            data["opt"] = all_data_end[spec_name, "particle_opticalDepthBW"].v
-        else:
+        if not is_photon:
             data["opt"] = all_data_end[spec_name, "particle_opticalDepthQSR"].v
 
         particle_data[spec_name] = data

--- a/Examples/Tests/qed/analysis_quantum_sync.py
+++ b/Examples/Tests/qed/analysis_quantum_sync.py
@@ -175,11 +175,12 @@ def get_spec(ytdata, specname, is_photon):
 
     w = ytdata[specname, "particle_weighting"].v
 
+    # Photons no longer carry a Breit-Wheeler optical depth: the BW probability
+    # is sampled stochastically each timestep.
     if is_photon:
-        opt = ytdata[specname, "particle_opticalDepthBW"].v
-    else:
-        opt = ytdata[specname, "particle_opticalDepthQSR"].v
+        return {"px": px, "py": py, "pz": pz, "w": w}
 
+    opt = ytdata[specname, "particle_opticalDepthQSR"].v
     return {"px": px, "py": py, "pz": pz, "w": w, "opt": opt}
 
 
@@ -210,14 +211,15 @@ def check_momenta(phot_data, p_phot, p0):
     print("  [OK] photons move along the initial particle direction")
 
 
-def check_opt_depths(part_data, phot_data):
-    data = (part_data, phot_data)
-    for dd in data:
-        # Remove the negative optical depths that will be
-        # reset at the beginning of the next timestep
-        loc, scale = st.expon.fit(dd["opt"][dd["opt"] > 0])
-        assert np.abs(loc - 0) < tol_red
-        assert np.abs(scale - 1) < tol_red
+def check_opt_depths(part_data):
+    # Photons no longer carry a Breit-Wheeler optical depth: their pair-production
+    # probability is sampled stochastically each timestep. Only the (charged)
+    # source species still carry a Quantum-Synchrotron optical depth.
+    # Remove the negative optical depths that will be reset at the beginning
+    # of the next timestep.
+    loc, scale = st.expon.fit(part_data["opt"][part_data["opt"] > 0])
+    assert np.abs(loc - 0) < tol_red
+    assert np.abs(scale - 1) < tol_red
     print("  [OK] optical depth distributions are still exponential")
 
 
@@ -335,7 +337,7 @@ def check():
 
         check_energy_distrib(gamma_phot, chi_part, gamma_part, n_phot, NNS[idx], idx)
 
-        check_opt_depths(part_data_final, phot_data)
+        check_opt_depths(part_data_final)
 
         print("*************\n")
 

--- a/Examples/Tests/qed/inputs_base_2d_breit_wheeler
+++ b/Examples/Tests/qed/inputs_base_2d_breit_wheeler
@@ -201,10 +201,10 @@ diagnostics.diags_names = diag1
 diag1.intervals = 2
 diag1.diag_type = Full
 diag1.fields_to_plot = Ex
-diag1.p1.variables = x z ux uy uz w opticalDepthBW
-diag1.p2.variables = x z ux uy uz w opticalDepthBW
-diag1.p3.variables = x z ux uy uz w opticalDepthBW
-diag1.p4.variables = x z ux uy uz w opticalDepthBW
+diag1.p1.variables = x z ux uy uz w
+diag1.p2.variables = x z ux uy uz w
+diag1.p3.variables = x z ux uy uz w
+diag1.p4.variables = x z ux uy uz w
 
 diag1.ele1.variables = x z ux uy uz w opticalDepthQSR
 diag1.ele2.variables = x z ux uy uz w opticalDepthQSR

--- a/Examples/Tests/qed/inputs_base_3d_breit_wheeler
+++ b/Examples/Tests/qed/inputs_base_3d_breit_wheeler
@@ -200,10 +200,10 @@ diagnostics.diags_names = diag1
 diag1.intervals = 2
 diag1.diag_type = Full
 diag1.fields_to_plot = Ex
-diag1.p1.variables = x y z ux uy uz w opticalDepthBW
-diag1.p2.variables = x y z ux uy uz w opticalDepthBW
-diag1.p3.variables = x y z ux uy uz w opticalDepthBW
-diag1.p4.variables = x y z ux uy uz w opticalDepthBW
+diag1.p1.variables = x y z ux uy uz w
+diag1.p2.variables = x y z ux uy uz w
+diag1.p3.variables = x y z ux uy uz w
+diag1.p4.variables = x y z ux uy uz w
 
 diag1.ele1.variables = x y z ux uy uz w opticalDepthQSR
 diag1.ele2.variables = x y z ux uy uz w opticalDepthQSR

--- a/Examples/Tests/qed/inputs_test_2d_qed_quantum_sync
+++ b/Examples/Tests/qed/inputs_test_2d_qed_quantum_sync
@@ -183,7 +183,7 @@ diag1.p2.variables = x z ux uy uz w opticalDepthQSR
 diag1.p3.variables = x z ux uy uz w opticalDepthQSR
 diag1.p4.variables = x z ux uy uz w opticalDepthQSR
 
-diag1.qsp_1.variables = x z ux uy uz w opticalDepthBW
-diag1.qsp_2.variables = x z ux uy uz w opticalDepthBW
-diag1.qsp_3.variables = x z ux uy uz w opticalDepthBW
-diag1.qsp_4.variables = x z ux uy uz w opticalDepthBW
+diag1.qsp_1.variables = x z ux uy uz w
+diag1.qsp_2.variables = x z ux uy uz w
+diag1.qsp_3.variables = x z ux uy uz w
+diag1.qsp_4.variables = x z ux uy uz w

--- a/Examples/Tests/qed/inputs_test_3d_qed_quantum_sync
+++ b/Examples/Tests/qed/inputs_test_3d_qed_quantum_sync
@@ -183,7 +183,7 @@ diag1.p2.variables = x y z ux uy uz w opticalDepthQSR
 diag1.p3.variables = x y z ux uy uz w opticalDepthQSR
 diag1.p4.variables = x y z ux uy uz w opticalDepthQSR
 
-diag1.qsp_1.variables = x y z ux uy uz w opticalDepthBW
-diag1.qsp_2.variables = x y z ux uy uz w opticalDepthBW
-diag1.qsp_3.variables = x y z ux uy uz w opticalDepthBW
-diag1.qsp_4.variables = x y z ux uy uz w opticalDepthBW
+diag1.qsp_1.variables = x y z ux uy uz w
+diag1.qsp_2.variables = x y z ux uy uz w
+diag1.qsp_3.variables = x y z ux uy uz w
+diag1.qsp_4.variables = x y z ux uy uz w

--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H
@@ -71,35 +71,6 @@ struct PicsarBreitWheelerCtrl
 // They can be included in GPU kernels.
 
 /**
- * Functor to initialize the optical depth of photons for the
- * Breit-Wheeler process
- */
-class BreitWheelerGetOpticalDepth
-{
-public:
-    /**
-     * Constructor does nothing because optical depth initialization
-     * does not require control parameters or lookup tables.
-     */
-    BreitWheelerGetOpticalDepth () = default;
-
-    /**
-     * () operator is just a thin wrapper around a very simple function to
-     * generate the optical depth. It can be used on GPU.
-     */
-    AMREX_GPU_HOST_DEVICE
-    AMREX_FORCE_INLINE
-    amrex::ParticleReal operator() (amrex::RandomEngine const& engine) const noexcept
-    {
-        namespace pxr_bw = picsar::multi_physics::phys::breit_wheeler;
-
-        //A random number in [0,1) should be provided as an argument.
-        return pxr_bw::get_optical_depth(amrex::Random(engine));
-    }
-};
-//____________________________________________
-
-/**
  * Functor to evolve the optical depth of photons due to the
  * Breit-Wheeler process
  */
@@ -125,17 +96,17 @@ public:
         m_table_view{table_view}, m_bw_minimum_chi_phot{bw_minimum_chi_phot}{}
 
     /**
-     * Evolves the optical depth. It can be used on GPU.
-     * If the  quantum parameter parameter of the photon is
-     * < bw_minimum_chi_phot, the method returns immediately.
-     * The method returns also if the energy of the photon is insufficient
-     * to generate a pair.
+     * Stochastically decides if a BW pair generation event occurs this timestep.
+     * Sets opt_depth to -1 if the event fires, 0 otherwise.
+     * Returns immediately (no event) if chi_phot < m_bw_minimum_chi_phot or
+     * the photon energy is below the pair-creation threshold.
      *
      * @param[in] ux,uy,uz gamma*v components of the photon.
      * @param[in] ex,ey,ez electric field components (SI units)
      * @param[in] bx,by,bz magnetic field components (SI units)
      * @param[in] dt timestep (SI units)
-     * @param[in,out] opt_depth optical depth of the photon.
+     * @param[out] opt_depth set to -1 if pair generated, 0 otherwise.
+     * @param[in] engine random number engine
      * @return a flag which is 1 if chi_phot was out of table
      */
     AMREX_GPU_DEVICE
@@ -146,7 +117,8 @@ public:
         const amrex::ParticleReal ey, const amrex::ParticleReal ez,
         const amrex::ParticleReal bx, const amrex::ParticleReal by,
         const amrex::ParticleReal bz, const amrex::Real dt,
-        amrex::ParticleReal& opt_depth) const noexcept
+        amrex::ParticleReal& opt_depth,
+        amrex::RandomEngine const& engine) const noexcept
     {
         namespace pxr_m = picsar::multi_physics::math;
         namespace pxr_p = picsar::multi_physics::phys;
@@ -163,24 +135,29 @@ public:
         const auto chi_phot = QedUtils::chi_photon(
             px, py, pz, ex, ey, ez, bx, by, bz);
 
-        //Optical depth is not evolved for photons having less energy than what is
-        //required to generate a pair or a quantum parameter smaller than
-        //m_bw_minimum_chi_phot
         const auto gamma_photon = pxr_p::compute_gamma_photon<
                 amrex::ParticleReal, pxr_p::unit_system::SI>(
                     px, py, pz);
         if (gamma_photon < pxr_m::two<amrex::ParticleReal> ||
             chi_phot < m_bw_minimum_chi_phot) {
+            opt_depth = amrex::ParticleReal(0);
             return 0;
         }
 
-        const auto is_out = pxr_bw::evolve_optical_depth<
+        bool is_out = false;
+        const auto dndt = pxr_bw::get_dN_dt<
             amrex::ParticleReal,
             BW_dndt_table_view,
             pxr_p::unit_system::SI>(
-                energy, chi_phot, dt, opt_depth, m_table_view);
+                energy, chi_phot, m_table_view,
+                pxr_m::one<amrex::ParticleReal>, &is_out);
 
-        return is_out;
+        const auto prob = amrex::Real(1) - std::exp(
+            -static_cast<amrex::Real>(dndt) * dt);
+        opt_depth = (amrex::Random(engine) < prob) ?
+            amrex::ParticleReal(-1) : amrex::ParticleReal(0);
+
+        return static_cast<int>(is_out);
     }
 
 private:
@@ -297,11 +274,6 @@ public:
      * Constructor requires no arguments.
      */
     BreitWheelerEngine () = default;
-
-    /**
-     * Builds the functor to initialize the optical depth
-     */
-    [[nodiscard]] BreitWheelerGetOpticalDepth build_optical_depth_functor () const;
 
     /**
      * Builds the functor to evolve the optical depth

--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H
@@ -71,101 +71,6 @@ struct PicsarBreitWheelerCtrl
 // They can be included in GPU kernels.
 
 /**
- * Functor to evolve the optical depth of photons due to the
- * Breit-Wheeler process
- */
-class BreitWheelerEvolveOpticalDepth
-{
-public:
-
-    /**
-     * Default constructor: it leaves the functor in a non-initialized state.
-     */
-    BreitWheelerEvolveOpticalDepth () = default;
-
-
-    /**
-     * Constructor to be used to initialize the functor.
-     *
-     * @param[in] table_view a view of a BW_dndt_table lookup table
-     * @param[in] bw_minimum_chi_phot the minimum quantum parameter to evolve the optical depth
-     */
-    BreitWheelerEvolveOpticalDepth (
-        const BW_dndt_table_view table_view,
-        const amrex::ParticleReal bw_minimum_chi_phot):
-        m_table_view{table_view}, m_bw_minimum_chi_phot{bw_minimum_chi_phot}{}
-
-    /**
-     * Stochastically decides if a BW pair generation event occurs this timestep.
-     * Sets opt_depth to -1 if the event fires, 0 otherwise.
-     * Returns immediately (no event) if chi_phot < m_bw_minimum_chi_phot or
-     * the photon energy is below the pair-creation threshold.
-     *
-     * @param[in] ux,uy,uz gamma*v components of the photon.
-     * @param[in] ex,ey,ez electric field components (SI units)
-     * @param[in] bx,by,bz magnetic field components (SI units)
-     * @param[in] dt timestep (SI units)
-     * @param[out] opt_depth set to -1 if pair generated, 0 otherwise.
-     * @param[in] engine random number engine
-     * @return a flag which is 1 if chi_phot was out of table
-     */
-    AMREX_GPU_DEVICE
-    AMREX_FORCE_INLINE
-    int operator()(
-        const amrex::ParticleReal ux, const amrex::ParticleReal uy,
-        const amrex::ParticleReal uz, const amrex::ParticleReal ex,
-        const amrex::ParticleReal ey, const amrex::ParticleReal ez,
-        const amrex::ParticleReal bx, const amrex::ParticleReal by,
-        const amrex::ParticleReal bz, const amrex::Real dt,
-        amrex::ParticleReal& opt_depth,
-        amrex::RandomEngine const& engine) const noexcept
-    {
-        namespace pxr_m = picsar::multi_physics::math;
-        namespace pxr_p = picsar::multi_physics::phys;
-        namespace pxr_bw = picsar::multi_physics::phys::breit_wheeler;
-
-        constexpr amrex::ParticleReal m_e = PhysConst::m_e;
-        const auto u_norm = std::sqrt(ux*ux + uy*uy + uz*uz);
-        const auto energy = u_norm*m_e*PhysConst::c;
-
-        const auto px = m_e*ux;
-        const auto py = m_e*uy;
-        const auto pz = m_e*uz;
-
-        const auto chi_phot = QedUtils::chi_photon(
-            px, py, pz, ex, ey, ez, bx, by, bz);
-
-        const auto gamma_photon = pxr_p::compute_gamma_photon<
-                amrex::ParticleReal, pxr_p::unit_system::SI>(
-                    px, py, pz);
-        if (gamma_photon < pxr_m::two<amrex::ParticleReal> ||
-            chi_phot < m_bw_minimum_chi_phot) {
-            opt_depth = amrex::ParticleReal(0);
-            return 0;
-        }
-
-        bool is_out = false;
-        const auto dndt = pxr_bw::get_dN_dt<
-            amrex::ParticleReal,
-            BW_dndt_table_view,
-            pxr_p::unit_system::SI>(
-                energy, chi_phot, m_table_view,
-                pxr_m::one<amrex::ParticleReal>, &is_out);
-
-        const auto prob = amrex::Real(1) - std::exp(
-            -static_cast<amrex::Real>(dndt) * dt);
-        opt_depth = (amrex::Random(engine) < prob) ?
-            amrex::ParticleReal(-1) : amrex::ParticleReal(0);
-
-        return static_cast<int>(is_out);
-    }
-
-private:
-    BW_dndt_table_view m_table_view;
-    amrex::ParticleReal m_bw_minimum_chi_phot;
-};
-
-/**
  * Functor to generate a pair via the
  * Breit-Wheeler process
  */
@@ -276,14 +181,15 @@ public:
     BreitWheelerEngine () = default;
 
     /**
-     * Builds the functor to evolve the optical depth
-     */
-    [[nodiscard]] BreitWheelerEvolveOpticalDepth build_evolve_functor () const;
-
-    /**
      * Builds the functor to generate the pairs
      */
     [[nodiscard]] BreitWheelerGeneratePairs build_pair_functor () const;
+
+    /**
+     * Returns a view of the dN/dt lookup table. Used by the pair-generation
+     * filter functor to compute the per-timestep Breit-Wheeler probability.
+     */
+    [[nodiscard]] BW_dndt_table_view get_dndt_table_view () const;
 
     /**
      * Checks if the optical tables are properly initialized
@@ -302,7 +208,8 @@ public:
      * Init lookup tables from raw binary data.
      *
      * @param[in] raw_data a vector of char
-     * @param[in] bw_minimum_chi_phot minimum chi parameter to evolve the optical depth of a photon
+     * @param[in] bw_minimum_chi_phot minimum chi parameter below which the Breit-Wheeler
+     *            process is ignored for a photon
      * @return true if it succeeds, false if it cannot parse raw_data
      */
     bool init_lookup_tables_from_raw_data (
@@ -312,7 +219,8 @@ public:
     /**
      * Init lookup tables using built-in (low resolution) tables
      *
-     * @param[in] bw_minimum_chi_phot minimum chi parameter to evolve the optical depth of a photon
+     * @param[in] bw_minimum_chi_phot minimum chi parameter below which the Breit-Wheeler
+     *            process is ignored for a photon
      */
     void init_builtin_tables(amrex::ParticleReal bw_minimum_chi_phot);
 
@@ -320,7 +228,8 @@ public:
      * Computes the lookup tables. It does nothing unless WarpX is compiled with QED_TABLE_GEN=TRUE
      *
      * @param[in] ctrl control params to generate the tables
-     * @param[in] bw_minimum_chi_phot minimum chi parameter to evolve the optical depth of a photon
+     * @param[in] bw_minimum_chi_phot minimum chi parameter below which the Breit-Wheeler
+     *            process is ignored for a photon
      */
     void compute_lookup_tables (PicsarBreitWheelerCtrl ctrl,
         amrex::ParticleReal bw_minimum_chi_phot);
@@ -337,8 +246,7 @@ public:
 private:
     bool m_lookup_tables_initialized = false;
 
-    //Variables to store the minimum chi parameters to enable
-    //Quantum Synchrotron process
+    //Minimum chi parameter below which the Breit-Wheeler process is ignored
     amrex::ParticleReal m_bw_minimum_chi_phot;
 
     BW_dndt_table m_dndt_table;

--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.cpp
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.cpp
@@ -35,12 +35,6 @@ namespace pxr_sr = picsar::multi_physics::utils::serialization;
 
 // Factory class =============================
 
-BreitWheelerGetOpticalDepth
-BreitWheelerEngine::build_optical_depth_functor () const
-{
-    return {};
-}
-
 BreitWheelerEvolveOpticalDepth
 BreitWheelerEngine::build_evolve_functor () const
 {

--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.cpp
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.cpp
@@ -35,20 +35,20 @@ namespace pxr_sr = picsar::multi_physics::utils::serialization;
 
 // Factory class =============================
 
-BreitWheelerEvolveOpticalDepth
-BreitWheelerEngine::build_evolve_functor () const
-{
-    AMREX_ALWAYS_ASSERT(m_lookup_tables_initialized);
-
-    return {m_dndt_table.get_view(), m_bw_minimum_chi_phot};
-}
-
 BreitWheelerGeneratePairs
 BreitWheelerEngine::build_pair_functor () const
 {
     AMREX_ALWAYS_ASSERT(m_lookup_tables_initialized);
 
     return BreitWheelerGeneratePairs{m_pair_prod_table.get_view()};
+}
+
+BW_dndt_table_view
+BreitWheelerEngine::get_dndt_table_view () const
+{
+    AMREX_ALWAYS_ASSERT(m_lookup_tables_initialized);
+
+    return m_dndt_table.get_view();
 }
 
 bool BreitWheelerEngine::are_lookup_tables_initialized () const

--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper_fwd.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper_fwd.H
@@ -8,7 +8,6 @@
 #ifndef WARPX_BREIT_WHEELER_ENGINE_WRAPPER_FWD_H
 #define WARPX_BREIT_WHEELER_ENGINE_WRAPPER_FWD_H
 
-class BreitWheelerEvolveOpticalDepth;
 class BreitWheelerGeneratePairs;
 
 class BreitWheelerEngine;

--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper_fwd.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper_fwd.H
@@ -8,7 +8,6 @@
 #ifndef WARPX_BREIT_WHEELER_ENGINE_WRAPPER_FWD_H
 #define WARPX_BREIT_WHEELER_ENGINE_WRAPPER_FWD_H
 
-class BreitWheelerGetOpticalDepth;
 class BreitWheelerEvolveOpticalDepth;
 class BreitWheelerGeneratePairs;
 

--- a/Source/Particles/ElementaryProcess/QEDInternals/QedChiFunctions.H
+++ b/Source/Particles/ElementaryProcess/QEDInternals/QedChiFunctions.H
@@ -26,7 +26,7 @@ namespace QedUtils{
     * @param[in] bx,by,bz components of magnetic field (SI units)
     * @return chi parameter
     */
-    AMREX_GPU_DEVICE
+    AMREX_GPU_HOST_DEVICE
     AMREX_FORCE_INLINE
     amrex::Real chi_photon(
         const amrex::ParticleReal px, const amrex::ParticleReal py,

--- a/Source/Particles/ElementaryProcess/QEDPairGeneration.H
+++ b/Source/Particles/ElementaryProcess/QEDPairGeneration.H
@@ -13,6 +13,8 @@
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/WarpXParticleContainer.H"
 #include "QEDInternals/BreitWheelerEngineWrapper.H"
+#include "QEDInternals/QedChiFunctions.H"
+#include "Utils/WarpXConst.H"
 
 #include <AMReX_Array.H>
 #include <AMReX_Array4.H>
@@ -21,53 +23,182 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_IndexType.H>
 #include <AMReX_REAL.H>
+#include <AMReX_Random.H>
 
 #include <AMReX_BaseFwd.H>
+
+#include <picsar_qed/math/cmath_overloads.hpp>
+#include <picsar_qed/physics/breit_wheeler/breit_wheeler_engine_core.hpp>
+#include <picsar_qed/physics/gamma_functions.hpp>
+#include <picsar_qed/physics/unit_conversion.hpp>
+
+#include <cmath>
 
 /** @file
  *
  * This file contains the implementation of the elementary process
  * functors needed for Breit-Wheeler pair generation (one photon generates
- * and electron-positron pair).
+ * an electron-positron pair).
  */
 
 /**
- * \brief Filter functor for the Breit Wheeler process
+ * \brief Filter functor for the Breit-Wheeler process.
+ *
+ * The functor gathers E and B at the photon position, computes the photon
+ * quantum parameter chi, looks up the instantaneous pair-production rate
+ * dN/dt, and decides — by sampling a single random number — whether the
+ * photon undergoes pair production during the current timestep. The
+ * probability of an event is `1 - exp(-dN/dt * dt)`.
  */
 class PairGenerationFilterFunc
 {
 public:
 
+    PairGenerationFilterFunc () = default;
+
     /**
     * \brief Constructor of the PairGenerationFilterFunc functor.
     *
-    * @param[in] opt_depth_runtime_comp index of the optical depth runtime component
+    * @param[in] dndt_table_view view of the Breit-Wheeler dN/dt lookup table
+    * @param[in] bw_minimum_chi_phot minimum chi parameter below which the
+    *            Breit-Wheeler process is ignored
+    * @param[in] dt simulation timestep (SI units)
+    * @param[in] a_pti particle iterator to iterate over photons
+    * @param[in] lev   the mesh-refinement level
+    * @param[in] ngEB  number of guard cells allocated for the E and B MultiFabs
+    * @param[in] exfab,eyfab,ezfab,bxfab,byfab,bzfab field FArrayBoxes
+    * @param[in] E_external_particle reference to external E field
+    * @param[in] B_external_particle reference to external B field
+    * @param[in] a_offset offset to apply to the particle indices
     */
-    explicit PairGenerationFilterFunc(int const opt_depth_runtime_comp)
-        : m_opt_depth_runtime_comp(opt_depth_runtime_comp)
-        {}
+    PairGenerationFilterFunc (BW_dndt_table_view dndt_table_view,
+                              amrex::ParticleReal bw_minimum_chi_phot,
+                              amrex::Real dt,
+                              const WarpXParIter& a_pti, int lev, amrex::IntVect ngEB,
+                              amrex::FArrayBox const& exfab,
+                              amrex::FArrayBox const& eyfab,
+                              amrex::FArrayBox const& ezfab,
+                              amrex::FArrayBox const& bxfab,
+                              amrex::FArrayBox const& byfab,
+                              amrex::FArrayBox const& bzfab,
+                              amrex::Vector<amrex::ParticleReal>& E_external_particle,
+                              amrex::Vector<amrex::ParticleReal>& B_external_particle,
+                              int a_offset = 0);
 
     /**
-    * \brief Functor call. This method determines if a given (photon) particle
-    * should undergo pair generation.
+    * \brief Functor call. Determines if a given photon undergoes pair
+    * production during the current timestep.
     *
     * @param[in] ptd particle tile data
     * @param[in] i particle index
+    * @param[in] engine random number generator engine
     * @return true if a pair has to be generated, false otherwise
     */
     template <typename PData>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    bool operator() (const PData& ptd, int const i, amrex::RandomEngine const&) const noexcept
+    bool operator() (const PData& ptd, int const i,
+                     amrex::RandomEngine const& engine) const noexcept
     {
         using namespace amrex;
+        namespace pxr_m = picsar::multi_physics::math;
+        namespace pxr_p = picsar::multi_physics::phys;
+        namespace pxr_bw = picsar::multi_physics::phys::breit_wheeler;
 
-        const amrex::ParticleReal opt_depth =
-            ptd.m_runtime_rdata[m_opt_depth_runtime_comp][i];
-        return (opt_depth < 0.0_rt);
+        // gather E and B at the photon position
+        amrex::ParticleReal xp, yp, zp;
+        m_get_position(i, xp, yp, zp);
+
+        amrex::ParticleReal ex = m_Ex_external_particle;
+        amrex::ParticleReal ey = m_Ey_external_particle;
+        amrex::ParticleReal ez = m_Ez_external_particle;
+        amrex::ParticleReal bx = m_Bx_external_particle;
+        amrex::ParticleReal by = m_By_external_particle;
+        amrex::ParticleReal bz = m_Bz_external_particle;
+
+        m_get_externalEB(i, ex, ey, ez, bx, by, bz);
+
+        doGatherShapeN(xp, yp, zp, ex, ey, ez, bx, by, bz,
+                       m_ex_arr, m_ey_arr, m_ez_arr, m_bx_arr, m_by_arr, m_bz_arr,
+                       m_ex_type, m_ey_type, m_ez_type, m_bx_type, m_by_type, m_bz_type,
+                       m_dinv, m_xyzmin, m_lo, m_n_rz_azimuthal_modes,
+                       m_nox, m_galerkin_interpolation);
+
+        const auto ux = ptd.m_rdata[PIdx::ux][i];
+        const auto uy = ptd.m_rdata[PIdx::uy][i];
+        const auto uz = ptd.m_rdata[PIdx::uz][i];
+
+        constexpr amrex::ParticleReal m_e = PhysConst::m_e;
+        const auto px = m_e*ux;
+        const auto py = m_e*uy;
+        const auto pz = m_e*uz;
+
+        const auto chi_phot = QedUtils::chi_photon(
+            px, py, pz, ex, ey, ez, bx, by, bz);
+
+        const auto gamma_photon = pxr_p::compute_gamma_photon<
+                amrex::ParticleReal, pxr_p::unit_system::SI>(
+                    px, py, pz);
+
+        // Skip photons that cannot pair-produce
+        if (gamma_photon < pxr_m::two<amrex::ParticleReal> ||
+            chi_phot < m_bw_minimum_chi_phot) {
+            return false;
+        }
+
+        const auto u_norm = std::sqrt(ux*ux + uy*uy + uz*uz);
+        const auto energy = u_norm*m_e*PhysConst::c;
+
+        bool is_out = false;
+        const auto dndt = pxr_bw::get_dN_dt<
+            amrex::ParticleReal,
+            BW_dndt_table_view,
+            pxr_p::unit_system::SI>(
+                energy, chi_phot, m_dndt_table_view,
+                pxr_m::one<amrex::ParticleReal>, &is_out);
+
+        const auto prob = amrex::Real(1) - std::exp(
+            -static_cast<amrex::Real>(dndt) * m_dt);
+
+        return amrex::Random(engine) < prob;
     }
 
 private:
-    int m_opt_depth_runtime_comp = 0; /*!< Index of the optical depth runtime component of the species. */
+
+    BW_dndt_table_view m_dndt_table_view;
+    amrex::ParticleReal m_bw_minimum_chi_phot;
+    amrex::Real m_dt;
+
+    GetParticlePosition<PIdx> m_get_position;
+    GetExternalEBField m_get_externalEB;
+    amrex::ParticleReal m_Ex_external_particle;
+    amrex::ParticleReal m_Ey_external_particle;
+    amrex::ParticleReal m_Ez_external_particle;
+    amrex::ParticleReal m_Bx_external_particle;
+    amrex::ParticleReal m_By_external_particle;
+    amrex::ParticleReal m_Bz_external_particle;
+
+    amrex::Array4<const amrex::Real> m_ex_arr;
+    amrex::Array4<const amrex::Real> m_ey_arr;
+    amrex::Array4<const amrex::Real> m_ez_arr;
+    amrex::Array4<const amrex::Real> m_bx_arr;
+    amrex::Array4<const amrex::Real> m_by_arr;
+    amrex::Array4<const amrex::Real> m_bz_arr;
+
+    amrex::IndexType m_ex_type;
+    amrex::IndexType m_ey_type;
+    amrex::IndexType m_ez_type;
+    amrex::IndexType m_bx_type;
+    amrex::IndexType m_by_type;
+    amrex::IndexType m_bz_type;
+
+    amrex::XDim3 m_dinv;
+    amrex::XDim3 m_xyzmin;
+
+    bool m_galerkin_interpolation;
+    int m_nox;
+    int m_n_rz_azimuthal_modes;
+
+    amrex::Dim3 m_lo;
 };
 
 /**

--- a/Source/Particles/ElementaryProcess/QEDPairGeneration.cpp
+++ b/Source/Particles/ElementaryProcess/QEDPairGeneration.cpp
@@ -17,6 +17,64 @@
 #include <algorithm>
 #include <array>
 
+PairGenerationFilterFunc::
+PairGenerationFilterFunc (BW_dndt_table_view dndt_table_view,
+                          amrex::ParticleReal bw_minimum_chi_phot,
+                          amrex::Real dt,
+                          const WarpXParIter& a_pti, int lev, amrex::IntVect ngEB,
+                          amrex::FArrayBox const& exfab,
+                          amrex::FArrayBox const& eyfab,
+                          amrex::FArrayBox const& ezfab,
+                          amrex::FArrayBox const& bxfab,
+                          amrex::FArrayBox const& byfab,
+                          amrex::FArrayBox const& bzfab,
+                          amrex::Vector<amrex::ParticleReal>& E_external_particle,
+                          amrex::Vector<amrex::ParticleReal>& B_external_particle,
+                          int a_offset):
+    m_dndt_table_view{dndt_table_view},
+    m_bw_minimum_chi_phot{bw_minimum_chi_phot},
+    m_dt{dt},
+    m_Ex_external_particle{E_external_particle[0]},
+    m_Ey_external_particle{E_external_particle[1]},
+    m_Ez_external_particle{E_external_particle[2]},
+    m_Bx_external_particle{B_external_particle[0]},
+    m_By_external_particle{B_external_particle[1]},
+    m_Bz_external_particle{B_external_particle[2]},
+    m_galerkin_interpolation{WarpX::galerkin_interpolation},
+    m_nox{WarpX::nox},
+    m_n_rz_azimuthal_modes{WarpX::n_rz_azimuthal_modes}
+{
+    using namespace amrex::literals;
+
+    m_get_position  = GetParticlePosition<PIdx>(a_pti, a_offset);
+    m_get_externalEB = GetExternalEBField(a_pti, a_offset);
+
+    m_ex_arr = exfab.array();
+    m_ey_arr = eyfab.array();
+    m_ez_arr = ezfab.array();
+    m_bx_arr = bxfab.array();
+    m_by_arr = byfab.array();
+    m_bz_arr = bzfab.array();
+
+    m_ex_type = exfab.box().ixType();
+    m_ey_type = eyfab.box().ixType();
+    m_ez_type = ezfab.box().ixType();
+    m_bx_type = bxfab.box().ixType();
+    m_by_type = byfab.box().ixType();
+    m_bz_type = bzfab.box().ixType();
+
+    amrex::Box box = a_pti.tilebox();
+    box.grow(ngEB);
+
+    const std::array<amrex::Real,3>& dx = WarpX::CellSize(std::max(lev, 0));
+    m_dinv = amrex::XDim3{1._rt/dx[0], 1._rt/dx[1], 1._rt/dx[2]};
+
+    // Lower corner of tile box physical domain (take into account Galilean shift)
+    m_xyzmin = WarpX::LowerCorner(box, lev, 0._rt);
+
+    m_lo = amrex::lbound(box);
+}
+
 PairGenerationTransformFunc::
 PairGenerationTransformFunc (BreitWheelerGeneratePairs const generate_functor,
                              const WarpXParIter& a_pti, int lev, amrex::IntVect ngEB,

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -1753,11 +1753,13 @@ void MultiParticleContainer::doQedBreitWheeler (int lev,
         const SmartCopyFactory copy_factory_pos(*pc_source, *pc_product_pos);
         auto *phys_pc_ptr = static_cast<PhysicalParticleContainer*>(pc_source.get());
 
-        const auto Filter  = phys_pc_ptr->getPairGenerationFilterFunc();
         const auto CopyEle = copy_factory_ele.getSmartCopy();
         const auto CopyPos = copy_factory_pos.getSmartCopy();
 
         const auto pair_gen_functor = m_shr_p_bw_engine->build_pair_functor();
+        const auto bw_dndt_table_view = m_shr_p_bw_engine->get_dndt_table_view();
+        const auto bw_minimum_chi_phot = m_shr_p_bw_engine->get_minimum_chi_phot();
+        const auto dt = WarpX::GetInstance().getdt(lev);
 
         pc_source ->defineAllParticleTiles();
         pc_product_pos->defineAllParticleTiles();
@@ -1775,6 +1777,15 @@ void MultiParticleContainer::doQedBreitWheeler (int lev,
                 amrex::Gpu::synchronize();
             }
             auto wt = static_cast<amrex::Real>(amrex::second());
+
+            auto Filter = PairGenerationFilterFunc(bw_dndt_table_view,
+                                                   bw_minimum_chi_phot,
+                                                   dt,
+                                                   pti, lev, Ex.nGrowVect(),
+                                                   Ex[pti], Ey[pti], Ez[pti],
+                                                   Bx[pti], By[pti], Bz[pti],
+                                                   phys_pc_ptr->m_E_external_particle,
+                                                   phys_pc_ptr->m_B_external_particle);
 
             auto Transform = PairGenerationTransformFunc(pair_gen_functor,
                                                          pti, lev, Ex.nGrowVect(),

--- a/Source/Particles/ParticleCreation/AddParticles.cpp
+++ b/Source/Particles/ParticleCreation/AddParticles.cpp
@@ -1141,7 +1141,7 @@ PhysicalParticleContainer::AddPlasma (PlasmaInjector& plasma_injector, int lev, 
                 }
 
                 if(qed_helper.has_breit_wheeler){
-                    qed_helper.p_optical_depth_BW[ip] = qed_helper.breit_wheeler_get_opt(engine);
+                    qed_helper.p_optical_depth_BW[ip] = amrex::ParticleReal(0);
                 }
 #endif
                 // Initialize user-defined integers with user-defined parser
@@ -1649,7 +1649,7 @@ PhysicalParticleContainer::AddPlasmaFlux (PlasmaInjector const& plasma_injector,
                 }
 
                 if(qed_helper.has_breit_wheeler){
-                    qed_helper.p_optical_depth_BW[ip] = qed_helper.breit_wheeler_get_opt(engine);
+                    qed_helper.p_optical_depth_BW[ip] = amrex::ParticleReal(0);
                 }
 #endif
 

--- a/Source/Particles/ParticleCreation/AddParticles.cpp
+++ b/Source/Particles/ParticleCreation/AddParticles.cpp
@@ -165,8 +165,6 @@ namespace
      * \param pi ionization level data
      * \param has_quantum_sync whether species has quantum synchrotron
      * \param p_optical_depth_QSR quantum synchrotron optical depth data
-     * \param has_breit_wheeler whether species has Breit-Wheeler
-     * \param p_optical_depth_BW Breit-Wheeler optical depth data
      */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void ZeroInitializeAndSetNegativeID (
@@ -184,7 +182,6 @@ namespace
         if (do_field_ionization) {pi[ip] = 0;}
 #ifdef WARPX_QED
         if (qed_helper.has_quantum_sync) {qed_helper.p_optical_depth_QSR[ip] = 0._rt;}
-        if (qed_helper.has_breit_wheeler) {qed_helper.p_optical_depth_BW[ip] = 0._rt;}
 #endif
 
         idcpu[ip] = amrex::ParticleIdCpus::Invalid;
@@ -946,8 +943,8 @@ PhysicalParticleContainer::AddPlasma (PlasmaInjector& plasma_injector, int lev, 
 
 #ifdef WARPX_QED
         const QEDHelper qed_helper(soa, old_size,
-                                   has_quantum_sync(), has_breit_wheeler(),
-                                   m_shr_p_qs_engine, m_shr_p_bw_engine);
+                                   has_quantum_sync(),
+                                   m_shr_p_qs_engine);
 #endif
 
         const bool loc_do_field_ionization = do_field_ionization;
@@ -1138,10 +1135,6 @@ PhysicalParticleContainer::AddPlasma (PlasmaInjector& plasma_injector, int lev, 
 #ifdef WARPX_QED
                 if(qed_helper.has_quantum_sync){
                     qed_helper.p_optical_depth_QSR[ip] = qed_helper.quantum_sync_get_opt(engine);
-                }
-
-                if(qed_helper.has_breit_wheeler){
-                    qed_helper.p_optical_depth_BW[ip] = amrex::ParticleReal(0);
                 }
 #endif
                 // Initialize user-defined integers with user-defined parser
@@ -1429,8 +1422,8 @@ PhysicalParticleContainer::AddPlasmaFlux (PlasmaInjector const& plasma_injector,
 
 #ifdef WARPX_QED
         const QEDHelper qed_helper(soa, old_size,
-                                   has_quantum_sync(), has_breit_wheeler(),
-                                   m_shr_p_qs_engine, m_shr_p_bw_engine);
+                                   has_quantum_sync(),
+                                   m_shr_p_qs_engine);
 #endif
 
         const bool loc_do_field_ionization = do_field_ionization;
@@ -1646,10 +1639,6 @@ PhysicalParticleContainer::AddPlasmaFlux (PlasmaInjector const& plasma_injector,
 #ifdef WARPX_QED
                 if(qed_helper.has_quantum_sync){
                     qed_helper.p_optical_depth_QSR[ip] = qed_helper.quantum_sync_get_opt(engine);
-                }
-
-                if(qed_helper.has_breit_wheeler){
-                    qed_helper.p_optical_depth_BW[ip] = amrex::ParticleReal(0);
                 }
 #endif
 

--- a/Source/Particles/ParticleCreation/AddPlasmaUtilities.H
+++ b/Source/Particles/ParticleCreation/AddPlasmaUtilities.H
@@ -313,7 +313,7 @@ struct QEDHelper
     QEDHelper (SoAType& a_soa, std::size_t old_size,
                bool a_has_quantum_sync, bool a_has_breit_wheeler,
                const std::shared_ptr<QuantumSynchrotronEngine>& a_shr_p_qs_engine,
-               const std::shared_ptr<BreitWheelerEngine>& a_shr_p_bw_engine)
+               const std::shared_ptr<BreitWheelerEngine>& /*a_shr_p_bw_engine*/)
         : has_quantum_sync(a_has_quantum_sync), has_breit_wheeler(a_has_breit_wheeler)
     {
         if(has_quantum_sync){
@@ -322,8 +322,6 @@ struct QEDHelper
             p_optical_depth_QSR = a_soa.GetRealData("opticalDepthQSR").data() + old_size;
         }
         if(has_breit_wheeler){
-            breit_wheeler_get_opt =
-                a_shr_p_bw_engine->build_optical_depth_functor();
             p_optical_depth_BW = a_soa.GetRealData("opticalDepthBW").data() + old_size;
         }
     }
@@ -335,7 +333,6 @@ struct QEDHelper
     bool has_breit_wheeler;
 
     QuantumSynchrotronGetOpticalDepth quantum_sync_get_opt;
-    BreitWheelerGetOpticalDepth breit_wheeler_get_opt;
 };
 #endif
 

--- a/Source/Particles/ParticleCreation/AddPlasmaUtilities.H
+++ b/Source/Particles/ParticleCreation/AddPlasmaUtilities.H
@@ -11,7 +11,6 @@
 #include "Initialization/PlasmaInjector.H"
 
 #ifdef WARPX_QED
-#   include "Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H"
 #   include "Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper.H"
 #endif
 
@@ -311,26 +310,20 @@ struct QEDHelper
 {
     template <typename SoAType>
     QEDHelper (SoAType& a_soa, std::size_t old_size,
-               bool a_has_quantum_sync, bool a_has_breit_wheeler,
-               const std::shared_ptr<QuantumSynchrotronEngine>& a_shr_p_qs_engine,
-               const std::shared_ptr<BreitWheelerEngine>& /*a_shr_p_bw_engine*/)
-        : has_quantum_sync(a_has_quantum_sync), has_breit_wheeler(a_has_breit_wheeler)
+               bool a_has_quantum_sync,
+               const std::shared_ptr<QuantumSynchrotronEngine>& a_shr_p_qs_engine)
+        : has_quantum_sync(a_has_quantum_sync)
     {
         if(has_quantum_sync){
             quantum_sync_get_opt =
                 a_shr_p_qs_engine->build_optical_depth_functor();
             p_optical_depth_QSR = a_soa.GetRealData("opticalDepthQSR").data() + old_size;
         }
-        if(has_breit_wheeler){
-            p_optical_depth_BW = a_soa.GetRealData("opticalDepthBW").data() + old_size;
-        }
     }
 
     amrex::ParticleReal* p_optical_depth_QSR = nullptr;
-    amrex::ParticleReal* p_optical_depth_BW  = nullptr;
 
     bool has_quantum_sync;
-    bool has_breit_wheeler;
 
     QuantumSynchrotronGetOpticalDepth quantum_sync_get_opt;
 };

--- a/Source/Particles/ParticleCreation/DefaultInitialization.H
+++ b/Source/Particles/ParticleCreation/DefaultInitialization.H
@@ -10,7 +10,6 @@
 
 #include <WarpX.H>
 #ifdef WARPX_QED
-#   include "Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H"
 #   include "Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper.H"
 #endif
 
@@ -52,7 +51,6 @@ static std::map<std::string, InitializationPolicy> initialization_policies = {
 #endif
 
 #ifdef WARPX_QED
-    {"opticalDepthBW",   InitializationPolicy::Zero},
     {"opticalDepthQSR",   InitializationPolicy::RandomExp}
 #endif
 
@@ -180,21 +178,6 @@ void DefaultInitializeRuntimeAttributes (PTile& ptile,
                 }
             }
 
-            // Current runtime comp is Breit-Wheeler optical depth
-            auto const it_bw = std::find(particle_comps.begin(), particle_comps.end(), "opticalDepthBW");
-            if (it_bw != particle_comps.end() &&
-                std::distance(particle_comps.begin(), it_bw) == j)
-            {
-                if (!do_qed_comps) { continue; }
-                if (run_on_gpu) {
-                    amrex::ParallelFor(stop - start,
-                                       [=] AMREX_GPU_DEVICE (int i) noexcept {
-                                           attr_ptr[i + start] = amrex::ParticleReal(0);
-                                       });
-                } else {
-                    for (int ip = start; ip < stop; ++ip) { attr_ptr[ip] = amrex::ParticleReal(0); }
-                }
-            }
 #endif
 
             for (int ia = 0; ia < n_user_real_attribs; ++ia)

--- a/Source/Particles/ParticleCreation/DefaultInitialization.H
+++ b/Source/Particles/ParticleCreation/DefaultInitialization.H
@@ -52,7 +52,7 @@ static std::map<std::string, InitializationPolicy> initialization_policies = {
 #endif
 
 #ifdef WARPX_QED
-    {"opticalDepthBW",   InitializationPolicy::RandomExp},
+    {"opticalDepthBW",   InitializationPolicy::Zero},
     {"opticalDepthQSR",   InitializationPolicy::RandomExp}
 #endif
 
@@ -128,7 +128,6 @@ void DefaultInitializeRuntimeAttributes (PTile& ptile,
         const std::vector<amrex::Parser*>& user_real_attrib_parser = pc.getUserRealAttribParser();
         const std::vector<amrex::Parser*>& user_int_attrib_parser  = pc.getUserIntAttribParser();
 #ifdef WARPX_QED
-        BreitWheelerEngine*       p_bw_engine = pc.get_breit_wheeler_engine_ptr();
         QuantumSynchrotronEngine* p_qs_engine = pc.get_quantum_sync_engine_ptr();
 #endif
         const int ionization_initial_level = pc.getIonizationInitialLevel();
@@ -187,24 +186,13 @@ void DefaultInitializeRuntimeAttributes (PTile& ptile,
                 std::distance(particle_comps.begin(), it_bw) == j)
             {
                 if (!do_qed_comps) { continue; }
-                const BreitWheelerGetOpticalDepth breit_wheeler_get_opt =
-                                                p_bw_engine->build_optical_depth_functor();;
-                // If the particle tile was allocated in a memory pool that can run on GPU, launch GPU kernel
                 if (run_on_gpu) {
-                        amrex::ParallelForRNG(stop - start,
-                                              [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept {
-                                                  const int ip = i + start;
-                                                  attr_ptr[ip] = breit_wheeler_get_opt(engine);
-                                              });
-                // Otherwise (e.g. particle tile allocated in pinned memory), run on CPU
+                    amrex::ParallelFor(stop - start,
+                                       [=] AMREX_GPU_DEVICE (int i) noexcept {
+                                           attr_ptr[i + start] = amrex::ParticleReal(0);
+                                       });
                 } else {
-                    for (int ip = start; ip < stop; ++ip) {
-#ifdef AMREX_USE_GPU
-                        attr_ptr[ip] = breit_wheeler_get_opt(amrex::RandomEngine{nullptr});
-#else
-                        attr_ptr[ip] = breit_wheeler_get_opt(amrex::RandomEngine{});
-#endif
-                    }
+                    for (int ip = start; ip < stop; ++ip) { attr_ptr[ip] = amrex::ParticleReal(0); }
                 }
             }
 #endif

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -191,12 +191,12 @@ PhotonParticleContainer::PushPX (WarpXParIter& pti,
     // local copy for device lambda capture
     amrex::ParticleReal const mass = m_mass;
 
-    amrex::ParallelFor(TypeList<CompileTimeOptions<no_exteb,has_exteb>,
-                                CompileTimeOptions<no_qed  ,has_qed>>{},
-                       {exteb_runtime_flag, qed_runtime_flag},
-                       np_to_push,
-                       [=] AMREX_GPU_DEVICE (long i, auto exteb_control,
-                                             auto qed_control) {
+    amrex::AnyCTO(TypeList<CompileTimeOptions<no_exteb,has_exteb>,
+                           CompileTimeOptions<no_qed  ,has_qed>>{},
+                  {exteb_runtime_flag, qed_runtime_flag},
+                  [&](auto cto_func) { amrex::ParallelForRNG(np_to_push, cto_func); },
+                  [=] AMREX_GPU_DEVICE (long i, amrex::RandomEngine const& engine,
+                                        auto exteb_control, auto qed_control) {
             if (do_copy) { copyAttribs(i); }
             ParticleReal x, y, z;
             GetPosition(i, x, y, z);
@@ -232,10 +232,10 @@ PhotonParticleContainer::PushPX (WarpXParIter& pti,
             [[maybe_unused]] auto qed_dt_tmp = qed_dt;
             if constexpr (qed_control == has_qed) {
                 evolve_opt(ux[i], uy[i], uz[i], Exp, Eyp, Ezp, Bxp, Byp, Bzp,
-                           qed_dt, p_optical_depth_BW[i]);
+                           qed_dt, p_optical_depth_BW[i], engine);
             }
 #else
-            amrex::ignore_unused(qed_control);
+            amrex::ignore_unused(qed_control, engine);
 #endif
 
             if (position_push_type == PositionPushType::Full) {

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -7,9 +7,6 @@
  */
 #include "PhotonParticleContainer.H"
 
-#ifdef WARPX_QED
-#   include "Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.H"
-#endif
 #include "Particles/Gather/FieldGather.H"
 #include "Particles/Gather/GetExternalFields.H"
 #include "Particles/PhysicalParticleContainer.H"
@@ -123,18 +120,6 @@ PhotonParticleContainer::PushPX (WarpXParIter& pti,
     ParticleReal* const AMREX_RESTRICT uy = attribs[PIdx::uy].dataPtr() + offset;
     ParticleReal* const AMREX_RESTRICT uz = attribs[PIdx::uz].dataPtr() + offset;
 
-#ifdef WARPX_QED
-    BreitWheelerEvolveOpticalDepth evolve_opt;
-    amrex::ParticleReal* AMREX_RESTRICT p_optical_depth_BW = nullptr;
-    const amrex::Real qed_dt =
-        (momentum_push_type == MomentumPushType::Full) ? dt : amrex::Real(0.5) * dt;
-    const bool local_has_breit_wheeler = has_breit_wheeler();
-    if (local_has_breit_wheeler) {
-        evolve_opt = m_shr_p_bw_engine->build_evolve_functor();
-        p_optical_depth_BW = pti.GetAttribs("opticalDepthBW").dataPtr() + offset;
-    }
-#endif
-
     const int do_copy = (m_do_back_transformed_particles && (subcycling_half!=SubcyclingHalf::SecondHalf) );
     CopyParticleAttribs copyAttribs;
     if (do_copy) {
@@ -179,24 +164,16 @@ PhotonParticleContainer::PushPX (WarpXParIter& pti,
     const auto t_do_not_gather = do_not_gather;
 
     enum exteb_flags : int { no_exteb, has_exteb };
-    enum qed_flags : int { no_qed, has_qed };
 
     const int exteb_runtime_flag = getExternalEB.isNoOp() ? no_exteb : has_exteb;
-#ifdef WARPX_QED
-    const int qed_runtime_flag = (local_has_breit_wheeler) ? has_qed : no_qed;
-#else
-    const int qed_runtime_flag = no_qed;
-#endif
 
     // local copy for device lambda capture
     amrex::ParticleReal const mass = m_mass;
 
-    amrex::AnyCTO(TypeList<CompileTimeOptions<no_exteb,has_exteb>,
-                           CompileTimeOptions<no_qed  ,has_qed>>{},
-                  {exteb_runtime_flag, qed_runtime_flag},
-                  [&](auto cto_func) { amrex::ParallelForRNG(np_to_push, cto_func); },
-                  [=] AMREX_GPU_DEVICE (long i, amrex::RandomEngine const& engine,
-                                        auto exteb_control, auto qed_control) {
+    amrex::ParallelFor(TypeList<CompileTimeOptions<no_exteb,has_exteb>>{},
+                       {exteb_runtime_flag},
+                       np_to_push,
+                       [=] AMREX_GPU_DEVICE (long i, auto exteb_control) {
             if (do_copy) { copyAttribs(i); }
             ParticleReal x, y, z;
             GetPosition(i, x, y, z);
@@ -221,22 +198,6 @@ PhotonParticleContainer::PushPX (WarpXParIter& pti,
             if constexpr (exteb_control == has_exteb) {
                 getExternalEB(i, Exp, Eyp, Ezp, Bxp, Byp, Bzp);
             }
-
-#ifdef WARPX_QED
-            [[maybe_unused]] const auto& evolve_opt_tmp = evolve_opt;
-            [[maybe_unused]] auto *p_optical_depth_BW_tmp = p_optical_depth_BW;
-            [[maybe_unused]] auto *ux_tmp = ux; // for nvhpc
-            [[maybe_unused]] auto *uy_tmp = uy;
-            [[maybe_unused]] auto *uz_tmp = uz;
-            [[maybe_unused]] auto dt_tmp = dt;
-            [[maybe_unused]] auto qed_dt_tmp = qed_dt;
-            if constexpr (qed_control == has_qed) {
-                evolve_opt(ux[i], uy[i], uz[i], Exp, Eyp, Ezp, Bxp, Byp, Bzp,
-                           qed_dt, p_optical_depth_BW[i], engine);
-            }
-#else
-            amrex::ignore_unused(qed_control, engine);
-#endif
 
             if (position_push_type == PositionPushType::Full) {
                 UpdatePosition(x, y, z, ux[i], uy[i], uz[i], dt, mass);

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -399,8 +399,6 @@ public:
 
     PhotonEmissionFilterFunc getPhotonEmissionFilterFunc ();
 
-    PairGenerationFilterFunc getPairGenerationFilterFunc ();
-
     /**
      * Tells if this PhysicalParticleContainer has
      * virtual photons enabled

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -266,9 +266,6 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     }
 
     pp_species_name.query("do_qed_breit_wheeler", m_do_qed_breit_wheeler);
-    if (m_do_qed_breit_wheeler) {
-        AddRealComp("opticalDepthBW");
-    }
 
     if(m_do_qed_quantum_sync){
         pp_species_name.get("qed_quantum_sync_phot_product_species",
@@ -1806,13 +1803,6 @@ PhysicalParticleContainer::getPhotonEmissionFilterFunc ()
 {
     ABLASTR_PROFILE("PhysicalParticleContainer::getPhotonEmissionFunc()");
     return PhotonEmissionFilterFunc{GetRealCompIndex("opticalDepthQSR") - NArrayReal};
-}
-
-PairGenerationFilterFunc
-PhysicalParticleContainer::getPairGenerationFilterFunc ()
-{
-    ABLASTR_PROFILE("PhysicalParticleContainer::getPairGenerationFunc()");
-    return PairGenerationFilterFunc{GetRealCompIndex("opticalDepthBW") - NArrayReal};
 }
 
 #endif


### PR DESCRIPTION
Remove the per-particle optical depth accumulation for the nonlinear Breit-Wheeler process. Instead, at each timestep draw U ~ Uniform(0,1) and trigger pair generation if U < 1 - exp(-lambda_BW * dt). The two approaches are mathematically equivalent (both sample the same Poisson survival probability) but the new method eliminates the need to initialize and carry an optical depth attribute per photon.