### PR TITLE
Add support for RZ + EB with effective potential ES solver

### DIFF
--- a/Source/ablastr/fields/EffectivePotentialPoissonSolver.H
+++ b/Source/ablastr/fields/EffectivePotentialPoissonSolver.H
@@ -180,6 +180,9 @@ computeEffectivePotentialPhi (
                     linop_nodelap->setEBDirichlet(boundary_handler.getPhiEB(current_time.value()));
                 }
             }
+            if (is_rz) {
+                linop_nodelap->setRZ(true);
+            }
             linop_nodelap->setSigma(lev, sigma);
             linop = std::move(linop_nodelap);
 #endif

--- a/Source/ablastr/fields/EffectivePotentialPoissonSolver.H
+++ b/Source/ablastr/fields/EffectivePotentialPoissonSolver.H
@@ -189,6 +189,9 @@ computeEffectivePotentialPhi (
         }
         else if (is_rz)
         {
+            amrex::Abort("The effective potential ES solver is not supported in RZ without EBs.");
+            // The above assert can be removed once AMReX::MLEBNodeFDLaplacian
+            // is extended to support a sigma MF when not compiled with EB support.
             auto linop_nodelap = std::make_unique<amrex::MLEBNodeFDLaplacian>();
             linop_nodelap->define(
                 amrex::Vector<amrex::Geometry>{geom[lev]},


### PR DESCRIPTION
Requires 

- [ ] https://github.com/AMReX-Codes/amrex/pull/5507.

Besides adding new support for RZ + EB with the effective potential solver, this PR addresses a substantial issue present in that solver. Currently on `development` (with a release build) a user could execute RZ simulations (with or without EB support enabled) using the effective potential solver but both such cases would be wrong.
If EB support is enabled, the solver will simply use the Cartesian version of the `MLEBNodeFDLaplacian` with `sigma` MF, which obviously gives incorrect results in RZ.
If EB support is not enabled, the solver will use the RZ version of `MLEBNodeFDLaplacian` but will ignore `sigma` (since a MF `sigma` is not supported in that case in AMReX yet).

This PR remedies the situation by properly supporting the RZ + EB case and aborting on the RZ without EB case.