### PR TITLE
[WIP] Allow explicit FFT process grid for IGF solver

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -418,9 +418,12 @@ Overall simulation parameters
             As a consequence, this solver does not need to do an FFT along the :math:`z` direction,
             and instead uses only transverse FFTs (along :math:`x` and :math:`y`) at each :math:`z` position (or :math:`z` "slice").
 
-          * ``ablastr.nprocs_igf_fft`` (``int``) optional (default: number of MPI ranks): Number of MPI ranks used to parallelize the FFT solver.
-            This can be less or equal than then number of MPI ranks that are used to run the overall simulation.
+          * ``ablastr.nprocs_igf_fft`` (``int`` or list of ``int``) optional (default: number of MPI ranks): Number of MPI ranks used to parallelize the FFT solver.
+            This can be less or equal than the number of MPI ranks that are used to run the overall simulation.
             It can be useful if the auxiliary simulation boxes fit within a single process, so to avoid extra communications.
+            This parameter can be specified either as a single integer or as ``AMREX_SPACEDIM`` integers, similarly to :pp:param:`warpx.numprocs`.
+            When specified as a list, the entries define the FFT solver process grid and their product is the number of MPI ranks used by the FFT solver.
+            This allows the FFT solver to use a decomposition that differs from the overall simulation domain decomposition.
             The auxiliary boxes are extended boxes in real and spectral space that are used to perform the necessary FFTs.
             The extended simulation box size in real space is :math:`2n_x-1, 2n_y-1, 2n_z-1` with the 3D solver, :math:`2n_x-1, 2n_y -1, n_z` with the 2D solver.
             The extended simulation box size in spectral space is :math:`n_x, 2n_y-1, 2n_z-1` with the 3D solver, :math:`n_x, 2n_y-1, n_z` with the 2D solver.

--- a/Examples/Tests/open_bc_poisson_solver/inputs_test_3d_open_bc_poisson_solver
+++ b/Examples/Tests/open_bc_poisson_solver/inputs_test_3d_open_bc_poisson_solver
@@ -15,6 +15,7 @@ boundary.field_hi = open open open
 warpx.const_dt = 1e-14
 warpx.do_electrostatic = relativistic
 warpx.poisson_solver = fft
+ablastr.nprocs_igf_fft = 1 1 2
 algo.field_gathering = momentum-conserving
 algo.particle_shape = 1
 

--- a/Source/ablastr/fields/IntegratedGreenFunctionSolver.cpp
+++ b/Source/ablastr/fields/IntegratedGreenFunctionSolver.cpp
@@ -8,6 +8,7 @@
 
 #include <ablastr/constant.H>
 #include <ablastr/warn_manager/WarnManager.H>
+#include <Utils/Parser/ParserUtils.H>
 
 #include <AMReX_Array4.H>
 #include <AMReX_BaseFab.H>
@@ -28,6 +29,8 @@
 #include <AMReX_ParmParse.H>
 #include <AMReX_REAL.H>
 
+#include <vector>
+
 namespace ablastr::fields {
 
 void
@@ -47,9 +50,37 @@ computePhiIGF ( amrex::MultiFab const & rho,
     amrex::Box const domain = rho.boxArray().minimalBox();
 
     int nprocs = amrex::ParallelDescriptor::NProcs();
+    amrex::IntVect nprocs_igf_fft_proc_grid{0};
     {
         amrex::ParmParse pp("ablastr");
-        pp.queryAdd("nprocs_igf_fft", nprocs);
+        std::vector<int> nprocs_igf_fft;
+        ::utils::parser::queryArrWithParser(
+            pp, "nprocs_igf_fft", nprocs_igf_fft, 0, AMREX_SPACEDIM);
+        if (nprocs_igf_fft.empty()) {
+            pp.add("nprocs_igf_fft", nprocs);
+        } else if (nprocs_igf_fft.size() == 1) {
+            nprocs = nprocs_igf_fft[0];
+        } else {
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                nprocs_igf_fft.size() == AMREX_SPACEDIM,
+                "ablastr.nprocs_igf_fft, if specified as an array, must have "
+                "AMREX_SPACEDIM numbers");
+            nprocs = 1;
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                    nprocs_igf_fft[idim] > 0,
+                    "ablastr.nprocs_igf_fft entries must be positive");
+                nprocs_igf_fft_proc_grid[idim] = nprocs_igf_fft[idim];
+                nprocs *= nprocs_igf_fft[idim];
+            }
+        }
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            nprocs > 0,
+            "ablastr.nprocs_igf_fft must specify a positive number of MPI ranks");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            nprocs_igf_fft_proc_grid == 0 || nprocs <= amrex::ParallelDescriptor::NProcs(),
+            "The product of ablastr.nprocs_igf_fft entries cannot exceed the total "
+            "number of MPI ranks");
         nprocs = std::max(1,std::min(nprocs, amrex::ParallelDescriptor::NProcs()));
     }
 
@@ -60,7 +91,11 @@ computePhiIGF ( amrex::MultiFab const & rho,
     if (!obc_solver || obc_solver->Domain() != domain) {
         amrex::FFT::Info info{};
         if (is_igf_2d_slices) { info.setTwoDMode(true); } // do 2D FFTs
-        info.setNumProcs(nprocs);
+        if (nprocs_igf_fft_proc_grid != 0) {
+            info.setProcGrid(nprocs_igf_fft_proc_grid);
+        } else {
+            info.setNumProcs(nprocs);
+        }
         obc_solver = std::make_unique<amrex::FFT::OpenBCSolver<amrex::Real>>(domain, info);
     }
 


### PR DESCRIPTION
This adds explicit FFT process-grid control for the integrated Green function FFT Poisson solver via ablastr.nprocs_igf_fft.

Changes:
- accept ablastr.nprocs_igf_fft as either a scalar rank cap or an AMREX_SPACEDIM-entry process grid, matching the warpx.numprocs-style list interface
- pass list input to amrex::FFT::Info::setProcGrid so the FFT solver can use a decomposition independent of the simulation DistributionMapping
- keep scalar input on the existing setNumProcs path for backward compatibility
- document the new list behavior and exercise it in the 3D open-boundary Poisson input

Dependency:
- requires the AMReX change that adds amrex::FFT::Info::setProcGrid. Until WarpX's AMReX dependency includes that API, this PR should be treated as dependent on the AMReX-side PR/commit.

Validation:
- pre-commit hooks from git commit passed
- git diff --check mainline/development...HEAD passed
- configured a temporary 3D CPU build against local AMReX branch fft-proc-grid-info: cmake -S /home/arianna/Sources/WarpX -B /tmp/warpx-igf-fft-build -DCMAKE_PREFIX_PATH=/home/arianna/anaconda3/envs/warpx -DWarpX_DIMS=3 -DWarpX_COMPUTE=NOACC -DWarpX_MPI=OFF -DWarpX_OPENPMD=OFF -DWarpX_QED=OFF -DWarpX_EB=OFF -DWarpX_FFT=ON -DWarpX_APP=OFF -DWarpX_LIB=ON -DWarpX_amrex_src=/home/arianna/Sources/amrex
- cmake --build /tmp/warpx-igf-fft-build -j 8 --target Source/ablastr/fields/IntegratedGreenFunctionSolver.o passed
- cmake --build /tmp/warpx-igf-fft-build -j 8 --target ablastr_3d passed