### PR TITLE
[WIP] C++20 : use container.contains()

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -59,7 +59,6 @@ Checks: '
         -readability-named-parameter,
         -readability-uppercase-literal-suffix,
         -readability-redundant-casting,
-        -readability-container-contains,
         -readability-redundant-inline-specifier,
         -readability-redundant-member-init,
         -readability-reference-to-constructed-temporary
@@ -86,7 +85,6 @@ HeaderFilterRegex: 'Source[a-z_A-Z0-9\/]+\.H$'
 # -modernize-use-ranges
 # -modernize-use-integer-sign-comparison
 # -modernize-use-starts-ends-with
-# -readability-container-contains
 
 # TODO Consider enabling the following checks:
 # -bugprone-unused-local-non-trivial-variable

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -216,12 +216,7 @@ PhotonParticleContainer::PushPX (WarpXParIter& pti,
             }
 
 #ifdef WARPX_QED
-            [[maybe_unused]] const auto& evolve_opt_tmp = evolve_opt;
-            [[maybe_unused]] auto *p_optical_depth_BW_tmp = p_optical_depth_BW;
-            [[maybe_unused]] auto *ux_tmp = ux; // for nvhpc
-            [[maybe_unused]] auto *uy_tmp = uy;
-            [[maybe_unused]] auto *uz_tmp = uz;
-            [[maybe_unused]] auto dt_tmp = dt;
+            [[maybe_unused]] const auto& evolve_opt_tmp = evolve_opt; // workaround for nvcc
             if constexpr (qed_control == has_qed) {
                 evolve_opt(ux[i], uy[i], uz[i], Exp, Eyp, Ezp, Bxp, Byp, Bzp,
                            dt, p_optical_depth_BW[i]);

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1552,7 +1552,6 @@ PhysicalParticleContainer::PushPX (WarpXParIter& pti,
         }
 
 #ifdef WARPX_QED
-        [[maybe_unused]] auto foo_local_has_quantum_sync = local_has_quantum_sync;
         [[maybe_unused]] auto *foo_podq = p_optical_depth_QSR;
         [[maybe_unused]] const auto& foo_evolve_opt = evolve_opt; // have to do all these for nvcc
         if constexpr (qed_control == has_qed) {


### PR DESCRIPTION
In C++20 some containers (e.g., `std::set`, `std::unordered_set`, `std::map`, `std::unordered_map`) have a new method `.contains(x)`, which allows replacing rather verbose expressions like:
```
myMap.find(x) != myMap.end()
```
with the more readable : 
```
myMap.contains(x)
```