### PR TITLE
Always sort keys with json dump for benchmarks

### DIFF
--- a/Regression/Checksum/checksum.py
+++ b/Regression/Checksum/checksum.py
@@ -291,7 +291,7 @@ class Checksum:
             print("Benchmark: %s" % ref_benchmark.data.keys())
             print("Test file: %s" % self.data.keys())
             print(f"\nNew checksums file {self.test_name}.json:")
-            print(json.dumps(self.data, indent=2))
+            print(json.dumps(self.data, sort_keys=True, indent=2))
             sys.exit(1)
 
         # Dictionaries have same inner keys (field and particle quantities)?
@@ -308,7 +308,7 @@ class Checksum:
                 )
                 print("Test file inner keys in %s: %s" % (key1, self.data[key1].keys()))
                 print(f"\nNew checksums file {self.test_name}.json:")
-                print(json.dumps(self.data, indent=2))
+                print(json.dumps(self.data, sort_keys=True, indent=2))
                 sys.exit(1)
 
         # Dictionaries have same values?
@@ -347,5 +347,5 @@ class Checksum:
         print("\nMaximum relative error: {:.2e}".format(max_rel_err))
         if checksums_differ:
             print(f"\nNew checksums file {self.test_name}.json:")
-            print(json.dumps(self.data, indent=2))
+            print(json.dumps(self.data, sort_keys=True, indent=2))
             sys.exit(1)

--- a/Tools/DevUtils/update_benchmarks_from_azure_output.py
+++ b/Tools/DevUtils/update_benchmarks_from_azure_output.py
@@ -82,7 +82,7 @@ def update_benchmarks_from_log_text(log_text):
                 print(f"\nDumping new checksums file {json_filename}:")
                 print(json_file_string)
                 with open(json_filepath, "w") as json_f:
-                    json.dump(json_file, json_f, indent=2)
+                    json.dump(json_file, json_f, sort_keys=True, indent=2)
                 updated.append(json_filename)
                 # reset to continue searching for more failing tests
                 failing_test = ""


### PR DESCRIPTION
I've noticed often that the benchmark files have their sections arranged differenty, which makes comparing changes more difficult. The solution is to always sort keys in json dumps, ensuring that the benchmark files always have the same sorting.