### PR TITLE
ABLASTR: Move IntervalsParser

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -11,7 +11,7 @@
 #include "Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Utils/WarpXConst.H"
-#include "Utils/Parser/IntervalsParser.H"
+#include "Utils/Parser/BTDIntervalsParser.H"
 
 #include <AMReX_Box.H>
 #include <AMReX_Geometry.H>

--- a/Source/Diagnostics/BoundaryScrapingDiagnostics.H
+++ b/Source/Diagnostics/BoundaryScrapingDiagnostics.H
@@ -9,7 +9,8 @@
 
 #include "Diagnostics.H"
 #include "Particles/MultiParticleContainer.H"
-#include "Utils/Parser/IntervalsParser.H"
+
+#include <ablastr/utils/text/IntervalsParser.H>
 
 #include <string>
 
@@ -32,7 +33,7 @@ private:
     void ReadParameters ();
 
     /** Determines timesteps at which the particles are written out */
-    utils::parser::IntervalsParser m_intervals;
+    ablastr::utils::text::IntervalsParser m_intervals;
 
     /** \brief Flush data to file. */
     void Flush (int i_buffer, bool /* force_flush */) override;

--- a/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
+++ b/Source/Diagnostics/BoundaryScrapingDiagnostics.cpp
@@ -65,7 +65,7 @@ BoundaryScrapingDiagnostics::ReadParameters ()
     const amrex::ParmParse pp_diag_name(m_diag_name);
     std::vector<std::string> intervals_string_vec = {"0"};
     pp_diag_name.queryarr("intervals", intervals_string_vec);
-    m_intervals = utils::parser::IntervalsParser(intervals_string_vec);
+    m_intervals = ablastr::utils::text::IntervalsParser(intervals_string_vec);
 
 }
 

--- a/Source/Diagnostics/FullDiagnostics.H
+++ b/Source/Diagnostics/FullDiagnostics.H
@@ -3,7 +3,8 @@
 
 #include "Diagnostics.H"
 #include "Particles/MultiParticleContainer.H"
-#include "Utils/Parser/IntervalsParser.H"
+
+#include <ablastr/utils/text/IntervalsParser.H>
 
 #include <AMReX_REAL.H>
 
@@ -25,7 +26,7 @@ private:
     /** Read user-requested parameters for full diagnostics */
     void ReadParameters ();
     /** Determines timesteps at which full diagnostics are written to file */
-    utils::parser::IntervalsParser m_intervals;
+    ablastr::utils::text::IntervalsParser m_intervals;
     /** Whether to plot raw (i.e., NOT cell-centered) fields */
     bool m_plot_raw_fields = false;
     /** Whether to plot guard cells of raw fields */

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -120,7 +120,7 @@ FullDiagnostics::ReadParameters ()
         "<diag>.format must be plotfile or openpmd or checkpoint or ascent or catalyst or sensei");
     std::vector<std::string> intervals_string_vec = {"0"};
     pp_diag_name.getarr("intervals", intervals_string_vec);
-    m_intervals = utils::parser::IntervalsParser(intervals_string_vec);
+    m_intervals = ablastr::utils::text::IntervalsParser(intervals_string_vec);
     const bool plot_raw_fields_specified = pp_diag_name.query("plot_raw_fields", m_plot_raw_fields);
     const bool plot_raw_fields_guards_specified = pp_diag_name.query("plot_raw_fields_guards", m_plot_raw_fields_guards);
     const bool raw_specified = plot_raw_fields_specified || plot_raw_fields_guards_specified;

--- a/Source/Diagnostics/ReducedDiags/ReducedDiags.H
+++ b/Source/Diagnostics/ReducedDiags/ReducedDiags.H
@@ -8,7 +8,7 @@
 #ifndef WARPX_DIAGNOSTICS_REDUCEDDIAGS_REDUCEDDIAGS_H_
 #define WARPX_DIAGNOSTICS_REDUCEDDIAGS_REDUCEDDIAGS_H_
 
-#include "Utils/Parser/IntervalsParser.H"
+#include <ablastr/utils/text/IntervalsParser.H>
 
 #include <AMReX_REAL.H>
 
@@ -34,7 +34,7 @@ public:
     std::string m_rd_name;
 
     /// output intervals
-    utils::parser::IntervalsParser m_intervals;
+    ablastr::utils::text::IntervalsParser m_intervals;
 
     /// check if header should be written
     bool m_write_header = false;

--- a/Source/Diagnostics/ReducedDiags/ReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/ReducedDiags.cpp
@@ -8,9 +8,10 @@
 #include "ReducedDiags.H"
 
 #include "WarpX.H"
-#include "Utils/Parser/IntervalsParser.H"
 #include "Utils/Parser/ParserUtils.H"
 #include "Utils/TextMsg.H"
+
+#include <ablastr/utils/text/IntervalsParser.H>
 
 #include <AMReX.H>
 #include <AMReX_ParallelDescriptor.H>
@@ -66,7 +67,7 @@ m_rd_name{rd_name}
     std::vector<std::string> intervals_string_vec = {"1"};
     pp_rd.queryarr("intervals", intervals_string_vec);
     pp_rd_name.queryarr("intervals", intervals_string_vec);
