### PR TITLE
Node.js 20 actions are deprecated

### DIFF
--- a/.github/workflows/check_changes.yml
+++ b/.github/workflows/check_changes.yml
@@ -13,8 +13,8 @@ jobs:
     outputs:
       has_non_docs_changes: ${{ steps.set-output.outputs.has_non_docs_changes }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |

--- a/.github/workflows/clang_sanitizers.yml
+++ b/.github/workflows/clang_sanitizers.yml
@@ -28,7 +28,7 @@ jobs:
       # On CI for this test, Ninja is slower than the default:
       #CMAKE_GENERATOR: Ninja
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: install dependencies
       run: |
         .github/workflows/dependencies/clang.sh 19
@@ -90,7 +90,7 @@ jobs:
       # On CI for this test, Ninja is slower than the default:
       #CMAKE_GENERATOR: Ninja
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: install dependencies
       run: |
         .github/workflows/dependencies/clang.sh 19

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -27,7 +27,7 @@ jobs:
     needs: check_changes
     if: ${{ github.event.pull_request.draft == false }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       if: ${{ needs.check_changes.outputs.has_non_docs_changes == 'true' }}
     - name: install dependencies
       if: ${{ needs.check_changes.outputs.has_non_docs_changes == 'true' }}

--- a/.github/workflows/cleanup-cache-postpr.yml
+++ b/.github/workflows/cleanup-cache-postpr.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Clean up ccache
         run: |
           gh extension install actions/gh-actions-cache

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Clean up ccache
         run: |
           gh extension install actions/gh-actions-cache

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: actions/setup-python@v5
         name: Install Python

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -26,7 +26,7 @@ jobs:
     needs: check_changes
     if: ${{ github.event.pull_request.draft == false && needs.check_changes.outputs.has_non_docs_changes == 'true' }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: install dependencies
       shell: bash
       run: .github/workflows/dependencies/hip.sh 6.3.2
@@ -81,7 +81,7 @@ jobs:
     needs: check_changes
     if: ${{ github.event.pull_request.draft == false && needs.check_changes.outputs.has_non_docs_changes == 'true' }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: install dependencies
       shell: bash
       run: .github/workflows/dependencies/hip.sh 6.3.2

--- a/.github/workflows/insitu.yml
+++ b/.github/workflows/insitu.yml
@@ -30,7 +30,7 @@ jobs:
     container:
       image: alpinedav/ascent:0.9.3
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Configure
       run: |
         . /ascent_docker_setup_env.sh
@@ -76,7 +76,7 @@ jobs:
     container:
       image: kitware/paraview:ci-catalyst-amrex-warpx-20240828
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Configure
       run: |
         cmake -S . -B build   \

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -30,7 +30,7 @@ jobs:
     needs: check_changes
     if: ${{ github.event.pull_request.draft == false && needs.check_changes.outputs.has_non_docs_changes == 'true' }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: install dependencies
       shell: bash
       run: |
@@ -94,7 +94,7 @@ jobs:
     needs: check_changes
     if: ${{ github.event.pull_request.draft == false && needs.check_changes.outputs.has_non_docs_changes == 'true' }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: install dependencies
       shell: bash
       run: |

--- a/.github/workflows/jupyter.yml
+++ b/.github/workflows/jupyter.yml
@@ -23,7 +23,7 @@ jobs:
     needs: check_changes
     if: ${{ github.event.pull_request.draft == false && needs.check_changes.outputs.has_non_docs_changes == 'true' }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,7 +27,7 @@ jobs:
       # For macOS, Ninja is slower than the default:
       #CMAKE_GENERATOR: Ninja
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: actions/setup-python@v5
       name: Install Python
       with:

--- a/.github/workflows/monthly_release.yml
+++ b/.github/workflows/monthly_release.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           echo "DATE=$(date +'%y.%m')" >> $GITHUB_ENV
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -21,7 +21,7 @@ jobs:
   style:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Non-ASCII characters
       run: .github/workflows/source/hasNonASCII
     - name: TABs
@@ -39,7 +39,7 @@ jobs:
   zenodo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Validate Zenodo Metadata
         uses: vsoch/zenodo-validator@main
         with:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -25,7 +25,7 @@ jobs:
     env:
       CXXFLAGS: "-Werror"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: install dependencies
       run: |
         .github/workflows/dependencies/gcc_minimal.sh
@@ -66,7 +66,7 @@ jobs:
       CXX: "g++-13"
       CC: "gcc-13"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: install dependencies
       run: |
         .github/workflows/dependencies/gcc.sh 13
@@ -113,7 +113,7 @@ jobs:
       CXX: "g++-13"
       CC: "gcc-13"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: install dependencies
       run: |
         .github/workflows/dependencies/gcc_blaspp_lapackpp.sh 13
@@ -161,7 +161,7 @@ jobs:
       CMAKE_GENERATOR: Ninja
       CXXFLAGS: "-Werror"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: install dependencies
       run: |
         .github/workflows/dependencies/gcc_minimal.sh
@@ -200,7 +200,7 @@ jobs:
       # On CI for this test, Ninja is slower than the default:
       #CMAKE_GENERATOR: Ninja
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: install dependencies
       run: |
         .github/workflows/dependencies/pyfull.sh

--- a/.github/workflows/weekly_update.yml
+++ b/.github/workflows/weekly_update.yml
@@ -17,7 +17,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,7 +25,7 @@ jobs:
     #needs: check_changes
     #if: ${{ github.event.pull_request.draft == false && needs.check_changes.outputs.has_non_docs_changes == 'true' }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
@@ -77,7 +77,7 @@ jobs:
     needs: check_changes
     if: ${{ github.event.pull_request.draft == false && needs.check_changes.outputs.has_non_docs_changes == 'true' }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: actions/setup-python@v5
       with:
         python-version: '3.11'


### PR DESCRIPTION
While working on #6940, I noticed this GitHub warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/checkout@v4`, `dorny/paths-filter@v3`. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true`. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/.

This PR updates actions/checkout@v4 and dorny/paths-filter@v3 to v6 and v4, respectively.