### PR TITLE
Add dependabot.yml for GitHub Actions version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Basic `dependabot.yml` file with minimum configuration for package managers.
+# Reference: https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configure-version-updates.
+
+version: 2
+updates:
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "development"


### PR DESCRIPTION
## Overview

Implement @WeiqunZhang's suggestion in https://github.com/BLAST-WarpX/warpx/pull/6941#issuecomment-4662960880 and add a basic `dependabot.yml` file with minimum configuration for package managers (only GitHub Actions for now).

## Notes

Style and comments copied from https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configure-version-updates.

Configuration copied from AMReX's [`dependabot.yml`](https://github.com/AMReX-Codes/amrex/blob/development/.github/dependabot.yml):
```yaml
# Dependabot configuration
# ref: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
version: 2
updates:
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "weekly"
    target-branch: "development"
```

I noticed that ImpactX's [`dependabot.yml`](https://github.com/BLAST-ImpactX/impactx/blob/development/.github/dependabot.yml) does not have the `target-branch` spec:
```yaml
# Set update schedule for updating modules used in
# our GitHub Actions.

version: 2
updates:
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "weekly"
```

Not sure which one is more correct, but it seems like AMReX's one was the result of some troubleshooting (see, e.g., https://github.com/AMReX-Codes/amrex/commit/edd55a55429e033b9bb9c47303339b04ca690cf0).