-    m_intervals = utils::parser::IntervalsParser(intervals_string_vec);
+    m_intervals = ablastr::utils::text::IntervalsParser(intervals_string_vec);
 
     // read separator
     pp_rd.query("separator", m_sep);

--- a/Source/Particles/Resampling/ResamplingTrigger.H
+++ b/Source/Particles/Resampling/ResamplingTrigger.H
@@ -7,7 +7,7 @@
 #ifndef WARPX_RESAMPLING_TRIGGER_H_
 #define WARPX_RESAMPLING_TRIGGER_H_
 
-#include "Utils/Parser/IntervalsParser.H"
+#include <ablastr/utils/text/IntervalsParser.H>
 
 #include <AMReX_REAL.H>
 
@@ -54,7 +54,7 @@ public:
 private:
     // Intervals that define predetermined timesteps at which resampling is performed for all
     // species.
-    utils::parser::IntervalsParser m_resampling_intervals;
+    ablastr::utils::text::IntervalsParser m_resampling_intervals;
 
     // Average number of particles per cell above which resampling is performed for a given species
     amrex::Real m_max_avg_ppc = std::numeric_limits<amrex::Real>::max();

--- a/Source/Particles/Resampling/ResamplingTrigger.cpp
+++ b/Source/Particles/Resampling/ResamplingTrigger.cpp
@@ -20,7 +20,8 @@ ResamplingTrigger::ResamplingTrigger (const std::string& species_name)
 
     std::vector<std::string> resampling_trigger_int_string_vec = {"0"};
     pp_species_name.queryarr("resampling_trigger_intervals", resampling_trigger_int_string_vec);
-    m_resampling_intervals = utils::parser::IntervalsParser(resampling_trigger_int_string_vec);
+    m_resampling_intervals =
+        ablastr::utils::text::IntervalsParser(resampling_trigger_int_string_vec);
 
     utils::parser::queryWithParser(
         pp_species_name, "resampling_trigger_max_avg_ppc", m_max_avg_ppc);

--- a/Source/Utils/Make.package
+++ b/Source/Utils/Make.package
@@ -2,7 +2,6 @@ CEXE_sources += WarpXMovingWindow.cpp
 CEXE_sources += WarpXUtil.cpp
 CEXE_sources += WarpXVersion.cpp
 CEXE_sources += Interpolate.cpp
-CEXE_sources += IntervalsParser.cpp
 CEXE_sources += ParticleUtils.cpp
 CEXE_sources += SpeciesUtils.cpp
 

--- a/Source/Utils/Parser/BTDIntervalsParser.H
+++ b/Source/Utils/Parser/BTDIntervalsParser.H
@@ -6,8 +6,8 @@
  * License: BSD-3-Clause-LBNL
  */
 
-#ifndef WARPX_UTILS_PARSER_INTERVALSPARSER_H_
-#define WARPX_UTILS_PARSER_INTERVALSPARSER_H_
+#ifndef WARPX_UTILS_PARSER_BTDINTERVALSPARSER_H_
+#define WARPX_UTILS_PARSER_BTDINTERVALSPARSER_H_
 
 #include <ablastr/utils/text/IntervalsParser.H>
 
