### PR TITLE
Small performance improvement in RKF45 integrator

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -744,9 +744,6 @@ void HybridPICModel::BfieldEvolveRKF45 (
         if (t + dt_sub > dt_half) { dt_sub = dt_half - t; }
 
         // ---- Stage 1: B = B_old, FieldPush, K[comp0] = h*k1 ----
-        for (int ii = 0; ii < 3; ii++) {
-            MultiFab::Copy(*Bfield[lev][ii], B_old[ii], 0, 0, 1, ng);
-        }
         FieldPush(Bfield, Efield, Jfield, rhofield, eb_update_E,
                   dt_sub, subcycling_half, ng, nodal_sync);
         for (int ii = 0; ii < 3; ii++) {


### PR DESCRIPTION
I noticed this after approving #6844 and didn't want to delay merging.

Copying `B_old` to `Bfield` at the start of the RKF45 while loop is redundant. The possible scenarios are as follows:
- First pass through while loop block: `B_old == Bfield` from line 725. 
- Successful previous step: `B_old == Bfield` from line 1046.
- Unsuccessful previous step: `Bfield == B_old` from line 1051.