### PR TITLE
Increase CCACHE_MAXSIZE for Clang sanitizers workflows

### DIFF
--- a/.github/workflows/clang_sanitizers.yml
+++ b/.github/workflows/clang_sanitizers.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
-        export CCACHE_MAXSIZE=100M
+        export CCACHE_MAXSIZE=300M
         ccache -z
 
         export CXX=$(which clang++-19)
@@ -105,7 +105,7 @@ jobs:
       run: |
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
-        export CCACHE_MAXSIZE=100M
+        export CCACHE_MAXSIZE=300M
         ccache -z
 
         export CXX=$(which clang++-19)


### PR DESCRIPTION
Followin up on a Slack thread in **#build**:

> **Remi Lehe** 
> Building WarpX took 1h30 in this CI test: https://github.com/BLAST-WarpX/warpx/actions/runs/26902601619/job/79358744155?pr=6921. The corresponding PR does not change the WarpX source code. So I would have expected CCache to save us a lot for time. How can I see, in the logs, whether or not CCache kicked in?
>
> **Weiqun Zhang**
> ```
> Cacheable calls:   1358 / 1358 (100.0%)
>   Hits:              46 / 1358 ( 3.39%)
>     Direct:           0 /   46 ( 0.00%)
>     Preprocessed:    46 /   46 (100.0%)
>   Misses:          1312 / 1358 (96.61%)
> Local storage:
>   Cache size (GB):  0.2 /  0.1 (182.9%)
>   Cleanups:        1358
>   Hits:              46 / 1358 ( 3.39%)
>   Misses:          1312 / 1358 (96.61%)
> 178M	/home/runner/.cache/ccache
> ```
> Maybe the previous cache is not update to date? `export CCACHE_MAXSIZE=100M`: the size might also be too small.
>
> **Remi Lehe**
> `Cache size (GB):  0.2 /  0.1 (182.9%)`: this seems to confirm that the cache size was too small?
>
> **Axel Huebl** 
> That makes sense. Other builders do not build 4 geometries at the same time and this one does UB tests for all cartesian + RZ. Let's bump it to 300MB I would say, commensurate with the 3 AMReX libs it builds.