### PR TITLE
[WIP] Prototype: Runtime Dimensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,12 @@ math(EXPR list_last "${list_len} - 1")
 list(GET WarpX_DIMS ${list_last} WarpX_DIMS_LAST)
 warpx_set_suffix_dims(WarpX_DIMS_LAST ${WarpX_DIMS_LAST})
 
+# prototype of the runtime-dimensionality WarpX architecture:
+# one binary, built against AMReX 3D only, selecting 1D/2D/3D at runtime
+option(WarpX_RUNTIME_DIMS_PROTO
+    "Build the runtime-dimensionality prototype app (AMReX 3D)" OFF)
+mark_as_advanced(WarpX_RUNTIME_DIMS_PROTO)
+
 set(WarpX_PRECISION_VALUES SINGLE DOUBLE)
 set(WarpX_PRECISION DOUBLE CACHE STRING "Floating point precision (SINGLE/DOUBLE)")
 set_property(CACHE WarpX_PRECISION PROPERTY STRINGS ${WarpX_PRECISION_VALUES})
@@ -235,6 +241,10 @@ set(WarpX_amrex_dim ${WarpX_DIMS})  # RZ is AMReX 2D
 list(TRANSFORM WarpX_amrex_dim REPLACE RZ 2)
 list(TRANSFORM WarpX_amrex_dim REPLACE RCYLINDER 1)
 list(TRANSFORM WarpX_amrex_dim REPLACE RSPHERE 1)
+if(WarpX_RUNTIME_DIMS_PROTO)
+    # the runtime-dimensionality prototype is always built against AMReX 3D
+    list(APPEND WarpX_amrex_dim 3)
+endif()
 list(REMOVE_DUPLICATES WarpX_amrex_dim)
 
 include(${WarpX_SOURCE_DIR}/cmake/dependencies/AMReX.cmake)
@@ -510,6 +520,9 @@ if(WarpX_LIB)
 endif()
 if(WarpX_QED_TOOLS)
     add_subdirectory(Tools/QedTablesUtils)
+endif()
+if(WarpX_RUNTIME_DIMS_PROTO)
+    add_subdirectory(Tools/Prototypes/RuntimeDims)
 endif()
 
 # Interprocedural optimization (IPO) / Link-Time Optimization (LTO)

--- a/Docs/source/developers/dimensionality.rst
+++ b/Docs/source/developers/dimensionality.rst
@@ -66,3 +66,33 @@ Conventions
 
 In 2D, we assume that the position of a particle in ``y`` is equal to ``0``.
 In 1D, we assume that the position of a particle in ``x`` and ``y`` is equal to ``0``.
+
+Towards Runtime Dimensionality
+------------------------------
+
+WarpX is migrating towards a single binary that supports all dimensionalities,
+selected at runtime via the ``geometry.dims`` input parameter, built against
+AMReX compiled once with ``AMREX_SPACEDIM=3``.
+The transition infrastructure lives in ``Source/Utils/WarpXDim.H`` (the runtime
+``warpx::Dim`` enum, the ``warpx::CompileDim`` bridge from the macros above and
+constexpr traits like ``warpx::has_x``), ``Source/Utils/WarpXDimDispatch.H``
+(``warpx::dim_dispatch``, mapping the runtime dimensionality to a compile-time
+template argument like the existing particle-shape-order dispatch) and
+``Source/Utils/WarpXDimIndexing.H`` (``warpx::IdxMap``, replacing
+``WARPX_ZINDEX``, and ``warpx::field_at``).
+
+Kernels are converted from ``#if defined(WARPX_DIM_*)`` blocks to
+``template <warpx::Dim D>`` with ``if constexpr`` branches that default to
+``warpx::CompileDim``, so per-dimension builds compile unchanged and produce
+bit-identical results during the migration.
+
+In unified builds (``WARPX_DIM_RUNTIME``), fields of all dimensionalities are
+stored in degenerate-3D ``MultiFab`` s: collapsed dimensions have extent 1,
+``prob_lo/hi = [-0.5, 0.5)`` (unit cell size, matching the conventions of
+``WarpX::CellSize`` for absent dimensions), zero guard cells, cell-centered
+staggering and periodic boundaries; ``z`` is always at index 2 (1D uses
+``(1, 1, nz)``, 2D and RZ use ``(nx, 1, nz)``).
+Particle positions are always three SoA components; components of collapsed
+dimensions are 0 and are never updated by the pusher.
+See ``Tools/Prototypes/RuntimeDims/`` for the prototype application that runs
+1D, 2D and 3D simulations from one executable.

--- a/Source/AcceleratorLattice/AcceleratorLattice.H
+++ b/Source/AcceleratorLattice/AcceleratorLattice.H
@@ -12,6 +12,8 @@
 #include "LatticeElements/HardEdgedQuadrupole.H"
 #include "LatticeElements/HardEdgedPlasmaLens.H"
 
+#include <AMReX_LayoutData.H>
+
 #include <memory>
 #include <string>
 

--- a/Source/AcceleratorLattice/AcceleratorLattice.cpp
+++ b/Source/AcceleratorLattice/AcceleratorLattice.cpp
@@ -11,6 +11,8 @@
 #include "LatticeElements/Drift.H"
 #include "LatticeElements/HardEdgedQuadrupole.H"
 #include "LatticeElements/HardEdgedPlasmaLens.H"
+#include "Particles/WarpXParticleContainer.H"
+#include "Utils/TextMsg.H"
 
 #include <AMReX_REAL.H>
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H
@@ -10,6 +10,8 @@
 
 #include "FieldAccessorFunctors.H"
 #include "Utils/WarpXConst.H"
+#include "Utils/WarpXDim.H"
+#include "Utils/WarpXDimIndexing.H"
 
 #include <AMReX.H>
 #include <AMReX_Array4.H>
@@ -19,12 +21,14 @@
 #include <array>
 #include <cmath>
 
-
 /**
  * This struct contains only static functions to initialize the stencil coefficients
  * and to compute finite-difference derivatives for the Cartesian Yee algorithm.
+ *
+ * \tparam D dimensionality of the simulation
  */
-struct CartesianYeeAlgorithm {
+template <warpx::Dim D>
+struct CartesianYeeAlgorithmND {
 
     static void InitializeStencilCoefficients (
         std::array<amrex::Real,3>& cell_size,
@@ -44,14 +48,25 @@ struct CartesianYeeAlgorithm {
 
     /**
      * Compute the maximum timestep, for which the scheme remains stable
-     * (Courant-Friedrichs-Levy limit) */
+     * (Courant-Friedrichs-Levy limit)
+     *
+     * The sum extends over the axes present on the grid only, so that the
+     * unit cell sizes of collapsed dimensions in unified
+     * (runtime-dimensionality) builds do not perturb the timestep.
+     */
     static amrex::Real ComputeMaxDt ( amrex::Real const * const dx ) {
         using namespace amrex::literals;
-        amrex::Real const delta_t  = 1._rt / ( std::sqrt( AMREX_D_TERM(
-                                           1._rt / (dx[0]*dx[0]),
-                                         + 1._rt / (dx[1]*dx[1]),
-                                         + 1._rt / (dx[2]*dx[2])
-                                     ) ) * PhysConst::c );
+        amrex::Real inv_dx2_sum = 0._rt;
+        if constexpr (warpx::has_x<D>) {
+            inv_dx2_sum += 1._rt / (dx[warpx::IdxMap<D>::x]*dx[warpx::IdxMap<D>::x]);
+        }
+        if constexpr (warpx::has_y<D>) {
+            inv_dx2_sum += 1._rt / (dx[warpx::IdxMap<D>::y]*dx[warpx::IdxMap<D>::y]);
+        }
+        if constexpr (warpx::has_z<D>) {
+            inv_dx2_sum += 1._rt / (dx[warpx::IdxMap<D>::z]*dx[warpx::IdxMap<D>::z]);
+        }
+        amrex::Real const delta_t = 1._rt / ( std::sqrt( inv_dx2_sum ) * PhysConst::c );
         return delta_t;
     }
 
@@ -59,8 +74,77 @@ struct CartesianYeeAlgorithm {
      * \brief Returns maximum number of guard cells required by the field-solve
      */
     static amrex::IntVect GetMaxGuardCell () {
-        // The yee solver requires one guard cell in each dimension
-        return amrex::IntVect{AMREX_D_DECL(1,1,1)};
+        // The yee solver requires one guard cell along each axis present on the grid
+        amrex::IntVect ng(0);
+        if constexpr (warpx::has_x<D>) { ng[warpx::IdxMap<D>::x] = 1; }
+        if constexpr (warpx::has_y<D>) { ng[warpx::IdxMap<D>::y] = 1; }
+        if constexpr (warpx::has_z<D>) { ng[warpx::IdxMap<D>::z] = 1; }
+        return ng;
+    }
+
+    /**
+     * Perform an upward (cell-centered, from a nodal field `F`) first
+     * derivative along the array slot `slot` */
+    template <int slot, typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real UpwardD (
+        T_Field const& F,
+        amrex::Real const * const coefs,
+        int const i, int const j, int const k, int const ncomp ) {
+
+        using namespace amrex::literals;
+        static_assert(0 <= slot && slot <= 2);
+        amrex::Real const inv_d = coefs[0];
+        if constexpr (slot == 0) {
+            return inv_d*( F(i+1,j,k,ncomp) - F(i,j,k,ncomp) );
+        } else if constexpr (slot == 1) {
+            return inv_d*( F(i,j+1,k,ncomp) - F(i,j,k,ncomp) );
+        } else {
+            return inv_d*( F(i,j,k+1,ncomp) - F(i,j,k,ncomp) );
+        }
+    }
+
+    /**
+     * Perform a downward (nodal, from a cell-centered field `F`) first
+     * derivative along the array slot `slot` */
+    template <int slot, typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real DownwardD (
+        T_Field const& F,
+        amrex::Real const * const coefs,
+        int const i, int const j, int const k, int const ncomp ) {
+
+        using namespace amrex::literals;
+        static_assert(0 <= slot && slot <= 2);
+        amrex::Real const inv_d = coefs[0];
+        if constexpr (slot == 0) {
+            return inv_d*( F(i,j,k,ncomp) - F(i-1,j,k,ncomp) );
+        } else if constexpr (slot == 1) {
+            return inv_d*( F(i,j,k,ncomp) - F(i,j-1,k,ncomp) );
+        } else {
+            return inv_d*( F(i,j,k,ncomp) - F(i,j,k-1,ncomp) );
+        }
+    }
+
+    /**
+     * Perform a centered second derivative along the array slot `slot` */
+    template <int slot, typename T_Field>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real DD (
+        T_Field const& F,
+        amrex::Real const * const coefs,
+        int const i, int const j, int const k, int const ncomp ) {
+
+        using namespace amrex::literals;
+        static_assert(0 <= slot && slot <= 2);
+        amrex::Real const inv_d2 = coefs[0]*coefs[0];
+        if constexpr (slot == 0) {
+            return inv_d2*( F(i-1,j,k,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i+1,j,k,ncomp) );
+        } else if constexpr (slot == 1) {
+            return inv_d2*( F(i,j-1,k,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i,j+1,k,ncomp) );
+        } else {
+            return inv_d2*( F(i,j,k-1,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i,j,k+1,ncomp) );
+        }
     }
 
     /**
@@ -68,17 +152,17 @@ struct CartesianYeeAlgorithm {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static amrex::Real UpwardDx (
         amrex::Array4<amrex::Real const> const& F,
-        amrex::Real const * const coefs_x, int const /*n_coefs_x*/,
+        amrex::Real const * const coefs_x, int const n_coefs_x,
         int const i, int const j, int const k, int const ncomp=0 ) {
 
         using namespace amrex;
-#if (defined WARPX_DIM_1D_Z)
-        amrex::ignore_unused(F, coefs_x, i, j, k, ncomp);
-        return 0._rt; // 1D Cartesian: derivative along x is 0
-#else
-        amrex::Real const inv_dx = coefs_x[0];
-        return inv_dx*( F(i+1,j,k,ncomp) - F(i,j,k,ncomp) );
-#endif
+        amrex::ignore_unused(n_coefs_x);
+        if constexpr (warpx::has_x<D>) {
+            return UpwardD<warpx::IdxMap<D>::x>(F, coefs_x, i, j, k, ncomp);
+        } else {
+            amrex::ignore_unused(F, coefs_x, i, j, k, ncomp);
+            return 0._rt; // 1D Cartesian: derivative along x is 0
+        }
     }
 
     /**
@@ -87,17 +171,17 @@ struct CartesianYeeAlgorithm {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static amrex::Real DownwardDx (
         T_Field const& F,
-        amrex::Real const * const coefs_x, int const /*n_coefs_x*/,
+        amrex::Real const * const coefs_x, int const n_coefs_x,
         int const i, int const j, int const k, int const ncomp=0 ) {
 
         using namespace amrex;
-#if (defined WARPX_DIM_1D_Z)
-        amrex::ignore_unused(F, coefs_x, i, j, k, ncomp);
-        return 0._rt; // 1D Cartesian: derivative along x is 0
-#else
-        amrex::Real const inv_dx = coefs_x[0];
-        return inv_dx*( F(i,j,k,ncomp) - F(i-1,j,k,ncomp) );
-#endif
+        amrex::ignore_unused(n_coefs_x);
+        if constexpr (warpx::has_x<D>) {
+            return DownwardD<warpx::IdxMap<D>::x>(F, coefs_x, i, j, k, ncomp);
+        } else {
+            amrex::ignore_unused(F, coefs_x, i, j, k, ncomp);
+            return 0._rt; // 1D Cartesian: derivative along x is 0
+        }
     }
 
     /**
@@ -106,17 +190,17 @@ struct CartesianYeeAlgorithm {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static amrex::Real Dxx (
         T_Field const& F,
-        amrex::Real const * const coefs_x, int const /*n_coefs_x*/,
+        amrex::Real const * const coefs_x, int const n_coefs_x,
         int const i, int const j, int const k, int const ncomp=0 ) {
 
         using namespace amrex;
-#if (defined WARPX_DIM_1D_Z)
-        amrex::ignore_unused(F, coefs_x, i, j, k, ncomp);
-        return 0._rt; // 1D Cartesian: derivative along x is 0
-#else
-        amrex::Real const inv_dx2 = coefs_x[0]*coefs_x[0];
-        return inv_dx2*( F(i-1,j,k,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i+1,j,k,ncomp) );
-#endif
+        amrex::ignore_unused(n_coefs_x);
+        if constexpr (warpx::has_x<D>) {
+            return DD<warpx::IdxMap<D>::x>(F, coefs_x, i, j, k, ncomp);
+        } else {
+            amrex::ignore_unused(F, coefs_x, i, j, k, ncomp);
+            return 0._rt; // 1D Cartesian: derivative along x is 0
+        }
     }
 
     /**
@@ -128,18 +212,13 @@ struct CartesianYeeAlgorithm {
         int const i, int const j, int const k, int const ncomp=0 ) {
 
         using namespace amrex;
-#if defined WARPX_DIM_3D
-        Real const inv_dy = coefs_y[0];
         amrex::ignore_unused(n_coefs_y);
-        return inv_dy*( F(i,j+1,k,ncomp) - F(i,j,k,ncomp) );
-#elif (defined WARPX_DIM_XZ || WARPX_DIM_1D_Z)
-        amrex::ignore_unused(F, coefs_y, n_coefs_y,
-            i, j, k, ncomp);
-        return 0._rt; // 1D and 2D Cartesian: derivative along y is 0
-#else
-        amrex::ignore_unused(F, coefs_y, n_coefs_y,
-            i, j, k, ncomp);
-#endif
+        if constexpr (warpx::has_y<D>) {
+            return UpwardD<warpx::IdxMap<D>::y>(F, coefs_y, i, j, k, ncomp);
+        } else {
+            amrex::ignore_unused(F, coefs_y, i, j, k, ncomp);
+            return 0._rt; // 1D and 2D Cartesian: derivative along y is 0
+        }
     }
 
     /**
@@ -152,56 +231,50 @@ struct CartesianYeeAlgorithm {
         int const i, int const j, int const k, int const ncomp=0 ) {
 
         using namespace amrex;
-#if defined WARPX_DIM_3D
-        Real const inv_dy = coefs_y[0];
         amrex::ignore_unused(n_coefs_y);
-        return inv_dy*( F(i,j,k,ncomp) - F(i,j-1,k,ncomp) );
-#elif (defined WARPX_DIM_XZ || WARPX_DIM_1D_Z)
-        amrex::ignore_unused(F, coefs_y, n_coefs_y,
-            i, j, k, ncomp);
-        return 0._rt; // 1D and 2D Cartesian: derivative along y is 0
-#else
-        amrex::ignore_unused(F, coefs_y, n_coefs_y,
-            i, j, k, ncomp);
-#endif
+        if constexpr (warpx::has_y<D>) {
+            return DownwardD<warpx::IdxMap<D>::y>(F, coefs_y, i, j, k, ncomp);
+        } else {
+            amrex::ignore_unused(F, coefs_y, i, j, k, ncomp);
+            return 0._rt; // 1D and 2D Cartesian: derivative along y is 0
+        }
     }
 
     /**
-     * Perform derivative along y on a nodal grid, from a cell-centered field `F`*/
+     * Perform second derivative along y on a cell-centered grid, from a cell-centered field `F`*/
     template< typename T_Field>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static amrex::Real Dyy (
         T_Field const& F,
-        amrex::Real const * const coefs_y, int const /*n_coefs_y*/,
+        amrex::Real const * const coefs_y, int const n_coefs_y,
         int const i, int const j, int const k, int const ncomp=0 ) {
 
         using namespace amrex;
-#if defined WARPX_DIM_3D
-        Real const inv_dy2 = coefs_y[0]*coefs_y[0];
-        return inv_dy2*( F(i,j-1,k,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i,j+1,k,ncomp) );
-#elif (defined WARPX_DIM_XZ || WARPX_DIM_1D_Z)
-        amrex::ignore_unused(F, coefs_y, i, j, k, ncomp);
-        return 0._rt; // 1D and 2D Cartesian: derivative along y is 0
-#endif
+        amrex::ignore_unused(n_coefs_y);
+        if constexpr (warpx::has_y<D>) {
+            return DD<warpx::IdxMap<D>::y>(F, coefs_y, i, j, k, ncomp);
+        } else {
+            amrex::ignore_unused(F, coefs_y, i, j, k, ncomp);
+            return 0._rt; // 1D and 2D Cartesian: derivative along y is 0
+        }
     }
 
     /**
      * Perform derivative along z on a cell-centered grid, from a nodal field `F`*/
-   AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static amrex::Real UpwardDz (
         amrex::Array4<amrex::Real const> const& F,
-        amrex::Real const * const coefs_z, int const /*n_coefs_z*/,
+        amrex::Real const * const coefs_z, int const n_coefs_z,
         int const i, int const j, int const k, int const ncomp=0 ) {
 
         using namespace amrex;
-        Real const inv_dz = coefs_z[0];
-#if defined WARPX_DIM_3D
-        return inv_dz*( F(i,j,k+1,ncomp) - F(i,j,k,ncomp) );
-#elif (defined WARPX_DIM_XZ)
-        return inv_dz*( F(i,j+1,k,ncomp) - F(i,j,k,ncomp) );
-#elif (defined WARPX_DIM_1D_Z)
-        return inv_dz*( F(i+1,j,k,ncomp) - F(i,j,k,ncomp) );
-#endif
+        amrex::ignore_unused(n_coefs_z);
+        if constexpr (warpx::has_z<D>) {
+            return UpwardD<warpx::IdxMap<D>::z>(F, coefs_z, i, j, k, ncomp);
+        } else {
+            amrex::ignore_unused(F, coefs_z, i, j, k, ncomp);
+            return 0._rt; // 1D radial: derivative along z is 0
+        }
     }
 
     /**
@@ -210,18 +283,17 @@ struct CartesianYeeAlgorithm {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static amrex::Real DownwardDz (
         T_Field const& F,
-        amrex::Real const * const coefs_z, int const /*n_coefs_z*/,
+        amrex::Real const * const coefs_z, int const n_coefs_z,
         int const i, int const j, int const k, int const ncomp=0 ) {
 
         using namespace amrex;
-        Real const inv_dz = coefs_z[0];
-#if defined WARPX_DIM_3D
-        return inv_dz*( F(i,j,k,ncomp) - F(i,j,k-1,ncomp) );
-#elif (defined WARPX_DIM_XZ)
-        return inv_dz*( F(i,j,k,ncomp) - F(i,j-1,k,ncomp) );
-#elif (defined WARPX_DIM_1D_Z)
-        return inv_dz*( F(i,j,k,ncomp) - F(i-1,j,k,ncomp) );
-#endif
+        amrex::ignore_unused(n_coefs_z);
+        if constexpr (warpx::has_z<D>) {
+            return DownwardD<warpx::IdxMap<D>::z>(F, coefs_z, i, j, k, ncomp);
+        } else {
+            amrex::ignore_unused(F, coefs_z, i, j, k, ncomp);
+            return 0._rt; // 1D radial: derivative along z is 0
+        }
     }
 
     /**
@@ -230,20 +302,23 @@ struct CartesianYeeAlgorithm {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static amrex::Real Dzz (
         T_Field const& F,
-        amrex::Real const * const coefs_z, int const /*n_coefs_z*/,
+        amrex::Real const * const coefs_z, int const n_coefs_z,
         int const i, int const j, int const k, int const ncomp=0 ) {
 
         using namespace amrex;
-        Real const inv_dz2 = coefs_z[0]*coefs_z[0];
-#if defined WARPX_DIM_3D
-        return inv_dz2*( F(i,j,k-1,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i,j,k+1,ncomp) );
-#elif (defined WARPX_DIM_XZ)
-        return inv_dz2*( F(i,j-1,k,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i,j+1,k,ncomp) );
-#elif (defined WARPX_DIM_1D_Z)
-        return inv_dz2*( F(i-1,j,k,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i+1,j,k,ncomp) );
-#endif
+        amrex::ignore_unused(n_coefs_z);
+        if constexpr (warpx::has_z<D>) {
+            return DD<warpx::IdxMap<D>::z>(F, coefs_z, i, j, k, ncomp);
+        } else {
+            amrex::ignore_unused(F, coefs_z, i, j, k, ncomp);
+            return 0._rt; // 1D radial: derivative along z is 0
+        }
     }
 
 };
+
+/** In per-dimension builds, the unqualified name refers to the algorithm of
+ *  the compiled dimensionality, so that existing use sites stay unchanged. */
+using CartesianYeeAlgorithm = CartesianYeeAlgorithmND<warpx::CompileDim>;
 
 #endif // WARPX_FINITE_DIFFERENCE_ALGORITHM_CARTESIAN_YEE_H_

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -8,17 +8,19 @@
 #ifndef WARPX_CURRENTDEPOSITION_H_
 #define WARPX_CURRENTDEPOSITION_H_
 
-#include "Particles/Deposition/SharedDepositionUtils.H"
+#if !defined(WARPX_DIM_RUNTIME)
+#   include "Particles/Deposition/SharedDepositionUtils.H"
+#   include "Utils/ParticleUtils.H"
+#endif
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/Pusher/UpdatePosition.H"
 #include "Particles/ShapeFactors.H"
-#include "Utils/ParticleUtils.H"
 #include "Utils/TextMsg.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
-#ifdef WARPX_DIM_RZ
-#   include "Utils/WarpX_Complex.H"
-#endif
+#include "Utils/WarpXDim.H"
+#include "Utils/WarpXDimIndexing.H"
+#include "Utils/WarpX_Complex.H"
 
 #include <AMReX.H>
 #include <AMReX_Arena.H>
@@ -27,8 +29,115 @@
 #include <AMReX_REAL.H>
 
 /**
+ * \brief Shape factors and start indices along one logical axis, for the
+ *        deposition of one 3-component field (e.g., the current density)
+ *
+ * For an axis absent from the grid of the simulated dimensionality
+ * (active = false), the loop bound collapses to 0, weights to 1 and start
+ * indices to 0, so that the surrounding deposition loop nest degenerates to
+ * exactly the per-dimension loop nest of the corresponding compile-time
+ * dimensional code.
+ *
+ * \tparam depos_order deposition order
+ * \tparam active      whether this axis is present on the grid
+ */
+template <int depos_order, bool active>
+struct DepositAxisShape
+{
+    //! inclusive upper bound of the deposition loop along this axis
+    static constexpr int loop_max = active ? depos_order : 0;
+
+    //! shape factors along this axis of components 0, 1, 2, selected by their index type
+    amrex::Real s_j[3][active ? depos_order + 1 : 1] = {{amrex::Real(0.)}};
+    //! leftmost grid point indices along this axis of components 0, 1, 2
+    int i_j[3] = {0, 0, 0};
+
+    /** Compute the shape factors along this axis at position mid (in cell units)
+     *
+     * \param type_0,type_1,type_2 grid index types of the three field components
+     * \param slot                 array slot of this axis (e.g., warpx::IdxMap<D>::z)
+     * \param mid                  particle position along this axis, in cell units
+     */
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void compute ([[maybe_unused]] amrex::IntVect const& type_0,
+                  [[maybe_unused]] amrex::IntVect const& type_1,
+                  [[maybe_unused]] amrex::IntVect const& type_2,
+                  [[maybe_unused]] int const slot,
+                  [[maybe_unused]] double const mid)
+    {
+        if constexpr (active) {
+            using namespace amrex::literals;
+
+            constexpr int NODE = amrex::IndexType::NODE;
+            constexpr int CELL = amrex::IndexType::CELL;
+
+            const int t[3] = {type_0[slot], type_1[slot], type_2[slot]};
+
+            // Keep these double to avoid bug in single precision
+            double s_node[depos_order + 1] = {0.};
+            double s_cell[depos_order + 1] = {0.};
+            int i_node = 0;
+            int i_cell = 0;
+            Compute_shape_factor<depos_order> const compute_shape_factor;
+            if (t[0] == NODE || t[1] == NODE || t[2] == NODE) {
+                i_node = compute_shape_factor(s_node, mid);
+            }
+            if (t[0] == CELL || t[1] == CELL || t[2] == CELL) {
+                i_cell = compute_shape_factor(s_cell, mid - 0.5);
+            }
+            for (int c = 0; c < 3; ++c) {
+                for (int i = 0; i <= depos_order; ++i) {
+                    s_j[c][i] = ((t[c] == NODE) ? amrex::Real(s_node[i]) : amrex::Real(s_cell[i]));
+                }
+                i_j[c] = ((t[c] == NODE) ? i_node : i_cell);
+            }
+        }
+    }
+
+    //! shape factor of component c at loop index i; 1 for an absent axis
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    amrex::Real w ([[maybe_unused]] int const c, [[maybe_unused]] int const i) const
+    {
+        using namespace amrex::literals;
+        if constexpr (active) { return s_j[c][i]; } else { return 1._rt; }
+    }
+
+    //! leftmost grid point index of component c; 0 for an absent axis
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    int i0 ([[maybe_unused]] int const c) const
+    {
+        if constexpr (active) { return i_j[c]; } else { return 0; }
+    }
+};
+
+/**
+ * \brief Combine the per-axis shape factors of component c into one weight,
+ *        multiplying only the factors of axes present on the grid (in x, y, z
+ *        order, matching the per-dimension compile-time code)
+ */
+template <warpx::Dim D, typename T_AX, typename T_AY, typename T_AZ>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real combineShapeFactors (T_AX const& ax, T_AY const& ay, T_AZ const& az,
+                                 int const c, int const ix, int const iy, int const iz)
+{
+    if constexpr (!warpx::has_x<D>) {           // 1D (z)
+        amrex::ignore_unused(ax, ay, ix, iy);
+        return az.w(c, iz);
+    } else if constexpr (!warpx::has_z<D>) {    // 1D radial (r)
+        amrex::ignore_unused(ay, az, iy, iz);
+        return ax.w(c, ix);
+    } else if constexpr (!warpx::has_y<D>) {    // 2D (x/r, z)
+        amrex::ignore_unused(ay, iy);
+        return ax.w(c, ix)*az.w(c, iz);
+    } else {                                    // 3D (x, y, z)
+        return ax.w(c, ix)*ay.w(c, iy)*az.w(c, iz);
+    }
+}
+
+/**
  * \brief Kernel for the direct current deposition for thread thread_num
  * \tparam depos_order deposition order
+ * \tparam D           dimensionality of the simulation
  * \param xp, yp, zp    The particle positions.
  * \param wq            The charge of the macroparticle
  * \param vx,vy,vz      The particle velocities
@@ -44,7 +153,7 @@
  * \param lo            Index lower bounds of domain.
  * \param n_rz_azimuthal_modes Number of azimuthal modes when using RZ geometry.
  */
