### PR TITLE
Do not trigger CI on changes to .zenodo.json

### DIFF
--- a/.github/workflows/check_changes.yml
+++ b/.github/workflows/check_changes.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           filters: |
             non_docs:
+              - '!.zenodo.json'
               - '!Docs/**'
               - '!Tools/machines/**'
               - '!**.rst'


### PR DESCRIPTION
I noticed in #6905 that changes to .zenodo.json trigger all CI checks and I think it is unnecessary.