### PR TITLE
Deposition: Templated Float Precision

### DIFF
--- a/Source/Particles/Deposition/ChargeDeposition.H
+++ b/Source/Particles/Deposition/ChargeDeposition.H
@@ -33,9 +33,9 @@
  * \param q            species charge.
  * \param n_rz_azimuthal_modes Number of azimuthal modes when using RZ geometry.
  */
-template <int depos_order>
-void doChargeDepositionShapeN (const GetParticlePosition<PIdx>& GetPosition,
-                               const amrex::ParticleReal * const wp,
+template <int depos_order, class T_PReal = amrex::ParticleReal>
+void doChargeDepositionShapeN (const GetParticlePosition<PIdx, T_PReal>& GetPosition,
+                               const T_PReal * const wp,
                                const int* ion_lev,
                                amrex::FArrayBox& rho_fab,
                                long np_to_deposit,
@@ -69,7 +69,7 @@ void doChargeDepositionShapeN (const GetParticlePosition<PIdx>& GetPosition,
                 wq *= ion_lev[ip];
             }
 
-            amrex::ParticleReal xp, yp, zp;
+            T_PReal xp, yp, zp;
             GetPosition(ip, xp, yp, zp);
 
             // --- Compute shape factors

--- a/Source/Particles/Pusher/GetAndSetPosition.H
+++ b/Source/Particles/Pusher/GetAndSetPosition.H
@@ -70,10 +70,10 @@ void get_particle_position (const WarpXParticleContainer::SuperParticleType& p,
  *
  * \tparam T_PIdx particle index enumerator
 */
-template<typename T_PIdx = PIdx>
+template<typename T_PIdx = PIdx, class T_RType = amrex::ParticleReal>
 struct GetParticlePosition
 {
-    using RType = amrex::ParticleReal;
+    using RType = T_RType;
 
     const RType* AMREX_RESTRICT m_x = nullptr;
     const RType* AMREX_RESTRICT m_y = nullptr;
@@ -209,10 +209,10 @@ struct GetParticlePosition
  * \param a_pti iterator to the tile being modified
  * \param a_offset offset to apply to the particle indices
 */
-template<typename T_PIdx = PIdx>
+template<typename T_PIdx = PIdx, class T_RType = amrex::ParticleReal>
 struct SetParticlePosition
 {
-    using RType = amrex::ParticleReal;
+    using RType = T_RType;
 
 #if defined(WARPX_DIM_3D)
     RType* AMREX_RESTRICT m_x;

--- a/Source/ablastr/particles/DepositCharge.H
+++ b/Source/ablastr/particles/DepositCharge.H
@@ -170,7 +170,8 @@ deposit_charge (typename T_PC::ParIterType& pti,
     auto & rho_fab = local_rho;
 #endif
 
-    const auto GetPosition = GetParticlePosition<PIdx>(pti, offset);
+    using PReal_t = typename T_PC::RealVector::value_type;
+    const auto GetPosition = GetParticlePosition<PIdx, PReal_t>(pti, offset);
 
     // Indices of the lower bound
     const amrex::Dim3 lo = lbound(tilebox);


### PR DESCRIPTION
Reused deposition in ABLASTR as used in ImpactX: allow to deposit with DP and SP at the same time, using unique functions.

Related to https://github.com/AMReX-Codes/amrex/issues/5482