-template <int depos_order>
+template <int depos_order, warpx::Dim D = warpx::CompileDim>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void doDepositionShapeNKernel([[maybe_unused]] const amrex::ParticleReal xp,
                               [[maybe_unused]] const amrex::ParticleReal yp,
@@ -68,209 +177,103 @@ void doDepositionShapeNKernel([[maybe_unused]] const amrex::ParticleReal xp,
 {
     using namespace amrex::literals;
 
-    constexpr int NODE = amrex::IndexType::NODE;
-    constexpr int CELL = amrex::IndexType::CELL;
+    static_assert(D != warpx::Dim::Runtime,
+        "doDepositionShapeNKernel requires an explicit dimensionality");
 
     // wqx, wqy wqz are particle current in each direction
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-    // In RZ and RCYLINDER, wqx is actually wqr, and wqy is wqtheta
-    // Convert to cylindrical at the mid point
-    const amrex::Real xpmid = xp + relative_time*vx;
-    const amrex::Real ypmid = yp + relative_time*vy;
-    const amrex::Real rpmid = std::sqrt(xpmid*xpmid + ypmid*ypmid);
-    const amrex::Real costheta = (rpmid > 0._rt ? xpmid/rpmid : 1._rt);
-    const amrex::Real sintheta = (rpmid > 0._rt ? ypmid/rpmid : 0._rt);
-    const amrex::Real wqx = wq*invvol*(+vx*costheta + vy*sintheta);
-    const amrex::Real wqy = wq*invvol*(-vx*sintheta + vy*costheta);
-    const amrex::Real wqz = wq*invvol*vz;
-    #if defined(WARPX_DIM_RZ)
-    const Complex xy0 = Complex{costheta, sintheta};
-    #endif
-#elif defined(WARPX_DIM_RSPHERE)
-    // Convert to cylindrical at the mid point
-    const amrex::Real xpmid = xp + relative_time*vx;
-    const amrex::Real ypmid = yp + relative_time*vy;
-    const amrex::Real zpmid = zp + relative_time*vz;
-    const amrex::Real rpxymid = std::sqrt(xpmid*xpmid + ypmid*ypmid);
-    const amrex::Real rpmid = std::sqrt(xpmid*xpmid + ypmid*ypmid + zpmid*zpmid);
-    const amrex::Real costheta = (rpxymid > 0._rt ? xpmid/rpxymid : 1._rt);
-    const amrex::Real sintheta = (rpxymid > 0._rt ? ypmid/rpxymid : 0._rt);
-    const amrex::Real cosphi = (rpmid > 0._rt ? rpxymid/rpmid : 1._rt);
-    const amrex::Real sinphi = (rpmid > 0._rt ? zpmid/rpmid : 0._rt);
-    // convert from Cartesian to spherical
-    const amrex::Real wqx = wq*invvol*(+vx*costheta*cosphi + vy*sintheta*cosphi + vz*sinphi);
-    const amrex::Real wqy = wq*invvol*(-vx*sintheta + vy*costheta);
-    const amrex::Real wqz = wq*invvol*(-vx*costheta*sinphi - vy*sintheta*sinphi + vz*cosphi);
-#else
-    const amrex::Real wqx = wq*invvol*vx;
-    const amrex::Real wqy = wq*invvol*vy;
-    const amrex::Real wqz = wq*invvol*vz;
-#endif
-
-    // --- Compute shape factors
-    Compute_shape_factor< depos_order > const compute_shape_factor;
-#if !defined(WARPX_DIM_1D_Z)
-    // x direction
-    // Get particle position after 1/2 push back in position
-    // Keep these double to avoid bug in single precision
-
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
-    const double xmid = (rpmid - xyzmin.x)*dinv.x;
-#else
-    const double xmid = ((xp - xyzmin.x) + relative_time*vx)*dinv.x;
-#endif
-
-    // j_j[xyz] leftmost grid point in x that the particle touches for the centering of each current
-    // sx_j[xyz] shape factor along x for the centering of each current
-    // There are only two possible centerings, node or cell centered, so at most only two shape factor
-    // arrays will be needed.
-    // Keep these double to avoid bug in single precision
-    double sx_node[depos_order + 1] = {0.};
-    double sx_cell[depos_order + 1] = {0.};
-    int j_node = 0;
-    int j_cell = 0;
-    if (jx_type[0] == NODE || jy_type[0] == NODE || jz_type[0] == NODE) {
-        j_node = compute_shape_factor(sx_node, xmid);
-    }
-    if (jx_type[0] == CELL || jy_type[0] == CELL || jz_type[0] == CELL) {
-        j_cell = compute_shape_factor(sx_cell, xmid - 0.5);
+    [[maybe_unused]] amrex::Real costheta = 1._rt;
+    [[maybe_unused]] amrex::Real sintheta = 0._rt;
+    [[maybe_unused]] amrex::Real rpmid = 0._rt;
+    amrex::Real wqx, wqy, wqz;
+    if constexpr (D == warpx::Dim::RZ || D == warpx::Dim::RCylinder) {
+        // In RZ and RCYLINDER, wqx is actually wqr, and wqy is wqtheta
+        // Convert to cylindrical at the mid point
+        const amrex::Real xpmid = xp + relative_time*vx;
+        const amrex::Real ypmid = yp + relative_time*vy;
+        rpmid = std::sqrt(xpmid*xpmid + ypmid*ypmid);
+        costheta = (rpmid > 0._rt ? xpmid/rpmid : 1._rt);
+        sintheta = (rpmid > 0._rt ? ypmid/rpmid : 0._rt);
+        wqx = wq*invvol*(+vx*costheta + vy*sintheta);
+        wqy = wq*invvol*(-vx*sintheta + vy*costheta);
+        wqz = wq*invvol*vz;
+    } else if constexpr (D == warpx::Dim::RSphere) {
+        // Convert to cylindrical at the mid point
+        const amrex::Real xpmid = xp + relative_time*vx;
+        const amrex::Real ypmid = yp + relative_time*vy;
+        const amrex::Real zpmid = zp + relative_time*vz;
+        const amrex::Real rpxymid = std::sqrt(xpmid*xpmid + ypmid*ypmid);
+        rpmid = std::sqrt(xpmid*xpmid + ypmid*ypmid + zpmid*zpmid);
+        costheta = (rpxymid > 0._rt ? xpmid/rpxymid : 1._rt);
+        sintheta = (rpxymid > 0._rt ? ypmid/rpxymid : 0._rt);
+        const amrex::Real cosphi = (rpmid > 0._rt ? rpxymid/rpmid : 1._rt);
+        const amrex::Real sinphi = (rpmid > 0._rt ? zpmid/rpmid : 0._rt);
+        // convert from Cartesian to spherical
+        wqx = wq*invvol*(+vx*costheta*cosphi + vy*sintheta*cosphi + vz*sinphi);
+        wqy = wq*invvol*(-vx*sintheta + vy*costheta);
+        wqz = wq*invvol*(-vx*costheta*sinphi - vy*sintheta*sinphi + vz*cosphi);
+    } else {
+        wqx = wq*invvol*vx;
+        wqy = wq*invvol*vy;
+        wqz = wq*invvol*vz;
     }
 
-    amrex::Real sx_jx[depos_order + 1] = {0._rt};
-    amrex::Real sx_jy[depos_order + 1] = {0._rt};
-    amrex::Real sx_jz[depos_order + 1] = {0._rt};
-    for (int ix=0; ix<=depos_order; ix++)
-    {
-        sx_jx[ix] = ((jx_type[0] == NODE) ? amrex::Real(sx_node[ix]) : amrex::Real(sx_cell[ix]));
-        sx_jy[ix] = ((jy_type[0] == NODE) ? amrex::Real(sx_node[ix]) : amrex::Real(sx_cell[ix]));
-        sx_jz[ix] = ((jz_type[0] == NODE) ? amrex::Real(sx_node[ix]) : amrex::Real(sx_cell[ix]));
+    // --- Compute shape factors along each axis present on the grid
+    // Keep the particle positions in cell units double to avoid bug in single precision
+    DepositAxisShape<depos_order, warpx::has_x<D>> ax;
+    DepositAxisShape<depos_order, warpx::has_y<D>> ay;
+    DepositAxisShape<depos_order, warpx::has_z<D>> az;
+    if constexpr (warpx::has_x<D>) {
+        // x (or r) direction: get particle position after 1/2 push back in position
+        double xmid;
+        if constexpr (warpx::is_radial<D>) {
+            xmid = (rpmid - xyzmin.x)*dinv.x;
+        } else {
+            xmid = ((xp - xyzmin.x) + relative_time*vx)*dinv.x;
+        }
+        ax.compute(jx_type, jy_type, jz_type, warpx::IdxMap<D>::x, xmid);
+    }
+    if constexpr (warpx::has_y<D>) {
+        const double ymid = ((yp - xyzmin.y) + relative_time*vy)*dinv.y;
+        ay.compute(jx_type, jy_type, jz_type, warpx::IdxMap<D>::y, ymid);
+    }
+    if constexpr (warpx::has_z<D>) {
+        const double zmid = ((zp - xyzmin.z) + relative_time*vz)*dinv.z;
+        az.compute(jx_type, jy_type, jz_type, warpx::IdxMap<D>::z, zmid);
     }
 
-    int const j_jx = ((jx_type[0] == NODE) ? j_node : j_cell);
-    int const j_jy = ((jy_type[0] == NODE) ? j_node : j_cell);
-    int const j_jz = ((jz_type[0] == NODE) ? j_node : j_cell);
-#endif //!defined(WARPX_DIM_1D_Z)
-
-#if defined(WARPX_DIM_3D)
-    // y direction
-    // Keep these double to avoid bug in single precision
-    const double ymid = ((yp - xyzmin.y) + relative_time*vy)*dinv.y;
-    double sy_node[depos_order + 1] = {0.};
-    double sy_cell[depos_order + 1] = {0.};
-    int k_node = 0;
-    int k_cell = 0;
-    if (jx_type[1] == NODE || jy_type[1] == NODE || jz_type[1] == NODE) {
-        k_node = compute_shape_factor(sy_node, ymid);
-    }
-    if (jx_type[1] == CELL || jy_type[1] == CELL || jz_type[1] == CELL) {
-        k_cell = compute_shape_factor(sy_cell, ymid - 0.5);
-    }
-    amrex::Real sy_jx[depos_order + 1] = {0._rt};
-    amrex::Real sy_jy[depos_order + 1] = {0._rt};
-    amrex::Real sy_jz[depos_order + 1] = {0._rt};
-    for (int iy=0; iy<=depos_order; iy++)
-    {
-        sy_jx[iy] = ((jx_type[1] == NODE) ? amrex::Real(sy_node[iy]) : amrex::Real(sy_cell[iy]));
-        sy_jy[iy] = ((jy_type[1] == NODE) ? amrex::Real(sy_node[iy]) : amrex::Real(sy_cell[iy]));
-        sy_jz[iy] = ((jz_type[1] == NODE) ? amrex::Real(sy_node[iy]) : amrex::Real(sy_cell[iy]));
-    }
-    int const k_jx = ((jx_type[1] == NODE) ? k_node : k_cell);
-    int const k_jy = ((jy_type[1] == NODE) ? k_node : k_cell);
-    int const k_jz = ((jz_type[1] == NODE) ? k_node : k_cell);
-#endif
-
-#if !defined(WARPX_DIM_RCYLINDER) && !defined(WARPX_DIM_RSPHERE)
-    // z direction
-    // Keep these double to avoid bug in single precision
-    constexpr int zdir = WARPX_ZINDEX;
-    const double zmid = ((zp - xyzmin.z) + relative_time*vz)*dinv.z;
-    double sz_node[depos_order + 1] = {0.};
-    double sz_cell[depos_order + 1] = {0.};
-    int l_node = 0;
-    int l_cell = 0;
-    if (jx_type[zdir] == NODE || jy_type[zdir] == NODE || jz_type[zdir] == NODE) {
-        l_node = compute_shape_factor(sz_node, zmid);
-    }
-    if (jx_type[zdir] == CELL || jy_type[zdir] == CELL || jz_type[zdir] == CELL) {
-        l_cell = compute_shape_factor(sz_cell, zmid - 0.5);
-    }
-    amrex::Real sz_jx[depos_order + 1] = {0._rt};
-    amrex::Real sz_jy[depos_order + 1] = {0._rt};
-    amrex::Real sz_jz[depos_order + 1] = {0._rt};
-    for (int iz=0; iz<=depos_order; iz++)
-    {
-        sz_jx[iz] = ((jx_type[zdir] == NODE) ? amrex::Real(sz_node[iz]) : amrex::Real(sz_cell[iz]));
-        sz_jy[iz] = ((jy_type[zdir] == NODE) ? amrex::Real(sz_node[iz]) : amrex::Real(sz_cell[iz]));
-        sz_jz[iz] = ((jz_type[zdir] == NODE) ? amrex::Real(sz_node[iz]) : amrex::Real(sz_cell[iz]));
-    }
-    int const l_jx = ((jx_type[zdir] == NODE) ? l_node : l_cell);
-    int const l_jy = ((jy_type[zdir] == NODE) ? l_node : l_cell);
-    int const l_jz = ((jz_type[zdir] == NODE) ? l_node : l_cell);
-#endif
+    // index lower bounds of the tile in logical (x, y, z) space
+    const amrex::Dim3 llo = warpx::logical_lo<D>(lo);
 
     // Deposit current into jx_arr, jy_arr and jz_arr
-#if defined(WARPX_DIM_1D_Z)
-    for (int iz=0; iz<=depos_order; iz++){
-        amrex::Gpu::Atomic::AddNoRet(
-            &jx_arr(lo.x+l_jx+iz, 0, 0, 0),
-            sz_jx[iz]*wqx);
-        amrex::Gpu::Atomic::AddNoRet(
-            &jy_arr(lo.x+l_jy+iz, 0, 0, 0),
-            sz_jy[iz]*wqy);
-        amrex::Gpu::Atomic::AddNoRet(
-            &jz_arr(lo.x+l_jz+iz, 0, 0, 0),
-            sz_jz[iz]*wqz);
-    }
-#elif defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
-    for (int ix=0; ix<=depos_order; ix++){
-        amrex::Gpu::Atomic::AddNoRet( &jx_arr(lo.x+j_jx+ix, 0, 0, 0), sx_jx[ix]*wqx);
-        amrex::Gpu::Atomic::AddNoRet( &jy_arr(lo.x+j_jy+ix, 0, 0, 0), sx_jy[ix]*wqy);
-        amrex::Gpu::Atomic::AddNoRet( &jz_arr(lo.x+j_jz+ix, 0, 0, 0), sx_jz[ix]*wqz);
-    }
-#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-    for (int iz=0; iz<=depos_order; iz++){
-        for (int ix=0; ix<=depos_order; ix++){
-            amrex::Gpu::Atomic::AddNoRet(
-                &jx_arr(lo.x+j_jx+ix, lo.y+l_jx+iz, 0, 0),
-                sx_jx[ix]*sz_jx[iz]*wqx);
-            amrex::Gpu::Atomic::AddNoRet(
-                &jy_arr(lo.x+j_jy+ix, lo.y+l_jy+iz, 0, 0),
-                sx_jy[ix]*sz_jy[iz]*wqy);
-            amrex::Gpu::Atomic::AddNoRet(
-                &jz_arr(lo.x+j_jz+ix, lo.y+l_jz+iz, 0, 0),
-                sx_jz[ix]*sz_jz[iz]*wqz);
-#if defined(WARPX_DIM_RZ)
-            Complex xy = xy0; // Note that xy is equal to e^{i m theta}
-            for (int imode=1 ; imode < n_rz_azimuthal_modes ; imode++) {
-                // The factor 2 on the weighting comes from the normalization of the modes
-                amrex::Gpu::Atomic::AddNoRet( &jx_arr(lo.x+j_jx+ix, lo.y+l_jx+iz, 0, 2*imode-1), 2._rt*sx_jx[ix]*sz_jx[iz]*wqx*xy.real());
-                amrex::Gpu::Atomic::AddNoRet( &jx_arr(lo.x+j_jx+ix, lo.y+l_jx+iz, 0, 2*imode  ), 2._rt*sx_jx[ix]*sz_jx[iz]*wqx*xy.imag());
-                amrex::Gpu::Atomic::AddNoRet( &jy_arr(lo.x+j_jy+ix, lo.y+l_jy+iz, 0, 2*imode-1), 2._rt*sx_jy[ix]*sz_jy[iz]*wqy*xy.real());
-                amrex::Gpu::Atomic::AddNoRet( &jy_arr(lo.x+j_jy+ix, lo.y+l_jy+iz, 0, 2*imode  ), 2._rt*sx_jy[ix]*sz_jy[iz]*wqy*xy.imag());
-                amrex::Gpu::Atomic::AddNoRet( &jz_arr(lo.x+j_jz+ix, lo.y+l_jz+iz, 0, 2*imode-1), 2._rt*sx_jz[ix]*sz_jz[iz]*wqz*xy.real());
-                amrex::Gpu::Atomic::AddNoRet( &jz_arr(lo.x+j_jz+ix, lo.y+l_jz+iz, 0, 2*imode  ), 2._rt*sx_jz[ix]*sz_jz[iz]*wqz*xy.imag());
-                xy = xy*xy0;
-            }
-#endif
-        }
-    }
-#elif defined(WARPX_DIM_3D)
-    for (int iz=0; iz<=depos_order; iz++){
-        for (int iy=0; iy<=depos_order; iy++){
-            for (int ix=0; ix<=depos_order; ix++){
+    for (int iz=0; iz<=az.loop_max; iz++){
+        for (int iy=0; iy<=ay.loop_max; iy++){
+            for (int ix=0; ix<=ax.loop_max; ix++){
                 amrex::Gpu::Atomic::AddNoRet(
-                    &jx_arr(lo.x+j_jx+ix, lo.y+k_jx+iy, lo.z+l_jx+iz),
-                    sx_jx[ix]*sy_jx[iy]*sz_jx[iz]*wqx);
+                    &warpx::field_at<D>(jx_arr, llo.x+ax.i0(0)+ix, llo.y+ay.i0(0)+iy, llo.z+az.i0(0)+iz),
+                    combineShapeFactors<D>(ax, ay, az, 0, ix, iy, iz)*wqx);
                 amrex::Gpu::Atomic::AddNoRet(
-                    &jy_arr(lo.x+j_jy+ix, lo.y+k_jy+iy, lo.z+l_jy+iz),
-                    sx_jy[ix]*sy_jy[iy]*sz_jy[iz]*wqy);
+                    &warpx::field_at<D>(jy_arr, llo.x+ax.i0(1)+ix, llo.y+ay.i0(1)+iy, llo.z+az.i0(1)+iz),
+                    combineShapeFactors<D>(ax, ay, az, 1, ix, iy, iz)*wqy);
                 amrex::Gpu::Atomic::AddNoRet(
-                    &jz_arr(lo.x+j_jz+ix, lo.y+k_jz+iy, lo.z+l_jz+iz),
-                    sx_jz[ix]*sy_jz[iy]*sz_jz[iz]*wqz);
+                    &warpx::field_at<D>(jz_arr, llo.x+ax.i0(2)+ix, llo.y+ay.i0(2)+iy, llo.z+az.i0(2)+iz),
+                    combineShapeFactors<D>(ax, ay, az, 2, ix, iy, iz)*wqz);
+                if constexpr (D == warpx::Dim::RZ) {
+                    const Complex xy0 = Complex{costheta, sintheta};
+                    Complex xy = xy0; // Note that xy is equal to e^{i m theta}
+                    for (int imode=1 ; imode < n_rz_azimuthal_modes ; imode++) {
+                        // The factor 2 on the weighting comes from the normalization of the modes
+                        amrex::Gpu::Atomic::AddNoRet( &warpx::field_at<D>(jx_arr, llo.x+ax.i0(0)+ix, llo.y+ay.i0(0)+iy, llo.z+az.i0(0)+iz, 2*imode-1), 2._rt*ax.w(0, ix)*az.w(0, iz)*wqx*xy.real());
+                        amrex::Gpu::Atomic::AddNoRet( &warpx::field_at<D>(jx_arr, llo.x+ax.i0(0)+ix, llo.y+ay.i0(0)+iy, llo.z+az.i0(0)+iz, 2*imode  ), 2._rt*ax.w(0, ix)*az.w(0, iz)*wqx*xy.imag());
+                        amrex::Gpu::Atomic::AddNoRet( &warpx::field_at<D>(jy_arr, llo.x+ax.i0(1)+ix, llo.y+ay.i0(1)+iy, llo.z+az.i0(1)+iz, 2*imode-1), 2._rt*ax.w(1, ix)*az.w(1, iz)*wqy*xy.real());
+                        amrex::Gpu::Atomic::AddNoRet( &warpx::field_at<D>(jy_arr, llo.x+ax.i0(1)+ix, llo.y+ay.i0(1)+iy, llo.z+az.i0(1)+iz, 2*imode  ), 2._rt*ax.w(1, ix)*az.w(1, iz)*wqy*xy.imag());
+                        amrex::Gpu::Atomic::AddNoRet( &warpx::field_at<D>(jz_arr, llo.x+ax.i0(2)+ix, llo.y+ay.i0(2)+iy, llo.z+az.i0(2)+iz, 2*imode-1), 2._rt*ax.w(2, ix)*az.w(2, iz)*wqz*xy.real());
+                        amrex::Gpu::Atomic::AddNoRet( &warpx::field_at<D>(jz_arr, llo.x+ax.i0(2)+ix, llo.y+ay.i0(2)+iy, llo.z+az.i0(2)+iz, 2*imode  ), 2._rt*ax.w(2, ix)*az.w(2, iz)*wqz*xy.imag());
+                        xy = xy*xy0;
+                    }
+                }
             }
         }
     }
-#endif
 }
 
 /**
@@ -295,8 +298,8 @@ void doDepositionShapeNKernel([[maybe_unused]] const amrex::ParticleReal xp,
  * \param q            species charge.
  * \param n_rz_azimuthal_modes Number of azimuthal modes when using RZ geometry.
  */
-template <int depos_order>
-void doDepositionShapeN (const GetParticlePosition<PIdx>& GetPosition,
+template <int depos_order, warpx::Dim D = warpx::CompileDim>
+void doDepositionShapeN (const GetParticlePosition<PIdx, D>& GetPosition,
                          const amrex::ParticleReal * const wp,
                          const amrex::ParticleReal * const uxp,
                          const amrex::ParticleReal * const uyp,
@@ -350,14 +353,19 @@ void doDepositionShapeN (const GetParticlePosition<PIdx>& GetPosition,
                 wq *= ion_lev[ip];
             }
 
-            doDepositionShapeNKernel<depos_order>(xp, yp, zp, wq, vx, vy, vz, jx_arr, jy_arr, jz_arr,
-                                                  jx_type, jy_type, jz_type,
-                                                  relative_time, dinv, xyzmin,
-                                                  invvol, lo, n_rz_azimuthal_modes);
+            doDepositionShapeNKernel<depos_order, D>(xp, yp, zp, wq, vx, vy, vz, jx_arr, jy_arr, jz_arr,
+                                                     jx_type, jy_type, jz_type,
+                                                     relative_time, dinv, xyzmin,
+                                                     invvol, lo, n_rz_azimuthal_modes);
 
         }
     );
 }
+
+// Transition to runtime dimensionality: the deposition kernels below still
+// use compile-time WARPX_DIM_* branches; they are converted in later
+// migration steps and are not yet available in unified builds.
+#if !defined(WARPX_DIM_RUNTIME)
 
 /**
  * \brief Direct current deposition for thread thread_num for the implicit scheme
@@ -2670,4 +2678,6 @@ void doVayDepositionShapeN (const GetParticlePosition<PIdx>& GetPosition,
 
 #endif // #if !(defined WARPX_DIM_RZ || defined WARPX_DIM_1D_Z)
 }
+#endif // !defined(WARPX_DIM_RUNTIME)
+
 #endif // WARPX_CURRENTDEPOSITION_H_

--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -8,13 +8,21 @@
 #ifndef WARPX_FIELDGATHER_H_
 #define WARPX_FIELDGATHER_H_
 
-#include "Particles/Gather/GetExternalFields.H"
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/ShapeFactors.H"
+#include "Utils/WarpXDim.H"
+#include "Utils/WarpXDimIndexing.H"
 #include "Utils/WarpX_Complex.H"
-#include "Utils/ParticleUtils.H"
+#if !defined(WARPX_DIM_RUNTIME)
+#   include "Utils/ParticleUtils.H"
+#endif
 
 #include <AMReX.H>
+
+// Transition to runtime dimensionality: the gather kernels below still use
+// compile-time WARPX_DIM_* branches; they are converted in later migration
+// steps and are not yet available in unified builds.
+#if !defined(WARPX_DIM_RUNTIME)
 
 /**
  * \brief Gather vector field F for a single particle
@@ -327,12 +335,173 @@ void doDirectGatherVectorField (
 #endif
 }
 
+#endif // !defined(WARPX_DIM_RUNTIME)
+
+/**
+ * \brief Shape factors and start indices along one logical axis, for the
+ *        gather of the six electromagnetic field components
+ *
+ * With Galerkin (energy-conserving) interpolation, the parallel electric
+ * field component and the perpendicular magnetic field components use a
+ * shape function reduced by one order along this axis. Components are
+ * numbered 0..5 = Ex, Ey, Ez, Bx, By, Bz (or their radial counterparts).
+ *
+ * For an axis absent from the grid of the simulated dimensionality
+ * (active = false), the loop bound collapses to 0, weights to 1 and start
+ * indices to 0, so that the surrounding gather loop nest degenerates to
+ * exactly the per-dimension loop nest of the corresponding compile-time
+ * dimensional code.
+ *
+ * \tparam depos_order            particle shape order
+ * \tparam galerkin_interpolation lower the order by this value (0/1) for the
+ *                                order-reduced components
+ * \tparam axis                   logical axis index (0=x, 1=y, 2=z)
+ * \tparam active                 whether this axis is present on the grid
+ */
+template <int depos_order, int galerkin_interpolation, int axis, bool active>
+struct GatherAxisShape
+{
+    //! which components use the order-reduced shape along this axis:
+    //! the parallel E component and the perpendicular B components
+    static constexpr bool s_reduced[6] = {
+        axis == 0, axis == 1, axis == 2,    // Ex, Ey, Ez
+        axis != 0, axis != 1, axis != 2     // Bx, By, Bz
+    };
+
+    //! inclusive upper bound of the gather loop of component c along this axis
+    static constexpr int loop_max (int const c)
+    {
+        return active ? (s_reduced[c] ? depos_order - galerkin_interpolation : depos_order) : 0;
+    }
+
+    amrex::Real m_s_node[active ? depos_order + 1 : 1] = {amrex::Real(0.)};
+    amrex::Real m_s_cell[active ? depos_order + 1 : 1] = {amrex::Real(0.)};
+    amrex::Real m_s_node_red[active ? depos_order + 1 - galerkin_interpolation : 1] = {amrex::Real(0.)};
+    amrex::Real m_s_cell_red[active ? depos_order + 1 - galerkin_interpolation : 1] = {amrex::Real(0.)};
+
+    //! per-component shape factors (pointing to one of the arrays above) and
+    //! leftmost grid point indices along this axis
+    const amrex::Real* m_s[6] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+    int m_i0[6] = {0, 0, 0, 0, 0, 0};
+
+    /** Compute the shape factors along this axis at position pos (in cell units)
+     *
+     * \param types grid index types of the components Ex, Ey, Ez, Bx, By, Bz
+     * \param slot  array slot of this axis (e.g., warpx::IdxMap<D>::z)
+     * \param pos   particle position along this axis, in cell units
+     */
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void compute ([[maybe_unused]] amrex::IndexType const* types,
+                  [[maybe_unused]] int const slot,
+                  [[maybe_unused]] amrex::Real const pos)
+    {
+        if constexpr (active) {
+            using namespace amrex::literals;
+
+            constexpr int NODE = amrex::IndexType::NODE;
+
+            bool node[6];
+            bool any_node = false, any_cell = false, any_node_red = false, any_cell_red = false;
+            for (int c = 0; c < 6; ++c) {
+                node[c] = (types[c][slot] == NODE);
+                if (s_reduced[c]) {
+                    any_node_red = any_node_red || node[c];
+                    any_cell_red = any_cell_red || !node[c];
+                } else {
+                    any_node = any_node || node[c];
+                    any_cell = any_cell || !node[c];
+                }
+            }
+
+            Compute_shape_factor<depos_order> const compute_shape_factor;
+            Compute_shape_factor<depos_order - galerkin_interpolation> const compute_shape_factor_galerkin;
+
+            int i_node = 0;
+            int i_cell = 0;
+            int i_node_red = 0;
+            int i_cell_red = 0;
+            if (any_node)     { i_node     = compute_shape_factor(m_s_node, pos); }
+            if (any_cell)     { i_cell     = compute_shape_factor(m_s_cell, pos - 0.5_rt); }
+            if (any_node_red) { i_node_red = compute_shape_factor_galerkin(m_s_node_red, pos); }
+            if (any_cell_red) { i_cell_red = compute_shape_factor_galerkin(m_s_cell_red, pos - 0.5_rt); }
+
+            for (int c = 0; c < 6; ++c) {
+                m_s[c]  = s_reduced[c] ? (node[c] ? m_s_node_red : m_s_cell_red)
+                                       : (node[c] ? m_s_node     : m_s_cell);
+                m_i0[c] = s_reduced[c] ? (node[c] ? i_node_red : i_cell_red)
+                                       : (node[c] ? i_node     : i_cell);
+            }
+        }
+    }
+
+    //! shape factor of component c at loop index i; 1 for an absent axis
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    amrex::Real w ([[maybe_unused]] int const c, [[maybe_unused]] int const i) const
+    {
+        using namespace amrex::literals;
+        if constexpr (active) { return m_s[c][i]; } else { return 1._rt; }
+    }
+
+    //! leftmost grid point index of component c; 0 for an absent axis
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    int i0 ([[maybe_unused]] int const c) const
+    {
+        if constexpr (active) { return m_i0[c]; } else { return 0; }
+    }
+};
+
+/**
+ * \brief Gather one field component (numbered c = 0..5 for Ex..Bz) onto a particle
+ *
+ * Accumulates into Fp. With rz_mode = true, gathers the contribution of one
+ * azimuthal mode imode > 0 from the real and imaginary parts stored at array
+ * components (comp0, comp0 + 1), rotated by xy = e^{-i m theta}.
+ *
+ * \tparam c       field component index (0..5 = Ex, Ey, Ez, Bx, By, Bz)
+ * \tparam D       dimensionality of the simulation
+ * \tparam rz_mode gather an azimuthal mode > 0 (RZ)
+ */
+template <int c, warpx::Dim D, bool rz_mode = false,
+          typename T_AX, typename T_AY, typename T_AZ>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void doGatherComponent (amrex::ParticleReal& Fp,
+                        amrex::Array4<amrex::Real const> const& F_arr,
+                        T_AX const& ax, T_AY const& ay, T_AZ const& az,
+                        amrex::Dim3 const& llo,
+                        [[maybe_unused]] int const comp0 = 0,
+                        [[maybe_unused]] Complex const xy = Complex{amrex::Real(1.), amrex::Real(0.)})
+{
+    for (int iz=0; iz<=T_AZ::loop_max(c); iz++){
+        for (int iy=0; iy<=T_AY::loop_max(c); iy++){
+            for (int ix=0; ix<=T_AX::loop_max(c); ix++){
+                amrex::Real F;
+                if constexpr (rz_mode) {
+                    F = (+ warpx::field_at<D>(F_arr, llo.x+ax.i0(c)+ix, llo.y+ay.i0(c)+iy, llo.z+az.i0(c)+iz, comp0  )*xy.real()
+                         - warpx::field_at<D>(F_arr, llo.x+ax.i0(c)+ix, llo.y+ay.i0(c)+iy, llo.z+az.i0(c)+iz, comp0+1)*xy.imag());
+                } else {
+                    F = warpx::field_at<D>(F_arr, llo.x+ax.i0(c)+ix, llo.y+ay.i0(c)+iy, llo.z+az.i0(c)+iz, comp0);
+                }
+                if constexpr (!warpx::has_x<D>) {                   // 1D (z)
+                    Fp += az.w(c, iz)*F;
+                } else if constexpr (!warpx::has_z<D>) {            // 1D radial (r)
+                    Fp += ax.w(c, ix)*F;
+                } else if constexpr (!warpx::has_y<D>) {            // 2D (x/r, z)
+                    Fp += ax.w(c, ix)*az.w(c, iz)*F;
+                } else {                                            // 3D (x, y, z)
+                    Fp += ax.w(c, ix)*ay.w(c, iy)*az.w(c, iz)*F;
+                }
+            }
+        }
+    }
+}
+
 /**
  * \brief Field gather for a single particle
  *
  * \tparam depos_order              Particle shape order
  * \tparam galerkin_interpolation   Lower the order of the particle shape by
  *                                  this value (0/1) for the parallel field component
+ * \tparam D                        Dimensionality of the simulation
  * \param xp,yp,zp                        Particle position coordinates
  * \param Exp,Eyp,Ezp                     Electric field on particles.
  * \param Bxp,Byp,Bzp                     Magnetic field on particles.
@@ -345,7 +514,7 @@ void doDirectGatherVectorField (
  * \param lo                        Index lower bounds of domain.
  * \param n_rz_azimuthal_modes       Number of azimuthal modes when using RZ geometry
  */
-template <int depos_order, int galerkin_interpolation>
+template <int depos_order, int galerkin_interpolation, warpx::Dim D = warpx::CompileDim>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void doGatherShapeN ([[maybe_unused]] const amrex::ParticleReal xp,
                      [[maybe_unused]] const amrex::ParticleReal yp,
@@ -374,455 +543,130 @@ void doGatherShapeN ([[maybe_unused]] const amrex::ParticleReal xp,
                      [[maybe_unused]] const int n_rz_azimuthal_modes)
 {
     using namespace amrex;
+    using namespace amrex::literals;
 
-#ifdef WARPX_ZINDEX
-    constexpr int zdir = WARPX_ZINDEX;
-#endif
+    static_assert(D != warpx::Dim::Runtime,
+        "doGatherShapeN requires an explicit dimensionality");
 
-    constexpr int NODE = amrex::IndexType::NODE;
-    constexpr int CELL = amrex::IndexType::CELL;
-
-    // --- Compute shape factors
-
-    Compute_shape_factor< depos_order > const compute_shape_factor;
-    Compute_shape_factor<depos_order - galerkin_interpolation > const compute_shape_factor_galerkin;
-
-#if !defined(WARPX_DIM_1D_Z)
-    // x direction
-    // Get particle position
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-    const amrex::Real rp = std::sqrt(xp*xp + yp*yp);
-    const amrex::Real x = (rp - xyzmin.x)*dinv.x;
-#elif defined(WARPX_DIM_RSPHERE)
-    const amrex::Real rp = std::sqrt(xp*xp + yp*yp + zp*zp);
-    const amrex::Real x = (rp - xyzmin.x)*dinv.x;
-#else
-    const amrex::Real x = (xp - xyzmin.x)*dinv.x;
-#endif
-
-    // j_[eb][xyz] leftmost grid point in x that the particle touches for the centering of each current
-    // sx_[eb][xyz] shape factor along x for the centering of each current
-    // There are only two possible centerings, node or cell centered, so at most only two shape factor
-    // arrays will be needed.
-    amrex::Real sx_node[depos_order + 1] = {0._rt};
-    amrex::Real sx_cell[depos_order + 1] = {0._rt};
-    amrex::Real sx_node_galerkin[depos_order + 1 - galerkin_interpolation] = {0._rt};
-    amrex::Real sx_cell_galerkin[depos_order + 1 - galerkin_interpolation] = {0._rt};
-
-    int j_node = 0;
-    int j_cell = 0;
-    int j_node_v = 0;
-    int j_cell_v = 0;
-    if ((ey_type[0] == NODE) || (ez_type[0] == NODE) || (bx_type[0] == NODE)) {
-        j_node = compute_shape_factor(sx_node, x);
+    // Particle position in grid units along each axis present on the grid
+    [[maybe_unused]] amrex::Real rp = 0._rt; // radius, for the radial geometries
+    [[maybe_unused]] amrex::Real x = 0._rt;
+    [[maybe_unused]] amrex::Real y = 0._rt;
+    [[maybe_unused]] amrex::Real z = 0._rt;
+    if constexpr (D == warpx::Dim::RZ || D == warpx::Dim::RCylinder) {
+        rp = std::sqrt(xp*xp + yp*yp);
+        x = (rp - xyzmin.x)*dinv.x;
+    } else if constexpr (D == warpx::Dim::RSphere) {
+        rp = std::sqrt(xp*xp + yp*yp + zp*zp);
+        x = (rp - xyzmin.x)*dinv.x;
+    } else if constexpr (warpx::has_x<D>) {
+        x = (xp - xyzmin.x)*dinv.x;
     }
-    if ((ey_type[0] == CELL) || (ez_type[0] == CELL) || (bx_type[0] == CELL)) {
-        j_cell = compute_shape_factor(sx_cell, x - 0.5_rt);
+    if constexpr (warpx::has_y<D>) {
+        y = (yp - xyzmin.y)*dinv.y;
     }
-    if ((ex_type[0] == NODE) || (by_type[0] == NODE) || (bz_type[0] == NODE)) {
-        j_node_v = compute_shape_factor_galerkin(sx_node_galerkin, x);
-    }
-    if ((ex_type[0] == CELL) || (by_type[0] == CELL) || (bz_type[0] == CELL)) {
-        j_cell_v = compute_shape_factor_galerkin(sx_cell_galerkin, x - 0.5_rt);
-    }
-    const amrex::Real (&sx_ex)[depos_order + 1 - galerkin_interpolation] = ((ex_type[0] == NODE) ? sx_node_galerkin : sx_cell_galerkin);
-    const amrex::Real (&sx_ey)[depos_order + 1             ] = ((ey_type[0] == NODE) ? sx_node   : sx_cell  );
-    const amrex::Real (&sx_ez)[depos_order + 1             ] = ((ez_type[0] == NODE) ? sx_node   : sx_cell  );
-    const amrex::Real (&sx_bx)[depos_order + 1             ] = ((bx_type[0] == NODE) ? sx_node   : sx_cell  );
-    const amrex::Real (&sx_by)[depos_order + 1 - galerkin_interpolation] = ((by_type[0] == NODE) ? sx_node_galerkin : sx_cell_galerkin);
-    const amrex::Real (&sx_bz)[depos_order + 1 - galerkin_interpolation] = ((bz_type[0] == NODE) ? sx_node_galerkin : sx_cell_galerkin);
-    int const j_ex = ((ex_type[0] == NODE) ? j_node_v : j_cell_v);
-    int const j_ey = ((ey_type[0] == NODE) ? j_node   : j_cell  );
-    int const j_ez = ((ez_type[0] == NODE) ? j_node   : j_cell  );
-    int const j_bx = ((bx_type[0] == NODE) ? j_node   : j_cell  );
-    int const j_by = ((by_type[0] == NODE) ? j_node_v : j_cell_v);
-    int const j_bz = ((bz_type[0] == NODE) ? j_node_v : j_cell_v);
-#endif
-
-#if defined(WARPX_DIM_3D)
-    // y direction
-    const amrex::Real y = (yp-xyzmin.y)*dinv.y;
-    amrex::Real sy_node[depos_order + 1] = {0._rt};
-    amrex::Real sy_cell[depos_order + 1] = {0._rt};
-    amrex::Real sy_node_v[depos_order + 1 - galerkin_interpolation] = {0._rt};
-    amrex::Real sy_cell_v[depos_order + 1 - galerkin_interpolation] = {0._rt};
-    int k_node = 0;
-    int k_cell = 0;
-    int k_node_v = 0;
-    int k_cell_v = 0;
-    if ((ex_type[1] == NODE) || (ez_type[1] == NODE) || (by_type[1] == NODE)) {
-        k_node = compute_shape_factor(sy_node, y);
-    }
-    if ((ex_type[1] == CELL) || (ez_type[1] == CELL) || (by_type[1] == CELL)) {
-        k_cell = compute_shape_factor(sy_cell, y - 0.5_rt);
-    }
-    if ((ey_type[1] == NODE) || (bx_type[1] == NODE) || (bz_type[1] == NODE)) {
-        k_node_v = compute_shape_factor_galerkin(sy_node_v, y);
-    }
-    if ((ey_type[1] == CELL) || (bx_type[1] == CELL) || (bz_type[1] == CELL)) {
-        k_cell_v = compute_shape_factor_galerkin(sy_cell_v, y - 0.5_rt);
-    }
-    const amrex::Real (&sy_ex)[depos_order + 1             ] = ((ex_type[1] == NODE) ? sy_node   : sy_cell  );
-    const amrex::Real (&sy_ey)[depos_order + 1 - galerkin_interpolation] = ((ey_type[1] == NODE) ? sy_node_v : sy_cell_v);
-    const amrex::Real (&sy_ez)[depos_order + 1             ] = ((ez_type[1] == NODE) ? sy_node   : sy_cell  );
-    const amrex::Real (&sy_bx)[depos_order + 1 - galerkin_interpolation] = ((bx_type[1] == NODE) ? sy_node_v : sy_cell_v);
-    const amrex::Real (&sy_by)[depos_order + 1             ] = ((by_type[1] == NODE) ? sy_node   : sy_cell  );
-    const amrex::Real (&sy_bz)[depos_order + 1 - galerkin_interpolation] = ((bz_type[1] == NODE) ? sy_node_v : sy_cell_v);
-    int const k_ex = ((ex_type[1] == NODE) ? k_node   : k_cell  );
-    int const k_ey = ((ey_type[1] == NODE) ? k_node_v : k_cell_v);
-    int const k_ez = ((ez_type[1] == NODE) ? k_node   : k_cell  );
-    int const k_bx = ((bx_type[1] == NODE) ? k_node_v : k_cell_v);
-    int const k_by = ((by_type[1] == NODE) ? k_node   : k_cell  );
-    int const k_bz = ((bz_type[1] == NODE) ? k_node_v : k_cell_v);
-
-#endif
-
-#if !defined(WARPX_DIM_RCYLINDER) && !defined(WARPX_DIM_RSPHERE)
-    // z direction
-    const amrex::Real z = (zp-xyzmin.z)*dinv.z;
-    amrex::Real sz_node[depos_order + 1] = {0._rt};
-    amrex::Real sz_cell[depos_order + 1] = {0._rt};
-    amrex::Real sz_node_v[depos_order + 1 - galerkin_interpolation] = {0._rt};
-    amrex::Real sz_cell_v[depos_order + 1 - galerkin_interpolation] = {0._rt};
-    int l_node = 0;
-    int l_cell = 0;
-    int l_node_v = 0;
-    int l_cell_v = 0;
-    if ((ex_type[zdir] == NODE) || (ey_type[zdir] == NODE) || (bz_type[zdir] == NODE)) {
-        l_node = compute_shape_factor(sz_node, z);
-    }
-    if ((ex_type[zdir] == CELL) || (ey_type[zdir] == CELL) || (bz_type[zdir] == CELL)) {
-        l_cell = compute_shape_factor(sz_cell, z - 0.5_rt);
-    }
-    if ((ez_type[zdir] == NODE) || (bx_type[zdir] == NODE) || (by_type[zdir] == NODE)) {
-        l_node_v = compute_shape_factor_galerkin(sz_node_v, z);
-    }
-    if ((ez_type[zdir] == CELL) || (bx_type[zdir] == CELL) || (by_type[zdir] == CELL)) {
-        l_cell_v = compute_shape_factor_galerkin(sz_cell_v, z - 0.5_rt);
-    }
-    const amrex::Real (&sz_ex)[depos_order + 1             ] = ((ex_type[zdir] == NODE) ? sz_node   : sz_cell  );
-    const amrex::Real (&sz_ey)[depos_order + 1             ] = ((ey_type[zdir] == NODE) ? sz_node   : sz_cell  );
-    const amrex::Real (&sz_ez)[depos_order + 1 - galerkin_interpolation] = ((ez_type[zdir] == NODE) ? sz_node_v : sz_cell_v);
-    const amrex::Real (&sz_bx)[depos_order + 1 - galerkin_interpolation] = ((bx_type[zdir] == NODE) ? sz_node_v : sz_cell_v);
-    const amrex::Real (&sz_by)[depos_order + 1 - galerkin_interpolation] = ((by_type[zdir] == NODE) ? sz_node_v : sz_cell_v);
-    const amrex::Real (&sz_bz)[depos_order + 1             ] = ((bz_type[zdir] == NODE) ? sz_node   : sz_cell  );
-    int const l_ex = ((ex_type[zdir] == NODE) ? l_node   : l_cell  );
-    int const l_ey = ((ey_type[zdir] == NODE) ? l_node   : l_cell  );
-    int const l_ez = ((ez_type[zdir] == NODE) ? l_node_v : l_cell_v);
-    int const l_bx = ((bx_type[zdir] == NODE) ? l_node_v : l_cell_v);
-    int const l_by = ((by_type[zdir] == NODE) ? l_node_v : l_cell_v);
-    int const l_bz = ((bz_type[zdir] == NODE) ? l_node   : l_cell  );
-#endif
-
-    // Each field is gathered in a separate block of
-    // AMREX_SPACEDIM nested loops because the deposition
-    // order can differ for each component of each field
-    // when galerkin_interpolation is set to 1
-
-#if defined(WARPX_DIM_1D_Z)
-    // Gather field on particle Eyp from field on grid ey_arr
-    // Gather field on particle Exp from field on grid ex_arr
-    // Gather field on particle Bzp from field on grid bz_arr
-    for (int iz=0; iz<=depos_order; iz++){
-        Eyp += sz_ey[iz]*
-            ey_arr(lo.x+l_ey+iz, 0, 0, 0);
-        Exp += sz_ex[iz]*
-            ex_arr(lo.x+l_ex+iz, 0, 0, 0);
-        Bzp += sz_bz[iz]*
-            bz_arr(lo.x+l_bz+iz, 0, 0, 0);
+    if constexpr (warpx::has_z<D>) {
+        z = (zp - xyzmin.z)*dinv.z;
     }
 
-    // Gather field on particle Byp from field on grid by_arr
-    // Gather field on particle Ezp from field on grid ez_arr
-    // Gather field on particle Bxp from field on grid bx_arr
-    for (int iz=0; iz<=depos_order-galerkin_interpolation; iz++){
-        Ezp += sz_ez[iz]*
-            ez_arr(lo.x+l_ez+iz, 0, 0, 0);
-        Bxp += sz_bx[iz]*
-            bx_arr(lo.x+l_bx+iz, 0, 0, 0);
-        Byp += sz_by[iz]*
-            by_arr(lo.x+l_by+iz, 0, 0, 0);
-    }
+    // --- Compute shape factors along each axis present on the grid
+    amrex::IndexType const types[6] = {ex_type, ey_type, ez_type, bx_type, by_type, bz_type};
+    GatherAxisShape<depos_order, galerkin_interpolation, 0, warpx::has_x<D>> ax;
+    GatherAxisShape<depos_order, galerkin_interpolation, 1, warpx::has_y<D>> ay;
+    GatherAxisShape<depos_order, galerkin_interpolation, 2, warpx::has_z<D>> az;
+    if constexpr (warpx::has_x<D>) { ax.compute(types, warpx::IdxMap<D>::x, x); }
+    if constexpr (warpx::has_y<D>) { ay.compute(types, warpx::IdxMap<D>::y, y); }
+    if constexpr (warpx::has_z<D>) { az.compute(types, warpx::IdxMap<D>::z, z); }
 
-#elif defined(WARPX_DIM_XZ)
-    // Gather field on particle Eyp from field on grid ey_arr
-    for (int iz=0; iz<=depos_order; iz++){
-        for (int ix=0; ix<=depos_order; ix++){
-            Eyp += sx_ey[ix]*sz_ey[iz]*
-                ey_arr(lo.x+j_ey+ix, lo.y+l_ey+iz, 0, 0);
-        }
-    }
-    // Gather field on particle Exp from field on grid ex_arr
-    // Gather field on particle Bzp from field on grid bz_arr
-    for (int iz=0; iz<=depos_order; iz++){
-        for (int ix=0; ix<=depos_order-galerkin_interpolation; ix++){
-            Exp += sx_ex[ix]*sz_ex[iz]*
-                ex_arr(lo.x+j_ex+ix, lo.y+l_ex+iz, 0, 0);
-            Bzp += sx_bz[ix]*sz_bz[iz]*
-                bz_arr(lo.x+j_bz+ix, lo.y+l_bz+iz, 0, 0);
-        }
-    }
-    // Gather field on particle Ezp from field on grid ez_arr
-    // Gather field on particle Bxp from field on grid bx_arr
-    for (int iz=0; iz<=depos_order-galerkin_interpolation; iz++){
-        for (int ix=0; ix<=depos_order; ix++){
-            Ezp += sx_ez[ix]*sz_ez[iz]*
-                ez_arr(lo.x+j_ez+ix, lo.y+l_ez+iz, 0, 0);
-            Bxp += sx_bx[ix]*sz_bx[iz]*
-                bx_arr(lo.x+j_bx+ix, lo.y+l_bx+iz, 0, 0);
-        }
-    }
-    // Gather field on particle Byp from field on grid by_arr
-    for (int iz=0; iz<=depos_order-galerkin_interpolation; iz++){
-        for (int ix=0; ix<=depos_order-galerkin_interpolation; ix++){
-            Byp += sx_by[ix]*sz_by[iz]*
-                by_arr(lo.x+j_by+ix, lo.y+l_by+iz, 0, 0);
-        }
-    }
+    // index lower bounds of the tile in logical (x, y, z) space
+    const amrex::Dim3 llo = warpx::logical_lo<D>(lo);
 
-#elif defined(WARPX_DIM_RZ)
+    if constexpr (!warpx::is_radial<D>) {
 
-    amrex::ParticleReal Erp = 0.;
-    amrex::ParticleReal Ethetap = 0.;
-    amrex::ParticleReal Brp = 0.;
-    amrex::ParticleReal Bthetap = 0.;
+        // Gather each field component, with the loop bounds of each component
+        // reduced by the Galerkin order reduction along its parallel (E) or
+        // perpendicular (B) axes
+        doGatherComponent<0, D>(Exp, ex_arr, ax, ay, az, llo);
+        doGatherComponent<1, D>(Eyp, ey_arr, ax, ay, az, llo);
+        doGatherComponent<2, D>(Ezp, ez_arr, ax, ay, az, llo);
+        doGatherComponent<3, D>(Bxp, bx_arr, ax, ay, az, llo);
+        doGatherComponent<4, D>(Byp, by_arr, ax, ay, az, llo);
+        doGatherComponent<5, D>(Bzp, bz_arr, ax, ay, az, llo);
 
-    // Gather field on particle Ethetap from field on grid ey_arr
-    for (int iz=0; iz<=depos_order; iz++){
-        for (int ix=0; ix<=depos_order; ix++){
-            Ethetap += sx_ey[ix]*sz_ey[iz]*
-                ey_arr(lo.x+j_ey+ix, lo.y+l_ey+iz, 0, 0);
-        }
-    }
-    // Gather field on particle Erp from field on grid ex_arr
-    // Gather field on particle Bzp from field on grid bz_arr
-    for (int iz=0; iz<=depos_order; iz++){
-        for (int ix=0; ix<=depos_order-galerkin_interpolation; ix++){
-            Erp += sx_ex[ix]*sz_ex[iz]*
-                ex_arr(lo.x+j_ex+ix, lo.y+l_ex+iz, 0, 0);
-            Bzp += sx_bz[ix]*sz_bz[iz]*
-                bz_arr(lo.x+j_bz+ix, lo.y+l_bz+iz, 0, 0);
-        }
-    }
-    // Gather field on particle Ezp from field on grid ez_arr
-    // Gather field on particle Brp from field on grid bx_arr
-    for (int iz=0; iz<=depos_order-galerkin_interpolation; iz++){
-        for (int ix=0; ix<=depos_order; ix++){
-            Ezp += sx_ez[ix]*sz_ez[iz]*
-                ez_arr(lo.x+j_ez+ix, lo.y+l_ez+iz, 0, 0);
-            Brp += sx_bx[ix]*sz_bx[iz]*
-                bx_arr(lo.x+j_bx+ix, lo.y+l_bx+iz, 0, 0);
-        }
-    }
-    // Gather field on particle Bthetap from field on grid by_arr
-    for (int iz=0; iz<=depos_order-galerkin_interpolation; iz++){
-        for (int ix=0; ix<=depos_order-galerkin_interpolation; ix++){
-            Bthetap += sx_by[ix]*sz_by[iz]*
-                by_arr(lo.x+j_by+ix, lo.y+l_by+iz, 0, 0);
-        }
-    }
-
-    amrex::Real costheta;
-    amrex::Real sintheta;
-    if (rp > 0.) {
-        costheta = xp/rp;
-        sintheta = yp/rp;
     } else {
-        costheta = 1.;
-        sintheta = 0.;
-    }
-    const Complex xy0 = Complex{costheta, -sintheta};
-    Complex xy = xy0;
 
-    for (int imode=1 ; imode < n_rz_azimuthal_modes ; imode++) {
+        // Radial geometries gather the radial and azimuthal (RSPHERE: also
+        // polar) field components in mapped space and rotate them to
+        // Cartesian below; the z components (RZ, RCYLINDER) are gathered
+        // directly
+        amrex::ParticleReal F1p = 0.; // r
+        amrex::ParticleReal F2p = 0.; // theta
+        amrex::ParticleReal F3p = 0.; // RSPHERE only: phi
+        amrex::ParticleReal B1p = 0.;
+        amrex::ParticleReal B2p = 0.;
+        amrex::ParticleReal B3p = 0.;
+        amrex::ParticleReal& F3 = (D == warpx::Dim::RSphere) ? F3p : Ezp;
+        amrex::ParticleReal& B3 = (D == warpx::Dim::RSphere) ? B3p : Bzp;
 
-        // Gather field on particle Ethetap from field on grid ey_arr
-        for (int iz=0; iz<=depos_order; iz++){
-            for (int ix=0; ix<=depos_order; ix++){
-                const amrex::Real dEy = (+ ey_arr(lo.x+j_ey+ix, lo.y+l_ey+iz, 0, 2*imode-1)*xy.real()
-                                         - ey_arr(lo.x+j_ey+ix, lo.y+l_ey+iz, 0, 2*imode)*xy.imag());
-                Ethetap += sx_ey[ix]*sz_ey[iz]*dEy;
+        // Gather field for azimuthal mode = 0
+        doGatherComponent<0, D>(F1p, ex_arr, ax, ay, az, llo);
+        doGatherComponent<1, D>(F2p, ey_arr, ax, ay, az, llo);
+        doGatherComponent<2, D>(F3, ez_arr, ax, ay, az, llo);
+        doGatherComponent<3, D>(B1p, bx_arr, ax, ay, az, llo);
+        doGatherComponent<4, D>(B2p, by_arr, ax, ay, az, llo);
+        doGatherComponent<5, D>(B3, bz_arr, ax, ay, az, llo);
+
+        if constexpr (D == warpx::Dim::RZ) {
+            const auto costheta = static_cast<amrex::Real>(rp > 0._rt ? xp/rp : 1._rt);
+            const auto sintheta = static_cast<amrex::Real>(rp > 0._rt ? yp/rp : 0._rt);
+            const Complex xy0 = Complex{costheta, -sintheta};
+            Complex xy = xy0; // Throughout the following loop, xy takes the value e^{-i m theta}
+
+            // Gather field for azimuthal modes > 0
+            for (int imode=1 ; imode < n_rz_azimuthal_modes ; imode++) {
+                doGatherComponent<0, D, true>(F1p, ex_arr, ax, ay, az, llo, 2*imode-1, xy);
+                doGatherComponent<1, D, true>(F2p, ey_arr, ax, ay, az, llo, 2*imode-1, xy);
+                doGatherComponent<2, D, true>(F3, ez_arr, ax, ay, az, llo, 2*imode-1, xy);
+                doGatherComponent<3, D, true>(B1p, bx_arr, ax, ay, az, llo, 2*imode-1, xy);
+                doGatherComponent<4, D, true>(B2p, by_arr, ax, ay, az, llo, 2*imode-1, xy);
+                doGatherComponent<5, D, true>(B3, bz_arr, ax, ay, az, llo, 2*imode-1, xy);
+                xy = xy*xy0;
             }
-        }
-        // Gather field on particle Erp from field on grid ex_arr
-        // Gather field on particle Bzp from field on grid bz_arr
-        for (int iz=0; iz<=depos_order; iz++){
-            for (int ix=0; ix<=depos_order-galerkin_interpolation; ix++){
-                const amrex::Real dEx = (+ ex_arr(lo.x+j_ex+ix, lo.y+l_ex+iz, 0, 2*imode-1)*xy.real()
-                                         - ex_arr(lo.x+j_ex+ix, lo.y+l_ex+iz, 0, 2*imode)*xy.imag());
-                Erp += sx_ex[ix]*sz_ex[iz]*dEx;
-                const amrex::Real dBz = (+ bz_arr(lo.x+j_bz+ix, lo.y+l_bz+iz, 0, 2*imode-1)*xy.real()
-                                         - bz_arr(lo.x+j_bz+ix, lo.y+l_bz+iz, 0, 2*imode)*xy.imag());
-                Bzp += sx_bz[ix]*sz_bz[iz]*dBz;
-            }
-        }
-        // Gather field on particle Ezp from field on grid ez_arr
-        // Gather field on particle Brp from field on grid bx_arr
-        for (int iz=0; iz<=depos_order-galerkin_interpolation; iz++){
-            for (int ix=0; ix<=depos_order; ix++){
-                const amrex::Real dEz = (+ ez_arr(lo.x+j_ez+ix, lo.y+l_ez+iz, 0, 2*imode-1)*xy.real()
-                                         - ez_arr(lo.x+j_ez+ix, lo.y+l_ez+iz, 0, 2*imode)*xy.imag());
-                Ezp += sx_ez[ix]*sz_ez[iz]*dEz;
-                const amrex::Real dBx = (+ bx_arr(lo.x+j_bx+ix, lo.y+l_bx+iz, 0, 2*imode-1)*xy.real()
-                                         - bx_arr(lo.x+j_bx+ix, lo.y+l_bx+iz, 0, 2*imode)*xy.imag());
-                Brp += sx_bx[ix]*sz_bx[iz]*dBx;
-            }
-        }
-        // Gather field on particle Bthetap from field on grid by_arr
-        for (int iz=0; iz<=depos_order-galerkin_interpolation; iz++){
-            for (int ix=0; ix<=depos_order-galerkin_interpolation; ix++){
-                const amrex::Real dBy = (+ by_arr(lo.x+j_by+ix, lo.y+l_by+iz, 0, 2*imode-1)*xy.real()
-                                         - by_arr(lo.x+j_by+ix, lo.y+l_by+iz, 0, 2*imode)*xy.imag());
-                Bthetap += sx_by[ix]*sz_by[iz]*dBy;
-            }
-        }
-        xy = xy*xy0;
-    }
 
-    // Convert Erp, Ethetap, Brp, Bthetap to Exp, Eyp, Bxp, Byp
-    Exp += costheta*Erp - sintheta*Ethetap;
-    Eyp += costheta*Ethetap + sintheta*Erp;
-    Bxp += costheta*Brp - sintheta*Bthetap;
-    Byp += costheta*Bthetap + sintheta*Brp;
+            // Convert Fr, Ftheta to Fx, Fy
+            Exp += costheta*F1p - sintheta*F2p;
+            Eyp += costheta*F2p + sintheta*F1p;
+            Bxp += costheta*B1p - sintheta*B2p;
+            Byp += costheta*B2p + sintheta*B1p;
+        } else if constexpr (D == warpx::Dim::RCylinder) {
+            amrex::Real const costheta = (rp > 0. ? xp/rp : 1.);
+            amrex::Real const sintheta = (rp > 0. ? yp/rp : 0.);
 
-#elif defined(WARPX_DIM_RCYLINDER)
+            // Convert Fr, Ftheta to Fx, Fy
+            Exp += costheta*F1p - sintheta*F2p;
+            Eyp += costheta*F2p + sintheta*F1p;
+            Bxp += costheta*B1p - sintheta*B2p;
+            Byp += costheta*B2p + sintheta*B1p;
+        } else if constexpr (D == warpx::Dim::RSphere) {
+            const amrex::Real rpxy = std::sqrt(xp*xp + yp*yp);
+            amrex::Real const costheta = (rpxy > 0. ? xp/rpxy : 1.);
+            amrex::Real const sintheta = (rpxy > 0. ? yp/rpxy : 0.);
+            amrex::Real const cosphi = (rp > 0. ? rpxy/rp : 1.);
+            amrex::Real const sinphi = (rp > 0. ? zp/rp : 0.);
 
-    amrex::ParticleReal Erp = 0.;
-    amrex::ParticleReal Ethetap = 0.;
-    amrex::ParticleReal Brp = 0.;
-    amrex::ParticleReal Bthetap = 0.;
-
-    // Gather field on particle Ethetap from field on grid ey_arr
-    for (int ix=0; ix<=depos_order; ix++){
-        Ethetap += sx_ey[ix]*ey_arr(lo.x+j_ey+ix, 0, 0, 0);
-    }
-    // Gather field on particle Erp from field on grid ex_arr
-    // Gather field on particle Bzp from field on grid bz_arr
-    for (int ix=0; ix<=depos_order-galerkin_interpolation; ix++){
-        Erp += sx_ex[ix]*ex_arr(lo.x+j_ex+ix, 0, 0, 0);
-        Bzp += sx_bz[ix]*bz_arr(lo.x+j_bz+ix, 0, 0, 0);
-    }
-    // Gather field on particle Ezp from field on grid ez_arr
-    // Gather field on particle Brp from field on grid bx_arr
-    for (int ix=0; ix<=depos_order; ix++){
-        Ezp += sx_ez[ix]*ez_arr(lo.x+j_ez+ix, 0, 0, 0);
-        Brp += sx_bx[ix]*bx_arr(lo.x+j_bx+ix, 0, 0, 0);
-    }
-    // Gather field on particle Bthetap from field on grid by_arr
-    for (int ix=0; ix<=depos_order-galerkin_interpolation; ix++){
-        Bthetap += sx_by[ix]*by_arr(lo.x+j_by+ix, 0, 0, 0);
-    }
-
-    amrex::Real const costheta = (rp > 0. ? xp/rp : 1.);
-    amrex::Real const sintheta = (rp > 0. ? yp/rp : 0.);
-
-    // Convert Erp, Ethetap, Brp, Bthetap to Exp, Eyp, Bxp, Byp
-    Exp += costheta*Erp - sintheta*Ethetap;
-    Eyp += costheta*Ethetap + sintheta*Erp;
-    Bxp += costheta*Brp - sintheta*Bthetap;
-    Byp += costheta*Bthetap + sintheta*Brp;
-
-#elif defined(WARPX_DIM_RSPHERE)
-
-    amrex::ParticleReal Erp = 0.;
-    amrex::ParticleReal Ethetap = 0.;
-    amrex::ParticleReal Ephip = 0.;
-    amrex::ParticleReal Brp = 0.;
-    amrex::ParticleReal Bthetap = 0.;
-    amrex::ParticleReal Bphip = 0.;
-
-    // Gather field on particle Ethetap from field on grid ey_arr
-    for (int ix=0; ix<=depos_order; ix++){
-        Ethetap += sx_ey[ix]*ey_arr(lo.x+j_ey+ix, 0, 0, 0);
-    }
-    // Gather field on particle Erp from field on grid ex_arr
-    // Gather field on particle Bphip from field on grid bz_arr
-    for (int ix=0; ix<=depos_order-galerkin_interpolation; ix++){
-        Erp += sx_ex[ix]*ex_arr(lo.x+j_ex+ix, 0, 0, 0);
-        Bphip += sx_bz[ix]*bz_arr(lo.x+j_bz+ix, 0, 0, 0);
-    }
-    // Gather field on particle Ephip from field on grid ez_arr
-    // Gather field on particle Brp from field on grid bx_arr
-    for (int ix=0; ix<=depos_order; ix++){
-        Ephip += sx_ez[ix]*ez_arr(lo.x+j_ez+ix, 0, 0, 0);
-        Brp += sx_bx[ix]*bx_arr(lo.x+j_bx+ix, 0, 0, 0);
-    }
-    // Gather field on particle Bthetap from field on grid by_arr
-    for (int ix=0; ix<=depos_order-galerkin_interpolation; ix++){
-        Bthetap += sx_by[ix]*by_arr(lo.x+j_by+ix, 0, 0, 0);
-    }
-
-    const amrex::Real rpxy = std::sqrt(xp*xp + yp*yp);
-    amrex::Real const costheta = (rpxy > 0. ? xp/rpxy : 1.);
-    amrex::Real const sintheta = (rpxy > 0. ? yp/rpxy : 0.);
-    amrex::Real const cosphi = (rp > 0. ? rpxy/rp : 1.);
-    amrex::Real const sinphi = (rp > 0. ? zp/rp : 0.);
-
-    // Convert Erp, Ethetap, Ephip, Brp, Bthetap, Bphip to Exp, Eyp, Ezp, Bxp, Byp, Bzp
-    Exp += costheta*cosphi*Erp - sintheta*Ethetap - costheta*sinphi*Ephip;
-    Eyp += sintheta*cosphi*Erp + costheta*Ethetap - sintheta*sinphi*Ephip;
-    Ezp += sinphi*Erp + cosphi*Ephip;
-    Bxp += costheta*cosphi*Brp - sintheta*Bthetap - costheta*sinphi*Bphip;
-    Byp += sintheta*cosphi*Brp + costheta*Bthetap - sintheta*sinphi*Bphip;
-    Bzp += sinphi*Brp + cosphi*Bphip;
-
-#else // defined(WARPX_DIM_3D)
-    // Gather field on particle Exp from field on grid ex_arr
-    for (int iz=0; iz<=depos_order; iz++){
-        for (int iy=0; iy<=depos_order; iy++){
-            for (int ix=0; ix<= depos_order - galerkin_interpolation; ix++){
-                Exp += sx_ex[ix]*sy_ex[iy]*sz_ex[iz]*
-                    ex_arr(lo.x+j_ex+ix, lo.y+k_ex+iy, lo.z+l_ex+iz);
-            }
+            // Convert Fr, Ftheta, Fphi to Fx, Fy, Fz
+            Exp += costheta*cosphi*F1p - sintheta*F2p - costheta*sinphi*F3p;
+            Eyp += sintheta*cosphi*F1p + costheta*F2p - sintheta*sinphi*F3p;
+            Ezp += sinphi*F1p + cosphi*F3p;
+            Bxp += costheta*cosphi*B1p - sintheta*B2p - costheta*sinphi*B3p;
+            Byp += sintheta*cosphi*B1p + costheta*B2p - sintheta*sinphi*B3p;
+            Bzp += sinphi*B1p + cosphi*B3p;
         }
     }
-    // Gather field on particle Eyp from field on grid ey_arr
-    for (int iz=0; iz<=depos_order; iz++){
-        for (int iy=0; iy<= depos_order - galerkin_interpolation; iy++){
-            for (int ix=0; ix<=depos_order; ix++){
-                Eyp += sx_ey[ix]*sy_ey[iy]*sz_ey[iz]*
-                    ey_arr(lo.x+j_ey+ix, lo.y+k_ey+iy, lo.z+l_ey+iz);
-            }
-        }
-    }
-    // Gather field on particle Ezp from field on grid ez_arr
-    for (int iz=0; iz<= depos_order - galerkin_interpolation; iz++){
-        for (int iy=0; iy<=depos_order; iy++){
-            for (int ix=0; ix<=depos_order; ix++){
-                Ezp += sx_ez[ix]*sy_ez[iy]*sz_ez[iz]*
-                    ez_arr(lo.x+j_ez+ix, lo.y+k_ez+iy, lo.z+l_ez+iz);
-            }
-        }
-    }
-    // Gather field on particle Bzp from field on grid bz_arr
-    for (int iz=0; iz<=depos_order; iz++){
-        for (int iy=0; iy<= depos_order - galerkin_interpolation; iy++){
-            for (int ix=0; ix<= depos_order - galerkin_interpolation; ix++){
-                Bzp += sx_bz[ix]*sy_bz[iy]*sz_bz[iz]*
-                    bz_arr(lo.x+j_bz+ix, lo.y+k_bz+iy, lo.z+l_bz+iz);
-            }
-        }
-    }
-    // Gather field on particle Byp from field on grid by_arr
-    for (int iz=0; iz<= depos_order - galerkin_interpolation; iz++){
-        for (int iy=0; iy<=depos_order; iy++){
-            for (int ix=0; ix<= depos_order - galerkin_interpolation; ix++){
-                Byp += sx_by[ix]*sy_by[iy]*sz_by[iz]*
-                    by_arr(lo.x+j_by+ix, lo.y+k_by+iy, lo.z+l_by+iz);
-            }
-        }
-    }
-    // Gather field on particle Bxp from field on grid bx_arr
-    for (int iz=0; iz<= depos_order - galerkin_interpolation; iz++){
-        for (int iy=0; iy<= depos_order - galerkin_interpolation; iy++){
-            for (int ix=0; ix<=depos_order; ix++){
-                Bxp += sx_bx[ix]*sy_bx[iy]*sz_bx[iz]*
-                    bx_arr(lo.x+j_bx+ix, lo.y+k_bx+iy, lo.z+l_bx+iz);
-            }
-        }
-    }
-#endif
 }
+
+// Transition to runtime dimensionality, cf. above.
+#if !defined(WARPX_DIM_RUNTIME)
 
 /**
  * \brief Energy conserving field gather for thread thread_num for the implicit scheme
@@ -2125,6 +1969,8 @@ void doGatherPicnicShapeN (
 
 }
 
+#endif // !defined(WARPX_DIM_RUNTIME)
+
 /**
  * \brief Field gather for a single particle
  *
@@ -2141,7 +1987,10 @@ void doGatherPicnicShapeN (
  * \param n_rz_azimuthal_modes    Number of azimuthal modes when using RZ geometry
  * \param nox                     order of the particle shape function
  * \param galerkin_interpolation  whether to use lower order in v
+ *
+ * \tparam D dimensionality of the simulation
  */
+template <warpx::Dim D = warpx::CompileDim>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void doGatherShapeN (const amrex::ParticleReal xp,
                      const amrex::ParticleReal yp,
@@ -2173,44 +2022,44 @@ void doGatherShapeN (const amrex::ParticleReal xp,
 {
     if (galerkin_interpolation) {
         if (nox == 1) {
-            doGatherShapeN<1,1>(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+            doGatherShapeN<1,1,D>(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
                                 ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
                                 ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
                                 dinv, xyzmin, lo, n_rz_azimuthal_modes);
         } else if (nox == 2) {
-            doGatherShapeN<2,1>(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+            doGatherShapeN<2,1,D>(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
                                 ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
                                 ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
                                 dinv, xyzmin, lo, n_rz_azimuthal_modes);
         } else if (nox == 3) {
-            doGatherShapeN<3,1>(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+            doGatherShapeN<3,1,D>(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
                                 ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
                                 ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
                                 dinv, xyzmin, lo, n_rz_azimuthal_modes);
         } else if (nox == 4) {
-            doGatherShapeN<4,1>(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+            doGatherShapeN<4,1,D>(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
                                 ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
                                 ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
                                 dinv, xyzmin, lo, n_rz_azimuthal_modes);
         }
     } else {
         if (nox == 1) {
-            doGatherShapeN<1,0>(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+            doGatherShapeN<1,0,D>(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
                                 ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
                                 ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
                                 dinv, xyzmin, lo, n_rz_azimuthal_modes);
         } else if (nox == 2) {
-            doGatherShapeN<2,0>(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+            doGatherShapeN<2,0,D>(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
                                 ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
                                 ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
                                 dinv, xyzmin, lo, n_rz_azimuthal_modes);
         } else if (nox == 3) {
-            doGatherShapeN<3,0>(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+            doGatherShapeN<3,0,D>(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
                                 ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
                                 ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
                                 dinv, xyzmin, lo, n_rz_azimuthal_modes);
         } else if (nox == 4) {
-            doGatherShapeN<4,0>(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+            doGatherShapeN<4,0,D>(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
                                 ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
                                 ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
                                 dinv, xyzmin, lo, n_rz_azimuthal_modes);
@@ -2218,6 +2067,9 @@ void doGatherShapeN (const amrex::ParticleReal xp,
     }
 }
 
+
+// Transition to runtime dimensionality, cf. above.
+#if !defined(WARPX_DIM_RUNTIME)
 
 /**
  * \brief Field gather for a single particle
@@ -2352,5 +2204,7 @@ void doGatherShapeNImplicit (
         }
     }
 }
+
+#endif // !defined(WARPX_DIM_RUNTIME)
 
 #endif // WARPX_FIELDGATHER_H_

--- a/Source/Particles/PIdx.H
+++ b/Source/Particles/PIdx.H
@@ -1,0 +1,58 @@
+/* Copyright 2019-2020 Andrew Myers, Axel Huebl, David Grote
+ * Jean-Luc Vay, Junmin Gu, Luca Fedeli
+ * Maxence Thevenet, Remi Lehe, Revathi Jambunathan
+ * Weiqun Zhang, Yinjian Zhao
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef WARPX_PARTICLES_PIDX_H_
+#define WARPX_PARTICLES_PIDX_H_
+
+#include <initializer_list>
+
+/** Real Particle Attributes stored in amrex::ParticleContainer's struct of array
+ *
+ *  x, y, z  : position components
+ *  ux uy uz : momentum components, stored as proper velocity, i.e. gamma*v
+ *  w        : weight
+ *  theta    : azimuthal angle
+ *  phi      : polar angle, relative to the x-y plane
+ *  nattribs : number of compile-time attributes
+ */
+struct PIdx
+{
+#if defined(WARPX_DIM_RUNTIME)
+    // Unified runtime-dimensionality layout: pure-SoA particle containers
+    // require the positions to be the first AMREX_SPACEDIM real components
+    // and AMReX is always built 3D, so positions are always (x, y, z).
+    // Position components of collapsed dimensions are 0 and never updated.
+    enum                          { x ,  y,   z,   w,   ux,   uy,   uz,            nattribs};
+    static constexpr auto names = {"x", "y", "z", "w", "ux", "uy", "uz"};
+#elif defined(WARPX_DIM_1D_Z)
+    enum                          { z ,  w ,  ux ,  uy ,  uz,                      nattribs};
+    static constexpr auto names = {"z", "w", "ux", "uy", "uz"};
+#elif defined(WARPX_DIM_XZ)
+    enum                          { x ,  z ,  w ,  ux ,  uy ,  uz,                 nattribs};
+    static constexpr auto names = {"x", "z", "w", "ux", "uy", "uz"};
+#elif defined(WARPX_DIM_RZ)
+    enum                          { r ,  z ,  w ,  ux ,  uy ,  uz ,  theta,        nattribs};
+    static constexpr auto names = {"r", "z", "w", "ux", "uy", "uz", "theta"};
+#elif defined(WARPX_DIM_RCYLINDER)
+    enum                          { r ,  w ,  ux ,  uy ,  uz ,  theta,             nattribs};
+    static constexpr auto names = {"r", "w", "ux", "uy", "uz", "theta"};
+#elif defined(WARPX_DIM_RSPHERE)
+    enum                          { r ,  w ,  ux ,  uy ,  uz ,  theta ,  phi,      nattribs};
+    static constexpr auto names = {"r", "w", "ux", "uy", "uz", "theta", "phi"};
+#elif defined(WARPX_DIM_3D)
+    enum                          { x ,  y,   z,   w,   ux,   uy,   uz,            nattribs};
+    static constexpr auto names = {"x", "y", "z", "w", "ux", "uy", "uz"};
+#else
+  #error WarpX dimension is not correctly set!
+#endif
+
+    static_assert(names.size() == nattribs);
+};
+
+#endif // WARPX_PARTICLES_PIDX_H_

--- a/Source/Particles/Pusher/GetAndSetPosition.H
+++ b/Source/Particles/Pusher/GetAndSetPosition.H
@@ -8,69 +8,84 @@
 #ifndef WARPX_PARTICLES_PUSHER_GETANDSETPOSITION_H_
 #define WARPX_PARTICLES_PUSHER_GETANDSETPOSITION_H_
 
-#include "Particles/WarpXParticleContainer.H"
+#include "Particles/PIdx.H"
+#include "Utils/WarpXDim.H"
+#include "Utils/WarpXDimIndexing.H"
 
 #include <AMReX.H>
+#include <AMReX_Extension.H>
+#include <AMReX_GpuQualifiers.H>
 #include <AMReX_REAL.H>
 
 #include <cmath>
 #include <limits>
+
+// Note: in the pure-SoA particle containers, the particle positions are
+// stored in the first AMREX_SPACEDIM real components, in grid-axis order.
+// The position component of a logical axis is therefore the axis' array
+// slot, warpx::IdxMap, independent of the particle index enumerator T_PIdx
+// (whose position names may differ, cf. PIdx and FieldProbePIdx).
 
 /** \brief Extract the cartesian position coordinates of the particle
  *         p and store them in the variables `x`, `y`, `z`
  *         This version operates on a SuperParticle
  *
  * \tparam T_PIdx particle index enumerator
+ * \tparam D dimensionality of the simulation
  */
-template<typename T_PIdx = PIdx>
+template<typename T_PIdx = PIdx, warpx::Dim D = warpx::CompileDim, typename T_SuperParticle>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void get_particle_position (const WarpXParticleContainer::SuperParticleType& p,
+void get_particle_position (const T_SuperParticle& p,
                             amrex::ParticleReal& x,
                             amrex::ParticleReal& y,
                             amrex::ParticleReal& z) noexcept
 {
     using namespace amrex::literals;
 
-#if defined(WARPX_DIM_RZ)
-    amrex::ParticleReal const theta = p.rdata(T_PIdx::theta);
-    amrex::ParticleReal const r = p.pos(T_PIdx::r);
-    x = r*std::cos(theta);
-    y = r*std::sin(theta);
-    z = p.pos(PIdx::z);
-#elif defined(WARPX_DIM_RCYLINDER)
-    amrex::ParticleReal const theta = p.rdata(T_PIdx::theta);
-    amrex::ParticleReal const r = p.pos(T_PIdx::r);
-    x = r*std::cos(theta);
-    y = r*std::sin(theta);
-    z = 0_prt;
-#elif defined(WARPX_DIM_RSPHERE)
-    amrex::ParticleReal const theta = p.rdata(T_PIdx::theta);
-    amrex::ParticleReal const phi = p.rdata(T_PIdx::phi);
-    amrex::ParticleReal const r = p.pos(T_PIdx::r);
-    x = r*std::cos(theta)*std::cos(phi);
-    y = r*std::sin(theta)*std::cos(phi);
-    z = r*std::sin(phi);
-#elif defined(WARPX_DIM_3D)
-    x = p.pos(PIdx::x);
-    y = p.pos(PIdx::y);
-    z = p.pos(PIdx::z);
-#elif defined(WARPX_DIM_XZ)
-    x = p.pos(PIdx::x);
-    y = 0_prt;
-    z = p.pos(PIdx::z);
-#else
-    x = 0_prt;
-    y = 0_prt;
-    z = p.pos(PIdx::z);
-#endif
+    static_assert(D != warpx::Dim::Runtime,
+        "get_particle_position requires an explicit dimensionality");
+
+    if constexpr (D == warpx::Dim::RZ) {
+        amrex::ParticleReal const theta = p.rdata(T_PIdx::theta);
+        amrex::ParticleReal const r = p.pos(warpx::IdxMap<D>::x);
+        x = r*std::cos(theta);
+        y = r*std::sin(theta);
+        z = p.pos(warpx::IdxMap<D>::z);
+    } else if constexpr (D == warpx::Dim::RCylinder) {
+        amrex::ParticleReal const theta = p.rdata(T_PIdx::theta);
+        amrex::ParticleReal const r = p.pos(warpx::IdxMap<D>::x);
+        x = r*std::cos(theta);
+        y = r*std::sin(theta);
+        z = 0_prt;
+    } else if constexpr (D == warpx::Dim::RSphere) {
+        amrex::ParticleReal const theta = p.rdata(T_PIdx::theta);
+        amrex::ParticleReal const phi = p.rdata(T_PIdx::phi);
+        amrex::ParticleReal const r = p.pos(warpx::IdxMap<D>::x);
+        x = r*std::cos(theta)*std::cos(phi);
+        y = r*std::sin(theta)*std::cos(phi);
+        z = r*std::sin(phi);
+    } else {
+        if constexpr (warpx::has_x<D>) {
+            x = p.pos(warpx::IdxMap<D>::x);
+        } else {
+            x = 0_prt;
+        }
+        if constexpr (warpx::has_y<D>) {
+            y = p.pos(warpx::IdxMap<D>::y);
+        } else {
+            y = 0_prt;
+        }
+        z = p.pos(warpx::IdxMap<D>::z);
+    }
 }
 
 /** \brief Functor that can be used to extract the positions of the macroparticles
  *         inside a ParallelFor kernel
  *
  * \tparam T_PIdx particle index enumerator
+ * \tparam D dimensionality of the simulation
 */
-template<typename T_PIdx = PIdx>
+template<typename T_PIdx = PIdx, warpx::Dim D = warpx::CompileDim>
 struct GetParticlePosition
 {
     using RType = amrex::ParticleReal;
@@ -78,13 +93,10 @@ struct GetParticlePosition
     const RType* AMREX_RESTRICT m_x = nullptr;
     const RType* AMREX_RESTRICT m_y = nullptr;
     const RType* AMREX_RESTRICT m_z = nullptr;
-
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+    //! azimuthal angle; only bound in the radial geometries (RZ, RCYLINDER, RSPHERE)
     const RType* AMREX_RESTRICT m_theta = nullptr;
-#endif
-#if defined(WARPX_DIM_RSPHERE)
+    //! polar angle; only bound in 1D spherical geometry (RSPHERE)
     const RType* AMREX_RESTRICT m_phi = nullptr;
-#endif
 
     static constexpr RType m_x_default = RType(0.0);
     static constexpr RType m_y_default = RType(0.0);
@@ -103,31 +115,26 @@ struct GetParticlePosition
     explicit
     GetParticlePosition (const ptiType& a_pti, long a_offset = 0) noexcept
     {
+        static_assert(D != warpx::Dim::Runtime,
+            "GetParticlePosition requires an explicit dimensionality");
+
         const auto& soa = a_pti.GetStructOfArrays();
 
-#if defined(WARPX_DIM_RZ)
-        m_x = soa.GetRealData(PIdx::r).dataPtr() + a_offset;
-        m_z = soa.GetRealData(PIdx::z).dataPtr() + a_offset;
-#elif defined(WARPX_DIM_XZ)
-        m_x = soa.GetRealData(PIdx::x).dataPtr() + a_offset;
-        m_z = soa.GetRealData(PIdx::z).dataPtr() + a_offset;
-#elif defined(WARPX_DIM_3D)
-        m_x = soa.GetRealData(PIdx::x).dataPtr() + a_offset;
-        m_y = soa.GetRealData(PIdx::y).dataPtr() + a_offset;
-        m_z = soa.GetRealData(PIdx::z).dataPtr() + a_offset;
-#elif defined(WARPX_DIM_1D_Z)
-        m_z = soa.GetRealData(PIdx::z).dataPtr() + a_offset;
-#elif defined(WARPX_DIM_RCYLINDER)
-        m_x = soa.GetRealData(PIdx::r).dataPtr() + a_offset;
-        m_theta = soa.GetRealData(T_PIdx::theta).dataPtr() + a_offset;
-#elif defined(WARPX_DIM_RSPHERE)
-        m_x = soa.GetRealData(PIdx::r).dataPtr() + a_offset;
-        m_theta = soa.GetRealData(T_PIdx::theta).dataPtr() + a_offset;
-        m_phi = soa.GetRealData(T_PIdx::phi).dataPtr() + a_offset;
-#endif
-#if defined(WARPX_DIM_RZ)
-        m_theta = soa.GetRealData(T_PIdx::theta).dataPtr() + a_offset;
-#endif
+        if constexpr (warpx::has_x<D>) {
+            m_x = soa.GetRealData(warpx::IdxMap<D>::x).dataPtr() + a_offset;
+        }
+        if constexpr (warpx::has_y<D>) {
+            m_y = soa.GetRealData(warpx::IdxMap<D>::y).dataPtr() + a_offset;
+        }
+        if constexpr (warpx::has_z<D>) {
+            m_z = soa.GetRealData(warpx::IdxMap<D>::z).dataPtr() + a_offset;
+        }
+        if constexpr (warpx::is_radial<D>) {
+            m_theta = soa.GetRealData(T_PIdx::theta).dataPtr() + a_offset;
+        }
+        if constexpr (D == warpx::Dim::RSphere) {
+            m_phi = soa.GetRealData(T_PIdx::phi).dataPtr() + a_offset;
+        }
     }
 
     /** \brief Extract the cartesian position coordinates of the particle
@@ -136,69 +143,69 @@ struct GetParticlePosition
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void operator() (const long i, RType& x, RType& y, RType& z) const noexcept
     {
-#if defined(WARPX_DIM_RZ)
-        RType const r = m_x[i];
-        x = r*std::cos(m_theta[i]);
-        y = r*std::sin(m_theta[i]);
-        z = m_z[i];
-#elif defined(WARPX_DIM_RCYLINDER)
-        RType const r = m_x[i];
-        x = r*std::cos(m_theta[i]);
-        y = r*std::sin(m_theta[i]);
-        z = m_z_default;
-#elif defined(WARPX_DIM_RSPHERE)
-        RType const r = m_x[i];
-        x = r*std::cos(m_theta[i])*std::cos(m_phi[i]);
-        y = r*std::sin(m_theta[i])*std::cos(m_phi[i]);
-        z = r*std::sin(m_phi[i]);
-#elif defined(WARPX_DIM_3D)
-        x = m_x[i];
-        y = m_y[i];
-        z = m_z[i];
-#elif defined(WARPX_DIM_XZ)
-        x = m_x[i];
-        y = m_y_default;
-        z = m_z[i];
-#elif defined(WARPX_DIM_1D_Z)
-        x = m_x_default;
-        y = m_y_default;
-        z = m_z[i];
-#endif
+        if constexpr (D == warpx::Dim::RZ) {
+            RType const r = m_x[i];
+            x = r*std::cos(m_theta[i]);
+            y = r*std::sin(m_theta[i]);
+            z = m_z[i];
+        } else if constexpr (D == warpx::Dim::RCylinder) {
+            RType const r = m_x[i];
+            x = r*std::cos(m_theta[i]);
+            y = r*std::sin(m_theta[i]);
+            z = m_z_default;
+        } else if constexpr (D == warpx::Dim::RSphere) {
+            RType const r = m_x[i];
+            x = r*std::cos(m_theta[i])*std::cos(m_phi[i]);
+            y = r*std::sin(m_theta[i])*std::cos(m_phi[i]);
+            z = r*std::sin(m_phi[i]);
+        } else {
+            if constexpr (warpx::has_x<D>) {
+                x = m_x[i];
+            } else {
+                x = m_x_default;
+            }
+            if constexpr (warpx::has_y<D>) {
+                y = m_y[i];
+            } else {
+                y = m_y_default;
+            }
+            z = m_z[i];
+        }
     }
 
     /** \brief Extract the position coordinates of the particle as stored
      *         located at index `i + a_offset` and store them in the variables
      *         `x`, `y`, `z`
-     *         This is only different for RZ since this returns (r, theta, z)
-     *         in that case. */
+     *         This is only different for the radial geometries since this
+     *         returns the stored angles in that case. */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void AsStored (const long i, RType& x, RType& y, RType& z) const noexcept
     {
-#if defined(WARPX_DIM_RZ)
-        x = m_x[i];
-        y = m_theta[i];
-        z = m_z[i];
-#elif defined(WARPX_DIM_RCYLINDER)
-        x = m_x[i];
-        y = m_theta[i];
-        z = m_z_default;
-#elif defined(WARPX_DIM_RSPHERE)
-        x = m_x[i];
-        y = m_theta[i];
-        z = m_phi[i];
-#elif defined(WARPX_DIM_3D)
-        x = m_x[i];
-        y = m_y[i];
-        z = m_z[i];
-#elif defined(WARPX_DIM_XZ)
-        x = m_x[i];
-        y = m_y_default;
-        z = m_z[i];
-#elif defined(WARPX_DIM_1D_Z)
-        x = m_x_default;
-        y = m_y_default;
-        z = m_z[i];
-#endif
+        if constexpr (D == warpx::Dim::RZ) {
+            x = m_x[i];
+            y = m_theta[i];
+            z = m_z[i];
+        } else if constexpr (D == warpx::Dim::RCylinder) {
+            x = m_x[i];
+            y = m_theta[i];
+            z = m_z_default;
+        } else if constexpr (D == warpx::Dim::RSphere) {
+            x = m_x[i];
+            y = m_theta[i];
+            z = m_phi[i];
+        } else {
+            if constexpr (warpx::has_x<D>) {
+                x = m_x[i];
+            } else {
+                x = m_x_default;
+            }
+            if constexpr (warpx::has_y<D>) {
+                y = m_y[i];
+            } else {
+                y = m_y_default;
+            }
+            z = m_z[i];
+        }
     }
 };
 
@@ -206,62 +213,47 @@ struct GetParticlePosition
  *         inside a ParallelFor kernel.
  *
  * \tparam T_PIdx particle index enumerator
+ * \tparam D dimensionality of the simulation
  * \param a_pti iterator to the tile being modified
  * \param a_offset offset to apply to the particle indices
 */
-template<typename T_PIdx = PIdx>
+template<typename T_PIdx = PIdx, warpx::Dim D = warpx::CompileDim>
 struct SetParticlePosition
 {
     using RType = amrex::ParticleReal;
 
-#if defined(WARPX_DIM_3D)
-    RType* AMREX_RESTRICT m_x;
-    RType* AMREX_RESTRICT m_y;
-    RType* AMREX_RESTRICT m_z;
-#elif defined(WARPX_DIM_RZ) || defined(WARPX_DIM_XZ)
-    RType* AMREX_RESTRICT m_x;
-    RType* AMREX_RESTRICT m_z;
-#elif defined(WARPX_DIM_1D_Z)
-    RType* AMREX_RESTRICT m_z;
-#elif defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
     RType* AMREX_RESTRICT m_x = nullptr;
-#endif
-
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
-    RType* AMREX_RESTRICT m_theta;
-#endif
-#if defined(WARPX_DIM_RSPHERE)
-    RType* AMREX_RESTRICT m_phi;
-#endif
+    RType* AMREX_RESTRICT m_y = nullptr;
+    RType* AMREX_RESTRICT m_z = nullptr;
+    //! azimuthal angle; only bound in the radial geometries (RZ, RCYLINDER, RSPHERE)
+    RType* AMREX_RESTRICT m_theta = nullptr;
+    //! polar angle; only bound in 1D spherical geometry (RSPHERE)
+    RType* AMREX_RESTRICT m_phi = nullptr;
 
     template <typename ptiType>
     explicit
     SetParticlePosition (const ptiType& a_pti, long a_offset = 0) noexcept
     {
+        static_assert(D != warpx::Dim::Runtime,
+            "SetParticlePosition requires an explicit dimensionality");
+
         auto& soa = a_pti.GetStructOfArrays();
-#if defined(WARPX_DIM_RZ)
-        m_x = soa.GetRealData(PIdx::r).dataPtr() + a_offset;
-        m_z = soa.GetRealData(PIdx::z).dataPtr() + a_offset;
-#elif defined(WARPX_DIM_XZ)
-        m_x = soa.GetRealData(PIdx::x).dataPtr() + a_offset;
-        m_z = soa.GetRealData(PIdx::z).dataPtr() + a_offset;
-#elif defined(WARPX_DIM_3D)
-        m_x = soa.GetRealData(PIdx::x).dataPtr() + a_offset;
-        m_y = soa.GetRealData(PIdx::y).dataPtr() + a_offset;
-        m_z = soa.GetRealData(PIdx::z).dataPtr() + a_offset;
-#elif defined(WARPX_DIM_1D_Z)
-        m_z = soa.GetRealData(PIdx::z).dataPtr() + a_offset;
-#elif defined(WARPX_DIM_RCYLINDER)
-        m_x = soa.GetRealData(PIdx::r).dataPtr() + a_offset;
-        m_theta = soa.GetRealData(T_PIdx::theta).dataPtr() + a_offset;
-#elif defined(WARPX_DIM_RSPHERE)
-        m_x = soa.GetRealData(PIdx::r).dataPtr() + a_offset;
-        m_theta = soa.GetRealData(T_PIdx::theta).dataPtr() + a_offset;
-        m_phi = soa.GetRealData(T_PIdx::phi).dataPtr() + a_offset;
-#endif
-#if defined(WARPX_DIM_RZ)
-        m_theta = soa.GetRealData(T_PIdx::theta).dataPtr() + a_offset;
-#endif
+
+        if constexpr (warpx::has_x<D>) {
+            m_x = soa.GetRealData(warpx::IdxMap<D>::x).dataPtr() + a_offset;
+        }
+        if constexpr (warpx::has_y<D>) {
+            m_y = soa.GetRealData(warpx::IdxMap<D>::y).dataPtr() + a_offset;
+        }
+        if constexpr (warpx::has_z<D>) {
+            m_z = soa.GetRealData(warpx::IdxMap<D>::z).dataPtr() + a_offset;
+        }
+        if constexpr (warpx::is_radial<D>) {
+            m_theta = soa.GetRealData(T_PIdx::theta).dataPtr() + a_offset;
+        }
+        if constexpr (D == warpx::Dim::RSphere) {
+            m_phi = soa.GetRealData(T_PIdx::phi).dataPtr() + a_offset;
+        }
     }
 
     /** \brief Set the position of the particle at index `i + a_offset`
@@ -270,60 +262,58 @@ struct SetParticlePosition
     void operator() (const long i, RType x, RType y, RType z) const noexcept
     {
         amrex::ignore_unused(x,y,z);
-#if defined(WARPX_DIM_RZ)
-        m_theta[i] = std::atan2(y, x);
-        m_x[i] = std::sqrt(x*x + y*y);
-        m_z[i] = z;
-#elif defined(WARPX_DIM_RCYLINDER)
-        m_theta[i] = std::atan2(y, x);
-        m_x[i] = std::sqrt(x*x + y*y);
-#elif defined(WARPX_DIM_RSPHERE)
-        RType const rxy = std::sqrt(x*x + y*y);
-        RType const r = std::sqrt(x*x + y*y + z*z);
-        m_x[i] = r;
-        m_theta[i] = std::atan2(y, x);
-        m_phi[i] = std::atan2(z, rxy);
-#elif defined(WARPX_DIM_3D)
-        m_x[i] = x;
-        m_y[i] = y;
-        m_z[i] = z;
-#elif defined(WARPX_DIM_XZ)
-        m_x[i] = x;
-        m_z[i] = z;
-#elif defined(WARPX_DIM_1D_Z)
-        m_z[i] = z;
-#endif
+        if constexpr (D == warpx::Dim::RZ) {
+            m_theta[i] = std::atan2(y, x);
+            m_x[i] = std::sqrt(x*x + y*y);
+            m_z[i] = z;
+        } else if constexpr (D == warpx::Dim::RCylinder) {
+            m_theta[i] = std::atan2(y, x);
+            m_x[i] = std::sqrt(x*x + y*y);
+        } else if constexpr (D == warpx::Dim::RSphere) {
+            RType const rxy = std::sqrt(x*x + y*y);
+            RType const r = std::sqrt(x*x + y*y + z*z);
+            m_x[i] = r;
+            m_theta[i] = std::atan2(y, x);
+            m_phi[i] = std::atan2(z, rxy);
+        } else {
+            if constexpr (warpx::has_x<D>) {
+                m_x[i] = x;
+            }
+            if constexpr (warpx::has_y<D>) {
+                m_y[i] = y;
+            }
+            m_z[i] = z;
+        }
     }
 
     /** \brief Set the position of the particle at index `i + a_offset`
      *         to `x`, `y`, `z`
-     *         This is only different for RZ since the input should
-     *         be (r, theta, z) in that case. */
+     *         This is only different for the radial geometries since the
+     *         input should contain the angles in that case. */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void AsStored (const long i, RType x, RType y, RType z) const noexcept
     {
         amrex::ignore_unused(x,y,z);
-#if defined(WARPX_DIM_RZ)
-        m_x[i] = x;
-        m_theta[i] = y;
-        m_z[i] = z;
-#elif defined(WARPX_DIM_RCYLINDER)
-        m_x[i] = x;
-        m_theta[i] = y;
-#elif defined(WARPX_DIM_RSPHERE)
-        m_x[i] = x;
-        m_theta[i] = y;
-        m_phi[i] = z;
-#elif defined(WARPX_DIM_3D)
-        m_x[i] = x;
-        m_y[i] = y;
-        m_z[i] = z;
-#elif defined(WARPX_DIM_XZ)
-        m_x[i] = x;
-        m_z[i] = z;
-#elif defined(WARPX_DIM_1D_Z)
-        m_z[i] = z;
-#endif
+        if constexpr (D == warpx::Dim::RZ) {
+            m_x[i] = x;
+            m_theta[i] = y;
+            m_z[i] = z;
+        } else if constexpr (D == warpx::Dim::RCylinder) {
+            m_x[i] = x;
+            m_theta[i] = y;
+        } else if constexpr (D == warpx::Dim::RSphere) {
+            m_x[i] = x;
+            m_theta[i] = y;
+            m_phi[i] = z;
+        } else {
+            if constexpr (warpx::has_x<D>) {
+                m_x[i] = x;
+            }
+            if constexpr (warpx::has_y<D>) {
+                m_y[i] = y;
+            }
+            m_z[i] = z;
+        }
     }
 };
 

--- a/Source/Particles/Pusher/UpdatePosition.H
+++ b/Source/Particles/Pusher/UpdatePosition.H
@@ -9,6 +9,7 @@
 #define WARPX_PARTICLES_PUSHER_UPDATEPOSITION_H_
 
 #include "Utils/WarpXConst.H"
+#include "Utils/WarpXDim.H"
 
 #include <AMReX.H>
 #include <AMReX_FArrayBox.H>
@@ -19,7 +20,10 @@
 /** \brief Push the particle position over one time step,
  *         given the value of its momenta `ux`, `uy`, `uz`,
  *         using the standard leapfrog algorithm x(t+dt) = x(t) + v(t+dt/2)*dt.
+ *
+ * \tparam D dimensionality of the simulation
  */
+template <warpx::Dim D = warpx::CompileDim>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void UpdatePosition ([[maybe_unused]] amrex::ParticleReal& x,
                      [[maybe_unused]] amrex::ParticleReal& y,
@@ -30,6 +34,8 @@ void UpdatePosition ([[maybe_unused]] amrex::ParticleReal& x,
 {
     using namespace amrex::literals;
 
+    static_assert(D != warpx::Dim::Runtime, "UpdatePosition requires an explicit dimensionality");
+
     amrex::ParticleReal const u2 = ux*ux + uy*uy + uz*uz;
 
     // massive particles
@@ -38,16 +44,16 @@ void UpdatePosition ([[maybe_unused]] amrex::ParticleReal& x,
         const amrex::ParticleReal inv_gamma = 1._prt/std::sqrt(1._prt + u2*inv_c2);
 
         // Update positions over one time step
-#if !defined(WARPX_DIM_1D_Z)
-        x += ux * inv_gamma * dt;
-#endif
-#if defined(WARPX_DIM_3D) || defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
-        // Particles pushed in 3D even in 1D cylindrical, 1D spherical, and 2D cylindrical geometry
-        y += uy * inv_gamma * dt;
-#endif
-#if !defined(WARPX_DIM_RCYLINDER)
-        z += uz * inv_gamma * dt;
-#endif
+        if constexpr (warpx::pushes_x_3d<D>) {
+            x += ux * inv_gamma * dt;
+        }
+        if constexpr (warpx::pushes_y_3d<D>) {
+            // Particles pushed in 3D even in 1D cylindrical, 1D spherical, and 2D cylindrical geometry
+            y += uy * inv_gamma * dt;
+        }
+        if constexpr (warpx::pushes_z_3d<D>) {
+            z += uz * inv_gamma * dt;
+        }
     }
     // massless particles (photons)
     else {
@@ -55,16 +61,16 @@ void UpdatePosition ([[maybe_unused]] amrex::ParticleReal& x,
             amrex::ParticleReal const c_over_unorm = PhysConst::c/std::sqrt(u2);
 
             // Update positions over one time step
-#if !defined(WARPX_DIM_1D_Z)
-            x += ux * c_over_unorm * dt;
-#endif
-#if defined(WARPX_DIM_3D) || defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
-            // Particles pushed in 3D even in 1D cylindrical, 1D spherical, and 2D cylindrical geometry
-            y += uy * c_over_unorm * dt;
-#endif
-#if !defined(WARPX_DIM_RCYLINDER)
-            z += uz * c_over_unorm * dt;
-#endif
+            if constexpr (warpx::pushes_x_3d<D>) {
+                x += ux * c_over_unorm * dt;
+            }
+            if constexpr (warpx::pushes_y_3d<D>) {
+                // Particles pushed in 3D even in 1D cylindrical, 1D spherical, and 2D cylindrical geometry
+                y += uy * c_over_unorm * dt;
+            }
+            if constexpr (warpx::pushes_z_3d<D>) {
+                z += uz * c_over_unorm * dt;
+            }
         }
     }
 }
@@ -100,7 +106,10 @@ amrex::ParticleReal GetImplicitGammaInverse (const amrex::ParticleReal uxp_n,
  *    The implicit version is the Crank-Nicolson scheme,
  *    x^{n+1} - x^{n} = dt*(u^{n+1} + u^{n})/(gamma^{n+1} + gamma^{n})
  *    See Eqs. 15 and 17 in Chen, JCP 407 (2020) 109228.
+ *
+ * \tparam D dimensionality of the simulation
  */
+template <warpx::Dim D = warpx::CompileDim>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void UpdatePositionImplicit ([[maybe_unused]] amrex::ParticleReal& x,
                              [[maybe_unused]] amrex::ParticleReal& y,
@@ -109,27 +118,31 @@ void UpdatePositionImplicit ([[maybe_unused]] amrex::ParticleReal& x,
                              const amrex::ParticleReal ux, const amrex::ParticleReal uy, const amrex::ParticleReal uz,
                              const amrex::Real dt )
 {
+    static_assert(D != warpx::Dim::Runtime, "UpdatePositionImplicit requires an explicit dimensionality");
 
     // Compute inverse Lorentz factor, the average of gamma at time levels n and n+1
     const amrex::ParticleReal inv_gamma = GetImplicitGammaInverse(ux_n, uy_n, uz_n, ux, uy, uz);
 
     // Update positions over one time step
-#if !defined(WARPX_DIM_1D_Z)
-    x += ux * inv_gamma * dt;
-#endif
-#if defined(WARPX_DIM_3D) || defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
-    // Radial pushes particles in 3D
-    y += uy * inv_gamma * dt;
-#endif
-#if !defined(WARPX_DIM_RCYLINDER)
-    z += uz * inv_gamma * dt;
-#endif
+    if constexpr (warpx::pushes_x_3d<D>) {
+        x += ux * inv_gamma * dt;
+    }
+    if constexpr (warpx::pushes_y_3d<D>) {
+        // Radial pushes particles in 3D
+        y += uy * inv_gamma * dt;
+    }
+    if constexpr (warpx::pushes_z_3d<D>) {
+        z += uz * inv_gamma * dt;
+    }
 }
 
 /** \brief Check particle position for convergence. This is used by the Picard method
  *         used to achieve a self-consistent time-centered update of the particles
  *         for given electric and magnetic fields on the grid.
+ *
+ * \tparam D dimensionality of the simulation
  */
+template <warpx::Dim D = warpx::CompileDim>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void PositionNorm ([[maybe_unused]] const amrex::ParticleReal dxp,
                    [[maybe_unused]] const amrex::ParticleReal dyp,
@@ -144,19 +157,21 @@ void PositionNorm ([[maybe_unused]] const amrex::ParticleReal dxp,
 {
     using namespace amrex::literals;
 
-#if !defined(WARPX_DIM_RCYLINDER)
-    step_norm = (dzp - dzp_save)*(dzp - dzp_save)*idzg2;
-#else
-    step_norm = 0._prt;
-#endif
-#if !defined(WARPX_DIM_1D_Z)
-    step_norm += (dxp - dxp_save)*(dxp - dxp_save)*idxg2;
-#endif
-#if defined(WARPX_DIM_3D)
-    step_norm += (dyp - dyp_save)*(dyp - dyp_save)*idyg2;
-#elif defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
-    step_norm += (dyp - dyp_save)*(dyp - dyp_save)*idxg2;
-#endif
+    static_assert(D != warpx::Dim::Runtime, "PositionNorm requires an explicit dimensionality");
+
+    if constexpr (warpx::pushes_z_3d<D>) {
+        step_norm = (dzp - dzp_save)*(dzp - dzp_save)*idzg2;
+    } else {
+        step_norm = 0._prt;
+    }
+    if constexpr (warpx::pushes_x_3d<D>) {
+        step_norm += (dxp - dxp_save)*(dxp - dxp_save)*idxg2;
+    }
+    if constexpr (D == warpx::Dim::XYZ) {
+        step_norm += (dyp - dyp_save)*(dyp - dyp_save)*idyg2;
+    } else if constexpr (warpx::is_radial<D>) {
+        step_norm += (dyp - dyp_save)*(dyp - dyp_save)*idxg2;
+    }
     step_norm = std::sqrt(step_norm);
 
 }

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -16,6 +16,7 @@
 #include "Initialization/PlasmaInjector.H"
 #include "Particles/Algorithms/KineticEnergy.H"
 #include "Particles/ParticleBoundaries.H"
+#include "Particles/PIdx.H"
 #include "SpeciesPhysicalProperties.H"
 
 #ifdef WARPX_QED
@@ -51,43 +52,6 @@
 #include <memory>
 #include <string>
 #include <utility>
-
-/** Real Particle Attributes stored in amrex::ParticleContainer's struct of array
- *
- *  x, y, z  : position components
- *  ux uy uz : momentum components, stored as proper velocity, i.e. gamma*v
- *  w        : weight
- *  theta    : azimuthal angle
- *  phi      : polar angle, relative to the x-y plane
- *  nattribs : number of compile-time attributes
- */
-struct PIdx
-{
-#if defined(WARPX_DIM_1D_Z)
-    enum                          { z ,  w ,  ux ,  uy ,  uz,                      nattribs};
-    static constexpr auto names = {"z", "w", "ux", "uy", "uz"};
-#elif defined(WARPX_DIM_XZ)
-    enum                          { x ,  z ,  w ,  ux ,  uy ,  uz,                 nattribs};
-    static constexpr auto names = {"x", "z", "w", "ux", "uy", "uz"};
-#elif defined(WARPX_DIM_RZ)
-    enum                          { r ,  z ,  w ,  ux ,  uy ,  uz ,  theta,        nattribs};
-    static constexpr auto names = {"r", "z", "w", "ux", "uy", "uz", "theta"};
-#elif defined(WARPX_DIM_RCYLINDER)
-    enum                          { r ,  w ,  ux ,  uy ,  uz ,  theta,             nattribs};
-    static constexpr auto names = {"r", "w", "ux", "uy", "uz", "theta"};
-#elif defined(WARPX_DIM_RSPHERE)
-    enum                          { r ,  w ,  ux ,  uy ,  uz ,  theta ,  phi,      nattribs};
-    static constexpr auto names = {"r", "w", "ux", "uy", "uz", "theta", "phi"};
-#elif defined(WARPX_DIM_3D)
-    enum                          { x ,  y,   z,   w,   ux,   uy,   uz,            nattribs};
-    static constexpr auto names = {"x", "y", "z", "w", "ux", "uy", "uz"};
-#else
-  #error WarpX dimension is not correctly set!
-#endif
-
-    static_assert(names.size() == nattribs);
-};
-
 
 struct IntIdx {
     enum

--- a/Source/Utils/WarpXDim.H
+++ b/Source/Utils/WarpXDim.H
@@ -1,0 +1,120 @@
+/* Copyright 2026 Axel Huebl
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef WARPX_UTILS_WARPXDIM_H_
+#define WARPX_UTILS_WARPXDIM_H_
+
+#include <AMReX.H>
+
+#include <string>
+
+namespace warpx
+{
+    /** Dimensionality of the simulation (geometry.dims)
+     *
+     * Runtime counterpart of the compile-time WARPX_DIM_* macros. During the
+     * transition to runtime-selectable dimensionality, kernels are templated
+     * on this enum and instantiate to exactly the code the macros used to
+     * select.
+     */
+    enum class Dim : int
+    {
+        Z = 0,      //!< geometry.dims = 1          (WARPX_DIM_1D_Z)
+        XZ,         //!< geometry.dims = 2          (WARPX_DIM_XZ)
+        XYZ,        //!< geometry.dims = 3          (WARPX_DIM_3D)
+        RZ,         //!< geometry.dims = RZ         (WARPX_DIM_RZ)
+        RCylinder,  //!< geometry.dims = RCYLINDER  (WARPX_DIM_RCYLINDER)
+        RSphere,    //!< geometry.dims = RSPHERE    (WARPX_DIM_RSPHERE)
+        Runtime     //!< sentinel: "selected at runtime", never a valid kernel instantiation
+    };
+
+    /** Dimensionality selected at compile time via the WARPX_DIM_* macros
+     *
+     * In per-dimension builds, kernel templates default to this value, so
+     * existing call sites compile unchanged. In unified (runtime-dimension)
+     * builds this is the Dim::Runtime sentinel and kernels must receive their
+     * dimension explicitly (see WarpXDimDispatch.H).
+     */
+#if   defined(WARPX_DIM_1D_Z)
+    inline constexpr Dim CompileDim = Dim::Z;
+#elif defined(WARPX_DIM_XZ)
+    inline constexpr Dim CompileDim = Dim::XZ;
+#elif defined(WARPX_DIM_3D)
+    inline constexpr Dim CompileDim = Dim::XYZ;
+#elif defined(WARPX_DIM_RZ)
+    inline constexpr Dim CompileDim = Dim::RZ;
+#elif defined(WARPX_DIM_RCYLINDER)
+    inline constexpr Dim CompileDim = Dim::RCylinder;
+#elif defined(WARPX_DIM_RSPHERE)
+    inline constexpr Dim CompileDim = Dim::RSphere;
+#elif defined(WARPX_DIM_RUNTIME)
+    inline constexpr Dim CompileDim = Dim::Runtime;
+#else
+#   error WarpX dimension is not correctly set!
+#endif
+
+    /** Traits replacing the compile-time WARPX_DIM_* conditions 1:1
+     *
+     * "x"/"y"/"z" are logical axes: for the radial geometries (RZ, RCYLINDER,
+     * RSPHERE), the radial coordinate r takes the place of the x axis, as in
+     * the existing per-dimension code.
+     * @{
+     */
+    //! the simulated grid has an x (or r) axis: !WARPX_DIM_1D_Z
+    template <Dim D> inline constexpr bool has_x = (D != Dim::Z);
+    //! the simulated grid has a y axis: WARPX_DIM_3D
+    template <Dim D> inline constexpr bool has_y = (D == Dim::XYZ);
+    //! the simulated grid has a z axis: !(WARPX_DIM_RCYLINDER || WARPX_DIM_RSPHERE)
+    template <Dim D> inline constexpr bool has_z = (D != Dim::RCylinder && D != Dim::RSphere);
+    //! radial geometry: WARPX_DIM_RZ || WARPX_DIM_RCYLINDER || WARPX_DIM_RSPHERE
+    template <Dim D> inline constexpr bool is_radial = (D == Dim::RZ || D == Dim::RCylinder || D == Dim::RSphere);
+    //! the particle pusher updates the (3D Cartesian) x position: !WARPX_DIM_1D_Z
+    template <Dim D> inline constexpr bool pushes_x_3d = has_x<D>;
+    //! the particle pusher updates the (3D Cartesian) y position:
+    //! particles are pushed in 3D even in the radial geometries
+    template <Dim D> inline constexpr bool pushes_y_3d = (D == Dim::XYZ) || is_radial<D>;
+    //! the particle pusher updates the (3D Cartesian) z position: !WARPX_DIM_RCYLINDER
+    template <Dim D> inline constexpr bool pushes_z_3d = (D != Dim::RCylinder);
+    /** @} */
+
+    /** Convert a geometry.dims input value to the corresponding Dim
+     *
+     * @param dims value of the geometry.dims input parameter ("1", "2", "3",
+     *             "RZ", "RCYLINDER" or "RSPHERE")
+     * @return the corresponding Dim; aborts on unknown values
+     */
+    inline Dim
+    dim_from_geometry_dims (std::string const& dims)
+    {
+        if (dims == "1")         { return Dim::Z; }
+        if (dims == "2")         { return Dim::XZ; }
+        if (dims == "3")         { return Dim::XYZ; }
+        if (dims == "RZ")        { return Dim::RZ; }
+        if (dims == "RCYLINDER") { return Dim::RCylinder; }
+        if (dims == "RSPHERE")   { return Dim::RSphere; }
+        amrex::Abort("geometry.dims must be one of 1, 2, 3, RZ, RCYLINDER or RSPHERE, but is '"
+                     + dims + "'");
+        return Dim::Runtime; // unreachable
+    }
+
+    /** Convert a Dim to the corresponding geometry.dims input value */
+    inline std::string
+    geometry_dims_name (Dim const dim)
+    {
+        switch (dim)
+        {
+            case Dim::Z:         return "1";
+            case Dim::XZ:        return "2";
+            case Dim::XYZ:       return "3";
+            case Dim::RZ:        return "RZ";
+            case Dim::RCylinder: return "RCYLINDER";
+            case Dim::RSphere:   return "RSPHERE";
+            default:             return "Runtime";
+        }
+    }
+} // namespace warpx
+
+#endif // WARPX_UTILS_WARPXDIM_H_

--- a/Source/Utils/WarpXDimDispatch.H
+++ b/Source/Utils/WarpXDimDispatch.H
@@ -1,0 +1,70 @@
+/* Copyright 2026 Axel Huebl
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef WARPX_UTILS_WARPXDIMDISPATCH_H_
+#define WARPX_UTILS_WARPXDIMDISPATCH_H_
+
+#include "Utils/WarpXDim.H"
+
+#include <AMReX.H>
+
+#include <type_traits>
+#include <utility>
+
+namespace warpx
+{
+    /** Dispatch the runtime dimensionality to a compile-time Dim
+     *
+     * Calls f with a std::integral_constant<Dim, D> matching the runtime
+     * dimension, so that f can instantiate Dim-templated kernels. This
+     * mirrors the runtime particle-shape-order dispatch, e.g., in
+     * WarpXParticleContainer::DepositCurrent.
+     *
+     * In per-dimension builds (WARPX_DIM_* defined), only the compiled
+     * dimension is instantiated and any other runtime dimension aborts. In
+     * unified builds (WARPX_DIM_RUNTIME), all supported dimensions are
+     * instantiated and selected at runtime.
+     *
+     * Note: f must not *define* extended device lambdas itself (an nvcc
+     * restriction on generic lambdas); it instead calls named function
+     * templates, which may.
+     *
+     * The dispatched dimensions are currently limited to the ones supported
+     * by the runtime-dimensionality prototype (1D, 2D, 3D); more are added as
+     * the migration proceeds.
+     *
+     * @param dim the runtime dimensionality
+     * @param f a callable taking a std::integral_constant<Dim, D>
+     * @return the value returned by f
+     */
+    template <typename F>
+    decltype(auto)
+    dim_dispatch (Dim const dim, F&& f)
+    {
+        if constexpr (CompileDim != Dim::Runtime)
+        {
+            if (dim != CompileDim) {
+                amrex::Abort("dim_dispatch: this binary was compiled for geometry.dims = "
+                             + geometry_dims_name(CompileDim)
+                             + ", but the runtime dimensionality is geometry.dims = "
+                             + geometry_dims_name(dim));
+            }
+            return std::forward<F>(f)(std::integral_constant<Dim, CompileDim>{});
+        }
+        else
+        {
+            if (dim == Dim::Z)  { return std::forward<F>(f)(std::integral_constant<Dim, Dim::Z>{}); }
+            if (dim == Dim::XZ) { return std::forward<F>(f)(std::integral_constant<Dim, Dim::XZ>{}); }
+            if (dim != Dim::XYZ) {
+                amrex::Abort("dim_dispatch: geometry.dims = " + geometry_dims_name(dim)
+                             + " is not compiled into this binary");
+            }
+            return std::forward<F>(f)(std::integral_constant<Dim, Dim::XYZ>{});
+        }
+    }
+} // namespace warpx
+
+#endif // WARPX_UTILS_WARPXDIMDISPATCH_H_

--- a/Source/Utils/WarpXDimIndexing.H
+++ b/Source/Utils/WarpXDimIndexing.H
@@ -1,0 +1,106 @@
+/* Copyright 2026 Axel Huebl
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef WARPX_UTILS_WARPXDIMINDEXING_H_
+#define WARPX_UTILS_WARPXDIMINDEXING_H_
+
+#include "Utils/WarpXDim.H"
+
+#include <AMReX_Array4.H>
+#include <AMReX_Dim3.H>
+#include <AMReX_Extension.H>
+#include <AMReX_GpuQualifiers.H>
+
+namespace warpx
+{
+    /** Whether fields use the unified (degenerate-3D) index layout
+     *
+     * In unified builds (WARPX_DIM_RUNTIME, AMReX built with
+     * AMREX_SPACEDIM=3), fields of all dimensionalities are stored in 3D
+     * MultiFabs with collapsed dimensions of extent 1: 1D uses (1,1,nz), 2D
+     * and RZ use (nx,1,nz), so that z is always at index 2. In per-dimension
+     * builds (legacy), fields use the compact layout of the corresponding
+     * AMReX dimensionality, e.g., z at index 0 (1D), 1 (2D, RZ) or 2 (3D).
+     */
+#if defined(WARPX_DIM_RUNTIME)
+    inline constexpr bool unified_indexing = true;
+#else
+    inline constexpr bool unified_indexing = false;
+#endif
+
+    /** Array4/IntVect slot of each logical axis
+     *
+     * Maps the logical axes x (or r), y and z to their index slot in field
+     * arrays, replacing the WARPX_ZINDEX macro. Axes absent from the grid of
+     * dimensionality D use slot -1 in legacy builds (never dereferenced);
+     * in unified builds, every axis has a slot and absent axes have extent 1.
+     */
+    template <Dim D>
+    struct IdxMap
+    {
+        static constexpr int x = unified_indexing ? 0 : (has_x<D> ? 0 : -1);
+        static constexpr int y = unified_indexing ? 1 : (D == Dim::XYZ ? 1 : -1);
+        static constexpr int z = unified_indexing ? 2 :
+            (D == Dim::Z ? 0 :
+            (D == Dim::XZ || D == Dim::RZ ? 1 :
+            (D == Dim::XYZ ? 2 : -1)));
+    };
+
+    /** Access a field array at the logical index (ix,iy,iz)
+     *
+     * Collapses the indices of absent axes, so that one dimension-templated
+     * kernel body produces the compact indexing of today's per-dimension
+     * code in legacy builds, e.g., a(ix,iz,0) in 2D, and degenerate-3D
+     * indexing a(ix,iy,iz) in unified builds. The index of an absent axis
+     * must be 0.
+     */
+    template <Dim D, typename T>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    T&
+    field_at (amrex::Array4<T> const& a, int const ix, int const iy, int const iz,
+              int const comp = 0)
+    {
+        if constexpr (unified_indexing)
+        {
+            return a(ix, iy, iz, comp);
+        }
+        else
+        {
+            int idx[3] = {0, 0, 0};
+            if constexpr (IdxMap<D>::x >= 0) { idx[IdxMap<D>::x] = ix; }
+            if constexpr (IdxMap<D>::y >= 0) { idx[IdxMap<D>::y] = iy; }
+            if constexpr (IdxMap<D>::z >= 0) { idx[IdxMap<D>::z] = iz; }
+            return a(idx[0], idx[1], idx[2], comp);
+        }
+    }
+
+    /** Map an array-layout amrex::Dim3 (e.g., a box lower bound) into logical (x,y,z) space
+     *
+     * Components of absent axes are set to 0.
+     */
+    template <Dim D>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    constexpr amrex::Dim3
+    logical_lo (amrex::Dim3 const& lo)
+    {
+        auto const get = [&lo] (int const slot) constexpr {
+            return slot == 0 ? lo.x : (slot == 1 ? lo.y : (slot == 2 ? lo.z : 0));
+        };
+        return {get(IdxMap<D>::x), get(IdxMap<D>::y), get(IdxMap<D>::z)};
+    }
+
+    // Sanity checks of the index mappings, in both legacy and unified layouts
+    static_assert(IdxMap<Dim::XYZ>::x == 0 && IdxMap<Dim::XYZ>::y == 1 && IdxMap<Dim::XYZ>::z == 2);
+    static_assert(IdxMap<Dim::XZ>::x == 0 && IdxMap<Dim::XZ>::z == (unified_indexing ? 2 : 1));
+    static_assert(IdxMap<Dim::RZ>::x == 0 && IdxMap<Dim::RZ>::z == (unified_indexing ? 2 : 1));
+    static_assert(IdxMap<Dim::Z>::z == (unified_indexing ? 2 : 0));
+    static_assert(IdxMap<Dim::XZ>::y == (unified_indexing ? 1 : -1));
+    static_assert(IdxMap<Dim::Z>::x == (unified_indexing ? 0 : -1));
+    static_assert(IdxMap<Dim::RCylinder>::x == 0 && IdxMap<Dim::RSphere>::x == 0);
+    static_assert(IdxMap<Dim::RCylinder>::z == (unified_indexing ? 2 : -1));
+} // namespace warpx
+
+#endif // WARPX_UTILS_WARPXDIMINDEXING_H_

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -21,6 +21,7 @@
 #include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceSolver_fwd.H"
 #include "FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel_fwd.H"
 #include "FieldSolver/FiniteDifferenceSolver/MacroscopicProperties/MacroscopicProperties_fwd.H"
+#include "FieldSolver/ImplicitSolvers/ImplicitOptions.H"
 #include "FieldSolver/ImplicitSolvers/ImplicitSolver_fwd.H"
 #include "Filter/NCIGodfreyFilter_fwd.H"
 #include "Fluids/MultiFluidContainer_fwd.H"

--- a/Tools/Prototypes/RuntimeDims/CMakeLists.txt
+++ b/Tools/Prototypes/RuntimeDims/CMakeLists.txt
@@ -1,0 +1,110 @@
+# Runtime-dimensionality prototype
+#
+# Builds a single executable, warpx.unified, against AMReX compiled with
+# AMREX_SPACEDIM=3 only. The executable runs 1D, 2D and 3D simulations
+# selected at runtime via the geometry.dims input parameter, using the
+# dimension-templated WarpX kernel headers (compiled with WARPX_DIM_RUNTIME).
+#
+# This target deliberately does not link lib_<dim>/ablastr_<dim>: it only
+# includes the dimension-converted, self-contained kernel headers, which
+# proves they do not depend on per-dimension compile definitions.
+
+add_executable(app_unified
+    main.cpp
+    Simulation.cpp
+    ${WarpX_SOURCE_DIR}/Source/Utils/Parser/ParserUtils.cpp
+    ${WarpX_SOURCE_DIR}/Source/ablastr/utils/TextMsg.cpp
+)
+
+target_compile_definitions(app_unified PRIVATE WARPX_DIM_RUNTIME)
+target_compile_features(app_unified PUBLIC cxx_std_20)
+set_target_properties(app_unified PROPERTIES
+    CXX_EXTENSIONS OFF
+    CXX_STANDARD_REQUIRED ON
+    OUTPUT_NAME "warpx.unified"
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+)
+target_include_directories(app_unified PRIVATE ${WarpX_SOURCE_DIR}/Source)
+target_link_libraries(app_unified PRIVATE WarpX::thirdparty::amrex_3d)
+
+# Tests: run the existing Langmuir-multi inputs at runtime-selected
+# dimensionalities from the one binary (cf. Examples/Tests/langmuir), check
+# the fields against the analytic plasma-wave solution and, if the native
+# per-dimension binaries are built too, compare against them field by field.
+if(BUILD_TESTING)
+    if(NOT Python_EXECUTABLE)
+        find_package(Python COMPONENTS Interpreter QUIET)
+    endif()
+    set(langmuir_dir ${WarpX_SOURCE_DIR}/Examples/Tests/langmuir)
+    set(analysis_dir ${CMAKE_CURRENT_SOURCE_DIR}/analysis)
+    # both codes run with the same inputs overrides: direct current
+    # deposition (the prototype slice) and no openPMD output
+    set(test_overrides
+        algo.current_deposition=direct
+        diagnostics.diags_names=diag1
+        diag1.intervals=40
+        diag1.diag_type=Full
+    )
+    foreach(D IN ITEMS 1 2 3)
+        set(work_dir ${CMAKE_CURRENT_BINARY_DIR}/test_${D}d)
+        file(MAKE_DIRECTORY ${work_dir})
+        # some inputs files use ParmParse FILE includes relative to the
+        # working directory
+        file(COPY ${langmuir_dir}/inputs_test_${D}d_langmuir_multi DESTINATION ${work_dir})
+        if(EXISTS ${langmuir_dir}/inputs_base_${D}d)
+            file(COPY ${langmuir_dir}/inputs_base_${D}d DESTINATION ${work_dir})
+        endif()
+
+        add_test(
+            NAME test_unified_langmuir_${D}d.run
+            COMMAND
+                $<TARGET_FILE:app_unified>
+                inputs_test_${D}d_langmuir_multi
+                ${test_overrides}
+            WORKING_DIRECTORY ${work_dir}
+        )
+        add_test(
+            NAME test_unified_langmuir_${D}d.analysis
+            COMMAND
+                ${Python_EXECUTABLE} ${analysis_dir}/analysis_langmuir.py
+                ${work_dir}/diags/plt00040
+        )
+        set_tests_properties(test_unified_langmuir_${D}d.analysis PROPERTIES
+            DEPENDS test_unified_langmuir_${D}d.run
+        )
+
+        # comparison against the native per-dimension binary (serial, bitwise)
+        if(TARGET app_${D}d)
+            set(native_dir ${CMAKE_CURRENT_BINARY_DIR}/native_${D}d)
+            file(MAKE_DIRECTORY ${native_dir})
+            file(COPY ${langmuir_dir}/inputs_test_${D}d_langmuir_multi DESTINATION ${native_dir})
+            if(EXISTS ${langmuir_dir}/inputs_base_${D}d)
+                file(COPY ${langmuir_dir}/inputs_base_${D}d DESTINATION ${native_dir})
+            endif()
+            add_test(
+                NAME test_unified_langmuir_${D}d.native_run
+                COMMAND
+                    $<TARGET_FILE:app_${D}d>
+                    inputs_test_${D}d_langmuir_multi
+                    ${test_overrides}
+                WORKING_DIRECTORY ${native_dir}
+            )
+            add_test(
+                NAME test_unified_langmuir_${D}d.compare_native
+                COMMAND
+                    ${Python_EXECUTABLE} ${analysis_dir}/compare_native.py
+                    ${work_dir}/diags/plt00040
+                    ${native_dir}/diags/diag1000040
+            )
+            set_tests_properties(test_unified_langmuir_${D}d.compare_native PROPERTIES
+                DEPENDS "test_unified_langmuir_${D}d.run;test_unified_langmuir_${D}d.native_run"
+            )
+            # serial runs must agree bitwise: force one thread
+            set_tests_properties(
+                test_unified_langmuir_${D}d.run
+                test_unified_langmuir_${D}d.native_run
+                PROPERTIES ENVIRONMENT "OMP_NUM_THREADS=1"
+            )
+        endif()
+    endforeach()
+endif()

--- a/Tools/Prototypes/RuntimeDims/CMakeLists.txt
+++ b/Tools/Prototypes/RuntimeDims/CMakeLists.txt
@@ -95,6 +95,7 @@ if(BUILD_TESTING)
                     ${Python_EXECUTABLE} ${analysis_dir}/compare_native.py
                     ${work_dir}/diags/plt00040
                     ${native_dir}/diags/diag1000040
+                    1.e-12
             )
             set_tests_properties(test_unified_langmuir_${D}d.compare_native PROPERTIES
                 DEPENDS "test_unified_langmuir_${D}d.run;test_unified_langmuir_${D}d.native_run"

--- a/Tools/Prototypes/RuntimeDims/README.md
+++ b/Tools/Prototypes/RuntimeDims/README.md
@@ -61,19 +61,62 @@ parsed momentum functions, serial/MPI/OpenMP on CPU.
   analytic Langmuir-wave solution with the tolerances of the corresponding
   native tests.
 - `analysis/compare_native.py <unified_plt> <native_plt> [tol]` compares
-  against a native binary run on the same inputs. Both codes cell-center
-  diagnostics with the exact same averaging, so serial runs
-  (`mpirun -np 1`, `OMP_NUM_THREADS=1`) must agree **bitwise** (tol 0);
-  parallel runs agree up to atomic-reduction rounding (tol ~1e-9).
+  against a native binary run on the same inputs; both codes cell-center
+  diagnostics with the exact same averaging. Measured agreement of serial
+  runs (`mpirun -np 1`, `OMP_NUM_THREADS=1`, 40 steps): particle positions
+  and weights are **bitwise identical**; fields agree to a few 1e-14
+  relative (single-box runs: half the components bitwise, the rest within
+  1-2 ULP). The residue stems from per-cell floating-point summation-order
+  effects in cells with multiple deposition contributors; the test
+  tolerance is 1e-12. B components are normalized against
+  `max(|B|, |E|/c)`, since B is numerical noise in the electrostatic-like
+  Langmuir problem.
 
 Native comparison runs use the same inputs plus
 `algo.current_deposition=direct`.
 
 ## Performance
 
-(Results table to be filled by the performance harness; see the plan in the
-PR description: per-TinyProfiler-region times of unified vs. native runs for
-1D/2D/3D Langmuir problems at various sizes, plus Arena peak-memory reports.)
+`perf/run_perf.sh <build_dir> [steps] [threads]` runs `warpx.unified` and the
+native binaries on identical Langmuir problems and reports the TinyProfiler
+hot regions.
+
+Measured exclusive times (serial CPU, Release, GCC 13, 100 steps,
+`OMP_NUM_THREADS=1`; Langmuir-multi with direct deposition, shape order 1):
+
+| Case (cells, ppc/species)   | Region            | unified [s] | native [s] | delta |
+|-----------------------------|-------------------|------------:|-----------:|------:|
+| 1D (2^20, 8); 16.8M prt     | gather + push     |        80.9 |       76.5 |  +6 % |
+|                             | current deposition|        38.6 |       29.2 | +32 % |
+| 2D (1024^2, 4x4); 33.5M prt | gather + push     |       224.6 |      206.0 |  +9 % |
+|                             | current deposition|        79.6 |       72.2 | +10 % |
+| 3D (128^3, 2x2x2); 33.5M prt| gather + push     |       339.7 |      287.1 | +18 % |
+|                             | current deposition|       109.3 |      112.2 |  -3 % |
+
+Interpretation:
+
+- The 3D case is the *control*: its kernels instantiate to the same code as
+  the native 3D binary, so its +18 % gather delta measures the overhead of
+  the prototype *harness*, not of the dimension templating. The driver
+  iterates particles per box, while native WarpX iterates per tile with
+  cache-resident field data; the same locality gap explains the 1D
+  deposition delta (the driver deposits into a full-box local array, native
+  into small tile-local arrays).
+- The 1D and 2D deltas are *smaller than or equal to* the 3D control in the
+  gather, i.e., the runtime-dimensionality mechanics (degenerate-3D
+  indexing, `if constexpr` kernels, `dim_dispatch`) add no measurable
+  dimension-specific cost on top of the harness effects.
+- Structural particle-memory overhead of the unified layout (positions
+  always 3 SoA reals): +40 % in 1D (7 vs 5 reals), +17 % in 2D (7 vs 6),
+  0 % in 3D.
+- The native binaries also run particle boundary checks
+  (`ApplyBoundaryConditions`) that the prototype folds into `Redistribute`,
+  so total wall times are not directly comparable; the per-region kernel
+  times above are.
+
+Adopting WarpX's tiled particle iteration in the full migration (phases A-D)
+removes the harness-locality gap by construction, since the converted
+kernels are called from the existing containers.
 
 ## Known limitations / next steps
 

--- a/Tools/Prototypes/RuntimeDims/README.md
+++ b/Tools/Prototypes/RuntimeDims/README.md
@@ -1,0 +1,90 @@
+# Runtime-Dimensionality Prototype
+
+This prototype validates the planned WarpX architecture in which
+
+- AMReX is built **once**, with `AMREX_SPACEDIM=3`, instead of once per
+  dimensionality, and
+- a **single binary** supports all dimensionalities, selected at runtime via
+  the existing `geometry.dims` input parameter, and
+- per-dimension code paths are expressed as `template <warpx::Dim D>` kernels
+  with `if constexpr` branches (replacing the `#if defined(WARPX_DIM_*)`
+  macro snippets 1:1), instantiated for all dimensionalities and dispatched
+  at runtime (`warpx::dim_dispatch`), mirroring how WarpX already dispatches
+  the runtime particle shape order to compile-time template instantiations.
+
+## Layout conventions (unified, degenerate-3D)
+
+- Fields of all dimensionalities are stored in 3D `MultiFab`s with collapsed
+  dimensions of extent 1: 1D uses `(1, 1, nz)`, 2D uses `(nx, 1, nz)`; z is
+  always at index 2 (`warpx::IdxMap`, replacing `WARPX_ZINDEX`).
+- Collapsed dimensions use `prob_lo/hi = [-0.5, 0.5)` (cell size exactly 1 m,
+  matching the existing `WarpX::CellSize` convention for absent dimensions),
+  zero guard cells, cell-centered staggering, and periodic boundaries.
+- Particle positions are always three SoA components (`x`, `y`, `z`);
+  components of collapsed dimensions are 0 and never updated by the pusher
+  (e.g., 2D tracks `uy` but not `y`, exactly like the native 2D code).
+- Shape factors are not evaluated along collapsed dimensions; the deposition
+  and gather loop nests degenerate at compile time to exactly the loop nests
+  of the native per-dimension code.
+
+## Building
+
+```bash
+cmake -S . -B build -DWarpX_DIMS="1;2;3" -DWarpX_RUNTIME_DIMS_PROTO=ON
+cmake --build build -j 6 --target app_unified app_1d app_2d app_3d
+```
+
+This builds `build/bin/warpx.unified` (linked only against `amrex_3d` and
+compiled with `WARPX_DIM_RUNTIME`; it does not link the per-dimension WarpX
+libraries) plus the native binaries used for comparison. With
+`-DWarpX_DIMS=3`, AMReX is built exactly once — the intended end state.
+
+## Running
+
+The prototype consumes (a subset of) the standard WarpX inputs format:
+
+```bash
+cd build/bin
+./warpx.unified ../../Examples/Tests/langmuir/inputs_test_1d_langmuir_multi algo.current_deposition=direct
+./warpx.unified ../../Examples/Tests/langmuir/inputs_test_2d_langmuir_multi algo.current_deposition=direct
+./warpx.unified ../../Examples/Tests/langmuir/inputs_test_3d_langmuir_multi algo.current_deposition=direct
+```
+
+Supported physics (the prototype slice): explicit Yee FDTD, Boris pusher,
+direct current deposition (shape orders 1-4, energy-conserving gather),
+periodic boundaries, `NUniformPerCell` injection with constant density and
+parsed momentum functions, serial/MPI/OpenMP on CPU.
+
+## Validation
+
+- `analysis/analysis_langmuir.py <plotfile>` checks the fields against the
+  analytic Langmuir-wave solution with the tolerances of the corresponding
+  native tests.
+- `analysis/compare_native.py <unified_plt> <native_plt> [tol]` compares
+  against a native binary run on the same inputs. Both codes cell-center
+  diagnostics with the exact same averaging, so serial runs
+  (`mpirun -np 1`, `OMP_NUM_THREADS=1`) must agree **bitwise** (tol 0);
+  parallel runs agree up to atomic-reduction rounding (tol ~1e-9).
+
+Native comparison runs use the same inputs plus
+`algo.current_deposition=direct`.
+
+## Performance
+
+(Results table to be filled by the performance harness; see the plan in the
+PR description: per-TinyProfiler-region times of unified vs. native runs for
+1D/2D/3D Langmuir problems at various sizes, plus Arena peak-memory reports.)
+
+## Known limitations / next steps
+
+- RZ (and RCYLINDER/RSPHERE) are designed for (the `warpx::Dim` enum, traits
+  and `PIdx` cover them) but not yet dispatched at runtime; RZ additionally
+  needs AMReX enablers for the MLMG `setRZ`/`setRZCorrection` paths, which
+  are compiled out for `AMREX_SPACEDIM != 2` builds.
+- Unconverted kernels (Esirkepov/Villasenor/Vay deposition, implicit
+  pushers/gathers, shared-memory deposition) are guarded with
+  `#if !defined(WARPX_DIM_RUNTIME)` and keep compiling unchanged in
+  per-dimension builds; they are converted in later migration phases.
+- Particle initialization in the driver stages on the host (CPU); GPU runs
+  of the prototype require building the staging vectors as pinned memory
+  (the kernels themselves are CPU/GPU portable).

--- a/Tools/Prototypes/RuntimeDims/Simulation.H
+++ b/Tools/Prototypes/RuntimeDims/Simulation.H
@@ -1,0 +1,113 @@
+/* Copyright 2026 Axel Huebl
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#ifndef WARPX_PROTOTYPE_RUNTIMEDIMS_SIMULATION_H_
+#define WARPX_PROTOTYPE_RUNTIMEDIMS_SIMULATION_H_
+
+#include "Particles/PIdx.H"
+#include "Utils/WarpXDim.H"
+
+#include <AMReX_BoxArray.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_Geometry.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_Parser.H>
+#include <AMReX_Particles.H>
+#include <AMReX_REAL.H>
+#include <AMReX_RealBox.H>
+
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
+/** Particle container with the unified (runtime-dimensionality) PIdx layout:
+ *  positions are always the first three SoA real components (x, y, z). */
+using UnifiedParticleContainer = amrex::ParticleContainerPureSoA<PIdx::nattribs, 0>;
+using UnifiedParIter = amrex::ParIterSoA<PIdx::nattribs, 0>;
+
+/** One particle species read from the inputs (subset of WarpX's species support:
+ *  constant density profile, NUniformPerCell injection, parsed momentum functions). */
+struct Species
+{
+    std::string name;
+    amrex::Real charge = 0.;            //!< charge [C]
+    amrex::Real mass = 0.;              //!< mass [kg]
+    amrex::Real density = 0.;           //!< number density [1/m^3]
+    amrex::IntVect ppc{1, 1, 1};        //!< particles per cell along each logical axis
+    amrex::RealBox inject_box;          //!< injection bounds in logical (x, y, z)
+    std::unique_ptr<amrex::Parser> momentum_ux;
+    std::unique_ptr<amrex::Parser> momentum_uy;
+    std::unique_ptr<amrex::Parser> momentum_uz;
+    std::unique_ptr<UnifiedParticleContainer> pc;
+};
+
+/** Minimal electromagnetic PIC simulation with runtime-selected dimensionality
+ *
+ * Reproduces the explicit Yee FDTD + Boris pusher + direct current deposition
+ * PIC loop of WarpX (cf. WarpX::OneStep_nosub) on degenerate-3D AMReX data:
+ * collapsed dimensions have extent 1, prob_lo/hi = [-0.5, 0.5) (cell size 1 m)
+ * and zero guard cells.
+ */
+class Simulation
+{
+public:
+    explicit Simulation (warpx::Dim dim);
+
+    //! Set up geometry, fields and particles from the inputs file
+    void InitData ();
+
+    //! Run the PIC loop for max_step steps
+    void Evolve ();
+
+private:
+    void MakeGeometry ();
+    void ReadParameters ();
+    void AllocateFields ();
+    void InitParticles ();
+
+    //! field gather + Boris momentum push + position push + current deposition
+    void PushAndDeposit ();
+    void EvolveB (amrex::Real a_dt);
+    void EvolveE (amrex::Real a_dt);
+    void SumBoundaryJ ();
+    void FillBoundaryE ();
+    void FillBoundaryB ();
+
+    //! reduced field diagnostics (CSV) and plotfile output
+    void RunDiagnostics (int step, amrex::Real time);
+
+    //! nodal flags of a field, with collapsed dimensions forced to cell-centered
+    [[nodiscard]] amrex::IntVect UnifiedStagger (amrex::IntVect logical_flags) const;
+
+    warpx::Dim m_dim;
+
+    amrex::Geometry m_geom;
+    amrex::BoxArray m_ba;
+    amrex::DistributionMapping m_dm;
+
+    std::array<std::unique_ptr<amrex::MultiFab>, 3> m_E;
+    std::array<std::unique_ptr<amrex::MultiFab>, 3> m_B;
+    std::array<std::unique_ptr<amrex::MultiFab>, 3> m_j;
+
+    std::vector<Species> m_species;
+
+    // stencil coefficients (1/dx, 1/dy, 1/dz), cf. FiniteDifferenceSolver
+    amrex::Gpu::DeviceVector<amrex::Real> m_stencil_coefs_x;
+    amrex::Gpu::DeviceVector<amrex::Real> m_stencil_coefs_y;
+    amrex::Gpu::DeviceVector<amrex::Real> m_stencil_coefs_z;
+
+    amrex::Real m_dt = 0.;
+    amrex::Real m_cfl = 0.999;
+    int m_max_step = 0;
+    int m_nox = 1;                      //!< particle shape order
+    bool m_galerkin_interpolation = true;
+    int m_plot_int = -1;                //!< plotfile interval (diag1.intervals, simplified)
+    std::string m_plotfile_prefix = "diags/plt";
+};
+
+#endif // WARPX_PROTOTYPE_RUNTIMEDIMS_SIMULATION_H_

--- a/Tools/Prototypes/RuntimeDims/Simulation.cpp
+++ b/Tools/Prototypes/RuntimeDims/Simulation.cpp
@@ -1,0 +1,790 @@
+/* Copyright 2026 Axel Huebl
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#include "Simulation.H"
+
+#include "FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H"
+#include "Particles/Deposition/CurrentDeposition.H"
+#include "Particles/Gather/FieldGather.H"
+#include "Particles/PIdx.H"
+#include "Particles/Pusher/GetAndSetPosition.H"
+#include "Particles/Pusher/UpdateMomentumBoris.H"
+#include "Particles/Pusher/UpdatePosition.H"
+#include "Utils/Parser/ParserUtils.H"
+#include "Utils/WarpXConst.H"
+#include "Utils/WarpXDim.H"
+#include "Utils/WarpXDimDispatch.H"
+#include "Utils/WarpXDimIndexing.H"
+
+#include <ablastr/coarsen/sample.H>
+
+#include <AMReX.H>
+#include <AMReX_BLProfiler.H>
+#include <AMReX_MFIter.H>
+#include <AMReX_MultiFabUtil.H>
+#include <AMReX_ParallelDescriptor.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_PlotFileUtil.H>
+#include <AMReX_Print.H>
+#include <AMReX_REAL.H>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <fstream>
+#include <limits>
+#include <string>
+#include <vector>
+
+using namespace amrex::literals;
+
+namespace
+{
+    /** Array slots of the axes present on the grid, in inputs order
+     *
+     * Inputs like amr.n_cell and geometry.prob_lo list one value per grid
+     * axis; this maps each of them to its (unified, degenerate-3D) array slot.
+     */
+    amrex::Vector<int>
+    ActiveSlots (warpx::Dim const dim)
+    {
+        switch (dim)
+        {
+            case warpx::Dim::Z:   return {2};
+            case warpx::Dim::XZ:  return {0, 2};
+            case warpx::Dim::XYZ: return {0, 1, 2};
+            default:
+                amrex::Abort("RuntimeDims prototype: unsupported geometry.dims = "
+                             + warpx::geometry_dims_name(dim));
+        }
+        return {};
+    }
+
+    /** Names of the logical axes, by array slot */
+    constexpr std::array<char const*, 3> axis_names {"x", "y", "z"};
+}
+
+Simulation::Simulation (warpx::Dim const dim)
+    : m_dim(dim)
+{
+}
+
+void
+Simulation::ReadParameters ()
+{
+    const amrex::ParmParse pp;
+    utils::parser::getWithParser(pp, "max_step", m_max_step);
+
+    const amrex::ParmParse pp_warpx("warpx");
+    utils::parser::queryWithParser(pp_warpx, "cfl", m_cfl);
+
+    const amrex::ParmParse pp_algo("algo");
+    utils::parser::queryWithParser(pp_algo, "particle_shape", m_nox);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(1 <= m_nox && m_nox <= 4,
+        "algo.particle_shape must be between 1 and 4");
+
+    std::string current_deposition = "direct";
+    pp_algo.query("current_deposition", current_deposition);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(current_deposition == "direct",
+        "RuntimeDims prototype: only algo.current_deposition = direct is supported "
+        "(add it on the command line to override the inputs file)");
+
+    std::string field_gathering = "energy-conserving";
+    pp_algo.query("field_gathering", field_gathering);
+    m_galerkin_interpolation = (field_gathering == "energy-conserving");
+
+    // simplified diagnostics: only a plotfile interval and prefix
+    const amrex::ParmParse pp_diag("diag1");
+    m_plot_int = m_max_step;
+    utils::parser::queryWithParser(pp_diag, "intervals", m_plot_int);
+}
+
+amrex::IntVect
+Simulation::UnifiedStagger (amrex::IntVect logical_flags) const
+{
+    auto const slots = ActiveSlots(m_dim);
+    amrex::IntVect flags(0);
+    for (int const s : slots) {
+        flags[s] = logical_flags[s];
+    }
+    return flags;
+}
+
+void
+Simulation::MakeGeometry ()
+{
+    auto const slots = ActiveSlots(m_dim);
+    auto const ngrid = static_cast<int>(slots.size());
+
+    const amrex::ParmParse pp_amr("amr");
+    std::vector<int> n_cell_in;
+    utils::parser::getArrWithParser(pp_amr, "n_cell", n_cell_in, 0, ngrid);
+
+    std::vector<int> max_grid_size_in(static_cast<std::size_t>(ngrid), 32768);
+    utils::parser::queryArrWithParser(pp_amr, "max_grid_size", max_grid_size_in, 0, ngrid);
+
+    int max_level = 0;
+    utils::parser::queryWithParser(pp_amr, "max_level", max_level);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(max_level == 0,
+        "RuntimeDims prototype: mesh refinement is not supported");
+
+    const amrex::ParmParse pp_geometry("geometry");
+    std::vector<amrex::Real> prob_lo_in, prob_hi_in;
+    utils::parser::getArrWithParser(pp_geometry, "prob_lo", prob_lo_in, 0, ngrid);
+    utils::parser::getArrWithParser(pp_geometry, "prob_hi", prob_hi_in, 0, ngrid);
+
+    // boundary conditions: only fully periodic domains are supported
+    const amrex::ParmParse pp_boundary("boundary");
+    std::vector<std::string> field_lo(static_cast<std::size_t>(ngrid), "periodic");
+    std::vector<std::string> field_hi(static_cast<std::size_t>(ngrid), "periodic");
+    pp_boundary.queryarr("field_lo", field_lo, 0, ngrid);
+    pp_boundary.queryarr("field_hi", field_hi, 0, ngrid);
+    for (int g = 0; g < ngrid; ++g) {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            field_lo[g] == "periodic" && field_hi[g] == "periodic",
+            "RuntimeDims prototype: only periodic boundary conditions are supported");
+    }
+
+    // degenerate-3D domain: collapsed dimensions have one cell and
+    // prob_lo/hi = [-0.5, 0.5), so that their cell size is exactly 1
+    amrex::IntVect n_cell(1);
+    amrex::IntVect max_grid_size(1);
+    amrex::RealBox rb({AMREX_D_DECL(-0.5_rt, -0.5_rt, -0.5_rt)},
+                      {AMREX_D_DECL(0.5_rt, 0.5_rt, 0.5_rt)});
+    for (int g = 0; g < ngrid; ++g) {
+        int const s = slots[g];
+        n_cell[s] = n_cell_in[g];
+        max_grid_size[s] = max_grid_size_in[g];
+        rb.setLo(s, prob_lo_in[g]);
+        rb.setHi(s, prob_hi_in[g]);
+    }
+
+    const amrex::Box domain(amrex::IntVect(0), n_cell - amrex::IntVect(1));
+    const amrex::Array<int, 3> is_periodic {1, 1, 1};
+    m_geom.define(domain, rb, amrex::CoordSys::cartesian, is_periodic);
+
+    m_ba = amrex::BoxArray(domain);
+    m_ba.maxSize(max_grid_size);
+    m_dm = amrex::DistributionMapping(m_ba);
+
+    amrex::Print() << "  domain: " << domain << "\n"
+                   << "  boxes: " << m_ba.size() << "\n";
+}
+
+void
+Simulation::AllocateFields ()
+{
+    // guard cells along the simulated axes only
+    amrex::IntVect ng(0);
+    for (int const s : ActiveSlots(m_dim)) {
+        ng[s] = 2;
+    }
+
+    for (int c = 0; c < 3; ++c) {
+        // Yee staggering (logical): E and j are cell-centered along their own
+        // axis and nodal along the others; B is the opposite
+        amrex::IntVect e_flags(1), b_flags(0);
+        e_flags[c] = 0;
+        b_flags[c] = 1;
+
+        const auto e_stag = UnifiedStagger(e_flags);
+        const auto b_stag = UnifiedStagger(b_flags);
+
+        m_E[c] = std::make_unique<amrex::MultiFab>(amrex::convert(m_ba, e_stag), m_dm, 1, ng);
+        m_B[c] = std::make_unique<amrex::MultiFab>(amrex::convert(m_ba, b_stag), m_dm, 1, ng);
+        m_j[c] = std::make_unique<amrex::MultiFab>(amrex::convert(m_ba, e_stag), m_dm, 1, ng);
+
+        m_E[c]->setVal(0.0_rt);
+        m_B[c]->setVal(0.0_rt);
+        m_j[c]->setVal(0.0_rt);
+    }
+}
+
+void
+Simulation::InitData ()
+{
+    BL_PROFILE("Simulation::InitData()");
+
+    ReadParameters();
+    MakeGeometry();
+    AllocateFields();
+
+    // stencil coefficients and timestep
+    std::array<amrex::Real, 3> cell_size {m_geom.CellSize(0), m_geom.CellSize(1), m_geom.CellSize(2)};
+    amrex::Vector<amrex::Real> coefs_x, coefs_y, coefs_z;
+    amrex::Real dt_max = 0.0_rt;
+    warpx::dim_dispatch(m_dim, [&] (auto dim_const) {
+        constexpr warpx::Dim D = dim_const();
+        CartesianYeeAlgorithmND<D>::InitializeStencilCoefficients(cell_size, coefs_x, coefs_y, coefs_z);
+        dt_max = CartesianYeeAlgorithmND<D>::ComputeMaxDt(m_geom.CellSize());
+    });
+    m_dt = m_cfl * dt_max;
+
+    m_stencil_coefs_x.resize(coefs_x.size());
+    m_stencil_coefs_y.resize(coefs_y.size());
+    m_stencil_coefs_z.resize(coefs_z.size());
+    amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, coefs_x.begin(), coefs_x.end(), m_stencil_coefs_x.begin());
+    amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, coefs_y.begin(), coefs_y.end(), m_stencil_coefs_y.begin());
+    amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, coefs_z.begin(), coefs_z.end(), m_stencil_coefs_z.begin());
+    amrex::Gpu::synchronize();
+
+    amrex::Print() << "  dt = " << m_dt << " s (cfl = " << m_cfl << ")\n";
+
+    InitParticles();
+}
+
+void
+Simulation::InitParticles ()
+{
+    BL_PROFILE("Simulation::InitParticles()");
+
+    auto const slots = ActiveSlots(m_dim);
+    auto const ngrid = static_cast<int>(slots.size());
+
+    const amrex::ParmParse pp_particles("particles");
+    std::vector<std::string> species_names;
+    pp_particles.queryarr("species_names", species_names);
+
+    for (auto const& name : species_names)
+    {
+        Species sp;
+        sp.name = name;
+        const amrex::ParmParse pp_sp(name);
+
+        utils::parser::getWithParser(pp_sp, "charge", sp.charge);
+        utils::parser::getWithParser(pp_sp, "mass", sp.mass);
+
+        std::string injection_style;
+        pp_sp.get("injection_style", injection_style);
+        std::transform(injection_style.begin(), injection_style.end(),
+                       injection_style.begin(), ::tolower);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(injection_style == "nuniformpercell",
+            "RuntimeDims prototype: only injection_style = NUniformPerCell is supported");
+
+        std::string profile;
+        pp_sp.get("profile", profile);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(profile == "constant",
+            "RuntimeDims prototype: only profile = constant is supported");
+        utils::parser::getWithParser(pp_sp, "density", sp.density);
+
+        std::vector<int> ppc_in;
+        utils::parser::getArrWithParser(pp_sp, "num_particles_per_cell_each_dim", ppc_in, 0, ngrid);
+        for (int g = 0; g < ngrid; ++g) {
+            sp.ppc[slots[g]] = ppc_in[g];
+        }
+
+        std::string momentum_distribution;
+        pp_sp.get("momentum_distribution_type", momentum_distribution);
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(momentum_distribution == "parse_momentum_function",
+            "RuntimeDims prototype: only parse_momentum_function is supported");
+        std::string ux_str, uy_str, uz_str;
+        utils::parser::Store_parserString(pp_sp, "momentum_function_ux(x,y,z)", ux_str);
+        utils::parser::Store_parserString(pp_sp, "momentum_function_uy(x,y,z)", uy_str);
+        utils::parser::Store_parserString(pp_sp, "momentum_function_uz(x,y,z)", uz_str);
+        sp.momentum_ux = std::make_unique<amrex::Parser>(
+            utils::parser::makeParser(ux_str, {"x", "y", "z"}));
+        sp.momentum_uy = std::make_unique<amrex::Parser>(
+            utils::parser::makeParser(uy_str, {"x", "y", "z"}));
+        sp.momentum_uz = std::make_unique<amrex::Parser>(
+            utils::parser::makeParser(uz_str, {"x", "y", "z"}));
+
+        // injection bounds (default: unbounded)
+        for (int s = 0; s < 3; ++s) {
+            sp.inject_box.setLo(s, std::numeric_limits<amrex::Real>::lowest());
+            sp.inject_box.setHi(s, std::numeric_limits<amrex::Real>::max());
+        }
+        for (int s = 0; s < 3; ++s) {
+            amrex::Real bound;
+            if (utils::parser::queryWithParser(pp_sp, (std::string(axis_names[s]) + "min").c_str(), bound)) {
+                sp.inject_box.setLo(s, bound);
+            }
+            if (utils::parser::queryWithParser(pp_sp, (std::string(axis_names[s]) + "max").c_str(), bound)) {
+                sp.inject_box.setHi(s, bound);
+            }
+        }
+
+        sp.pc = std::make_unique<UnifiedParticleContainer>(m_geom, m_dm, m_ba);
+
+        // uniform injection, following the conventions of
+        // PhysicalParticleContainer::AddPlasma and InjectorPositionRegular
+        int num_ppc = 1;
+        amrex::Dim3 ppc_grid {1, 1, 1}; // per-cell counts in grid-axis (inputs) order
+        for (int g = 0; g < ngrid; ++g) {
+            num_ppc *= ppc_in[g];
+            if (g == 0) { ppc_grid.x = ppc_in[g]; }
+            if (g == 1) { ppc_grid.y = ppc_in[g]; }
+            if (g == 2) { ppc_grid.z = ppc_in[g]; }
+        }
+        const amrex::Real scale_fac =
+            m_geom.CellSize(0)*m_geom.CellSize(1)*m_geom.CellSize(2)/num_ppc;
+        const amrex::Real weight = sp.density*scale_fac;
+
+        auto const ux_exe = sp.momentum_ux->compile<3>();
+        auto const uy_exe = sp.momentum_uy->compile<3>();
+        auto const uz_exe = sp.momentum_uz->compile<3>();
+
+        auto const problo = m_geom.ProbLoArray();
+        auto const dx = m_geom.CellSizeArray();
+        const int cpuid = amrex::ParallelDescriptor::MyProc();
+        amrex::Long next_id = 1;
+
+        for (amrex::MFIter mfi(*m_E[0], false); mfi.isValid(); ++mfi)
+        {
+            // cell-centered box of this grid (the validbox of m_E[0] is
+            // staggered and would double-count cells at box boundaries)
+            const amrex::Box box = m_ba[mfi.index()];
+            auto& ptile = sp.pc->DefineAndReturnParticleTile(0, mfi.index(), mfi.LocalTileIndex());
+
+            // host-side staging of the new particles, in cell-then-particle order
+            std::array<std::vector<amrex::ParticleReal>, PIdx::nattribs> attribs;
+            std::vector<uint64_t> idcpu;
+
+            for (amrex::IntVect iv = box.smallEnd(); iv <= box.bigEnd(); box.next(iv))
+            {
+                for (int i_part = 0; i_part < num_ppc; ++i_part)
+                {
+                    // particle position within the unit cell, in grid-axis order,
+                    // cf. InjectorPositionRegular::getPositionUnitBox
+                    int const nx = ppc_grid.x;
+                    int const ny = ppc_grid.y;
+                    int const nz = ppc_grid.z;
+                    int const ix_part = i_part / (ny*nz);
+                    int const iz_part = (i_part - ix_part*(ny*nz)) / ny;
+                    int const iy_part = (i_part - ix_part*(ny*nz)) - ny*iz_part;
+                    const amrex::Real r_grid[3] = {
+                        (0.5_rt + ix_part) / nx,
+                        (0.5_rt + iy_part) / ny,
+                        (0.5_rt + iz_part) / nz
+                    };
+
+                    // particle position, cf. getCellCoords (AddParticles.cpp):
+                    // collapsed dimensions sit at the cell center, 0
+                    amrex::Real pos[3] = {0.0_rt, 0.0_rt, 0.0_rt};
+                    for (int g = 0; g < ngrid; ++g) {
+                        int const s = slots[g];
+                        pos[s] = problo[s] + (iv[s] + r_grid[g])*dx[s];
+                    }
+
+                    if (!sp.inject_box.contains(amrex::XDim3{pos[0], pos[1], pos[2]})) {
+                        continue;
+                    }
+
+                    // momentum from the parsed functions, in units of c
+                    const amrex::Real ux = ux_exe(pos[0], pos[1], pos[2])*PhysConst::c;
+                    const amrex::Real uy = uy_exe(pos[0], pos[1], pos[2])*PhysConst::c;
+                    const amrex::Real uz = uz_exe(pos[0], pos[1], pos[2])*PhysConst::c;
+
+                    attribs[PIdx::x].push_back(static_cast<amrex::ParticleReal>(pos[0]));
+                    attribs[PIdx::y].push_back(static_cast<amrex::ParticleReal>(pos[1]));
+                    attribs[PIdx::z].push_back(static_cast<amrex::ParticleReal>(pos[2]));
+                    attribs[PIdx::w].push_back(static_cast<amrex::ParticleReal>(weight));
+                    attribs[PIdx::ux].push_back(static_cast<amrex::ParticleReal>(ux));
+                    attribs[PIdx::uy].push_back(static_cast<amrex::ParticleReal>(uy));
+                    attribs[PIdx::uz].push_back(static_cast<amrex::ParticleReal>(uz));
+                    idcpu.push_back(amrex::SetParticleIDandCPU(next_id++, cpuid));
+                }
+            }
+
+            auto const np = static_cast<amrex::Long>(idcpu.size());
+            auto const old_np = ptile.numParticles();
+            ptile.resize(old_np + np);
+            auto& soa = ptile.GetStructOfArrays();
+            for (int comp = 0; comp < PIdx::nattribs; ++comp) {
+                amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
+                    attribs[comp].begin(), attribs[comp].end(),
+                    soa.GetRealData(comp).begin() + old_np);
+            }
+            amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice,
+                idcpu.begin(), idcpu.end(), soa.GetIdCPUData().begin() + old_np);
+            amrex::Gpu::synchronize();
+        }
+
+        amrex::Print() << "  species " << name << ": "
+                       << sp.pc->TotalNumberOfParticles() << " particles\n";
+
+        m_species.push_back(std::move(sp));
+    }
+}
+
+/** Gather fields, push momenta and positions, and deposit the current of one
+ *  species (cf. PhysicalParticleContainer::PushPX and DepositCurrent) */
+template <warpx::Dim D>
+void
+PushAndDepositSpecies (Species& sp,
+                       std::array<std::unique_ptr<amrex::MultiFab>, 3> const& E,
+                       std::array<std::unique_ptr<amrex::MultiFab>, 3> const& B,
+                       std::array<std::unique_ptr<amrex::MultiFab>, 3> const& j,
+                       amrex::Geometry const& geom,
+                       amrex::Real const dt, int const nox,
+                       bool const galerkin_interpolation)
+{
+    const amrex::ParticleReal q = sp.charge;
+    const amrex::ParticleReal m = sp.mass;
+
+    auto const problo = geom.ProbLoArray();
+    auto const dx_arr = geom.CellSizeArray();
+    const amrex::XDim3 dinv {1.0_rt/dx_arr[0], 1.0_rt/dx_arr[1], 1.0_rt/dx_arr[2]};
+    const amrex::Real invvol = dinv.x*dinv.y*dinv.z;
+
+    for (UnifiedParIter pti(*sp.pc, 0); pti.isValid(); ++pti)
+    {
+        auto const np = pti.numParticles();
+        auto& soa = pti.GetStructOfArrays();
+        amrex::ParticleReal* const AMREX_RESTRICT wp = soa.GetRealData(PIdx::w).dataPtr();
+        amrex::ParticleReal* const AMREX_RESTRICT uxp = soa.GetRealData(PIdx::ux).dataPtr();
+        amrex::ParticleReal* const AMREX_RESTRICT uyp = soa.GetRealData(PIdx::uy).dataPtr();
+        amrex::ParticleReal* const AMREX_RESTRICT uzp = soa.GetRealData(PIdx::uz).dataPtr();
+
+        const auto GetPosition = GetParticlePosition<PIdx, D>(pti);
+        const auto SetPosition = SetParticlePosition<PIdx, D>(pti);
+
+        // --- field gather + momentum push + position push
+
+        // box covering the gather region (valid + guard cells)
+        amrex::Box gather_box = pti.validbox();
+        gather_box.grow(E[0]->nGrowVect());
+        const amrex::Dim3 glo = amrex::lbound(gather_box);
+        const amrex::XDim3 gxyzmin {
+            problo[0] + gather_box.smallEnd(0)*dx_arr[0],
+            problo[1] + gather_box.smallEnd(1)*dx_arr[1],
+            problo[2] + gather_box.smallEnd(2)*dx_arr[2]};
+
+        amrex::Array4<amrex::Real const> const& ex_arr = (*E[0])[pti].const_array();
+        amrex::Array4<amrex::Real const> const& ey_arr = (*E[1])[pti].const_array();
+        amrex::Array4<amrex::Real const> const& ez_arr = (*E[2])[pti].const_array();
+        amrex::Array4<amrex::Real const> const& bx_arr = (*B[0])[pti].const_array();
+        amrex::Array4<amrex::Real const> const& by_arr = (*B[1])[pti].const_array();
+        amrex::Array4<amrex::Real const> const& bz_arr = (*B[2])[pti].const_array();
+        const amrex::IndexType ex_type = (*E[0])[pti].box().ixType();
+        const amrex::IndexType ey_type = (*E[1])[pti].box().ixType();
+        const amrex::IndexType ez_type = (*E[2])[pti].box().ixType();
+        const amrex::IndexType bx_type = (*B[0])[pti].box().ixType();
+        const amrex::IndexType by_type = (*B[1])[pti].box().ixType();
+        const amrex::IndexType bz_type = (*B[2])[pti].box().ixType();
+
+        {
+        BL_PROFILE("PushAndDeposit::GatherAndPush");
+        amrex::ParallelFor(np,
+            [=] AMREX_GPU_DEVICE (long ip) {
+                amrex::ParticleReal xp, yp, zp;
+                GetPosition(ip, xp, yp, zp);
+
+                amrex::ParticleReal Exp = 0._prt, Eyp = 0._prt, Ezp = 0._prt;
+                amrex::ParticleReal Bxp = 0._prt, Byp = 0._prt, Bzp = 0._prt;
+
+                doGatherShapeN<D>(xp, yp, zp, Exp, Eyp, Ezp, Bxp, Byp, Bzp,
+                                  ex_arr, ey_arr, ez_arr, bx_arr, by_arr, bz_arr,
+                                  ex_type, ey_type, ez_type, bx_type, by_type, bz_type,
+                                  dinv, gxyzmin, glo, 1, nox, galerkin_interpolation);
+
+                UpdateMomentumBoris(uxp[ip], uyp[ip], uzp[ip],
+                                    Exp, Eyp, Ezp, Bxp, Byp, Bzp, q, m, dt);
+
+                UpdatePosition<D>(xp, yp, zp, uxp[ip], uyp[ip], uzp[ip], dt, m);
+                SetPosition(ip, xp, yp, zp);
+            });
+        }
+
+        // --- direct current deposition at the half step (relative_time = -dt/2)
+
+        amrex::Box depos_box = pti.validbox();
+        depos_box.grow(j[0]->nGrowVect());
+        const amrex::Dim3 dlo = amrex::lbound(depos_box);
+        const amrex::XDim3 dxyzmin {
+            problo[0] + depos_box.smallEnd(0)*dx_arr[0],
+            problo[1] + depos_box.smallEnd(1)*dx_arr[1],
+            problo[2] + depos_box.smallEnd(2)*dx_arr[2]};
+
+        amrex::FArrayBox& jx_fab = (*j[0])[pti];
+        amrex::FArrayBox& jy_fab = (*j[1])[pti];
+        amrex::FArrayBox& jz_fab = (*j[2])[pti];
+
+        {
+        BL_PROFILE("PushAndDeposit::CurrentDeposition");
+        if        (nox == 1) {
+            doDepositionShapeN<1, D>(GetPosition, wp, uxp, uyp, uzp, nullptr,
+                                     jx_fab, jy_fab, jz_fab, np, -0.5_rt*dt, dinv,
+                                     dxyzmin, dlo, q, 1);
+        } else if (nox == 2) {
+            doDepositionShapeN<2, D>(GetPosition, wp, uxp, uyp, uzp, nullptr,
+                                     jx_fab, jy_fab, jz_fab, np, -0.5_rt*dt, dinv,
+                                     dxyzmin, dlo, q, 1);
+        } else if (nox == 3) {
+            doDepositionShapeN<3, D>(GetPosition, wp, uxp, uyp, uzp, nullptr,
+                                     jx_fab, jy_fab, jz_fab, np, -0.5_rt*dt, dinv,
+                                     dxyzmin, dlo, q, 1);
+        } else if (nox == 4) {
+            doDepositionShapeN<4, D>(GetPosition, wp, uxp, uyp, uzp, nullptr,
+                                     jx_fab, jy_fab, jz_fab, np, -0.5_rt*dt, dinv,
+                                     dxyzmin, dlo, q, 1);
+        }
+        }
+    }
+}
+
+void
+Simulation::PushAndDeposit ()
+{
+    BL_PROFILE("Simulation::PushAndDeposit()");
+
+    for (int c = 0; c < 3; ++c) {
+        m_j[c]->setVal(0.0_rt);
+    }
+
+    for (auto& sp : m_species) {
+        warpx::dim_dispatch(m_dim, [&] (auto dim_const) {
+            constexpr warpx::Dim D = dim_const();
+            PushAndDepositSpecies<D>(sp, m_E, m_B, m_j, m_geom, m_dt, m_nox,
+                                     m_galerkin_interpolation);
+        });
+    }
+}
+
+/** Faraday's law, cf. FiniteDifferenceSolver::EvolveBCartesian */
+template <warpx::Dim D>
+void
+EvolveBImpl (std::array<std::unique_ptr<amrex::MultiFab>, 3>& B,
+             std::array<std::unique_ptr<amrex::MultiFab>, 3> const& E,
+             amrex::Real const* coefs_x, amrex::Real const* coefs_y,
+             amrex::Real const* coefs_z, amrex::Real const dt)
+{
+    using T_Algo = CartesianYeeAlgorithmND<D>;
+    using namespace amrex;
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(*B[0], TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        Array4<Real> const& Bx = B[0]->array(mfi);
+        Array4<Real> const& By = B[1]->array(mfi);
+        Array4<Real> const& Bz = B[2]->array(mfi);
+        Array4<Real const> const& Ex = E[0]->const_array(mfi);
+        Array4<Real const> const& Ey = E[1]->const_array(mfi);
+        Array4<Real const> const& Ez = E[2]->const_array(mfi);
+
+        Box const& tbx = mfi.tilebox(B[0]->ixType().toIntVect());
+        Box const& tby = mfi.tilebox(B[1]->ixType().toIntVect());
+        Box const& tbz = mfi.tilebox(B[2]->ixType().toIntVect());
+
+        amrex::ParallelFor(tbx, tby, tbz,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+                Bx(i, j, k) += dt * T_Algo::UpwardDz(Ey, coefs_z, 1, i, j, k)
+                             - dt * T_Algo::UpwardDy(Ez, coefs_y, 1, i, j, k);
+            },
+            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+                By(i, j, k) += dt * T_Algo::UpwardDx(Ez, coefs_x, 1, i, j, k)
+                             - dt * T_Algo::UpwardDz(Ex, coefs_z, 1, i, j, k);
+            },
+            [=] AMREX_GPU_DEVICE (int i, int j, int k){
+                Bz(i, j, k) += dt * T_Algo::UpwardDy(Ex, coefs_y, 1, i, j, k)
+                             - dt * T_Algo::UpwardDx(Ey, coefs_x, 1, i, j, k);
+            }
+        );
+    }
+}
+
+/** Ampere's law, cf. FiniteDifferenceSolver::EvolveECartesian */
+template <warpx::Dim D>
+void
+EvolveEImpl (std::array<std::unique_ptr<amrex::MultiFab>, 3>& E,
+             std::array<std::unique_ptr<amrex::MultiFab>, 3> const& B,
+             std::array<std::unique_ptr<amrex::MultiFab>, 3> const& j,
+             amrex::Real const* coefs_x, amrex::Real const* coefs_y,
+             amrex::Real const* coefs_z, amrex::Real const dt)
+{
+    using T_Algo = CartesianYeeAlgorithmND<D>;
+    using namespace amrex;
+
+    Real constexpr c2 = PhysConst::c2;
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(*E[0], TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        Array4<Real> const& Ex = E[0]->array(mfi);
+        Array4<Real> const& Ey = E[1]->array(mfi);
+        Array4<Real> const& Ez = E[2]->array(mfi);
+        Array4<Real const> const& Bx = B[0]->const_array(mfi);
+        Array4<Real const> const& By = B[1]->const_array(mfi);
+        Array4<Real const> const& Bz = B[2]->const_array(mfi);
+        Array4<Real const> const& jx = j[0]->const_array(mfi);
+        Array4<Real const> const& jy = j[1]->const_array(mfi);
+        Array4<Real const> const& jz = j[2]->const_array(mfi);
+
+        Box const& tex = mfi.tilebox(E[0]->ixType().toIntVect());
+        Box const& tey = mfi.tilebox(E[1]->ixType().toIntVect());
+        Box const& tez = mfi.tilebox(E[2]->ixType().toIntVect());
+
+        amrex::ParallelFor(tex, tey, tez,
+            [=] AMREX_GPU_DEVICE (int i, int j_, int k){
+                Ex(i, j_, k) += c2 * dt * (
+                    - T_Algo::DownwardDz(By, coefs_z, 1, i, j_, k)
+                    + T_Algo::DownwardDy(Bz, coefs_y, 1, i, j_, k)
+                    - PhysConst::mu0 * jx(i, j_, k) );
+            },
+            [=] AMREX_GPU_DEVICE (int i, int j_, int k){
+                Ey(i, j_, k) += c2 * dt * (
+                    - T_Algo::DownwardDx(Bz, coefs_x, 1, i, j_, k)
+                    + T_Algo::DownwardDz(Bx, coefs_z, 1, i, j_, k)
+                    - PhysConst::mu0 * jy(i, j_, k) );
+            },
+            [=] AMREX_GPU_DEVICE (int i, int j_, int k){
+                Ez(i, j_, k) += c2 * dt * (
+                    - T_Algo::DownwardDy(Bx, coefs_y, 1, i, j_, k)
+                    + T_Algo::DownwardDx(By, coefs_x, 1, i, j_, k)
+                    - PhysConst::mu0 * jz(i, j_, k) );
+            }
+        );
+    }
+}
+
+void
+Simulation::EvolveB (amrex::Real const a_dt)
+{
+    BL_PROFILE("Simulation::EvolveB()");
+    warpx::dim_dispatch(m_dim, [&] (auto dim_const) {
+        constexpr warpx::Dim D = dim_const();
+        EvolveBImpl<D>(m_B, m_E, m_stencil_coefs_x.data(), m_stencil_coefs_y.data(),
+                       m_stencil_coefs_z.data(), a_dt);
+    });
+}
+
+void
+Simulation::EvolveE (amrex::Real const a_dt)
+{
+    BL_PROFILE("Simulation::EvolveE()");
+    warpx::dim_dispatch(m_dim, [&] (auto dim_const) {
+        constexpr warpx::Dim D = dim_const();
+        EvolveEImpl<D>(m_E, m_B, m_j, m_stencil_coefs_x.data(), m_stencil_coefs_y.data(),
+                       m_stencil_coefs_z.data(), a_dt);
+    });
+}
+
+void
+Simulation::SumBoundaryJ ()
+{
+    BL_PROFILE("Simulation::SumBoundaryJ()");
+    for (int c = 0; c < 3; ++c) {
+        m_j[c]->SumBoundary(m_geom.periodicity());
+    }
+}
+
+void
+Simulation::FillBoundaryE ()
+{
+    BL_PROFILE("Simulation::FillBoundaryE()");
+    for (int c = 0; c < 3; ++c) {
+        m_E[c]->FillBoundary(m_geom.periodicity());
+    }
+}
+
+void
+Simulation::FillBoundaryB ()
+{
+    BL_PROFILE("Simulation::FillBoundaryB()");
+    for (int c = 0; c < 3; ++c) {
+        m_B[c]->FillBoundary(m_geom.periodicity());
+    }
+}
+
+void
+Simulation::RunDiagnostics (int const step, amrex::Real const time)
+{
+    BL_PROFILE("Simulation::RunDiagnostics()");
+
+    // reduced diagnostics: maximum norm of each field component
+    const std::array<std::string, 9> names
+        {"Ex", "Ey", "Ez", "Bx", "By", "Bz", "jx", "jy", "jz"};
+    std::array<amrex::Real, 9> max_abs {};
+    for (int c = 0; c < 3; ++c) {
+        max_abs[c] = m_E[c]->norm0();
+        max_abs[3 + c] = m_B[c]->norm0();
+        max_abs[6 + c] = m_j[c]->norm0();
+    }
+    if (amrex::ParallelDescriptor::IOProcessor()) {
+        static bool first_call = true;
+        std::ofstream ofs("diags/reduced.csv", first_call ? std::ios::trunc : std::ios::app);
+        if (first_call) {
+            ofs << "step,time";
+            for (auto const& n : names) { ofs << ",max_" << n; }
+            ofs << "\n";
+            first_call = false;
+        }
+        ofs << step << "," << time;
+        ofs.precision(17);
+        for (auto const v : max_abs) { ofs << "," << v; }
+        ofs << "\n";
+    }
+
+    // plotfile with cell-centered fields, averaged exactly like the
+    // plotfile diagnostics of WarpX (ablastr::coarsen::sample)
+    const bool plot = (m_plot_int > 0) &&
+        ((step % m_plot_int == 0) || (step == m_max_step));
+    if (plot) {
+        amrex::MultiFab mf(m_ba, m_dm, 9, 0);
+        const std::array<amrex::MultiFab const*, 9> fields {
+            m_E[0].get(), m_E[1].get(), m_E[2].get(),
+            m_B[0].get(), m_B[1].get(), m_B[2].get(),
+            m_j[0].get(), m_j[1].get(), m_j[2].get()};
+        for (int c = 0; c < 9; ++c) {
+            const amrex::IntVect stag = fields[c]->ixType().toIntVect();
+            const amrex::GpuArray<int, 3> sf {stag[0], stag[1], stag[2]};
+            const amrex::GpuArray<int, 3> sc {0, 0, 0};
+            const amrex::GpuArray<int, 3> cr {1, 1, 1};
+            for (amrex::MFIter mfi(mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+                const amrex::Box bx = mfi.growntilebox();
+                amrex::Array4<amrex::Real> const& dst = mf.array(mfi);
+                amrex::Array4<amrex::Real const> const& src = fields[c]->const_array(mfi);
+                amrex::ParallelFor(bx,
+                    [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                        dst(i, j, k, c) = ablastr::coarsen::sample::Interp(src, sf, sc, cr, i, j, k, 0);
+                    });
+            }
+        }
+        const std::string plotname = amrex::Concatenate(m_plotfile_prefix, step, 5);
+        amrex::Print() << "  writing plotfile " << plotname << "\n";
+        amrex::WriteSingleLevelPlotfile(plotname, mf,
+            {names.begin(), names.end()}, m_geom, time, step);
+    }
+}
+
+void
+Simulation::Evolve ()
+{
+    BL_PROFILE("Simulation::Evolve()");
+
+    amrex::UtilCreateDirectoryDestructive("diags", false);
+
+    amrex::Real cur_time = 0.0_rt;
+    RunDiagnostics(0, cur_time);
+
+    for (int step = 1; step <= m_max_step; ++step)
+    {
+        // one PIC cycle, cf. WarpX::OneStep_nosub
+        PushAndDeposit();
+        SumBoundaryJ();
+
+        EvolveB(0.5_rt*m_dt);
+        FillBoundaryB();
+        EvolveE(m_dt);
+        FillBoundaryE();
+        EvolveB(0.5_rt*m_dt);
+        FillBoundaryB();
+
+        for (auto& sp : m_species) {
+            sp.pc->Redistribute();
+        }
+
+        cur_time += m_dt;
+        if (step % 10 == 0 || step == m_max_step) {
+            amrex::Print() << "step " << step << " of " << m_max_step
+                           << ", t = " << cur_time << " s\n";
+        }
+        RunDiagnostics(step, cur_time);
+    }
+}

--- a/Tools/Prototypes/RuntimeDims/Simulation.cpp
+++ b/Tools/Prototypes/RuntimeDims/Simulation.cpp
@@ -95,6 +95,11 @@ Simulation::ReadParameters ()
     std::string field_gathering = "energy-conserving";
     pp_algo.query("field_gathering", field_gathering);
     m_galerkin_interpolation = (field_gathering == "energy-conserving");
+    // Use same shape factors in all directions with direct current deposition
+    // and the electromagnetic solver, cf. WarpX::ReadParameters
+    if (current_deposition == "direct") {
+        m_galerkin_interpolation = false;
+    }
 
     // simplified diagnostics: only a plotfile interval and prefix
     const amrex::ParmParse pp_diag("diag1");
@@ -498,9 +503,22 @@ PushAndDepositSpecies (Species& sp,
             problo[1] + depos_box.smallEnd(1)*dx_arr[1],
             problo[2] + depos_box.smallEnd(2)*dx_arr[2]};
 
-        amrex::FArrayBox& jx_fab = (*j[0])[pti];
-        amrex::FArrayBox& jy_fab = (*j[1])[pti];
-        amrex::FArrayBox& jz_fab = (*j[2])[pti];
+        // Deposit into zeroed local arrays and accumulate them into j
+        // afterwards, like the CPU path of WarpXParticleContainer::
+        // DepositCurrent (this also keeps the per-cell floating-point
+        // summation order identical for the bitwise comparison runs)
+        amrex::Box tbx = amrex::convert(pti.validbox(), j[0]->ixType().toIntVect());
+        amrex::Box tby = amrex::convert(pti.validbox(), j[1]->ixType().toIntVect());
+        amrex::Box tbz = amrex::convert(pti.validbox(), j[2]->ixType().toIntVect());
+        tbx.grow(j[0]->nGrowVect());
+        tby.grow(j[1]->nGrowVect());
+        tbz.grow(j[2]->nGrowVect());
+        amrex::FArrayBox jx_fab(tbx, 1);
+        amrex::FArrayBox jy_fab(tby, 1);
+        amrex::FArrayBox jz_fab(tbz, 1);
+        jx_fab.setVal<amrex::RunOn::Device>(0.0_rt);
+        jy_fab.setVal<amrex::RunOn::Device>(0.0_rt);
+        jz_fab.setVal<amrex::RunOn::Device>(0.0_rt);
 
         {
         BL_PROFILE("PushAndDeposit::CurrentDeposition");
@@ -521,6 +539,10 @@ PushAndDepositSpecies (Species& sp,
                                      jx_fab, jy_fab, jz_fab, np, -0.5_rt*dt, dinv,
                                      dxyzmin, dlo, q, 1);
         }
+
+        (*j[0])[pti].lockAdd(jx_fab, tbx, tbx, 0, 0, 1);
+        (*j[1])[pti].lockAdd(jy_fab, tby, tby, 0, 0, 1);
+        (*j[2])[pti].lockAdd(jz_fab, tbz, tbz, 0, 0, 1);
         }
     }
 }
@@ -750,6 +772,25 @@ Simulation::RunDiagnostics (int const step, amrex::Real const time)
         amrex::Print() << "  writing plotfile " << plotname << "\n";
         amrex::WriteSingleLevelPlotfile(plotname, mf,
             {names.begin(), names.end()}, m_geom, time, step);
+        for (auto& sp : m_species) {
+            // full-precision CSV of the particle data, for debugging and
+            // bitwise comparisons against native runs (serial only)
+            if (amrex::ParallelDescriptor::NProcs() == 1) {
+                std::ofstream ofs(plotname + "/" + sp.name + "_particles.csv");
+                ofs.precision(17);
+                ofs << "x,y,z,w,ux,uy,uz\n";
+                for (UnifiedParIter pti(*sp.pc, 0); pti.isValid(); ++pti) {
+                    auto& soa = pti.GetStructOfArrays();
+                    auto const np = pti.numParticles();
+                    for (int i = 0; i < np; ++i) {
+                        for (int comp = 0; comp < PIdx::nattribs; ++comp) {
+                            ofs << soa.GetRealData(comp)[i]
+                                << (comp + 1 < PIdx::nattribs ? "," : "\n");
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/Tools/Prototypes/RuntimeDims/analysis/analysis_langmuir.py
+++ b/Tools/Prototypes/RuntimeDims/analysis/analysis_langmuir.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Axel Huebl
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+#
+# Validate a Langmuir-oscillation run of the runtime-dimensionality prototype
+# (warpx.unified) against the analytic plasma-wave solution, for any
+# dimensionality. The prototype stores fields in degenerate-3D plotfiles:
+# collapsed dimensions have extent 1, the analytic contribution along them
+# is 1.
+#
+# Usage: analysis_langmuir.py <plotfile>
+#
+# Cf. Examples/Tests/langmuir/analysis_{1,2,3}d.py; parameters must match
+# Examples/Tests/langmuir/inputs_base_{1,2,3}d.
+import sys
+
+import numpy as np
+import yt
+from scipy.constants import c, e, epsilon_0, m_e
+
+yt.funcs.mylog.setLevel(50)
+
+fn = sys.argv[1]
+
+# parameters of inputs_base_{1,2,3}d
+epsilon = 0.01
+n = 4.0e24  # 2e24 electrons + 2e24 positrons
+n_osc = 2
+wp = np.sqrt((n * e**2) / (m_e * epsilon_0))
+
+ds = yt.load(fn)
+t0 = ds.current_time.to_value()
+dims = np.array(ds.domain_dimensions)
+lo = np.array(ds.domain_left_edge)
+hi = np.array(ds.domain_right_edge)
+active = dims > 1
+print(f"domain {dims}, active axes {active}, t = {t0}")
+
+# wave vector along each active axis (collapsed axes do not contribute)
+k = np.where(active, 2.0 * np.pi * n_osc / (hi - lo), 0.0)
+
+data = ds.covering_grid(level=0, left_edge=ds.domain_left_edge, dims=dims)
+
+
+def get_contribution(axis, is_cos):
+    """analytic standing-wave factor along one axis, at cell centers"""
+    if not active[axis]:
+        return np.ones(1)
+    du = (hi[axis] - lo[axis]) / dims[axis]
+    u = lo[axis] + du * (0.5 + np.arange(dims[axis]))
+    return np.cos(k[axis] * u) if is_cos else np.sin(k[axis] * u)
+
+
+def get_theoretical_field(comp, t):
+    """E_comp = epsilon m_e c^2 k_comp / q_e sin(k_comp u_comp) prod_cos sin(w_p t)"""
+    amplitude = epsilon * (m_e * c**2 * k[comp]) / e * np.sin(wp * t)
+    f = [get_contribution(ax, is_cos=(ax != comp)) for ax in range(3)]
+    return (
+        amplitude
+        * f[0][:, np.newaxis, np.newaxis]
+        * f[1][np.newaxis, :, np.newaxis]
+        * f[2][np.newaxis, np.newaxis, :]
+    )
+
+
+error_rel = 0
+for comp, field in enumerate(["Ex", "Ey", "Ez"]):
+    if not active[comp]:
+        continue
+    E_sim = data[("boxlib", field)].to_ndarray()
+    E_th = get_theoretical_field(comp, t0)
+    max_error = abs(E_sim - E_th).max() / abs(E_th).max()
+    print(f"{field}: max error: {max_error:.2e}")
+    error_rel = max(error_rel, max_error)
+
+tolerance_rel = 0.05
+print(f"error_rel    : {error_rel}")
+print(f"tolerance_rel: {tolerance_rel}")
+assert error_rel < tolerance_rel
+print("PASS")

--- a/Tools/Prototypes/RuntimeDims/analysis/compare_native.py
+++ b/Tools/Prototypes/RuntimeDims/analysis/compare_native.py
@@ -42,6 +42,15 @@ assert abs(ds_u.current_time.to_value() - ds_n.current_time.to_value()) == 0.0, 
 )
 
 fields = ["Ex", "Ey", "Ez", "Bx", "By", "Bz", "jx", "jy", "jz"]
+
+# normalization floor for the B components: in electrostatic-like problems
+# (e.g., Langmuir waves) B is numerical noise, so normalize it against the
+# physically meaningful field scale E/c instead of against its own noise
+c = 299792458.0
+E_scale = max(
+    np.abs(data_n[("boxlib", f)].to_ndarray()).max() for f in ("Ex", "Ey", "Ez")
+)
+
 failed = []
 for field in fields:
     f_u = np.squeeze(data_u[("boxlib", field)].to_ndarray())
@@ -52,6 +61,8 @@ for field in fields:
         continue
     assert f_u.shape == f_n.shape, f"{field}: shape mismatch {f_u.shape} vs {f_n.shape}"
     norm = np.abs(f_n).max()
+    if field.startswith("B"):
+        norm = max(norm, E_scale / c)
     err = np.abs(f_u - f_n).max()
     rel = err / norm if norm > 0.0 else err
     exact = " (bitwise)" if err == 0.0 else ""

--- a/Tools/Prototypes/RuntimeDims/analysis/compare_native.py
+++ b/Tools/Prototypes/RuntimeDims/analysis/compare_native.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Axel Huebl
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+#
+# Compare a plotfile of the runtime-dimensionality prototype (warpx.unified,
+# degenerate-3D layout) against a plotfile of a native per-dimension WarpX
+# binary (warpx.1d/2d/3d), field by field.
+#
+# Both codes cell-center the staggered fields with the exact same averaging
+# (ablastr::coarsen::sample::Interp), so serial (1 rank, 1 thread) runs must
+# agree bitwise; parallel runs agree up to atomic-reduction rounding.
+#
+# Usage: compare_native.py <unified_plotfile> <native_plotfile> [tolerance]
+#        tolerance: maximum relative L-inf error (default 0.0, i.e., bitwise)
+import sys
+
+import numpy as np
+import yt
+
+yt.funcs.mylog.setLevel(50)
+
+fn_unified = sys.argv[1]
+fn_native = sys.argv[2]
+tolerance = float(sys.argv[3]) if len(sys.argv) > 3 else 0.0
+
+ds_u = yt.load(fn_unified)
+ds_n = yt.load(fn_native)
+
+data_u = ds_u.covering_grid(
+    level=0, left_edge=ds_u.domain_left_edge, dims=ds_u.domain_dimensions
+)
+data_n = ds_n.covering_grid(
+    level=0, left_edge=ds_n.domain_left_edge, dims=ds_n.domain_dimensions
+)
+
+assert abs(ds_u.current_time.to_value() - ds_n.current_time.to_value()) == 0.0, (
+    f"simulation times differ: {ds_u.current_time} vs {ds_n.current_time}"
+)
+
+fields = ["Ex", "Ey", "Ez", "Bx", "By", "Bz", "jx", "jy", "jz"]
+failed = []
+for field in fields:
+    f_u = np.squeeze(data_u[("boxlib", field)].to_ndarray())
+    try:
+        f_n = np.squeeze(data_n[("boxlib", field)].to_ndarray())
+    except Exception:
+        print(f"{field}: not in native output, skipped")
+        continue
+    assert f_u.shape == f_n.shape, f"{field}: shape mismatch {f_u.shape} vs {f_n.shape}"
+    norm = np.abs(f_n).max()
+    err = np.abs(f_u - f_n).max()
+    rel = err / norm if norm > 0.0 else err
+    exact = " (bitwise)" if err == 0.0 else ""
+    print(f"{field}: max |diff| = {err:.3e}, rel = {rel:.3e}{exact}")
+    if rel > tolerance:
+        failed.append(field)
+
+if failed:
+    print(f"FAIL: {failed} exceed tolerance {tolerance}")
+    sys.exit(1)
+print("PASS")

--- a/Tools/Prototypes/RuntimeDims/main.cpp
+++ b/Tools/Prototypes/RuntimeDims/main.cpp
@@ -1,0 +1,77 @@
+/* Copyright 2026 Axel Huebl
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+#include "Simulation.H"
+
+#include "Utils/WarpXConst.H"
+#include "Utils/WarpXDim.H"
+
+#include <AMReX.H>
+#include <AMReX_BLProfiler.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_Print.H>
+
+#include <string>
+
+namespace
+{
+    /** Make my_constants and the physical constants available in input-file
+     *  expressions, cf. warpx::initialization::add_constants */
+    void
+    add_constants ()
+    {
+        amrex::ParmParse::SetParserPrefix("my_constants");
+        amrex::ParmParse pp_constants("my_constants");
+        amrex::Real tmp = PhysConst::c;
+        pp_constants.queryAdd("clight", tmp);
+        tmp = PhysConst::epsilon_0;
+        pp_constants.queryAdd("epsilon0", tmp);
+        tmp = PhysConst::mu0;
+        pp_constants.queryAdd("mu0", tmp);
+        tmp = PhysConst::q_e;
+        pp_constants.queryAdd("q_e", tmp);
+        tmp = PhysConst::m_e;
+        pp_constants.queryAdd("m_e", tmp);
+        tmp = PhysConst::m_p;
+        pp_constants.queryAdd("m_p", tmp);
+        tmp = PhysConst::m_u;
+        pp_constants.queryAdd("m_u", tmp);
+        tmp = PhysConst::kb;
+        pp_constants.queryAdd("kb", tmp);
+        tmp = PhysConst::hbar;
+        pp_constants.queryAdd("hbar", tmp);
+        tmp = MathConst::pi;
+        pp_constants.queryAdd("pi", tmp);
+    }
+}
+
+int main (int argc, char* argv[])
+{
+    amrex::Initialize(argc, argv);
+    {
+        BL_PROFILE("main()");
+
+        add_constants();
+
+        // runtime dimensionality selection: this replaces the compile-time
+        // check in warpx::initialization::check_dims()
+        std::string dims;
+        const amrex::ParmParse pp_geometry("geometry");
+        pp_geometry.get("dims", dims);
+        const warpx::Dim dim = warpx::dim_from_geometry_dims(dims);
+
+        amrex::Print() << "WarpX runtime-dimensionality prototype"
+                       << " (AMReX " << amrex::Version() << ", AMREX_SPACEDIM="
+                       << AMREX_SPACEDIM << ")\n"
+                       << "Running with geometry.dims = " << dims << "\n";
+
+        Simulation sim(dim);
+        sim.InitData();
+        sim.Evolve();
+    }
+    amrex::Finalize();
+    return 0;
+}

--- a/Tools/Prototypes/RuntimeDims/perf/run_perf.sh
+++ b/Tools/Prototypes/RuntimeDims/perf/run_perf.sh
@@ -31,7 +31,6 @@ overrides=(
     diag1.diag_type=Full
     "max_step=${steps}"
     warpx.verbose=0
-    tiny_profiler.v=1
 )
 
 run_one () {
@@ -42,23 +41,22 @@ run_one () {
      OMP_NUM_THREADS=${threads} "${exe}" "$(basename "${inputs}")" "${overrides[@]}" "$@" \
          > run.log 2>&1)
     local total
-    total=$(grep -m1 "Total Times" -A4 "${dir}/run.log" | grep -m1 -oE "[0-9]+\.[0-9]+" | head -1)
-    [ -n "${total}" ] || total=$(grep -m1 -oE "Run time = [0-9.e+-]+" "${dir}/run.log" | grep -oE "[0-9.e+-]+$")
+    total=$(grep -m1 -oE "TinyProfiler total time across processes.*" "${dir}/run.log" | grep -oE "[0-9.]+" | head -1)
     echo "${label}: total ${total} s"
-    # top TinyProfiler inclusive regions
-    sed -n '/^TinyProfiler total time/,/^$/p' "${dir}/run.log" | head -3 || true
+    # top exclusive TinyProfiler regions
+    grep -m1 -A8 "Excl. Min" "${dir}/run.log" | tail -7 | sed "s/^/    /"
 }
 
 # problem sizes per dimensionality: <dim> <n_cell override> <grid override> <ppc>
 cases=(
     "1 amr.n_cell=1048576 amr.max_grid_size=1048576 8"
-    "2 amr.n_cell=1024_1024 amr.max_grid_size=1024 4"
-    "3 amr.n_cell=128_128_128 amr.max_grid_size=128 2"
+    "2 amr.n_cell=1024,1024 amr.max_grid_size=1024 4"
+    "3 amr.n_cell=128,128,128 amr.max_grid_size=128 2"
 )
 
 for c in "${cases[@]}"; do
     set -- $c
-    D=$1; ncell=${2//_/ }; mgs=$3; ppc=$4
+    D=$1; ncell=${2//,/ }; mgs=$3; ppc=$4
     inputs="${langmuir}/inputs_test_${D}d_langmuir_multi"
     ppc_arg=""
     case ${D} in
@@ -70,8 +68,8 @@ for c in "${cases[@]}"; do
     echo "## ${D}D: ${ncell}, ppc=${ppc}, ${steps} steps"
     # shellcheck disable=SC2086
     run_one "unified ${D}d" "${bin}/warpx.unified" "${inputs}" "${scratch}/u${D}" \
-        "${ncell}" "amr.max_grid_size=${mgs}" ${ppc_arg}
+        "${ncell}" "${mgs}" ${ppc_arg}
     # shellcheck disable=SC2086
     run_one "native  ${D}d" "${bin}/warpx.${D}d" "${inputs}" "${scratch}/n${D}" \
-        "${ncell}" "amr.max_grid_size=${mgs}" ${ppc_arg}
+        "${ncell}" "${mgs}" ${ppc_arg}
 done

--- a/Tools/Prototypes/RuntimeDims/perf/run_perf.sh
+++ b/Tools/Prototypes/RuntimeDims/perf/run_perf.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 Axel Huebl
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+#
+# Performance comparison harness for the runtime-dimensionality prototype:
+# runs warpx.unified vs. the native warpx.{1d,2d,3d} binaries on identical
+# Langmuir problems and reports total times and TinyProfiler hot regions.
+#
+# Usage: run_perf.sh <build_dir> [steps] [threads]
+set -eu
+
+build_dir=${1:?usage: run_perf.sh <build_dir> [steps] [threads]}
+steps=${2:-200}
+threads=${3:-1}
+
+repo=$(cd "$(dirname "$0")"/../../../.. && pwd)
+[ -d "${repo}/Examples/Tests/langmuir" ] || repo=$(cd "$(dirname "$0")"/../../.. && pwd)
+langmuir="${repo}/Examples/Tests/langmuir"
+bin="${build_dir}/bin"
+scratch=$(mktemp -d /tmp/warpx_perf.XXXXXX)
+echo "# scratch: ${scratch}; steps: ${steps}; OMP threads: ${threads}"
+
+overrides=(
+    algo.current_deposition=direct
+    diagnostics.diags_names=diag1
+    diag1.intervals=1000000
+    diag1.diag_type=Full
+    "max_step=${steps}"
+    warpx.verbose=0
+    tiny_profiler.v=1
+)
+
+run_one () {
+    local label=$1 exe=$2 inputs=$3 dir=$4; shift 4
+    mkdir -p "${dir}"
+    (cd "${dir}" && cp "${langmuir}/$(basename "${inputs}")" .
+     for b in "${langmuir}"/inputs_base_*; do cp "$b" . 2> /dev/null || true; done
+     OMP_NUM_THREADS=${threads} "${exe}" "$(basename "${inputs}")" "${overrides[@]}" "$@" \
+         > run.log 2>&1)
+    local total
+    total=$(grep -m1 "Total Times" -A4 "${dir}/run.log" | grep -m1 -oE "[0-9]+\.[0-9]+" | head -1)
+    [ -n "${total}" ] || total=$(grep -m1 -oE "Run time = [0-9.e+-]+" "${dir}/run.log" | grep -oE "[0-9.e+-]+$")
+    echo "${label}: total ${total} s"
+    # top TinyProfiler inclusive regions
+    sed -n '/^TinyProfiler total time/,/^$/p' "${dir}/run.log" | head -3 || true
+}
+
+# problem sizes per dimensionality: <dim> <n_cell override> <grid override> <ppc>
+cases=(
+    "1 amr.n_cell=1048576 amr.max_grid_size=1048576 8"
+    "2 amr.n_cell=1024_1024 amr.max_grid_size=1024 4"
+    "3 amr.n_cell=128_128_128 amr.max_grid_size=128 2"
+)
+
+for c in "${cases[@]}"; do
+    set -- $c
+    D=$1; ncell=${2//_/ }; mgs=$3; ppc=$4
+    inputs="${langmuir}/inputs_test_${D}d_langmuir_multi"
+    ppc_arg=""
+    case ${D} in
+        1) ppc_arg="electrons.num_particles_per_cell_each_dim=${ppc} positrons.num_particles_per_cell_each_dim=${ppc}";;
+        2) ppc_arg="electrons.num_particles_per_cell_each_dim=${ppc} ${ppc} positrons.num_particles_per_cell_each_dim=${ppc} ${ppc}";;
+        3) ppc_arg="electrons.num_particles_per_cell_each_dim=${ppc} ${ppc} ${ppc} positrons.num_particles_per_cell_each_dim=${ppc} ${ppc} ${ppc}";;
+    esac
+    echo
+    echo "## ${D}D: ${ncell}, ppc=${ppc}, ${steps} steps"
+    # shellcheck disable=SC2086
+    run_one "unified ${D}d" "${bin}/warpx.unified" "${inputs}" "${scratch}/u${D}" \
+        "${ncell}" "amr.max_grid_size=${mgs}" ${ppc_arg}
+    # shellcheck disable=SC2086
+    run_one "native  ${D}d" "${bin}/warpx.${D}d" "${inputs}" "${scratch}/n${D}" \
+        "${ncell}" "amr.max_grid_size=${mgs}" ${ppc_arg}
+done

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -163,6 +163,10 @@ macro(find_amrex)
         list(TRANSFORM WarpX_amrex_dim REPLACE RZ 2)
         list(TRANSFORM WarpX_amrex_dim REPLACE RCYLINDER 1)
         list(TRANSFORM WarpX_amrex_dim REPLACE RSPHERE 1)
+        if(WarpX_RUNTIME_DIMS_PROTO)
+            # the runtime-dimensionality prototype is always built against AMReX 3D
+            list(APPEND WarpX_amrex_dim 3)
+        endif()
         list(REMOVE_DUPLICATES WarpX_amrex_dim)
         set(AMReX_SPACEDIM ${WarpX_amrex_dim} CACHE INTERNAL "")
 


### PR DESCRIPTION
A first-day design flaw of WarpX that we discussed over the years is the macro-esque splitting and reuse of code at the expense of compiling now 3 Cartesian + 3 R-ish coordinates against 3 different variants of AMReX. This is a LLM-assisted prototype that shows one can overcome this and:
- depend only on AMReX 3D
- build a single version of WarpX that can be fully runtime controlled for dimensionality.

The goal is not to merge this PR but to follow a successive roadmap to finally solve this architectural flaw.

---

## Summary

This PR validates — with working code — the architecture in which

- **AMReX is built once, with `AMREX_SPACEDIM=3`**, instead of once per dimensionality,
- **a single WarpX binary supports all dimensionalities**, selected at runtime via the existing `geometry.dims` input parameter, and
- per-dimension code paths are written as **`template <warpx::Dim D>` kernels with `if constexpr` branches** that replace the `#if defined(WARPX_DIM_*)` macro snippets 1:1 and are dispatched at runtime (`warpx::dim_dispatch`), exactly like the existing runtime particle-shape-order dispatch.

It contains (a) the transition infrastructure, (b) the first vertical slice of kernel headers converted in place — **existing per-dimension builds compile unchanged and stay bit-identical** — and (c) a prototype application, `warpx.unified`, that runs the unmodified Langmuir-multi inputs at `geometry.dims = 1`, `2` and `3` from one executable built only against AMReX 3D.

## Why

Today every value of `WarpX_DIMS` rebuilds AMReX and the entire WarpX source tree, producing one executable per dimensionality. Dimensionality is baked in via ~1000 preprocessor sites across ~195 files. Building AMReX once (3D) and selecting dimensionality at runtime removes the N× build cost, simplifies packaging/distribution, and — by replacing macro snippets with shared dimension-generic kernels — *reduces* source duplication rather than adding to it (the direct-deposition conversion in this PR is net −136 lines).

## Design conventions

- **Unified degenerate-3D layout**: fields of all dimensionalities are 3D `MultiFab`s with collapsed dimensions of extent 1 — 1D is `(1, 1, nz)`, 2D/RZ are `(nx, 1, nz)`; z is always index 2 (`warpx::IdxMap`, replacing `WARPX_ZINDEX`). Collapsed dimensions use `prob_lo/hi = [-0.5, 0.5)` (cell size exactly 1 m, matching the existing `WarpX::CellSize` convention), zero guard cells, cell-centered staggering, periodic boundaries.
- **Particles**: positions are always three SoA components; components of collapsed dimensions are 0 and never updated by the pusher (2D tracks `uy` but not `y`, exactly like the native 2D code).
- **Kernels**: per-axis helpers (`DepositAxisShape`, `GatherAxisShape`) collapse the per-dimension loop nests into one dimension-generic nest whose collapsed axes degenerate at compile time to exactly the native per-dimension code. The `warpx::Dim` template parameter defaults to `warpx::CompileDim` (derived from today's macros), so all existing call sites compile unchanged.
- **Transition guards**: kernels not yet converted are wrapped in `#if !defined(WARPX_DIM_RUNTIME)` and remain untouched in per-dimension builds.
- AMReX precedent for the degenerate-dimension pattern: `amrex::FFT::R2C` documents 2D transforms on 3D builds via extent-1 dimensions.

## What's in this PR

1. **Infrastructure** — `Source/Utils/WarpXDim.H` (runtime `warpx::Dim` enum, `warpx::CompileDim` bridge, constexpr traits `has_x/has_y/has_z/is_radial/...` covering all six dimensionalities incl. RZ/RCYLINDER/RSPHERE), `WarpXDimDispatch.H` (`dim_dispatch`), `WarpXDimIndexing.H` (`IdxMap`, `field_at`).
2. **Converted in place** (per-dimension builds bit-identical, verified by run/analysis/**checksum** tests in 1D/2D/3D/RZ):
   - `Particles/PIdx.H` (split out of `WarpXParticleContainer.H`), `Pusher/UpdatePosition.H`, `Pusher/GetAndSetPosition.H`
   - `Deposition/CurrentDeposition.H` (direct path) and `Gather/FieldGather.H` (explicit path) — the four hand-written per-dimension scatter/gather nests each collapse to one loop
   - `FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H` → `CartesianYeeAlgorithmND<D>` (alias keeps all 19 use sites unchanged); the nine derivative methods deduplicate into three slot-generic helpers
3. **Prototype app** — `Tools/Prototypes/RuntimeDims/` behind the advanced CMake option `WarpX_RUNTIME_DIMS_PROTO` (off by default). It deliberately does **not** link `lib_<dim>`/`ablastr_<dim>`: it only includes the converted headers, proving they are free of per-dimension compile definitions. With `-DWarpX_DIMS=3`, AMReX is built exactly once — the intended end state.

## Validation

- **Per-dimension regression**: `langmuir_multi` run/analysis/checksum pass in 1D, 2D, 3D and RZ after every conversion step — the templates instantiate to bit-identical code.
- **Unified vs. native** (serial, 40 steps, same inputs, ctest `test_unified_langmuir_*`): particle positions and weights **bitwise identical**; fields agree to a few ×1e-14 relative (single-box runs: most components bitwise, the rest 1–2 ULP from per-cell summation order; comparison tolerance 1e-12). The comparison harness caught three real faithfulness bugs during development (staggered-box double-injection, the `direct deposition ⇒ Galerkin off` rule from `WarpX::ReadParameters`, local-fab accumulation order) — evidence that it is sharp enough to gate the future migration.
- **Physics**: the analytic Langmuir-wave checks pass in all three dimensionalities from the one binary, with the tolerances of the corresponding native tests.

## Performance

Serial CPU (Release, GCC 13), 100 steps, 17–34M particles; TinyProfiler exclusive times (`perf/run_perf.sh`):

| Case | gather + push | current deposition |
|---|---:|---:|
| 1D (2²⁰ cells, 8 ppc/species) | +6 % | +32 % |
| 2D (1024², 4×4) | +9 % | +10 % |
| **3D (128³, 2×2×2) — control** | **+18 %** | **−3 %** |

The 3D control instantiates the *same* kernels as the native 3D binary, so its delta measures prototype-*harness* overhead (per-box instead of WarpX's per-tile particle iteration; the same locality gap explains the 1D deposition delta). The 1D/2D gather deltas sit at or below the control: **the runtime-dimensionality mechanics add no measurable dimension-specific cost.** The structural particle-memory overhead of always-3D positions is +40 % (1D), +17 % (2D), 0 % (3D). In the full migration the converted kernels are called from the existing (tiled) containers, which removes the harness-locality gap by construction.

## Migration roadmap

Incremental, each phase landing as reviewable PRs with per-dimension builds staying the only shipping artifacts (and bit-identical) until the end:

- **Phase A — remaining particle kernels.** Convert the remaining deposition variants (Esirkepov, Villasenor, Vay, shared-memory, implicit; `SharedDepositionUtils.H`, `ChargeDeposition.H`), the remaining gather paths, `GetExternalFields.H`, the pushers and `ParticleUtils.H`; add `dim_dispatch` wrappers at the `WarpXParticleContainer`/`PhysicalParticleContainer` call sites next to the existing shape-order chains. The prototype app grows test coverage for each converted kernel.
- **Phase B — field solvers.** `CartesianCKCAlgorithm`/`CartesianNodalAlgorithm`, the `FiniteDifferenceSolver` class itself (collapse its `#if`-selected member sets into runtime-dimension state; fold the `Cylindrical`/`Spherical` evolves into the dispatch), PML, `MacroscopicEvolveE`, hybrid-PIC; PSATD on degenerate-3D FFTs (`amrex::FFT::R2C` already supports them).
- **Phase C — containers, initialization, I/O.** The unified `PIdx` becomes the only layout; `AddPlasma`/injectors, `GuardCellManager`, diagnostics. The plotfile layout for 1D/2D changes to degenerate-3D (checksum benchmarks regenerated once); openPMD writes true-dimensionality metadata. AMReX enabler PR: optional "real dims" plotfile metadata.
- **Phase D — WarpX core runtime dims.** `WarpX` holds the runtime dimensionality; `check_dims()` becomes `select_dims()`; `CellSize`/`LowerCorner`/moving window/boundary handling de-macroed; CMake gains `WarpX_DIMS=UNIFIED` building a single `lib`/`app` against `amrex_3d` (per-dimension builds become a compatibility option); `add_warpx_test()` runs all dimensionalities against the unified binary. Per-dimension tile-size defaults (e.g., large-z tiles in 1D) land here.
- **Phase E — RZ family and removal.** AMReX enabler PRs to make the RZ metric in `MLEBNodeFDLaplacian::setRZ`/`MLNodeLaplacian::setRZCorrection` usable from `AMREX_SPACEDIM=3` builds with a degenerate dimension (consumed at `ablastr/fields/PoissonSolver.H`, `EffectivePotentialPoissonSolver.H`, `VectorPoissonSolver.H`; WarpX otherwise uses Cartesian coordinates and applies the RZ metric in its own kernels). Migrate RZ (r in position slot 0, `theta` as extra SoA component, `CylindricalYeeAlgorithm` folded into the dispatch), then RCYLINDER/RSPHERE. Finally delete `WARPX_DIM_*`/`WARPX_ZINDEX`, the legacy paths of `WarpXDimIndexing.H` and the per-dimension CMake loop: AMReX is then built exactly once.

## Out of scope / known limitations

- Python bindings (deliberately untouched in this PR; addressed after phase D).
- RZ/RCYLINDER/RSPHERE are covered by the abstractions and design notes but not yet runtime-dispatched (the `dim_dispatch` case list is intentionally limited to 1/2/3 for now; later it becomes configure-time generated, which is also the escape hatch for trimming binary size/compile time).
- The prototype's particle initialization stages on the host; GPU runs of the *prototype* need pinned staging (the converted kernels themselves are CPU/GPU portable). A CUDA CI build of `app_unified` is a good early follow-up to lock in the nvcc-compatibility of the dispatch pattern.

## Points for discussion

- Naming: `warpx::Dim::{Z, XZ, XYZ, RZ, RCylinder, RSphere}` and the `...ND<D>` template + unqualified-alias pattern (mirrors AMReX's `BoxND`/`IntVectND`).
- Compile-time/binary-size budget once all dimensionalities are instantiated in one binary (linear in dispatched dims; measured next to phase A).
- Whether the 1D particle-memory overhead (+40 %) warrants a future AMReX enabler for pure-SoA containers with fewer-than-`AMREX_SPACEDIM` stored positions.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
