### PR TITLE
Add backward scattering angle model for two-product reactions

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -2966,9 +2966,10 @@ Details about the collision models can be found in the :ref:`theory section <mul
     :optional:
 
     Only for ``nuclearfusion``. The scattering angle for the products of the fusion reaction.
-    The possible values are ``isotropic`` and ``forward``.
+    The possible values are ``isotropic``, ``forward`` and ``backward``.
     With ``isotropic``, the scattering angle is drawn from an isotropic distribution.
-    With ``forward``, the scattering angle is set to zero, i.e. the products are emitted in the same direction as the reactant.
+    With ``forward``, the scattering angle is set to zero, i.e. the products are emitted in the same direction as the reactant (in the center of mass frame).
+    With ``backward``, the scattering angle is set to :math:`\pi`, i.e. the products are emitted in the opposite direction of the reactant (in the center of mass frame).
 
 .. pp:param:: <collision_name>.background_density
     :type: ``float``

--- a/Source/Particles/Collision/BinaryCollision/TwoProductUtil.H
+++ b/Source/Particles/Collision/BinaryCollision/TwoProductUtil.H
@@ -138,8 +138,10 @@ namespace {
             ParticleUtils::RandomizeVelocity(px_star_out, py_star_out, pz_star_out, std::sqrt(p_star_f_sq),
                                              engine);
         }
-        else if (scattering_angle_model == ScatteringAngleModel::Forward) {
+        else if (scattering_angle_model == ScatteringAngleModel::Forward ||
+                 scattering_angle_model == ScatteringAngleModel::Backward) {
             // Forward scattering: the products have the same direction as the incident particle in the center of mass frame
+            // Backward scattering: the products have the opposite direction of the incident particle in the center of mass frame
             amrex::ParticleReal p1x_star_in, p1y_star_in, p1z_star_in;
             if ( vc_sq > std::numeric_limits<amrex::ParticleReal>::min() )
             {
@@ -161,8 +163,11 @@ namespace {
             const amrex::ParticleReal p1_star_in = std::sqrt(p1x_star_in*p1x_star_in + p1y_star_in*p1y_star_in + p1z_star_in*p1z_star_in);
 
             // Momentum of the first product in the center of mass frame:
-            // same direction as the incident, but scaled to have the magnitude sqrt(p_star_f_sq)
-            const amrex::ParticleReal scaling = std::sqrt(p_star_f_sq)/p1_star_in;
+            // same (forward) or opposite (backward) direction as the incident, scaled to have
+            // the magnitude sqrt(p_star_f_sq)
+            const amrex::ParticleReal sign = (scattering_angle_model == ScatteringAngleModel::Backward)
+                                             ? -1._prt : 1._prt;
+            const amrex::ParticleReal scaling = sign*std::sqrt(p_star_f_sq)/p1_star_in;
             px_star_out = p1x_star_in * scaling;
             py_star_out = p1y_star_in * scaling;
             pz_star_out = p1z_star_in * scaling;

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -193,6 +193,7 @@ AMREX_ENUM(
 AMREX_ENUM(
     ScatteringAngleModel,
     Forward,    /**< Scattering angle is zero, i.e., products have the same direction as the incident particle in the center of mass frame */
+    Backward,   /**< Scattering angle is pi, i.e., products have the opposite direction of the incident particle in the center of mass frame */
     Isotropic,  /**< Scattering angle is random, i.e., products are scattered isotropically in the center of mass frame */
     Default = Isotropic  /**< Isotropic */
 );


### PR DESCRIPTION
## Description

Adds a `backward` option to `<collision_name>.scattering_angle_model` for two-product reactions (e.g. nuclear fusion).

With `backward`, the reaction products are emitted in the **opposite** direction of the reactant in the center of mass frame (scattering angle = pi), mirroring the existing `forward` model (angle = 0).

## Changes
- `ScatteringAngleModel` enum: add `Backward`
- `TwoProductComputeProductMomenta`: handle the backward case by flipping the sign of the product momentum scaling (shares the forward code path)
- Documentation updated in `parameters.rst`

## Notes
- No regression test added yet: testing will be included as part of future PRs that will reuse these functions in DSMC and MCC

🤖 Generated with [Claude Code](https://claude.com/claude-code)