### PR TITLE
Fix odd indentation in .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,30 +20,30 @@ ci:
 
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
-    hooks:
-    - id: trailing-whitespace
-      args: [--markdown-linebreak-ext=md]
-    - id: end-of-file-fixer
-      exclude: '.json$'
-    - id: mixed-line-ending
-    - id: check-json
-    - id: check-toml
-    - id: check-yaml
-    - id: check-added-large-files
-      args: ['--maxkb=40']
-    - id: requirements-txt-fixer
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v6.0.0
+  hooks:
+  - id: trailing-whitespace
+    args: [--markdown-linebreak-ext=md]
+  - id: end-of-file-fixer
+    exclude: '.json$'
+  - id: mixed-line-ending
+  - id: check-json
+  - id: check-toml
+  - id: check-yaml
+  - id: check-added-large-files
+    args: ['--maxkb=40']
+  - id: requirements-txt-fixer
 #  - id: fix-encoding-pragma
 #    exclude: ^noxfile.py$
 
 # documentation files: .rst
--   repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.10.0
-    hooks:
-#    - id: rst-backticks
-    - id: rst-directive-colons
-    - id: rst-inline-touching-normal
+- repo: https://github.com/pre-commit/pygrep-hooks
+  rev: v1.10.0
+  hooks:
+#  - id: rst-backticks
+  - id: rst-directive-colons
+  - id: rst-inline-touching-normal
 
 #- repo: https://github.com/asottile/pyupgrade
 #  rev: v2.29.0


### PR DESCRIPTION
Fix some odd (double) indentation in .pre-commit-config.yaml, noticed while reviewing #6929.