### PR TITLE
Reduce MPI communication in RKF45 integrator

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -1049,13 +1049,14 @@ void HybridPICModel::BfieldEvolveRKF45 (
         }
 
         // ---- Error norm and adaptive step control ----
-        // norm0() with local=false (default) performs the MPI AllReduce internally
+        // Compute local maxima first, then one combined AllReduce for both norms.
         amrex::Real err_norm = 0._rt;
         amrex::Real B4_norm  = 0._rt;
         for (int ii = 0; ii < 3; ii++) {
-            err_norm = std::max(err_norm, err_scratch[ii].norm0());
-            B4_norm  = std::max(B4_norm,  Bfield[lev][ii]->norm0());
+            err_norm = std::max(err_norm, err_scratch[ii].norm0(0, 0, true));
+            B4_norm  = std::max(B4_norm,  Bfield[lev][ii]->norm0(0, 0, true));
         }
+        amrex::ParallelDescriptor::ReduceRealMax({err_norm, B4_norm});
         const amrex::Real err_scalar = err_norm / (m_substep_atol + m_substep_rtol * B4_norm);
         const amrex::Real factor = m_substep_safety * std::pow(err_scalar + 1.e-10_rt, -0.2_rt);
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -1053,8 +1053,8 @@ void HybridPICModel::BfieldEvolveRKF45 (
         amrex::Real err_norm = 0._rt;
         amrex::Real B4_norm  = 0._rt;
         for (int ii = 0; ii < 3; ii++) {
-            err_norm = std::max(err_norm, err_scratch[ii].norm0(0, 0, true));
-            B4_norm  = std::max(B4_norm,  Bfield[lev][ii]->norm0(0, 0, true));
+            err_norm = std::max(err_norm, err_scratch[ii].norm0(/*comp=*/0, /*nghost=*/0, /*local=*/true));
+            B4_norm  = std::max(B4_norm,  Bfield[lev][ii]->norm0(/*comp=*/0, /*nghost=*/0, /*local=*/true));
         }
         amrex::ParallelDescriptor::ReduceRealMax({err_norm, B4_norm});
         const amrex::Real err_scalar = err_norm / (m_substep_atol + m_substep_rtol * B4_norm);


### PR DESCRIPTION
Instead of reducing across MPI ranks 6 times (3x for `err_norm` and 3x for `B4_norm`, in this PR `err_norm` and `B4_norm` is first calculated locally for all directions and then a single MPI AllReduce is used to get the global maxima.