### PR TITLE
clang-sanitizers CI test : bump clang version from 17 to 19

### DIFF
--- a/.github/workflows/clang_sanitizers.yml
+++ b/.github/workflows/clang_sanitizers.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: install dependencies
       run: |
-        .github/workflows/dependencies/clang.sh 17
+        .github/workflows/dependencies/clang.sh 19
     - name: CCache Cache
       uses: actions/cache@v4
       with:
@@ -46,8 +46,8 @@ jobs:
         export CCACHE_MAXSIZE=100M
         ccache -z
 
-        export CXX=$(which clang++-17)
-        export CC=$(which clang-17)
+        export CXX=$(which clang++-19)
+        export CC=$(which clang-19)
         export CXXFLAGS="-fsanitize=undefined,address,pointer-compare -fno-sanitize-recover=all"
 
         cmake -S . -B build                 \
@@ -93,7 +93,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: install dependencies
       run: |
-        .github/workflows/dependencies/clang.sh 17
+        .github/workflows/dependencies/clang.sh 19
     - name: CCache Cache
       uses: actions/cache@v4
       with:
@@ -108,8 +108,8 @@ jobs:
         export CCACHE_MAXSIZE=100M
         ccache -z
 
-        export CXX=$(which clang++-17)
-        export CC=$(which clang-17)
+        export CXX=$(which clang++-19)
+        export CC=$(which clang-19)
         export CXXFLAGS="-fsanitize=thread"
 
         cmake -S . -B build                 \
@@ -142,7 +142,7 @@ jobs:
         # When the Archer library is used and ARCHER_OPTIONS="verbose=1",
         # the following message should be displayed:
         # Archer detected OpenMP application with TSan, supplying OpenMP synchronization semantics
-        export OMP_TOOL_LIBRARIES=/usr/lib/llvm-17/lib/libarcher.so
+        export OMP_TOOL_LIBRARIES=/usr/lib/llvm-19/lib/libarcher.so
         export ARCHER_OPTIONS="verbose=1"
 
         # This option is required to avoid false positive reports from the OpenMP runtime


### PR DESCRIPTION
This PR bumps the version of `clang` used in sanitizers CI tests from 17 to 19, for consistency with the `clang-tidy` CI test (which now uses `clang-tidy` v19).