### PR TITLE
CI: trust openpmd tap to fix brew untrusted formula error

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -47,8 +47,9 @@ jobs:
         brew install pkg-config
         set -e
         brew tap openpmd/openpmd
+        brew trust openpmd/openpmd
         brew uninstall cmake  # https://github.com/actions/runner-images/issues/12912
-        brew install openpmd-api
+        brew install openpmd/openpmd/openpmd-api
     - name: install pip dependencies
       run: |
         python3 -m pip install --upgrade pip


### PR DESCRIPTION
## Overview

Fix brew untrusted formula error observed in the macOS / AppleClang CI workflow:
```
Cloning into '/opt/homebrew/Library/Taps/openpmd/homebrew-openpmd'...
Tapped 1 formula (15 files, 60KB).
Uninstalling /opt/homebrew/Cellar/cmake/4.3.3... (4,041 files, 65.9MB)
cmake 4.3.2 is still installed.
To remove all versions, run:
  brew uninstall --force cmake
Error: Refusing to load formula openpmd/openpmd/openpmd-api from untrusted tap openpmd/openpmd.
Run `brew trust --formula openpmd/openpmd/openpmd-api` or `brew trust openpmd/openpmd` to trust it.
Error: Process completed with exit code 1.
```

## Notes

Original error seen in https://github.com/BLAST-WarpX/warpx/actions/runs/27359117263/job/80847830800?pr=6940.