@@ -16,12 +16,6 @@
 
 namespace utils::parser
 {
-    /** \brief Parser for slices of the form i:j:k */
-    using SliceParser = ablastr::utils::text::SliceParser;
-
-    /** \brief Parser for multiple slices of the form x,y,z,... */
-    using IntervalsParser = ablastr::utils::text::IntervalsParser;
-
     /**
      * \brief This class is a parser for multiple slices of the form x,y,z,... where x, y and z are
      * slices of the form i:j:k, as defined in the SliceParser class. This class contains a vector of
@@ -70,11 +64,11 @@ namespace utils::parser
 
     private:
         std::vector<int> m_btd_iterations;
-        std::vector<SliceParser> m_slices;
+        std::vector<ablastr::utils::text::SliceParser> m_slices;
         std::vector<int> m_slice_starting_i_buffer;
         static constexpr char m_separator = ',';
         bool m_activated = false;
     };
 }
 
-#endif // WARPX_UTILS_PARSER_INTERVALSPARSER_H_
+#endif // WARPX_UTILS_PARSER_BTDINTERVALSPARSER_H_

--- a/Source/Utils/Parser/BTDIntervalsParser.cpp
+++ b/Source/Utils/Parser/BTDIntervalsParser.cpp
@@ -6,7 +6,7 @@
  * License: BSD-3-Clause-LBNL
  */
 
-#include "IntervalsParser.H"
+#include "BTDIntervalsParser.H"
 
 #include <ablastr/utils/text/StringUtils.H>
 
@@ -27,7 +27,7 @@ utils::parser::BTDIntervalsParser::BTDIntervalsParser (
     for(const auto& inslc : insplit)
     {
         constexpr bool require_stop = true;
-        const SliceParser temp_slice(inslc, require_stop);
+        const ablastr::utils::text::SliceParser temp_slice(inslc, require_stop);
         if (!m_slices.empty())
         {
             // find the last index i_slice where

--- a/Source/Utils/Parser/CMakeLists.txt
+++ b/Source/Utils/Parser/CMakeLists.txt
@@ -2,7 +2,7 @@ foreach(D IN LISTS WarpX_DIMS)
     warpx_set_suffix_dims(SD ${D})
     target_sources(lib_${SD}
       PRIVATE
-        IntervalsParser.cpp
+        BTDIntervalsParser.cpp
         ParserUtils.cpp
     )
 endforeach()

--- a/Source/Utils/Parser/IntervalsParser.H
+++ b/Source/Utils/Parser/IntervalsParser.H
@@ -1,172 +1,26 @@
-/* Copyright 2022 Andrew Myers, Burlen Loring, Luca Fedeli
- * Maxence Thevenet, Remi Lehe, Revathi Jambunathan
+/* Copyright 2022 The WarpX Community
  *
  * This file is part of WarpX.
  *
+ * Authors: Neil Zaim, Luca Fedeli, Weiqun Zhang, Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
 
 #ifndef WARPX_UTILS_PARSER_INTERVALSPARSER_H_
 #define WARPX_UTILS_PARSER_INTERVALSPARSER_H_
 
-#include <limits>
+#include <ablastr/utils/text/IntervalsParser.H>
+
 #include <string>
 #include <vector>
 
 namespace utils::parser
 {
+    /** \brief Parser for slices of the form i:j:k */
+    using SliceParser = ablastr::utils::text::SliceParser;
 
-    /**
-     * \brief This class is a parser for slices of the form i:j:k where i, j and k are integers
-     * representing respectively the starting point, the stopping point and the period.
-     */
-    class SliceParser
-    {
-    public:
-        /**
-        * \brief Constructor of the SliceParser class.
-        *
-        * @param[in] instr an input string of the form "i:j:k", "i:j" or "k" where i, j and k are
-        * integers representing respectively the starting point, the stopping point and the period.
-        * Any of these integers may be omitted in which case it will be equal to their default value
-        * (0 for the starting point, std::numeric_limits<int>::max() for the stopping point and 1 for
-        * the period). For example SliceParser(":1000:") is equivalent to SliceParser("0:1000:1").
-        * @param[in] isBTD whether this is a back-transformed diagnostic
-        */
-        explicit SliceParser (const std::string& instr, bool isBTD=false);
-
-        /**
-        * \brief A method that returns true if the input integer is contained in the slice. (e.g. if
-        * the list is initialized with "300:500:100", this method returns true if and only if n is
-        * 300, 400 or 500). If the period is negative or 0, the function always returns false.
-        *
-        * @param[in] n the input integer
-        */
-        [[nodiscard]] bool contains (int n) const;
-
-        /**
-        * \brief A method that returns the smallest integer strictly greater than n such that
-        * contains(n) is true. Returns std::numeric_limits<int>::max() if there is no such integer.
-        *
-        * @param[in] n the input integer
-        */
-        [[nodiscard]] int nextContains (int n) const;
-
-        /**
-        * \brief A method that returns the greatest integer strictly smaller than n such that
-        * contains(n) is true. Returns 0 if there is no such integer.
-        *
-        * @param[in] n the input integer
-        */
-        [[nodiscard]] int previousContains (int n) const;
-
-        /**
-        * \brief A method that returns the slice period.
-        *
-        */
-        [[nodiscard]] int getPeriod () const;
-
-        /**
-        * \brief A method that returns the slice start.
-        *
-        */
-        [[nodiscard]] int getStart () const;
-
-        /**
-        * \brief A method that returns the slice stop.
-        *
-        */
-        [[nodiscard]] int getStop () const;
-
-        /**
-        * @brief A method that returns the number of integers contained by the slice.
-        *
-        */
-        [[nodiscard]] int numContained() const;
-
-    private:
-        bool m_isBTD = false;
-        int m_start = 0;
-        int m_stop = std::numeric_limits<int>::max();
-        int m_period = 1;
-        std::string m_separator = ":";
-
-    };
-
-
-    /**
-     * \brief This class is a parser for multiple slices of the form x,y,z,... where x, y and z are
-     * slices of the form i:j:k, as defined in the SliceParser class. This class contains a vector of
-     * SliceParsers.
-     */
-    class IntervalsParser
-    {
-    public:
-        /**
-        * \brief Default constructor of the IntervalsParser class.
-        */
-        IntervalsParser () = default;
-
-        /**
-        * \brief Constructor of the IntervalsParser class.
-        *
-        * @param[in] instr_vec an input vector string, which when concatenated is of the form
-        * "x,y,z,...". This will call the constructor of SliceParser using x, y and z as input
-        * arguments.
-        */
-        explicit IntervalsParser (const std::vector<std::string>& instr_vec);
-
-        /**
-        * \brief A method that returns true if the input integer is contained in any of the slices
-        * contained by the IntervalsParser.
-        *
-        * @param[in] n the input integer
-        */
-        [[nodiscard]] bool contains (int n) const;
-
-        /**
-        * \brief A method that returns the smallest integer strictly greater than n such that
-        * contains(n) is true. Returns std::numeric_limits<int>::max() if there is no such integer.
-        *
-        * @param[in] n the input integer
-        */
-        [[nodiscard]] int nextContains (int n) const;
-
-        /**
-        * \brief A method that returns the greatest integer strictly smaller than n such that
-        * contains(n) is true. Returns 0 if there is no such integer.
-        *
-        * @param[in] n the input integer
-        */
-        [[nodiscard]] int previousContains (int n) const;
-
-        /**
-        * \brief A method that returns the greatest integer smaller than or equal to n such that
-        * contains(n) is true. Returns 0 if there is no such integer.
-        *
-        * @param[in] n the input integer
-        */
-        [[nodiscard]] int previousContainsInclusive (int n) const;
-
-        /**
-        * \brief A method the local period (in timesteps) of the IntervalsParser at timestep n.
-        * The period is defined by nextContains(n) - previousContainsInclusive(n)
-        *
-        * @param[in] n the input integer
-        */
-        [[nodiscard]] int localPeriod (int n) const;
-
-        /**
-        * \brief A method that returns true if any of the slices contained by the IntervalsParser
-        * has a strictly positive period.
-        */
-        [[nodiscard]] bool isActivated () const;
-
-    private:
-        std::vector<SliceParser> m_slices;
-        std::string m_separator = ",";
-        bool m_activated = false;
-    };
+    /** \brief Parser for multiple slices of the form x,y,z,... */
+    using IntervalsParser = ablastr::utils::text::IntervalsParser;
 
     /**
      * \brief This class is a parser for multiple slices of the form x,y,z,... where x, y and z are

--- a/Source/Utils/Parser/IntervalsParser.cpp
+++ b/Source/Utils/Parser/IntervalsParser.cpp
@@ -1,156 +1,16 @@
-/* Copyright 2022 Andrew Myers, Burlen Loring, Luca Fedeli
- * Maxence Thevenet, Remi Lehe, Revathi Jambunathan
+/* Copyright 2022 The WarpX Community
  *
  * This file is part of WarpX.
  *
+ * Authors: Neil Zaim, Luca Fedeli, Weiqun Zhang, Axel Huebl
  * License: BSD-3-Clause-LBNL
  */
 
 #include "IntervalsParser.H"
 
-#include "ablastr/utils/text/StringUtils.H"
-#include "ParserUtils.H"
-#include "Utils/TextMsg.H"
+#include <ablastr/utils/text/StringUtils.H>
 
-#include <AMReX_Utility.H>
-
-#include <algorithm>
-
-utils::parser::SliceParser::SliceParser (const std::string& instr, const bool isBTD):
-    m_isBTD{isBTD}
-{
-    const amrex::ParmParse pp;
-
-    // split string and trim whitespaces
-    auto insplit = ablastr::utils::text::split_string<std::vector<std::string>>(
-        instr, m_separator, true);
-
-    if(insplit.size() == 1){ // no colon in input string. The input is the period.
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(!m_isBTD, "must specify interval stop for BTD");
-        m_period = int(std::round(pp.eval<double>(insplit[0])));}
-    else if(insplit.size() == 2) // 1 colon in input string. The input is start:stop
-    {
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(!m_isBTD || !insplit[1].empty(), "must specify interval stop for BTD");
-        if (!insplit[0].empty()){
-            m_start = int(std::round(pp.eval<double>(insplit[0])));}
-        if (!insplit[1].empty()){
-            m_stop = int(std::round(pp.eval<double>(insplit[1])));}
-    }
-    else // 2 colons in input string. The input is start:stop:period
-    {
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(!m_isBTD || !insplit[1].empty(), "must specify interval stop for BTD");
-        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            insplit.size() == 3,
-            instr + "' is not a valid syntax for a slice.");
-        if (!insplit[0].empty()){
-            m_start = int(std::round(pp.eval<double>(insplit[0])));}
-        if (!insplit[1].empty()){
-            m_stop = int(std::round(pp.eval<double>(insplit[1])));}
-        if (!insplit[2].empty()){
-            m_period = int(std::round(pp.eval<double>(insplit[2])));}
-    }
-}
-
-
-bool utils::parser::SliceParser::contains (const int n) const
-{
-    if (m_period <= 0) {return false;}
-    return (n - m_start) % m_period == 0 && n >= m_start && n <= m_stop;
-}
-
-
-int utils::parser::SliceParser::nextContains (const int n) const
-{
-    if (m_period <= 0) {return std::numeric_limits<int>::max();}
-    int next = m_start;
-    if (n >= m_start) {next = ((n-m_start)/m_period + 1)*m_period+m_start;}
-    if (next > m_stop) {next = std::numeric_limits<int>::max();}
-    return next;
-}
-
-
-int utils::parser::SliceParser::previousContains (const int n) const
-{
-    if (m_period <= 0) {return false;}
-    int previous = ((std::min(n-1,m_stop)-m_start)/m_period)*m_period+m_start;
-    if ((n < m_start) || (previous < 0)) {previous = 0;}
-    return previous;
-}
-
-
-int utils::parser::SliceParser::getPeriod () const {return m_period;}
-
-
-int utils::parser::SliceParser::getStart () const {return m_start;}
-
-
-int utils::parser::SliceParser::getStop () const {return m_stop;}
-
-
-int utils::parser::SliceParser::numContained () const {
-    return (m_stop - m_start) / m_period + 1;}
-
-utils::parser::IntervalsParser::IntervalsParser (
-    const std::vector<std::string>& instr_vec)
-{
-    std::string inconcatenated;
-    for (const auto& instr_element : instr_vec) { inconcatenated +=instr_element; }
-
-    auto insplit = ablastr::utils::text::split_string<std::vector<std::string>>(
-        inconcatenated, m_separator);
-
-    for(const auto& inslc : insplit)
-    {
-        const SliceParser temp_slice(inslc);
-        m_slices.push_back(temp_slice);
-        if ((temp_slice.getPeriod() > 0) &&
-               (temp_slice.getStop() >= temp_slice.getStart())) { m_activated = true; }
-    }
-}
-
-
-bool utils::parser::IntervalsParser::contains (const int n) const
-{
-    return std::any_of(m_slices.begin(), m_slices.end(),
-        [&](const auto& slice){return slice.contains(n);});
-}
-
-
-int utils::parser::IntervalsParser::nextContains (const int n) const
-{
-    int next = std::numeric_limits<int>::max();
-    for(const auto& slice: m_slices){
-        next = std::min(slice.nextContains(n),next);
-    }
-    return next;
-}
-
-
-int utils::parser::IntervalsParser::previousContains (const int n) const
-{
-    int previous = 0;
-    for(const auto& slice: m_slices){
-        previous = std::max(slice.previousContains(n),previous);
-    }
-    return previous;
-}
-
-
-int utils::parser::IntervalsParser::previousContainsInclusive (
-    const int n) const
-{
-    if (contains(n)){return n;}
-    else {return previousContains(n);}
-}
-
-
-int utils::parser::IntervalsParser::localPeriod (const int n) const
-{
-    return nextContains(n) - previousContainsInclusive(n);
-}
-
-
-bool utils::parser::IntervalsParser::isActivated () const {return m_activated;}
+#include <string>
 
 
 utils::parser::BTDIntervalsParser::BTDIntervalsParser (
@@ -166,8 +26,8 @@ utils::parser::BTDIntervalsParser::BTDIntervalsParser (
     // in order of increasing Slice start value
     for(const auto& inslc : insplit)
     {
-        constexpr bool isBTD = true;
-        const SliceParser temp_slice(inslc, isBTD);
+        constexpr bool require_stop = true;
+        const SliceParser temp_slice(inslc, require_stop);
         if (!m_slices.empty())
         {
             // find the last index i_slice where

--- a/Source/Utils/Parser/Make.package
+++ b/Source/Utils/Parser/Make.package
@@ -1,4 +1,4 @@
-CEXE_sources += IntervalsParser.cpp
+CEXE_sources += BTDIntervalsParser.cpp
 CEXE_sources += ParserUtils.cpp
 
 VPATH_LOCATIONS   += $(WARPX_HOME)/Source/Utils/Parser

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -47,11 +47,11 @@
 #include "Parallelization/GuardCellManager.H"
 #include "Particles/ParticleThermalizer/ParticleThermalizer.H"
 #include "Utils/export.H"
-#include "Utils/Parser/IntervalsParser.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 
 #include <ablastr/fields/MultiFabRegister.H>
 #include <ablastr/utils/Enums.H>
+#include <ablastr/utils/text/IntervalsParser.H>
 
 #include <AMReX_BaseFwd.H>
 #include <AMReX_AmrCoreFwd.H>
@@ -329,7 +329,7 @@ public:
     static bool do_dynamic_scheduling;
     static bool refine_plasma;
 
-    static utils::parser::IntervalsParser sort_intervals;
+    static ablastr::utils::text::IntervalsParser sort_intervals;
     static amrex::IntVect sort_bin_size;
 
     //! If true, particles will be sorted in the order x -> y -> z -> ppc for faster deposition
@@ -541,7 +541,7 @@ public:
 
     /** \brief returns the load balance interval
      */
-    [[nodiscard]] utils::parser::IntervalsParser get_load_balance_intervals () const
+    [[nodiscard]] ablastr::utils::text::IntervalsParser get_load_balance_intervals () const
     {
         return load_balance_intervals;
     }
@@ -1170,7 +1170,8 @@ private:
     amrex::Vector<amrex::Real> t_new;
     amrex::Vector<amrex::Real> t_old;
     amrex::Vector<amrex::Real> dt;
-    utils::parser::IntervalsParser m_dt_update_interval = utils::parser::IntervalsParser{}; // How often to update the timestep when using adaptive timestepping
+    // How often to update the timestep when using adaptive timestepping
+    ablastr::utils::text::IntervalsParser m_dt_update_interval;
     std::string m_dt_update_diagnostic_file;
 
     bool m_safe_guard_cells = false;
@@ -1312,7 +1313,7 @@ private:
     // Load balancing
     /** Load balancing intervals that reads the "load_balance_intervals" string int the input file
      * for getting steps at which load balancing is performed */
-    utils::parser::IntervalsParser load_balance_intervals;
+    ablastr::utils::text::IntervalsParser load_balance_intervals;
     /** Collection of LayoutData to keep track of weights used in load balancing
      * routines. Contains timer-based or heuristic-based costs depending on input option */
     amrex::Vector<std::unique_ptr<amrex::LayoutData<amrex::Real> > > costs;
@@ -1345,7 +1346,7 @@ private:
     amrex::Real costs_heuristic_particles_wt = amrex::Real(0);
 
     // Determines timesteps for override sync
-    utils::parser::IntervalsParser override_sync_intervals;
+    ablastr::utils::text::IntervalsParser override_sync_intervals;
 
     // Other runtime parameters
     int verbose = 1;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -161,7 +161,7 @@ bool WarpX::use_filter_compensation = false;
 bool WarpX::serialize_initial_conditions = false;
 bool WarpX::refine_plasma     = false;
 
-utils::parser::IntervalsParser WarpX::sort_intervals;
+ablastr::utils::text::IntervalsParser WarpX::sort_intervals;
 amrex::IntVect WarpX::sort_bin_size(AMREX_D_DECL(1,1,1));
 
 bool WarpX::do_dynamic_scheduling = true;
@@ -686,7 +686,7 @@ WarpX::ReadParameters ()
         std::vector<std::string> override_sync_intervals_string_vec = {"1"};
         pp_warpx.queryarr("override_sync_intervals", override_sync_intervals_string_vec);
         override_sync_intervals =
-            utils::parser::IntervalsParser(override_sync_intervals_string_vec);
+            ablastr::utils::text::IntervalsParser(override_sync_intervals_string_vec);
 
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_do_subcycling != 1 || max_level <= 1,
                                          "Subcycling method 1 only works for 2 levels.");
@@ -800,7 +800,7 @@ WarpX::ReadParameters ()
         utils::parser::queryWithParser(pp_warpx, "max_omegac_dt", m_max_omegac_dt);
         std::vector<std::string> dt_interval_vec = {"-1"};
         pp_warpx.queryarr("dt_update_interval", dt_interval_vec);
-        m_dt_update_interval = utils::parser::IntervalsParser(dt_interval_vec);
+        m_dt_update_interval = ablastr::utils::text::IntervalsParser(dt_interval_vec);
         if (m_dt_update_interval.isActivated()) {
             pp_warpx.query("dt_update_diagnostic_file", m_dt_update_diagnostic_file);
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
@@ -1400,7 +1400,7 @@ WarpX::ReadParameters ()
         // Load balancing parameters
         std::vector<std::string> load_balance_intervals_string_vec = {"0"};
         pp_algo.queryarr("load_balance_intervals", load_balance_intervals_string_vec);
-        load_balance_intervals = utils::parser::IntervalsParser(
+        load_balance_intervals = ablastr::utils::text::IntervalsParser(
             load_balance_intervals_string_vec);
         pp_algo.query("load_balance_with_sfc", load_balance_with_sfc);
         // Knapsack factor only used with non-SFC strategy
@@ -1483,7 +1483,7 @@ WarpX::ReadParameters ()
 
         const amrex::ParmParse pp_warpx("warpx");
         pp_warpx.queryarr("sort_intervals", sort_intervals_string_vec);
-        sort_intervals = utils::parser::IntervalsParser(sort_intervals_string_vec);
+        sort_intervals = ablastr::utils::text::IntervalsParser(sort_intervals_string_vec);
 
         Vector<int> vect_sort_bin_size(AMREX_SPACEDIM,1);
         const bool sort_bin_size_is_specified =

--- a/Source/ablastr/utils/text/CMakeLists.txt
+++ b/Source/ablastr/utils/text/CMakeLists.txt
@@ -2,6 +2,7 @@ foreach(D IN LISTS WarpX_DIMS)
     warpx_set_suffix_dims(SD ${D})
     target_sources(ablastr_${SD}
       PRIVATE
+        IntervalsParser.cpp
         StreamUtils.cpp
         StringUtils.cpp
     )

--- a/Source/ablastr/utils/text/IntervalsParser.H
+++ b/Source/ablastr/utils/text/IntervalsParser.H
@@ -1,0 +1,175 @@
+/* Copyright 2022 The ABLASTR Community
+ *
+ * This file is part of ABLASTR.
+ *
+ * Authors: Neil Zaim, Luca Fedeli, Weiqun Zhang, Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+
+#ifndef ABLASTR_UTILS_TEXT_INTERVALSPARSER_H_
+#define ABLASTR_UTILS_TEXT_INTERVALSPARSER_H_
+
+#include <limits>
+#include <string>
+#include <vector>
+
+
+namespace ablastr::utils::text
+{
+
+    /**
+     * \brief This class is a parser for slices of the form i:j:k where i, j and k are integers
+     * representing respectively the starting point, the stopping point and the period.
+     */
+    class SliceParser
+    {
+    public:
+        /**
+        * \brief Constructor of the SliceParser class.
+        *
+        * @param[in] instr an input string of the form "i:j:k", "i:j" or "k" where i, j and k are
+        * integers representing respectively the starting point, the stopping point and the period.
+        * Any of these integers may be omitted in which case it will be equal to their default value
+        * (0 for the starting point, std::numeric_limits<int>::max() for the stopping point and 1 for
+        * the period). For example SliceParser(":1000:") is equivalent to SliceParser("0:1000:1").
+        * @param[in] require_stop whether the stopping point must be explicitly specified
+        * (e.g., for back-transformed diagnostics)
+        */
+        explicit SliceParser (const std::string& instr, bool require_stop=false);
+
+        /**
+        * \brief A method that returns true if the input integer is contained in the slice. (e.g. if
+        * the list is initialized with "300:500:100", this method returns true if and only if n is
+        * 300, 400 or 500). If the period is negative or 0, the function always returns false.
+        *
+        * @param[in] n the input integer
+        */
+        [[nodiscard]] bool contains (int n) const;
+
+        /**
+        * \brief A method that returns the smallest integer strictly greater than n such that
+        * contains(n) is true. Returns std::numeric_limits<int>::max() if there is no such integer.
+        *
+        * @param[in] n the input integer
+        */
+        [[nodiscard]] int nextContains (int n) const;
+
+        /**
+        * \brief A method that returns the greatest integer strictly smaller than n such that
+        * contains(n) is true. Returns 0 if there is no such integer.
+        *
+        * @param[in] n the input integer
+        */
+        [[nodiscard]] int previousContains (int n) const;
+
+        /**
+        * \brief A method that returns the slice period.
+        *
+        */
+        [[nodiscard]] int getPeriod () const;
+
+        /**
+        * \brief A method that returns the slice start.
+        *
+        */
+        [[nodiscard]] int getStart () const;
+
+        /**
+        * \brief A method that returns the slice stop.
+        *
+        */
+        [[nodiscard]] int getStop () const;
+
+        /**
+        * @brief A method that returns the number of integers contained by the slice.
+        *
+        */
+        [[nodiscard]] int numContained() const;
+
+    private:
+        bool m_require_stop = false;
+        int m_start = 0;
+        int m_stop = std::numeric_limits<int>::max();
+        int m_period = 1;
+        std::string m_separator = ":";
+
+    };
+
+
+    /**
+     * \brief This class is a parser for multiple slices of the form x,y,z,... where x, y and z are
+     * slices of the form i:j:k, as defined in the SliceParser class. This class contains a vector of
+     * SliceParsers.
+     */
+    class IntervalsParser
+    {
+    public:
+        /**
+        * \brief Default constructor of the IntervalsParser class.
+        */
+        IntervalsParser () = default;
+
+        /**
+        * \brief Constructor of the IntervalsParser class.
+        *
+        * @param[in] instr_vec an input vector string, which when concatenated is of the form
+        * "x,y,z,...". This will call the constructor of SliceParser using x, y and z as input
+        * arguments.
+        */
+        explicit IntervalsParser (const std::vector<std::string>& instr_vec);
+
+        /**
+        * \brief A method that returns true if the input integer is contained in any of the slices
+        * contained by the IntervalsParser.
+        *
+        * @param[in] n the input integer
+        */
+        [[nodiscard]] bool contains (int n) const;
+
+        /**
+        * \brief A method that returns the smallest integer strictly greater than n such that
+        * contains(n) is true. Returns std::numeric_limits<int>::max() if there is no such integer.
+        *
+        * @param[in] n the input integer
+        */
+        [[nodiscard]] int nextContains (int n) const;
+
+        /**
+        * \brief A method that returns the greatest integer strictly smaller than n such that
+        * contains(n) is true. Returns 0 if there is no such integer.
+        *
+        * @param[in] n the input integer
+        */
+        [[nodiscard]] int previousContains (int n) const;
+
+        /**
+        * \brief A method that returns the greatest integer smaller than or equal to n such that
+        * contains(n) is true. Returns 0 if there is no such integer.
+        *
+        * @param[in] n the input integer
+        */
+        [[nodiscard]] int previousContainsInclusive (int n) const;
+
+        /**
+        * \brief A method the local period (in timesteps) of the IntervalsParser at timestep n.
+        * The period is defined by nextContains(n) - previousContainsInclusive(n)
+        *
+        * @param[in] n the input integer
+        */
+        [[nodiscard]] int localPeriod (int n) const;
+
+        /**
+        * \brief A method that returns true if any of the slices contained by the IntervalsParser
+        * has a strictly positive period.
+        */
+        [[nodiscard]] bool isActivated () const;
+
+    private:
+        std::vector<SliceParser> m_slices;
+        std::string m_separator = ",";
+        bool m_activated = false;
+    };
+
+}
+
+#endif // ABLASTR_UTILS_TEXT_INTERVALSPARSER_H_

--- a/Source/ablastr/utils/text/IntervalsParser.cpp
+++ b/Source/ablastr/utils/text/IntervalsParser.cpp
@@ -1,0 +1,159 @@
+/* Copyright 2022 The ABLASTR Community
+ *
+ * This file is part of ABLASTR.
+ *
+ * Authors: Neil Zaim, Luca Fedeli, Weiqun Zhang, Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+
+#include "IntervalsParser.H"
+
+#include "ablastr/utils/TextMsg.H"
+#include "StringUtils.H"
+
+#include <AMReX_ParmParse.H>
+
+#include <algorithm>
+#include <cmath>
+
+
+namespace ablastr::utils::text
+{
+
+SliceParser::SliceParser (const std::string& instr, const bool require_stop):
+    m_require_stop{require_stop}
+{
+    const amrex::ParmParse pp;
+
+    // split string and trim whitespaces
+    auto insplit = split_string<std::vector<std::string>>(instr, m_separator, true);
+
+    if(insplit.size() == 1){ // no colon in input string. The input is the period.
+        ABLASTR_ALWAYS_ASSERT_WITH_MESSAGE(!m_require_stop,
+            "interval stop required but not specified in '" + instr + "'");
+        m_period = int(std::round(pp.eval<double>(insplit[0])));}
+    else if(insplit.size() == 2) // 1 colon in input string. The input is start:stop
+    {
+        ABLASTR_ALWAYS_ASSERT_WITH_MESSAGE(!m_require_stop || !insplit[1].empty(),
+            "interval stop required but not specified in '" + instr + "'");
+        if (!insplit[0].empty()){
+            m_start = int(std::round(pp.eval<double>(insplit[0])));}
+        if (!insplit[1].empty()){
+            m_stop = int(std::round(pp.eval<double>(insplit[1])));}
+    }
+    else // 2 colons in input string. The input is start:stop:period
+    {
+        ABLASTR_ALWAYS_ASSERT_WITH_MESSAGE(!m_require_stop || !insplit[1].empty(),
+            "interval stop required but not specified in '" + instr + "'");
+        ABLASTR_ALWAYS_ASSERT_WITH_MESSAGE(
+            insplit.size() == 3,
+            instr + "' is not a valid syntax for a slice.");
+        if (!insplit[0].empty()){
+            m_start = int(std::round(pp.eval<double>(insplit[0])));}
+        if (!insplit[1].empty()){
+            m_stop = int(std::round(pp.eval<double>(insplit[1])));}
+        if (!insplit[2].empty()){
+            m_period = int(std::round(pp.eval<double>(insplit[2])));}
+    }
+}
+
+
+bool SliceParser::contains (const int n) const
+{
+    if (m_period <= 0) {return false;}
+    return (n - m_start) % m_period == 0 && n >= m_start && n <= m_stop;
+}
+
+
+int SliceParser::nextContains (const int n) const
+{
+    if (m_period <= 0) {return std::numeric_limits<int>::max();}
+    int next = m_start;
+    if (n >= m_start) {next = ((n-m_start)/m_period + 1)*m_period+m_start;}
+    if (next > m_stop) {next = std::numeric_limits<int>::max();}
+    return next;
+}
+
+
+int SliceParser::previousContains (const int n) const
+{
+    if (m_period <= 0) {return 0;}
+    int previous = ((std::min(n-1,m_stop)-m_start)/m_period)*m_period+m_start;
+    if ((n < m_start) || (previous < 0)) {previous = 0;}
+    return previous;
+}
+
+
+int SliceParser::getPeriod () const {return m_period;}
+
+
+int SliceParser::getStart () const {return m_start;}
+
+
+int SliceParser::getStop () const {return m_stop;}
+
+
+int SliceParser::numContained () const {
+    return (m_stop - m_start) / m_period + 1;}
+
+
+IntervalsParser::IntervalsParser (const std::vector<std::string>& instr_vec)
+{
+    std::string inconcatenated;
+    for (const auto& instr_element : instr_vec) { inconcatenated +=instr_element; }
+
+    auto insplit = split_string<std::vector<std::string>>(inconcatenated, m_separator);
+
+    for(const auto& inslc : insplit)
+    {
+        const SliceParser temp_slice(inslc);
+        m_slices.push_back(temp_slice);
+        if ((temp_slice.getPeriod() > 0) &&
+               (temp_slice.getStop() >= temp_slice.getStart())) { m_activated = true; }
+    }
+}
+
+
+bool IntervalsParser::contains (const int n) const
+{
+    return std::any_of(m_slices.begin(), m_slices.end(),
+        [&](const auto& slice){return slice.contains(n);});
+}
+
+
+int IntervalsParser::nextContains (const int n) const
+{
+    int next = std::numeric_limits<int>::max();
+    for(const auto& slice: m_slices){
+        next = std::min(slice.nextContains(n),next);
+    }
+    return next;
+}
+
+
+int IntervalsParser::previousContains (const int n) const
+{
+    int previous = 0;
+    for(const auto& slice: m_slices){
+        previous = std::max(slice.previousContains(n),previous);
+    }
+    return previous;
+}
+
+
+int IntervalsParser::previousContainsInclusive (const int n) const
+{
+    if (contains(n)){return n;}
+    else {return previousContains(n);}
+}
+
+
+int IntervalsParser::localPeriod (const int n) const
+{
+    return nextContains(n) - previousContainsInclusive(n);
+}
+
+
+bool IntervalsParser::isActivated () const {return m_activated;}
+
+} // namespace ablastr::utils::text

--- a/Source/ablastr/utils/text/Make.package
+++ b/Source/ablastr/utils/text/Make.package
@@ -1,3 +1,4 @@
+CEXE_sources += IntervalsParser.cpp
 CEXE_sources += StreamUtils.cpp
 CEXE_sources += StringUtils.cpp
 


### PR DESCRIPTION
Move the `IntervalsParser` for time intervals to ABLASTR, so we can reuse it in other codes. I need it next in ImpactX :)